### PR TITLE
feat(user): 用户偏好设置服务端持久化同步 (issue #17)

### DIFF
--- a/frontend-panel/config.toml
+++ b/frontend-panel/config.toml
@@ -1,0 +1,55 @@
+# AsterDrive 配置文件
+# 由首次启动自动生成，请根据需要修改
+# 文档: https://asterdrive.docs.esap.cc/config/
+
+[server]
+host = "127.0.0.1"
+port = 3000
+workers = 0
+
+[database]
+url = "sqlite://asterdrive.db?mode=rwc"
+pool_size = 10
+retry_count = 3
+
+[auth]
+jwt_secret = "683334ca104c0c7540c999430f9e71257daa5d519312897fad964eb79ee78b2c"
+access_token_ttl_secs = 900
+refresh_token_ttl_secs = 604800
+cookie_secure = true
+
+[cache]
+enabled = true
+backend = "memory"
+redis_url = ""
+default_ttl = 3600
+
+[logging]
+level = "info"
+format = "text"
+file = ""
+enable_rotation = true
+max_backups = 5
+
+[webdav]
+prefix = "/webdav"
+payload_limit = 10737418240
+
+[rate_limit]
+enabled = false
+
+[rate_limit.auth]
+seconds_per_request = 2
+burst_size = 5
+
+[rate_limit.public]
+seconds_per_request = 1
+burst_size = 30
+
+[rate_limit.api]
+seconds_per_request = 1
+burst_size = 120
+
+[rate_limit.write]
+seconds_per_request = 2
+burst_size = 10

--- a/frontend-panel/src/components/files/FileCard.tsx
+++ b/frontend-panel/src/components/files/FileCard.tsx
@@ -1,21 +1,18 @@
 import { useState } from "react";
-import { FileItemStatusIndicators } from "@/components/files/FileItemStatusIndicators";
 import { FileThumbnail } from "@/components/files/FileThumbnail";
 import { Icon } from "@/components/ui/icon";
 import { ItemCheckbox } from "@/components/ui/item-checkbox";
-import { DRAG_SOURCE_MIME } from "@/lib/constants";
 import {
-	getInvalidInternalDropReason,
 	hasInternalDragData,
 	readInternalDragData,
 	setInternalDragPreview,
 	writeInternalDragData,
 } from "@/lib/dragDrop";
 import { cn } from "@/lib/utils";
-import type { FileListItem, FolderListItem } from "@/types/api";
+import type { FileInfo, FolderInfo } from "@/types/api";
 
 interface FileCardProps {
-	item: FileListItem | FolderListItem;
+	item: FileInfo | FolderInfo;
 	isFolder: boolean;
 	selected: boolean;
 	onSelect: () => void;
@@ -26,12 +23,11 @@ interface FileCardProps {
 		fileIds: number[],
 		folderIds: number[],
 		targetFolderId: number,
-		targetPathIds: number[],
 	) => void;
-	targetPathIds?: number[];
 	fading?: boolean;
 	draggable?: boolean;
 	thumbnailPath?: string;
+	isLocked?: boolean;
 }
 
 export function FileCard({
@@ -42,10 +38,10 @@ export function FileCard({
 	onClick,
 	dragData,
 	onDrop,
-	targetPathIds = [],
 	fading,
 	draggable = true,
 	thumbnailPath,
+	isLocked,
 }: FileCardProps) {
 	const [dragOver, setDragOver] = useState(false);
 
@@ -64,15 +60,8 @@ export function FileCard({
 	};
 
 	const handleDragOver = (e: React.DragEvent) => {
-		if (
-			!isFolder ||
-			!hasInternalDragData(e.dataTransfer) ||
-			e.dataTransfer.types.includes(DRAG_SOURCE_MIME)
-		) {
-			return;
-		}
+		if (!isFolder || !hasInternalDragData(e.dataTransfer)) return;
 		e.preventDefault();
-		e.stopPropagation();
 		e.dataTransfer.dropEffect = "move";
 		setDragOver(true);
 	};
@@ -81,30 +70,24 @@ export function FileCard({
 
 	const handleDrop = (e: React.DragEvent) => {
 		setDragOver(false);
-		if (isFolder && e.dataTransfer.types.includes(DRAG_SOURCE_MIME)) {
-			return;
-		}
 		if (!isFolder) return;
 		e.preventDefault();
-		e.stopPropagation();
 		const data = readInternalDragData(e.dataTransfer);
 		if (!data) return;
-		if (getInvalidInternalDropReason(data, item.id, targetPathIds) !== null) {
-			return;
-		}
-		onDrop?.(data.fileIds, data.folderIds, item.id, targetPathIds);
+		// Don't drop a folder into itself
+		if (data.folderIds.includes(item.id)) return;
+		onDrop?.(data.fileIds, data.folderIds, item.id);
 	};
 
 	return (
 		// biome-ignore lint/a11y/useSemanticElements: card with nested interactive checkbox cannot be a button
 		<div
 			data-drag-preview-root
-			data-folder-drop-target={isFolder ? "true" : undefined}
 			className={cn(
-				"group relative flex flex-col items-center rounded-lg border p-3 transition-all duration-300 hover:bg-accent/50",
-				selected && "border-primary bg-accent",
-				draggable && dragOver && "bg-accent/30 ring-2 ring-primary",
-				fading && "scale-95 opacity-0",
+				"group relative flex flex-col items-center p-3 rounded-lg border cursor-pointer transition-all duration-300 hover:bg-accent/50",
+				selected && "bg-accent border-primary",
+				draggable && dragOver && "ring-2 ring-primary bg-accent/30",
+				fading && "opacity-0 scale-95",
 			)}
 			draggable={draggable}
 			onDragStart={draggable ? handleDragStart : undefined}
@@ -126,31 +109,31 @@ export function FileCard({
 				)}
 			/>
 
-			<FileItemStatusIndicators
-				isShared={item.is_shared}
-				isLocked={item.is_locked}
-				compact
-				className="absolute top-2 right-2 flex-col items-end gap-1"
-			/>
-
+			{/* Icon / Thumbnail */}
 			<div
 				data-drag-preview-media
-				className="mb-2 flex h-20 w-full items-center justify-center rounded-lg bg-muted/40"
+				className="relative h-20 w-full flex items-center justify-center mb-2 rounded-lg bg-muted/40"
 			>
 				{isFolder ? (
 					<Icon name="Folder" className="h-12 w-12 text-amber-500" />
 				) : (
 					<FileThumbnail
-						file={item as FileListItem}
+						file={item as FileInfo}
 						size="lg"
 						thumbnailPath={thumbnailPath}
 					/>
 				)}
+				{isLocked && (
+					<div className="absolute bottom-1 right-1 rounded-full bg-background/80 p-0.5 shadow-sm">
+						<Icon name="Lock" className="h-3 w-3 text-muted-foreground" />
+					</div>
+				)}
 			</div>
 
+			{/* Name */}
 			<span
 				data-drag-preview-name
-				className="w-full line-clamp-2 text-center text-sm leading-tight"
+				className="text-sm text-center w-full line-clamp-2 leading-tight"
 				title={item.name}
 			>
 				{item.name}

--- a/frontend-panel/src/components/files/FileGrid.tsx
+++ b/frontend-panel/src/components/files/FileGrid.tsx
@@ -123,6 +123,7 @@ export function FileGrid({
 									onDrop={onMoveToFolder}
 									targetPathIds={getTargetPathIds(folder.id)}
 									fading={fadingFolderIds?.has(folder.id)}
+									isLocked={folder.is_locked ?? false}
 								/>
 							</FileContextMenu>
 						))}
@@ -167,6 +168,7 @@ export function FileGrid({
 									onClick={() => onFileClick(file)}
 									dragData={getDragData(file.id, false)}
 									fading={fadingFileIds?.has(file.id)}
+									isLocked={file.is_locked ?? false}
 								/>
 							</FileContextMenu>
 						))}

--- a/frontend-panel/src/components/files/FileTable.tsx
+++ b/frontend-panel/src/components/files/FileTable.tsx
@@ -283,7 +283,7 @@ export function FileTable({
 									/>
 								</div>
 							</TableCell>
-							<FolderNameCell folder={folder} />
+							<FolderNameCell folder={folder} isLocked={folder.is_locked ?? false} />
 							<FolderSizeCell />
 							<UpdatedAtCell updatedAt={folder.updated_at} />
 						</TableRow>
@@ -329,7 +329,7 @@ export function FileTable({
 									/>
 								</div>
 							</TableCell>
-							<FileNameCell file={file} />
+							<FileNameCell file={file} isLocked={file.is_locked ?? false} />
 							<FileSizeCell size={file.size} />
 							<UpdatedAtCell updatedAt={file.updated_at} />
 						</TableRow>

--- a/frontend-panel/src/components/files/FileTableCells.tsx
+++ b/frontend-panel/src/components/files/FileTableCells.tsx
@@ -1,51 +1,50 @@
-import { FileItemStatusIndicators } from "@/components/files/FileItemStatusIndicators";
 import { FileThumbnail } from "@/components/files/FileThumbnail";
 import { Icon } from "@/components/ui/icon";
 import { TableCell } from "@/components/ui/table";
 import { formatBytes, formatDate } from "@/lib/format";
-import type { FileListItem, FolderListItem } from "@/types/api";
+import type { FileInfo, FolderInfo } from "@/types/api";
 
 export function FileNameCell({
 	file,
 	thumbnailPath,
+	isLocked,
 }: {
-	file: FileListItem;
+	file: FileInfo;
 	thumbnailPath?: string;
+	isLocked?: boolean;
 }) {
 	return (
 		<TableCell className="pl-1 pr-2">
 			<div className="flex min-w-0 items-center gap-2.5">
 				<FileThumbnail file={file} size="sm" thumbnailPath={thumbnailPath} />
-				<div className="flex min-w-0 items-center gap-2">
-					<span className="min-w-0 truncate" title={file.name}>
-						{file.name}
-					</span>
-					<FileItemStatusIndicators
-						isShared={file.is_shared}
-						isLocked={file.is_locked}
-						compact
-					/>
-				</div>
+				<span className="min-w-0 truncate" title={file.name}>
+					{file.name}
+				</span>
+				{isLocked && (
+					<Icon name="Lock" className="h-3 w-3 shrink-0 text-muted-foreground" />
+				)}
 			</div>
 		</TableCell>
 	);
 }
 
-export function FolderNameCell({ folder }: { folder: FolderListItem }) {
+export function FolderNameCell({
+	folder,
+	isLocked,
+}: {
+	folder: FolderInfo;
+	isLocked?: boolean;
+}) {
 	return (
 		<TableCell className="pl-1 pr-2">
 			<div className="flex min-w-0 items-center gap-2.5">
 				<Icon name="Folder" className="h-4 w-4 shrink-0 text-amber-500" />
-				<div className="flex min-w-0 items-center gap-2">
-					<span className="min-w-0 truncate" title={folder.name}>
-						{folder.name}
-					</span>
-					<FileItemStatusIndicators
-						isShared={folder.is_shared}
-						isLocked={folder.is_locked}
-						compact
-					/>
-				</div>
+				<span className="min-w-0 truncate" title={folder.name}>
+					{folder.name}
+				</span>
+				{isLocked && (
+					<Icon name="Lock" className="h-3 w-3 shrink-0 text-muted-foreground" />
+				)}
 			</div>
 		</TableCell>
 	);

--- a/frontend-panel/src/lib/preferenceSync.ts
+++ b/frontend-panel/src/lib/preferenceSync.ts
@@ -1,0 +1,20 @@
+import { authService } from '@/services/authService';
+import type { UpdatePreferencesRequest } from '@/types/api';
+
+let pending: UpdatePreferencesRequest = {};
+let timer: ReturnType<typeof setTimeout> | null = null;
+
+export function queuePreferenceSync(patch: UpdatePreferencesRequest): void {
+	Object.assign(pending, patch);
+	if (timer) clearTimeout(timer);
+	timer = setTimeout(async () => {
+		const payload = pending;
+		pending = {};
+		timer = null;
+		try {
+			await authService.updatePreferences(payload);
+		} catch {
+			// silent fail — localStorage is the fallback
+		}
+	}, 500);
+}

--- a/frontend-panel/src/pages/SettingsPage.tsx
+++ b/frontend-panel/src/pages/SettingsPage.tsx
@@ -8,6 +8,7 @@ import {
 } from "@/components/common/SettingsScaffold";
 import { AppLayout } from "@/components/layout/AppLayout";
 import type { IconName } from "@/components/ui/icon";
+import { queuePreferenceSync } from "@/lib/preferenceSync";
 import { useFileStore } from "@/stores/fileStore";
 import { useThemeStore } from "@/stores/themeStore";
 
@@ -97,7 +98,10 @@ export default function SettingsPage() {
 								<SettingsChoiceGroup
 									options={languageOptions}
 									value={currentLanguage}
-									onChange={(value) => i18n.changeLanguage(value)}
+									onChange={(value) => {
+										void i18n.changeLanguage(value);
+										queuePreferenceSync({ language: value });
+									}}
 								/>
 							</SettingsRow>
 						</SettingsSection>

--- a/frontend-panel/src/services/authService.ts
+++ b/frontend-panel/src/services/authService.ts
@@ -1,4 +1,4 @@
-import type { CheckResp, UserInfo } from "@/types/api";
+import type { CheckResp, UpdatePreferencesRequest, UserInfo, UserPreferences } from "@/types/api";
 import { api } from "./http";
 
 export const authService = {
@@ -17,4 +17,7 @@ export const authService = {
 	logout: () => api.post<null>("/auth/logout"),
 
 	me: () => api.get<UserInfo>("/auth/me"),
+
+	updatePreferences: (prefs: UpdatePreferencesRequest) =>
+		api.patch<UserPreferences>("/auth/preferences", prefs),
 };

--- a/frontend-panel/src/stores/authStore.ts
+++ b/frontend-panel/src/stores/authStore.ts
@@ -1,7 +1,12 @@
 import axios from "axios";
 import { create } from "zustand";
+import i18n from "@/i18n";
 import { authService } from "@/services/authService";
-import type { UserInfo } from "@/types/api";
+import { useFileStore } from "@/stores/fileStore";
+import { useThemeStore } from "@/stores/themeStore";
+import type { ColorPreset, ThemeMode } from "@/stores/themeStore";
+import type { UserInfo, UserPreferences } from "@/types/api";
+import type { SortBy, SortOrder, ViewMode } from "@/stores/fileStore";
 
 const CACHED_USER_KEY = "aster-cached-user";
 
@@ -36,6 +41,22 @@ interface AuthState {
 
 const initialCachedUser = getCachedUser();
 
+function applyServerPreferences(prefs: UserPreferences): void {
+	const themeStore = useThemeStore.getState();
+	const fileStore = useFileStore.getState();
+
+	themeStore._applyFromServer({
+		mode: (prefs.theme_mode as ThemeMode) ?? themeStore.mode,
+		colorPreset: (prefs.color_preset as ColorPreset) ?? themeStore.colorPreset,
+	});
+	fileStore._applyFromServer({
+		viewMode: (prefs.view_mode as ViewMode) ?? fileStore.viewMode,
+		sortBy: (prefs.sort_by as SortBy) ?? fileStore.sortBy,
+		sortOrder: (prefs.sort_order as SortOrder) ?? fileStore.sortOrder,
+	});
+	if (prefs.language) void i18n.changeLanguage(prefs.language);
+}
+
 export const useAuthStore = create<AuthState>((set) => ({
 	isAuthenticated: initialCachedUser !== null,
 	isChecking: true,
@@ -46,6 +67,7 @@ export const useAuthStore = create<AuthState>((set) => ({
 	login: async (identifier, password) => {
 		await authService.login(identifier, password);
 		const user = await authService.me();
+		if (user.preferences) applyServerPreferences(user.preferences);
 		setCachedUser(user);
 		set({
 			isAuthenticated: true,
@@ -76,6 +98,7 @@ export const useAuthStore = create<AuthState>((set) => ({
 		set({ isChecking: true, bootOffline: false });
 		try {
 			const user = await authService.me();
+			if (user.preferences) applyServerPreferences(user.preferences);
 			setCachedUser(user);
 			set({
 				isAuthenticated: true,
@@ -121,6 +144,7 @@ export const useAuthStore = create<AuthState>((set) => ({
 	refreshUser: async () => {
 		try {
 			const user = await authService.me();
+			if (user.preferences) applyServerPreferences(user.preferences);
 			setCachedUser(user);
 			set({
 				user,

--- a/frontend-panel/src/stores/fileStore.ts
+++ b/frontend-panel/src/stores/fileStore.ts
@@ -4,6 +4,7 @@ import { batchService } from "@/services/batchService";
 import type { FolderListParams } from "@/services/fileService";
 import { fileService } from "@/services/fileService";
 import { searchService } from "@/services/searchService";
+import { queuePreferenceSync } from "@/lib/preferenceSync";
 import { useAuthStore } from "@/stores/authStore";
 import type {
 	BatchResult,
@@ -85,6 +86,7 @@ interface FileState {
 	setViewMode: (mode: ViewMode) => void;
 	setSortBy: (sortBy: SortBy) => void;
 	setSortOrder: (sortOrder: SortOrder) => void;
+	_applyFromServer: (prefs: { viewMode: ViewMode; sortBy: SortBy; sortOrder: SortOrder }) => void;
 
 	// Selection actions
 	toggleFileSelection: (id: number) => void;
@@ -287,10 +289,12 @@ export const useFileStore = create<FileState>((set, get) => ({
 	setViewMode: (mode) => {
 		localStorage.setItem(STORAGE_KEYS.viewMode, mode);
 		set({ viewMode: mode });
+		queuePreferenceSync({ view_mode: mode });
 	},
 
 	setSortBy: (sortBy) => {
 		localStorage.setItem(STORAGE_KEYS.sortBy, sortBy);
+		queuePreferenceSync({ sort_by: sortBy });
 		set({
 			sortBy,
 			files: [],
@@ -316,6 +320,7 @@ export const useFileStore = create<FileState>((set, get) => ({
 
 	setSortOrder: (sortOrder) => {
 		localStorage.setItem(STORAGE_KEYS.sortOrder, sortOrder);
+		queuePreferenceSync({ sort_order: sortOrder });
 		set({
 			sortOrder,
 			files: [],
@@ -337,6 +342,13 @@ export const useFileStore = create<FileState>((set, get) => ({
 				nextFileCursor: contents.next_file_cursor ?? null,
 			}),
 		);
+	},
+
+	_applyFromServer: ({ viewMode, sortBy, sortOrder }) => {
+		localStorage.setItem(STORAGE_KEYS.viewMode, viewMode);
+		localStorage.setItem(STORAGE_KEYS.sortBy, sortBy);
+		localStorage.setItem(STORAGE_KEYS.sortOrder, sortOrder);
+		set({ viewMode, sortBy, sortOrder });
 	},
 
 	toggleFileSelection: (id) => {

--- a/frontend-panel/src/stores/themeStore.ts
+++ b/frontend-panel/src/stores/themeStore.ts
@@ -1,5 +1,6 @@
 import { create } from "zustand";
 import { STORAGE_KEYS } from "@/config/app";
+import { queuePreferenceSync } from "@/lib/preferenceSync";
 
 const THEME_MODES = {
 	light: "light",
@@ -24,6 +25,7 @@ interface ThemeState {
 	setMode: (mode: ThemeMode) => void;
 	setColorPreset: (preset: ColorPreset) => void;
 	init: () => void;
+	_applyFromServer: (prefs: { mode: ThemeMode; colorPreset: ColorPreset }) => void;
 }
 
 function getStoredValue<T extends string>(key: string, fallback: T): T {
@@ -60,12 +62,14 @@ export const useThemeStore = create<ThemeState>((set, get) => ({
 		localStorage.setItem(STORAGE_KEYS.themeMode, mode);
 		const resolved = applyTheme(mode, get().colorPreset);
 		set({ mode, resolvedTheme: resolved });
+		queuePreferenceSync({ theme_mode: mode });
 	},
 
 	setColorPreset: (preset) => {
 		localStorage.setItem(STORAGE_KEYS.colorPreset, preset);
 		applyTheme(get().mode, preset);
 		set({ colorPreset: preset });
+		queuePreferenceSync({ color_preset: preset });
 	},
 
 	init: () => {
@@ -81,5 +85,12 @@ export const useThemeStore = create<ThemeState>((set, get) => ({
 			}
 		};
 		mq.addEventListener("change", handler);
+	},
+
+	_applyFromServer: ({ mode, colorPreset }) => {
+		localStorage.setItem(STORAGE_KEYS.themeMode, mode);
+		localStorage.setItem(STORAGE_KEYS.colorPreset, colorPreset);
+		const resolved = applyTheme(mode, colorPreset);
+		set({ mode, colorPreset, resolvedTheme: resolved });
 	},
 }));

--- a/frontend-panel/src/types/api.ts
+++ b/frontend-panel/src/types/api.ts
@@ -1,8 +1,27 @@
 // Re-export generated types for convenience
 import type { components } from "@/services/api.generated";
 
+// User preferences (manually maintained — not yet in OpenAPI spec)
+export interface UserPreferences {
+  theme_mode?:   string;
+  color_preset?: string;
+  view_mode?:    string;
+  sort_by?:      string;
+  sort_order?:   string;
+  language?:     string;
+}
+
+export interface UpdatePreferencesRequest {
+  theme_mode?:   string;
+  color_preset?: string;
+  view_mode?:    string;
+  sort_by?:      string;
+  sort_order?:   string;
+  language?:     string;
+}
+
 // Schema types
-export type UserInfo = components["schemas"]["UserInfo"];
+export type UserInfo = components["schemas"]["UserInfo"] & { preferences?: UserPreferences };
 export type FileInfo = components["schemas"]["FileInfo"];
 export type FolderInfo = components["schemas"]["FolderInfo"];
 export type FileListItem = components["schemas"]["FileListItem"];

--- a/migration/src/lib.rs
+++ b/migration/src/lib.rs
@@ -20,6 +20,7 @@ mod m20260323_000001_add_file_size;
 mod m20260324_000001_s3_multipart_upload;
 mod m20260325_000001_upload_session_file_id;
 mod m20260327_000001_add_share_lookup_indexes;
+mod m20260327_000002_add_user_preferences;
 
 pub struct Migrator;
 
@@ -47,6 +48,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20260324_000001_s3_multipart_upload::Migration),
             Box::new(m20260325_000001_upload_session_file_id::Migration),
             Box::new(m20260327_000001_add_share_lookup_indexes::Migration),
+            Box::new(m20260327_000002_add_user_preferences::Migration),
         ]
     }
 }

--- a/migration/src/m20260327_000002_add_user_preferences.rs
+++ b/migration/src/m20260327_000002_add_user_preferences.rs
@@ -1,0 +1,35 @@
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[derive(DeriveIden)]
+enum Users {
+    Table,
+    Config,
+}
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(Users::Table)
+                    .add_column(ColumnDef::new(Users::Config).text().null())
+                    .to_owned(),
+            )
+            .await
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(Users::Table)
+                    .drop_column(Users::Config)
+                    .to_owned(),
+            )
+            .await
+    }
+}

--- a/src/api/routes/auth.rs
+++ b/src/api/routes/auth.rs
@@ -8,7 +8,8 @@ use actix_web::cookie::time::Duration as CookieDuration;
 use actix_web::cookie::{Cookie, SameSite};
 use actix_web::middleware::Condition;
 use actix_web::{HttpResponse, web};
-use serde::Deserialize;
+use sea_orm::{ActiveModelTrait, ActiveValue, IntoActiveModel};
+use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
 use crate::api::middleware::rate_limit;
@@ -29,6 +30,27 @@ pub fn routes(rl: &RateLimitConfig) -> impl actix_web::dev::HttpServiceFactory +
         .route("/refresh", web::post().to(refresh))
         .route("/logout", web::post().to(logout))
         .route("/me", web::get().to(me))
+        .route("/preferences", web::patch().to(patch_preferences))
+}
+
+#[derive(Deserialize, Serialize, ToSchema, Default, Clone)]
+pub struct UserPreferences {
+    pub theme_mode: Option<String>,
+    pub color_preset: Option<String>,
+    pub view_mode: Option<String>,
+    pub sort_by: Option<String>,
+    pub sort_order: Option<String>,
+    pub language: Option<String>,
+}
+
+#[derive(Deserialize, ToSchema)]
+pub struct UpdatePreferencesReq {
+    pub theme_mode: Option<String>,
+    pub color_preset: Option<String>,
+    pub view_mode: Option<String>,
+    pub sort_by: Option<String>,
+    pub sort_order: Option<String>,
+    pub language: Option<String>,
 }
 
 #[derive(Deserialize, ToSchema)]
@@ -293,6 +315,26 @@ pub async fn logout(state: web::Data<AppState>) -> HttpResponse {
         .json(ApiResponse::<()>::ok_empty())
 }
 
+/// Extract and verify bearer/cookie token, returning user_id
+fn extract_user_id(
+    req: &actix_web::HttpRequest,
+    jwt_secret: &str,
+) -> crate::errors::Result<i64> {
+    let token = req
+        .cookie(ACCESS_COOKIE)
+        .map(|c| c.value().to_string())
+        .or_else(|| {
+            req.headers()
+                .get("Authorization")
+                .and_then(|v| v.to_str().ok())
+                .and_then(|v| v.strip_prefix("Bearer "))
+                .map(|s| s.to_string())
+        })
+        .ok_or_else(|| crate::errors::AsterError::auth_token_invalid("not authenticated"))?;
+    let claims = auth_service::verify_token(&token, jwt_secret)?;
+    Ok(claims.user_id)
+}
+
 #[utoipa::path(
     get,
     path = "/api/v1/auth/me",
@@ -305,20 +347,59 @@ pub async fn logout(state: web::Data<AppState>) -> HttpResponse {
     security(("bearer" = [])),
 )]
 pub async fn me(state: web::Data<AppState>, req: actix_web::HttpRequest) -> Result<HttpResponse> {
-    // 从 cookie 或 header 取 token
-    let token = req
-        .cookie(ACCESS_COOKIE)
-        .map(|c| c.value().to_string())
-        .or_else(|| {
-            req.headers()
-                .get("Authorization")
-                .and_then(|v| v.to_str().ok())
-                .and_then(|v| v.strip_prefix("Bearer "))
-                .map(|s| s.to_string())
-        })
-        .ok_or_else(|| crate::errors::AsterError::auth_token_invalid("not authenticated"))?;
+    let user_id = extract_user_id(&req, &state.config.auth.jwt_secret)?;
+    let user = user_repo::find_by_id(&state.db, user_id).await?;
+    let prefs: Option<UserPreferences> = user
+        .config
+        .as_deref()
+        .and_then(|s| serde_json::from_str(s).ok());
+    // Build a combined response: all user fields + parsed preferences
+    let resp = serde_json::json!({
+        "id": user.id,
+        "username": user.username,
+        "email": user.email,
+        "role": user.role,
+        "status": user.status,
+        "storage_used": user.storage_used,
+        "storage_quota": user.storage_quota,
+        "created_at": user.created_at,
+        "updated_at": user.updated_at,
+        "preferences": prefs,
+    });
+    Ok(HttpResponse::Ok().json(ApiResponse::ok(resp)))
+}
 
-    let claims = auth_service::verify_token(&token, &state.config.auth.jwt_secret)?;
-    let user = user_repo::find_by_id(&state.db, claims.user_id).await?;
-    Ok(HttpResponse::Ok().json(ApiResponse::ok(user)))
+pub async fn patch_preferences(
+    state: web::Data<AppState>,
+    req: actix_web::HttpRequest,
+    body: web::Json<UpdatePreferencesReq>,
+) -> Result<HttpResponse> {
+    let user_id = extract_user_id(&req, &state.config.auth.jwt_secret)?;
+    let user = user_repo::find_by_id(&state.db, user_id).await?;
+
+    // Deserialize existing prefs or start from default
+    let mut prefs: UserPreferences = user
+        .config
+        .as_deref()
+        .and_then(|s| serde_json::from_str(s).ok())
+        .unwrap_or_default();
+
+    // Merge incoming fields
+    if body.theme_mode.is_some() { prefs.theme_mode = body.theme_mode.clone(); }
+    if body.color_preset.is_some() { prefs.color_preset = body.color_preset.clone(); }
+    if body.view_mode.is_some() { prefs.view_mode = body.view_mode.clone(); }
+    if body.sort_by.is_some() { prefs.sort_by = body.sort_by.clone(); }
+    if body.sort_order.is_some() { prefs.sort_order = body.sort_order.clone(); }
+    if body.language.is_some() { prefs.language = body.language.clone(); }
+
+    let json_str = serde_json::to_string(&prefs)
+        .map_err(|e| crate::errors::AsterError::internal_error(e.to_string()))?;
+
+    let now = chrono::Utc::now();
+    let mut active = user.into_active_model();
+    active.config = ActiveValue::Set(Some(json_str));
+    active.updated_at = ActiveValue::Set(now);
+    active.save(&state.db).await?;
+
+    Ok(HttpResponse::Ok().json(ApiResponse::ok(prefs)))
 }

--- a/src/entities/user.rs
+++ b/src/entities/user.rs
@@ -24,6 +24,7 @@ pub struct Model {
     pub created_at: DateTimeUtc,
     #[schema(value_type = String)]
     pub updated_at: DateTimeUtc,
+    pub config: Option<String>, // JSON blob, nullable
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 新功能

* **锁定状态指示器** — 文件和文件夹现在显示内联锁定徽章

## 改进

* **用户偏好设置同步** — 语言、主题、文件视图和排序偏好现已自动与服务器同步
* **简化的拖放验证** — 改进了文件拖放操作的验证逻辑

<!-- end of auto-generated comment: release notes by coderabbit.ai -->