### PR TITLE
feat(db): 引入 SQLite 读写分离连接池 DbHandles

### DIFF
--- a/developer-docs/architecture.md
+++ b/developer-docs/architecture.md
@@ -207,6 +207,15 @@ WebDAV 不走 `src/api/routes/**`，而是：
 10. 根据节点模式重载 `DriverRegistry`
 11. 初始化缓存后端
 
+### 数据库连接句柄
+
+运行态通过 `DbHandles` 同时保存 writer 和 reader：
+
+- `state.db` / `state.writer_db()` 是 writer。所有事务、写入、读后写、配额权威判断、登录签发 session、refresh token rotation、上传 init/chunk/complete/cancel、依赖 SQLite 单连接模拟锁语义的 repo helper，都必须继续走 writer。
+- `state.reader_db()` 是纯读入口。SQLite 文件数据库下它会在 writer 完成 migration 和默认数据初始化后打开独立 reader pool，使用 WAL、`mode=ro` 和 `PRAGMA query_only=ON`；PostgreSQL/MySQL 或内存 SQLite 下它和 writer 指向同一个池。
+- reader 查询允许 WAL 快照级别的短暂滞后。只能用于列表、详情、搜索、上传进度、recoverable sessions、presign 查询阶段、auth snapshot cache miss、public runtime snapshot、admin overview 统计这类不会马上做权威写入判断的路径。
+- 不要把通用校验 helper 偷偷改成 reader，除非已经确认所有调用方都是纯读。更推荐在 service 入口显式选择 `reader_db()` 或 `writer_db()`，让调用语义能从代码上看出来。
+
 ### Primary 特有启动
 
 `src/runtime/startup/primary.rs` 额外准备：

--- a/src/api/middleware/cors/tests.rs
+++ b/src/api/middleware/cors/tests.rs
@@ -77,7 +77,6 @@ async fn test_state(configs: &[(&str, &str)]) -> PrimaryAppState {
         );
 
     PrimaryAppState {
-        db: db.clone(),
         db_handles: crate::db::DbHandles::single(db),
         driver_registry: Arc::new(crate::storage::DriverRegistry::new()),
         runtime_config: runtime_config.clone(),

--- a/src/api/middleware/cors/tests.rs
+++ b/src/api/middleware/cors/tests.rs
@@ -77,7 +77,8 @@ async fn test_state(configs: &[(&str, &str)]) -> PrimaryAppState {
         );
 
     PrimaryAppState {
-        db,
+        db: db.clone(),
+        db_handles: crate::db::DbHandles::single(db),
         driver_registry: Arc::new(crate::storage::DriverRegistry::new()),
         runtime_config: runtime_config.clone(),
         policy_snapshot: Arc::new(crate::storage::PolicySnapshot::new()),

--- a/src/api/routes/files/access.rs
+++ b/src/api/routes/files/access.rs
@@ -1084,7 +1084,8 @@ mod tests {
             );
 
         let state = PrimaryAppState {
-            db,
+            db: db.clone(),
+            db_handles: crate::db::DbHandles::single(db),
             driver_registry,
             runtime_config: runtime_config.clone(),
             policy_snapshot,

--- a/src/api/routes/files/access.rs
+++ b/src/api/routes/files/access.rs
@@ -1084,7 +1084,6 @@ mod tests {
             );
 
         let state = PrimaryAppState {
-            db: db.clone(),
             db_handles: crate::db::DbHandles::single(db),
             driver_registry,
             runtime_config: runtime_config.clone(),

--- a/src/api/routes/health.rs
+++ b/src/api/routes/health.rs
@@ -306,7 +306,8 @@ mod tests {
             );
 
         PrimaryAppState {
-            db,
+            db: db.clone(),
+            db_handles: crate::db::DbHandles::single(db),
             driver_registry,
             runtime_config: runtime_config.clone(),
             policy_snapshot,

--- a/src/api/routes/health.rs
+++ b/src/api/routes/health.rs
@@ -65,7 +65,7 @@ pub async fn health() -> HttpResponse {
     ),
 )]
 pub async fn primary_ready(state: web::Data<PrimaryAppState>) -> HttpResponse {
-    if let Err(error) = health_service::ping_database(&state.db).await {
+    if let Err(error) = health_service::ping_database(state.writer_db()).await {
         return ready_database_error(error);
     }
 
@@ -76,7 +76,7 @@ pub async fn primary_ready(state: web::Data<PrimaryAppState>) -> HttpResponse {
 }
 
 pub async fn follower_ready(state: web::Data<FollowerAppState>) -> HttpResponse {
-    if let Err(error) = health_service::ping_database(&state.db).await {
+    if let Err(error) = health_service::ping_database(state.writer_db()).await {
         return ready_database_error(error);
     }
 
@@ -306,7 +306,6 @@ mod tests {
             );
 
         PrimaryAppState {
-            db: db.clone(),
             db_handles: crate::db::DbHandles::single(db),
             driver_registry,
             runtime_config: runtime_config.clone(),

--- a/src/cli/database_migration.rs
+++ b/src/cli/database_migration.rs
@@ -51,6 +51,7 @@ const COPY_TABLE_ORDER: &[&str] = &[
     "folders",
     "webdav_accounts",
     "file_blobs",
+    "blob_media_metadata",
     "files",
     "file_versions",
     "shares",

--- a/src/db/connection.rs
+++ b/src/db/connection.rs
@@ -4,12 +4,63 @@ use crate::config::DatabaseConfig;
 use crate::errors::{AsterError, MapAsterErr, Result};
 use sea_orm::{ConnectOptions, ConnectionTrait, Database, DatabaseConnection, SqlxSqliteConnector};
 
+#[derive(Clone)]
+pub struct DbHandles {
+    writer: DatabaseConnection,
+    reader: DatabaseConnection,
+    sqlite_read_write_split: bool,
+}
+
+impl DbHandles {
+    pub fn single(db: DatabaseConnection) -> Self {
+        Self {
+            writer: db.clone(),
+            reader: db,
+            sqlite_read_write_split: false,
+        }
+    }
+
+    pub fn writer(&self) -> &DatabaseConnection {
+        &self.writer
+    }
+
+    pub fn reader(&self) -> &DatabaseConnection {
+        &self.reader
+    }
+
+    pub fn sqlite_read_write_split(&self) -> bool {
+        self.sqlite_read_write_split
+    }
+}
+
 pub async fn connect(cfg: &DatabaseConfig) -> Result<DatabaseConnection> {
     let retry_config = crate::db::retry::RetryConfig {
         max_retries: cfg.retry_count,
         ..Default::default()
     };
     crate::db::retry::with_retry(&retry_config, || connect_once(cfg)).await
+}
+
+pub async fn connect_handles(cfg: &DatabaseConfig) -> Result<DbHandles> {
+    let writer = connect(cfg).await?;
+    connect_reader_for_writer(cfg, writer).await
+}
+
+pub async fn connect_reader_for_writer(
+    cfg: &DatabaseConfig,
+    writer: DatabaseConnection,
+) -> Result<DbHandles> {
+    let url = normalize_database_url(&cfg.url);
+    if !sqlite_reader_pool_enabled(&url) {
+        return Ok(DbHandles::single(writer));
+    }
+
+    let reader = connect_sqlite_reader_once(cfg, &url).await?;
+    Ok(DbHandles {
+        writer,
+        reader,
+        sqlite_read_write_split: true,
+    })
 }
 
 async fn connect_once(cfg: &DatabaseConfig) -> Result<DatabaseConnection> {
@@ -65,6 +116,42 @@ async fn connect_once(cfg: &DatabaseConfig) -> Result<DatabaseConnection> {
     Ok(db)
 }
 
+async fn connect_sqlite_reader_once(
+    cfg: &DatabaseConfig,
+    normalized_writer_url: &str,
+) -> Result<DatabaseConnection> {
+    let reader_url = sqlite_reader_url(normalized_writer_url);
+    let max_connections = cfg.pool_size.max(1);
+    let mut opt = ConnectOptions::new(&reader_url);
+    opt.max_connections(max_connections)
+        .min_connections(1)
+        .sqlx_logging(false)
+        .test_before_acquire(true)
+        .map_sqlx_sqlite_pool_opts(|pool_options| {
+            pool_options.after_connect(|conn, _meta| {
+                Box::pin(async move {
+                    use sea_orm::sqlx::Executor;
+
+                    conn.execute("PRAGMA busy_timeout=15000;").await?;
+                    conn.execute("PRAGMA synchronous=NORMAL;").await?;
+                    conn.execute("PRAGMA foreign_keys=ON;").await?;
+                    conn.execute("PRAGMA query_only=ON;").await?;
+                    Ok(())
+                })
+            })
+        });
+
+    let db = SqlxSqliteConnector::connect(opt)
+        .await
+        .map_aster_err(AsterError::database_operation)?;
+
+    tracing::info!(
+        max_connections,
+        "SQLite reader pool connected with query_only pragma"
+    );
+    Ok(db)
+}
+
 fn normalize_database_url(database_url: &str) -> String {
     if database_url == "sqlite::memory:" {
         return database_url.to_string();
@@ -77,6 +164,42 @@ fn normalize_database_url(database_url: &str) -> String {
     database_url.to_string()
 }
 
+fn sqlite_reader_pool_enabled(normalized_url: &str) -> bool {
+    normalized_url.starts_with("sqlite:") && !is_sqlite_memory_url(normalized_url)
+}
+
+fn is_sqlite_memory_url(normalized_url: &str) -> bool {
+    normalized_url == "sqlite::memory:"
+        || normalized_url
+            .split_once('?')
+            .is_some_and(|(_, query)| query.split('&').any(|param| param == "mode=memory"))
+}
+
+fn sqlite_reader_url(normalized_writer_url: &str) -> String {
+    let Some((base, query)) = normalized_writer_url.split_once('?') else {
+        return format!("{normalized_writer_url}?mode=ro");
+    };
+
+    let mut saw_mode = false;
+    let query = query
+        .split('&')
+        .map(|param| {
+            if param.starts_with("mode=") {
+                saw_mode = true;
+                "mode=ro"
+            } else {
+                param
+            }
+        })
+        .collect::<Vec<_>>();
+
+    if saw_mode {
+        format!("{base}?{}", query.join("&"))
+    } else {
+        format!("{base}?mode=ro&{}", query.join("&"))
+    }
+}
+
 #[cfg(feature = "metrics")]
 fn install_db_metrics(db: &mut DatabaseConnection) {
     db.set_metric_callback(crate::metrics::record_db_query);
@@ -86,7 +209,7 @@ fn install_db_metrics(db: &mut DatabaseConnection) {
 mod tests {
     use super::normalize_database_url;
     use crate::config::DatabaseConfig;
-    use sea_orm::ConnectionTrait;
+    use sea_orm::{ConnectionTrait, TransactionTrait};
 
     #[test]
     fn sqlite_urls_without_query_default_to_rwc_mode() {
@@ -113,6 +236,29 @@ mod tests {
         );
     }
 
+    #[test]
+    fn sqlite_reader_pool_skips_memory_databases() {
+        assert!(!super::sqlite_reader_pool_enabled("sqlite::memory:"));
+        assert!(!super::sqlite_reader_pool_enabled(
+            "sqlite://memory-test?mode=memory&cache=shared"
+        ));
+        assert!(super::sqlite_reader_pool_enabled(
+            "sqlite:///var/lib/asterdrive/app.db?mode=rwc"
+        ));
+    }
+
+    #[test]
+    fn sqlite_reader_url_forces_read_only_mode() {
+        assert_eq!(
+            super::sqlite_reader_url("sqlite:///var/lib/asterdrive/app.db?mode=rwc"),
+            "sqlite:///var/lib/asterdrive/app.db?mode=ro"
+        );
+        assert_eq!(
+            super::sqlite_reader_url("sqlite:///var/lib/asterdrive/app.db?cache=shared"),
+            "sqlite:///var/lib/asterdrive/app.db?mode=ro&cache=shared"
+        );
+    }
+
     #[tokio::test]
     async fn sqlite_connector_accepts_windows_style_urls() {
         let url = format!(
@@ -130,5 +276,89 @@ mod tests {
         db.execute_unprepared("SELECT 1;")
             .await
             .expect("sqlite query should succeed");
+    }
+
+    #[tokio::test]
+    async fn sqlite_reader_pool_is_query_only() {
+        let url = format!(
+            "sqlite:///tmp/asterdrive-reader-pool-{}.db?mode=rwc",
+            uuid::Uuid::new_v4()
+        );
+        let handles = super::connect_handles(&DatabaseConfig {
+            url,
+            pool_size: 4,
+            retry_count: 0,
+        })
+        .await
+        .expect("sqlite handles should connect");
+
+        handles
+            .writer()
+            .execute_unprepared("CREATE TABLE reader_guard (id INTEGER PRIMARY KEY);")
+            .await
+            .expect("writer should create table");
+
+        let write_result = handles
+            .reader()
+            .execute_unprepared("INSERT INTO reader_guard (id) VALUES (1);")
+            .await;
+        assert!(write_result.is_err(), "reader pool must reject writes");
+    }
+
+    #[tokio::test]
+    async fn sqlite_reader_pool_reads_while_writer_connection_is_busy() {
+        let url = format!(
+            "sqlite:///tmp/asterdrive-reader-writer-split-{}.db?mode=rwc",
+            uuid::Uuid::new_v4()
+        );
+        let handles = super::connect_handles(&DatabaseConfig {
+            url,
+            pool_size: 4,
+            retry_count: 0,
+        })
+        .await
+        .expect("sqlite handles should connect");
+
+        handles
+            .writer()
+            .execute_unprepared("CREATE TABLE split_guard (id INTEGER PRIMARY KEY, name TEXT);")
+            .await
+            .expect("writer should create table");
+        handles
+            .writer()
+            .execute_unprepared("INSERT INTO split_guard (id, name) VALUES (1, 'ready');")
+            .await
+            .expect("writer should seed row");
+
+        let txn = handles
+            .writer()
+            .begin()
+            .await
+            .expect("writer transaction should begin");
+        txn.execute_unprepared("UPDATE split_guard SET name = 'held' WHERE id = 1;")
+            .await
+            .expect("writer transaction should hold a write lock");
+
+        let read = tokio::time::timeout(std::time::Duration::from_millis(250), async {
+            handles
+                .reader()
+                .query_one_raw(sea_orm::Statement::from_string(
+                    sea_orm::DbBackend::Sqlite,
+                    "SELECT name FROM split_guard WHERE id = 1",
+                ))
+                .await
+        })
+        .await
+        .expect("reader should not wait on the writer pool queue")
+        .expect("reader query should succeed")
+        .expect("reader query should return row");
+        let name: String = read
+            .try_get_by_index(0)
+            .expect("reader query should decode name");
+        assert_eq!(name, "ready");
+
+        txn.rollback()
+            .await
+            .expect("writer transaction should roll back");
     }
 }

--- a/src/db/connection.rs
+++ b/src/db/connection.rs
@@ -183,6 +183,7 @@ fn sqlite_reader_url(normalized_writer_url: &str) -> String {
     let mut saw_mode = false;
     let query = query
         .split('&')
+        .filter(|param| !param.is_empty())
         .map(|param| {
             if param.starts_with("mode=") {
                 saw_mode = true;
@@ -195,6 +196,8 @@ fn sqlite_reader_url(normalized_writer_url: &str) -> String {
 
     if saw_mode {
         format!("{base}?{}", query.join("&"))
+    } else if query.is_empty() {
+        format!("{base}?mode=ro")
     } else {
         format!("{base}?mode=ro&{}", query.join("&"))
     }
@@ -256,6 +259,18 @@ mod tests {
         assert_eq!(
             super::sqlite_reader_url("sqlite:///var/lib/asterdrive/app.db?cache=shared"),
             "sqlite:///var/lib/asterdrive/app.db?mode=ro&cache=shared"
+        );
+        assert_eq!(
+            super::sqlite_reader_url("sqlite:///var/lib/asterdrive/app.db?"),
+            "sqlite:///var/lib/asterdrive/app.db?mode=ro"
+        );
+        assert_eq!(
+            super::sqlite_reader_url("sqlite:///var/lib/asterdrive/app.db?&cache=shared"),
+            "sqlite:///var/lib/asterdrive/app.db?mode=ro&cache=shared"
+        );
+        assert_eq!(
+            super::sqlite_reader_url("sqlite:///var/lib/asterdrive/app.db?mode=rwc&"),
+            "sqlite:///var/lib/asterdrive/app.db?mode=ro"
         );
     }
 

--- a/src/db/connection.rs
+++ b/src/db/connection.rs
@@ -294,6 +294,23 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn sqlite_memory_handles_use_single_connection() {
+        let handles = super::connect_handles(&DatabaseConfig {
+            url: "sqlite::memory:".to_string(),
+            pool_size: 4,
+            retry_count: 0,
+        })
+        .await
+        .expect("sqlite memory handles should connect");
+
+        assert!(!handles.sqlite_read_write_split());
+        assert_eq!(
+            handles.writer().get_database_backend(),
+            handles.reader().get_database_backend()
+        );
+    }
+
+    #[tokio::test]
     async fn sqlite_reader_pool_is_query_only() {
         let url = format!(
             "sqlite:///tmp/asterdrive-reader-pool-{}.db?mode=rwc",
@@ -306,6 +323,7 @@ mod tests {
         })
         .await
         .expect("sqlite handles should connect");
+        assert!(handles.sqlite_read_write_split());
 
         handles
             .writer()
@@ -333,6 +351,7 @@ mod tests {
         })
         .await
         .expect("sqlite handles should connect");
+        assert!(handles.sqlite_read_write_split());
 
         handles
             .writer()

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -6,4 +6,4 @@ pub mod retry;
 pub mod sqlite_search;
 pub mod transaction;
 
-pub use connection::connect;
+pub use connection::{DbHandles, connect, connect_handles, connect_reader_for_writer};

--- a/src/main.rs
+++ b/src/main.rs
@@ -221,8 +221,8 @@ async fn run_primary_http_server(
         "starting HTTP service"
     );
 
-    let configure_db = state.db.clone();
-    let shutdown_db = state.db.clone();
+    let configure_db = state.writer_db().clone();
+    let shutdown_db = state.writer_db().clone();
     let http_shutdown_token = CancellationToken::new();
     let state = web::Data::new(state);
     let task_state = state.clone();
@@ -283,7 +283,7 @@ async fn run_follower_http_server(
         "starting HTTP service"
     );
 
-    let shutdown_db = state.db.clone();
+    let shutdown_db = state.writer_db().clone();
     let state = web::Data::new(state);
     let http_shutdown_token = CancellationToken::new();
     let server = HttpServer::new(move || {

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -310,8 +310,20 @@ mod tests {
             follower.db().get_database_backend()
         );
         assert_eq!(
+            state.writer_db().get_database_backend(),
+            follower.writer_db().get_database_backend()
+        );
+        assert_eq!(
             state.reader_db().get_database_backend(),
             follower.reader_db().get_database_backend()
+        );
+        assert_eq!(
+            SharedRuntimeState::writer_db(&state).get_database_backend(),
+            SharedRuntimeState::writer_db(&follower).get_database_backend()
+        );
+        assert_eq!(
+            SharedRuntimeState::reader_db(&state).get_database_backend(),
+            SharedRuntimeState::reader_db(&follower).get_database_backend()
         );
     }
 
@@ -320,9 +332,29 @@ mod tests {
         let state = setup_state().await;
         let data = web::Data::new(state.clone());
 
+        assert_eq!(
+            SharedRuntimeState::db(&data).get_database_backend(),
+            state.db.get_database_backend()
+        );
+        assert_eq!(
+            SharedRuntimeState::writer_db(&data).get_database_backend(),
+            state.writer_db().get_database_backend()
+        );
+        assert_eq!(
+            SharedRuntimeState::reader_db(&data).get_database_backend(),
+            state.reader_db().get_database_backend()
+        );
         assert!(Arc::ptr_eq(&state.runtime_config, data.runtime_config()));
         assert!(Arc::ptr_eq(&state.mail_sender, data.mail_sender()));
         assert!(Arc::ptr_eq(&state.driver_registry, data.driver_registry()));
+        assert!(Arc::ptr_eq(
+            &state.policy_snapshot,
+            SharedRuntimeState::policy_snapshot(&data)
+        ));
+        assert!(Arc::ptr_eq(
+            &state.config,
+            SharedRuntimeState::config(&data)
+        ));
         assert_eq!(
             state.storage_change_tx.receiver_count(),
             data.storage_change_tx().receiver_count()
@@ -338,6 +370,26 @@ mod tests {
 
         let follower = setup_state().await.follower_view();
         let data = web::Data::new(follower);
+        assert_eq!(
+            SharedRuntimeState::writer_db(&data).get_database_backend(),
+            data.get_ref().writer_db().get_database_backend()
+        );
+        assert_eq!(
+            SharedRuntimeState::reader_db(&data).get_database_backend(),
+            data.get_ref().reader_db().get_database_backend()
+        );
         assert_follower_state(&data);
+    }
+
+    #[tokio::test]
+    async fn primary_state_wakes_background_task_dispatcher() {
+        let state = setup_state().await;
+        let notified = state.background_task_dispatch_wakeup.notified();
+
+        state.wake_background_task_dispatcher();
+
+        tokio::time::timeout(std::time::Duration::from_secs(1), notified)
+            .await
+            .expect("background dispatcher wakeup should notify waiters");
     }
 }

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -21,8 +21,6 @@ use tokio::sync::Notify;
 
 #[derive(Clone)]
 pub struct PrimaryAppState {
-    /// Writer connection. Keep all transactions and write-capable flows on this handle.
-    pub db: DatabaseConnection,
     pub db_handles: DbHandles,
     pub driver_registry: Arc<DriverRegistry>,
     pub runtime_config: Arc<RuntimeConfig>,
@@ -40,8 +38,6 @@ pub struct PrimaryAppState {
 
 #[derive(Clone)]
 pub struct FollowerAppState {
-    /// Writer connection. Keep all transactions and write-capable flows on this handle.
-    pub db: DatabaseConnection,
     pub db_handles: DbHandles,
     pub driver_registry: Arc<DriverRegistry>,
     pub policy_snapshot: Arc<PolicySnapshot>,
@@ -50,7 +46,6 @@ pub struct FollowerAppState {
 }
 
 pub trait SharedRuntimeState {
-    fn db(&self) -> &DatabaseConnection;
     fn writer_db(&self) -> &DatabaseConnection;
     fn reader_db(&self) -> &DatabaseConnection;
     fn driver_registry(&self) -> &Arc<DriverRegistry>;
@@ -81,6 +76,10 @@ impl PrimaryAppState {
         self.db_handles.reader()
     }
 
+    pub fn sqlite_read_write_split(&self) -> bool {
+        self.db_handles.sqlite_read_write_split()
+    }
+
     pub fn wake_background_task_dispatcher(&self) {
         self.background_task_dispatch_wakeup.notify_one();
     }
@@ -93,7 +92,6 @@ impl PrimaryAppState {
 impl From<&PrimaryAppState> for FollowerAppState {
     fn from(state: &PrimaryAppState) -> Self {
         Self {
-            db: state.db.clone(),
             db_handles: state.db_handles.clone(),
             driver_registry: state.driver_registry.clone(),
             policy_snapshot: state.policy_snapshot.clone(),
@@ -111,13 +109,13 @@ impl FollowerAppState {
     pub fn reader_db(&self) -> &DatabaseConnection {
         self.db_handles.reader()
     }
+
+    pub fn sqlite_read_write_split(&self) -> bool {
+        self.db_handles.sqlite_read_write_split()
+    }
 }
 
 impl SharedRuntimeState for PrimaryAppState {
-    fn db(&self) -> &DatabaseConnection {
-        &self.db
-    }
-
     fn writer_db(&self) -> &DatabaseConnection {
         self.db_handles.writer()
     }
@@ -162,10 +160,6 @@ impl PrimaryRuntimeState for PrimaryAppState {
 }
 
 impl SharedRuntimeState for FollowerAppState {
-    fn db(&self) -> &DatabaseConnection {
-        &self.db
-    }
-
     fn writer_db(&self) -> &DatabaseConnection {
         self.db_handles.writer()
     }
@@ -194,10 +188,6 @@ impl SharedRuntimeState for FollowerAppState {
 impl FollowerRuntimeState for FollowerAppState {}
 
 impl<T: SharedRuntimeState> SharedRuntimeState for web::Data<T> {
-    fn db(&self) -> &DatabaseConnection {
-        self.get_ref().db()
-    }
-
     fn writer_db(&self) -> &DatabaseConnection {
         self.get_ref().writer_db()
     }
@@ -275,7 +265,6 @@ mod tests {
         let (share_download_rollback, _worker) = build_share_download_rollback_queue(db.clone(), 1);
 
         PrimaryAppState {
-            db: db.clone(),
             db_handles: crate::db::DbHandles::single(db),
             driver_registry: Arc::new(DriverRegistry::new()),
             runtime_config,
@@ -306,8 +295,8 @@ mod tests {
         assert!(Arc::ptr_eq(&state.config, follower.config()));
         assert!(Arc::ptr_eq(&state.cache, follower.cache()));
         assert_eq!(
-            state.db.get_database_backend(),
-            follower.db().get_database_backend()
+            state.writer_db().get_database_backend(),
+            follower.writer_db().get_database_backend()
         );
         assert_eq!(
             state.writer_db().get_database_backend(),
@@ -333,8 +322,8 @@ mod tests {
         let data = web::Data::new(state.clone());
 
         assert_eq!(
-            SharedRuntimeState::db(&data).get_database_backend(),
-            state.db.get_database_backend()
+            SharedRuntimeState::writer_db(&data).get_database_backend(),
+            state.writer_db().get_database_backend()
         );
         assert_eq!(
             SharedRuntimeState::writer_db(&data).get_database_backend(),

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -8,6 +8,7 @@ pub mod tasks;
 
 use crate::cache::CacheBackend;
 use crate::config::{Config, RuntimeConfig};
+use crate::db::DbHandles;
 use crate::services::{
     mail_service::MailSender, share_service::ShareDownloadRollbackQueue,
     storage_change_service::StorageChangeEvent,
@@ -20,7 +21,9 @@ use tokio::sync::Notify;
 
 #[derive(Clone)]
 pub struct PrimaryAppState {
+    /// Writer connection. Keep all transactions and write-capable flows on this handle.
     pub db: DatabaseConnection,
+    pub db_handles: DbHandles,
     pub driver_registry: Arc<DriverRegistry>,
     pub runtime_config: Arc<RuntimeConfig>,
     pub policy_snapshot: Arc<PolicySnapshot>,
@@ -37,7 +40,9 @@ pub struct PrimaryAppState {
 
 #[derive(Clone)]
 pub struct FollowerAppState {
+    /// Writer connection. Keep all transactions and write-capable flows on this handle.
     pub db: DatabaseConnection,
+    pub db_handles: DbHandles,
     pub driver_registry: Arc<DriverRegistry>,
     pub policy_snapshot: Arc<PolicySnapshot>,
     pub config: Arc<Config>,
@@ -46,6 +51,8 @@ pub struct FollowerAppState {
 
 pub trait SharedRuntimeState {
     fn db(&self) -> &DatabaseConnection;
+    fn writer_db(&self) -> &DatabaseConnection;
+    fn reader_db(&self) -> &DatabaseConnection;
     fn driver_registry(&self) -> &Arc<DriverRegistry>;
     fn policy_snapshot(&self) -> &Arc<PolicySnapshot>;
     fn config(&self) -> &Arc<Config>;
@@ -66,6 +73,14 @@ impl PrimaryAppState {
         Arc::new(Notify::new())
     }
 
+    pub fn writer_db(&self) -> &DatabaseConnection {
+        self.db_handles.writer()
+    }
+
+    pub fn reader_db(&self) -> &DatabaseConnection {
+        self.db_handles.reader()
+    }
+
     pub fn wake_background_task_dispatcher(&self) {
         self.background_task_dispatch_wakeup.notify_one();
     }
@@ -79,6 +94,7 @@ impl From<&PrimaryAppState> for FollowerAppState {
     fn from(state: &PrimaryAppState) -> Self {
         Self {
             db: state.db.clone(),
+            db_handles: state.db_handles.clone(),
             driver_registry: state.driver_registry.clone(),
             policy_snapshot: state.policy_snapshot.clone(),
             config: state.config.clone(),
@@ -87,9 +103,27 @@ impl From<&PrimaryAppState> for FollowerAppState {
     }
 }
 
+impl FollowerAppState {
+    pub fn writer_db(&self) -> &DatabaseConnection {
+        self.db_handles.writer()
+    }
+
+    pub fn reader_db(&self) -> &DatabaseConnection {
+        self.db_handles.reader()
+    }
+}
+
 impl SharedRuntimeState for PrimaryAppState {
     fn db(&self) -> &DatabaseConnection {
         &self.db
+    }
+
+    fn writer_db(&self) -> &DatabaseConnection {
+        self.db_handles.writer()
+    }
+
+    fn reader_db(&self) -> &DatabaseConnection {
+        self.db_handles.reader()
     }
 
     fn driver_registry(&self) -> &Arc<DriverRegistry> {
@@ -132,6 +166,14 @@ impl SharedRuntimeState for FollowerAppState {
         &self.db
     }
 
+    fn writer_db(&self) -> &DatabaseConnection {
+        self.db_handles.writer()
+    }
+
+    fn reader_db(&self) -> &DatabaseConnection {
+        self.db_handles.reader()
+    }
+
     fn driver_registry(&self) -> &Arc<DriverRegistry> {
         &self.driver_registry
     }
@@ -154,6 +196,14 @@ impl FollowerRuntimeState for FollowerAppState {}
 impl<T: SharedRuntimeState> SharedRuntimeState for web::Data<T> {
     fn db(&self) -> &DatabaseConnection {
         self.get_ref().db()
+    }
+
+    fn writer_db(&self) -> &DatabaseConnection {
+        self.get_ref().writer_db()
+    }
+
+    fn reader_db(&self) -> &DatabaseConnection {
+        self.get_ref().reader_db()
     }
 
     fn driver_registry(&self) -> &Arc<DriverRegistry> {
@@ -225,7 +275,8 @@ mod tests {
         let (share_download_rollback, _worker) = build_share_download_rollback_queue(db.clone(), 1);
 
         PrimaryAppState {
-            db,
+            db: db.clone(),
+            db_handles: crate::db::DbHandles::single(db),
             driver_registry: Arc::new(DriverRegistry::new()),
             runtime_config,
             policy_snapshot: Arc::new(PolicySnapshot::new()),
@@ -257,6 +308,10 @@ mod tests {
         assert_eq!(
             state.db.get_database_backend(),
             follower.db().get_database_backend()
+        );
+        assert_eq!(
+            state.reader_db().get_database_backend(),
+            follower.reader_db().get_database_backend()
         );
     }
 

--- a/src/runtime/startup/common.rs
+++ b/src/runtime/startup/common.rs
@@ -10,6 +10,7 @@ use std::sync::Arc;
 
 pub(super) struct CommonRuntimeParts {
     pub cfg: Arc<crate::config::Config>,
+    pub db_handles: db::DbHandles,
     pub database: sea_orm::DatabaseConnection,
     pub driver_registry: Arc<DriverRegistry>,
     pub policy_snapshot: Arc<crate::storage::PolicySnapshot>,
@@ -26,6 +27,7 @@ pub(super) async fn prepare_common(mode: NodeRuntimeMode) -> Result<CommonRuntim
 
     let database = db::connect(&cfg.database).await?;
     initialize_database_state(&database, cfg.as_ref(), mode).await?;
+    let db_handles = db::connect_reader_for_writer(&cfg.database, database.clone()).await?;
 
     let policy_snapshot = Arc::new(crate::storage::PolicySnapshot::new());
     policy_snapshot.reload(&database).await?;
@@ -40,6 +42,7 @@ pub(super) async fn prepare_common(mode: NodeRuntimeMode) -> Result<CommonRuntim
 
     Ok(CommonRuntimeParts {
         cfg,
+        db_handles,
         database,
         driver_registry,
         policy_snapshot,

--- a/src/runtime/startup/follower.rs
+++ b/src/runtime/startup/follower.rs
@@ -21,6 +21,7 @@ pub async fn prepare_follower() -> Result<PreparedFollowerRuntime> {
     Ok(PreparedFollowerRuntime {
         state: FollowerAppState {
             db: common.database,
+            db_handles: common.db_handles,
             driver_registry: common.driver_registry,
             policy_snapshot: common.policy_snapshot,
             config: common.cfg,

--- a/src/runtime/startup/follower.rs
+++ b/src/runtime/startup/follower.rs
@@ -20,7 +20,6 @@ pub async fn prepare_follower() -> Result<PreparedFollowerRuntime> {
 
     Ok(PreparedFollowerRuntime {
         state: FollowerAppState {
-            db: common.database,
             db_handles: common.db_handles,
             driver_registry: common.driver_registry,
             policy_snapshot: common.policy_snapshot,

--- a/src/runtime/startup/primary.rs
+++ b/src/runtime/startup/primary.rs
@@ -37,7 +37,6 @@ pub async fn prepare_primary() -> Result<PreparedPrimaryRuntime> {
 
     Ok(PreparedPrimaryRuntime {
         state: PrimaryAppState {
-            db: common.database,
             db_handles: common.db_handles,
             driver_registry: common.driver_registry,
             runtime_config,

--- a/src/runtime/startup/primary.rs
+++ b/src/runtime/startup/primary.rs
@@ -38,6 +38,7 @@ pub async fn prepare_primary() -> Result<PreparedPrimaryRuntime> {
     Ok(PreparedPrimaryRuntime {
         state: PrimaryAppState {
             db: common.database,
+            db_handles: common.db_handles,
             driver_registry: common.driver_registry,
             runtime_config,
             policy_snapshot: common.policy_snapshot,

--- a/src/runtime/tasks.rs
+++ b/src/runtime/tasks.rs
@@ -918,7 +918,8 @@ mod tests {
             crate::services::share_service::build_share_download_rollback_queue(db.clone(), 1);
 
         web::Data::new(PrimaryAppState {
-            db,
+            db: db.clone(),
+            db_handles: crate::db::DbHandles::single(db),
             driver_registry: Arc::new(crate::storage::DriverRegistry::new()),
             runtime_config,
             policy_snapshot: Arc::new(crate::storage::PolicySnapshot::new()),

--- a/src/runtime/tasks.rs
+++ b/src/runtime/tasks.rs
@@ -918,7 +918,6 @@ mod tests {
             crate::services::share_service::build_share_download_rollback_queue(db.clone(), 1);
 
         web::Data::new(PrimaryAppState {
-            db: db.clone(),
             db_handles: crate::db::DbHandles::single(db),
             driver_registry: Arc::new(crate::storage::DriverRegistry::new()),
             runtime_config,
@@ -1209,7 +1208,7 @@ mod tests {
         .await;
 
         let tasks = crate::entities::background_task::Entity::find()
-            .all(&state.db)
+            .all(state.writer_db())
             .await
             .unwrap();
         assert_eq!(tasks.len(), 1);
@@ -1235,7 +1234,7 @@ mod tests {
         .await;
 
         let tasks = crate::entities::background_task::Entity::find()
-            .all(&state.db)
+            .all(state.writer_db())
             .await
             .unwrap();
         assert_eq!(tasks.len(), 1);

--- a/src/services/admin_service.rs
+++ b/src/services/admin_service.rs
@@ -224,17 +224,17 @@ pub async fn get_overview(
         daily_reports,
         latest_health_task,
     ) = tokio::try_join!(
-        user_repo::count_all(&state.db),
-        user_repo::count_by_status(&state.db, UserStatus::Active),
-        user_repo::count_by_status(&state.db, UserStatus::Disabled),
-        file_repo::count_live_files(&state.db),
-        file_repo::sum_live_file_bytes(&state.db),
-        file_repo::count_all_blobs(&state.db),
-        file_repo::sum_blob_bytes(&state.db),
-        share_repo::count_all(&state.db),
+        user_repo::count_all(state.reader_db()),
+        user_repo::count_by_status(state.reader_db(), UserStatus::Active),
+        user_repo::count_by_status(state.reader_db(), UserStatus::Disabled),
+        file_repo::count_live_files(state.reader_db()),
+        file_repo::sum_live_file_bytes(state.reader_db()),
+        file_repo::count_all_blobs(state.reader_db()),
+        file_repo::sum_blob_bytes(state.reader_db()),
+        share_repo::count_all(state.reader_db()),
         build_daily_reports(state, today, days, timezone),
         background_task_repo::find_latest_system_runtime_by_task_name(
-            &state.db,
+            state.reader_db(),
             SYSTEM_HEALTH_TASK_NAME
         ),
     )?;
@@ -309,7 +309,7 @@ async fn load_recent_overview_events(
             crate::api::pagination::AdminAuditLogSortBy::CreatedAt,
             crate::api::pagination::SortOrder::Desc,
         ),
-        background_task_repo::list_recent(&state.db, event_limit),
+        background_task_repo::list_recent(state.reader_db(), event_limit),
     )?;
     Ok((
         recent_events.items,
@@ -475,7 +475,7 @@ async fn build_daily_reports(
     let end = start_of_local_day(today + Duration::days(1), timezone)?;
 
     audit_service::flush_global_audit_log_manager().await;
-    let events = audit_log_repo::find_actions_in_range(&state.db, start, end).await?;
+    let events = audit_log_repo::find_actions_in_range(state.reader_db(), start, end).await?;
 
     for (action, created_at) in events {
         let date = created_at.with_timezone(&timezone).date_naive();

--- a/src/services/archive_preview_service.rs
+++ b/src/services/archive_preview_service.rs
@@ -132,7 +132,8 @@ pub(crate) async fn preview_file_in_scope(
 ) -> Result<ArchivePreviewManifestLookup> {
     ensure_user_preview_enabled(state)?;
     workspace_storage_service::require_scope_access(state, scope).await?;
-    let source_file = workspace_storage_service::verify_file_access(state, scope, file_id).await?;
+    let source_file =
+        workspace_storage_service::verify_file_access_for_read(state, scope, file_id).await?;
     workspace_storage_service::ensure_active_file_scope(&source_file, scope)?;
     preview_verified_file(state, &source_file).await
 }
@@ -194,7 +195,7 @@ async fn preview_verified_file(
     source_file: &file::Model,
 ) -> Result<ArchivePreviewManifestLookup> {
     ensure_archive_preview_source_supported(source_file)?;
-    let blob = file_repo::find_blob_by_id(&state.db, source_file.blob_id).await?;
+    let blob = file_repo::find_blob_by_id(state.reader_db(), source_file.blob_id).await?;
     if let Some(cached) = load_cached_manifest(state, source_file, &blob).await? {
         return Ok(ArchivePreviewManifestLookup::Ready(cached));
     }
@@ -275,7 +276,7 @@ async fn load_cached_manifest(
     blob: &file_blob::Model,
 ) -> Result<Option<ArchivePreviewManifest>> {
     let Some(prop) = property_repo::find_by_key(
-        &state.db,
+        state.reader_db(),
         EntityType::File,
         source_file.id,
         CACHE_NAMESPACE,

--- a/src/services/archive_preview_service.rs
+++ b/src/services/archive_preview_service.rs
@@ -335,7 +335,7 @@ pub(crate) async fn store_cached_manifest(
     }
 
     property_repo::upsert(
-        &state.db,
+        state.writer_db(),
         EntityType::File,
         source_file.id,
         CACHE_NAMESPACE,

--- a/src/services/audit_service/manager.rs
+++ b/src/services/audit_service/manager.rs
@@ -309,6 +309,6 @@ pub async fn log(
     if let Some(manager) = GLOBAL_AUDIT_LOG_MANAGER.get() {
         manager.record(model).await;
     } else {
-        write_audit_model(&state.db, model).await;
+        write_audit_model(state.writer_db(), model).await;
     }
 }

--- a/src/services/audit_service/query.rs
+++ b/src/services/audit_service/query.rs
@@ -26,7 +26,7 @@ async fn query_models(
     flush_global_audit_log_manager().await;
     load_offset_page(limit, offset, 200, |limit, offset| async move {
         audit_log_repo::find_with_filters(
-            &state.db,
+            state.reader_db(),
             audit_log_repo::AuditLogQuery {
                 user_id: filters.user_id,
                 action: filters.action.as_deref(),

--- a/src/services/audit_service/query.rs
+++ b/src/services/audit_service/query.rs
@@ -213,7 +213,7 @@ pub async fn cleanup_expired(state: &PrimaryAppState) -> Result<u64> {
         });
 
     let cutoff = Utc::now() - Duration::days(retention_days);
-    let deleted = audit_log_repo::delete_before(&state.db, cutoff).await?;
+    let deleted = audit_log_repo::delete_before(state.writer_db(), cutoff).await?;
     if deleted > 0 {
         tracing::info!("cleaned up {deleted} expired audit log entries");
     }

--- a/src/services/audit_service/tests.rs
+++ b/src/services/audit_service/tests.rs
@@ -380,6 +380,7 @@ async fn log_writes_synchronously_without_global_manager() {
         );
     let state = crate::runtime::PrimaryAppState {
         db: db.clone(),
+        db_handles: crate::db::DbHandles::single(db.clone()),
         driver_registry: std::sync::Arc::new(crate::storage::DriverRegistry::new()),
         runtime_config,
         policy_snapshot: std::sync::Arc::new(crate::storage::PolicySnapshot::new()),

--- a/src/services/audit_service/tests.rs
+++ b/src/services/audit_service/tests.rs
@@ -379,7 +379,6 @@ async fn log_writes_synchronously_without_global_manager() {
             crate::config::operations::DEFAULT_SHARE_DOWNLOAD_ROLLBACK_QUEUE_CAPACITY,
         );
     let state = crate::runtime::PrimaryAppState {
-        db: db.clone(),
         db_handles: crate::db::DbHandles::single(db.clone()),
         driver_registry: std::sync::Arc::new(crate::storage::DriverRegistry::new()),
         runtime_config,

--- a/src/services/auth_service/contact_verification.rs
+++ b/src/services/auth_service/contact_verification.rs
@@ -30,7 +30,7 @@ pub async fn request_email_change(
 ) -> Result<AuthUserInfo> {
     tracing::debug!(user_id, "requesting email change");
     let normalized_email = normalize_email(new_email)?;
-    let existing = user_repo::find_by_id(&state.db, user_id).await?;
+    let existing = user_repo::find_by_id(state.writer_db(), user_id).await?;
 
     if !existing.status.is_active() {
         return Err(AsterError::auth_forbidden("account is disabled"));
@@ -46,11 +46,11 @@ pub async fn request_email_change(
         ));
     }
 
-    ensure_email_available(&state.db, &normalized_email, Some(existing.id)).await?;
+    ensure_email_available(state.writer_db(), &normalized_email, Some(existing.id)).await?;
     if existing.pending_email.as_deref() == Some(normalized_email.as_str()) {
         ensure_resend_allowed(
             state,
-            &state.db,
+            state.writer_db(),
             existing.id,
             VerificationPurpose::ContactChange,
         )
@@ -61,7 +61,7 @@ pub async fn request_email_change(
         &state.runtime_config,
     );
     let site_name = branding::title_or_default(&state.runtime_config);
-    let txn = crate::db::transaction::begin(&state.db).await?;
+    let txn = crate::db::transaction::begin(state.writer_db()).await?;
     let mut active = existing.into_active_model();
     active.pending_email = Set(Some(normalized_email.clone()));
     active.updated_at = Set(Utc::now());
@@ -95,7 +95,7 @@ pub async fn resend_email_change(
     state: &PrimaryAppState,
     user_id: i64,
 ) -> Result<Option<UserAuditInfo>> {
-    let user = user_repo::find_by_id(&state.db, user_id).await?;
+    let user = user_repo::find_by_id(state.writer_db(), user_id).await?;
     let pending_email = user
         .pending_email
         .clone()
@@ -110,10 +110,10 @@ pub async fn resend_email_change(
         ));
     }
 
-    ensure_email_available(&state.db, &pending_email, Some(user.id)).await?;
+    ensure_email_available(state.writer_db(), &pending_email, Some(user.id)).await?;
     if !resend_allowed(
         state,
-        &state.db,
+        state.writer_db(),
         user.id,
         VerificationPurpose::ContactChange,
     )
@@ -130,7 +130,7 @@ pub async fn resend_email_change(
     );
     let site_name = branding::title_or_default(&state.runtime_config);
 
-    let txn = crate::db::transaction::begin(&state.db).await?;
+    let txn = crate::db::transaction::begin(state.writer_db()).await?;
     let token = match issue_contact_verification_token(
         &txn,
         user.id,
@@ -162,7 +162,7 @@ pub async fn request_password_reset(
 ) -> Result<PasswordResetRequestResult> {
     tracing::debug!("requesting password reset");
     let normalized_email = normalize_email(email)?;
-    let Some(user) = user_repo::find_by_email(&state.db, &normalized_email).await? else {
+    let Some(user) = user_repo::find_by_email(state.writer_db(), &normalized_email).await? else {
         return Ok(PasswordResetRequestResult { user: None });
     };
 
@@ -170,7 +170,7 @@ pub async fn request_password_reset(
         return Ok(PasswordResetRequestResult { user: None });
     }
 
-    if !password_reset_request_allowed(state, &state.db, user.id).await? {
+    if !password_reset_request_allowed(state, state.writer_db(), user.id).await? {
         tracing::debug!(
             user_id = user.id,
             "password reset request skipped due to cooldown"
@@ -184,7 +184,7 @@ pub async fn request_password_reset(
         &state.runtime_config,
     );
     let site_name = branding::title_or_default(&state.runtime_config);
-    let txn = crate::db::transaction::begin(&state.db).await?;
+    let txn = crate::db::transaction::begin(state.writer_db()).await?;
     let token = match issue_contact_verification_token(
         &txn,
         user.id,
@@ -226,11 +226,12 @@ pub async fn confirm_password_reset(
     validate_password(new_password)?;
 
     let token_hash = hash::sha256_hex(token.as_bytes());
-    let record = contact_verification_token_repo::find_by_token_hash(&state.db, &token_hash)
-        .await?
-        .ok_or_else(|| {
-            AsterError::contact_verification_invalid("password reset link is invalid")
-        })?;
+    let record =
+        contact_verification_token_repo::find_by_token_hash(state.writer_db(), &token_hash)
+            .await?
+            .ok_or_else(|| {
+                AsterError::contact_verification_invalid("password reset link is invalid")
+            })?;
 
     if record.purpose != VerificationPurpose::PasswordReset {
         return Err(AsterError::contact_verification_invalid(
@@ -248,7 +249,7 @@ pub async fn confirm_password_reset(
         ));
     }
 
-    let txn = crate::db::transaction::begin(&state.db).await?;
+    let txn = crate::db::transaction::begin(state.writer_db()).await?;
     let existing_user = user_repo::find_by_id(&txn, record.user_id).await?;
     if !existing_user.status.is_active() {
         return Err(AsterError::auth_forbidden("account is disabled"));
@@ -292,11 +293,12 @@ pub async fn confirm_contact_verification(
 ) -> Result<ContactVerificationConfirmResult> {
     tracing::debug!("confirming contact verification");
     let token_hash = hash::sha256_hex(token.as_bytes());
-    let record = contact_verification_token_repo::find_by_token_hash(&state.db, &token_hash)
-        .await?
-        .ok_or_else(|| {
-            AsterError::contact_verification_invalid("contact verification link is invalid")
-        })?;
+    let record =
+        contact_verification_token_repo::find_by_token_hash(state.writer_db(), &token_hash)
+            .await?
+            .ok_or_else(|| {
+                AsterError::contact_verification_invalid("contact verification link is invalid")
+            })?;
 
     if record.consumed_at.is_some() {
         return Err(AsterError::contact_verification_invalid(
@@ -314,7 +316,7 @@ pub async fn confirm_contact_verification(
     let user_id = record.user_id;
     tracing::debug!(user_id, purpose = ?purpose, "loaded contact verification record");
 
-    let txn = crate::db::transaction::begin(&state.db).await?;
+    let txn = crate::db::transaction::begin(state.writer_db()).await?;
     let existing_user = user_repo::find_by_id(&txn, user_id).await?;
     if !existing_user.status.is_active() {
         return Err(AsterError::auth_forbidden("account is disabled"));
@@ -408,5 +410,5 @@ pub async fn confirm_contact_verification(
 }
 
 pub async fn cleanup_expired_contact_verification_tokens(state: &PrimaryAppState) -> Result<u64> {
-    contact_verification_token_repo::delete_expired(&state.db).await
+    contact_verification_token_repo::delete_expired(state.writer_db()).await
 }

--- a/src/services/auth_service/mod.rs
+++ b/src/services/auth_service/mod.rs
@@ -29,6 +29,8 @@ pub use session::{
     cleanup_expired_auth_sessions, get_auth_snapshot, invalidate_auth_snapshot_cache,
     list_auth_sessions, revoke_auth_session, revoke_other_auth_sessions, revoke_user_sessions,
 };
+#[cfg(debug_assertions)]
+pub use tokens::test_support;
 pub use tokens::{
     authenticate_access_token, authenticate_refresh_token, issue_tokens_for_session,
     issue_tokens_for_user, refresh_tokens, revoke_refresh_token, verify_token,

--- a/src/services/auth_service/password.rs
+++ b/src/services/auth_service/password.rs
@@ -25,7 +25,7 @@ pub async fn login(
     };
     tracing::debug!(identifier_kind, "login attempt");
 
-    let Some(user) = find_user_by_identifier(&state.db, identifier).await? else {
+    let Some(user) = find_user_by_identifier(state.writer_db(), identifier).await? else {
         tracing::debug!(identifier_kind, "login rejected: user not found");
         return Err(AsterError::auth_invalid_credentials("user not found"));
     };
@@ -74,7 +74,7 @@ pub async fn change_password(
     new_password: &str,
 ) -> Result<AuthUserInfo> {
     tracing::debug!(user_id, "changing password");
-    let user = user_repo::find_by_id(&state.db, user_id).await?;
+    let user = user_repo::find_by_id(state.writer_db(), user_id).await?;
 
     if !user.status.is_active() {
         return Err(auth_forbidden_with_subcode(
@@ -96,7 +96,7 @@ pub async fn set_password(
     new_password: &str,
 ) -> Result<AuthUserInfo> {
     tracing::debug!(user_id, "setting password");
-    let txn = crate::db::transaction::begin(&state.db).await?;
+    let txn = crate::db::transaction::begin(state.writer_db()).await?;
     let result = async {
         let user = user_repo::find_by_id(&txn, user_id).await?;
         let updated = update_password_in_connection(&txn, user, new_password).await?;

--- a/src/services/auth_service/registration.rs
+++ b/src/services/auth_service/registration.rs
@@ -26,7 +26,7 @@ pub async fn create_user_by_admin(
     password: &str,
 ) -> Result<AuthUserInfo> {
     let user = create_user_with_role(
-        &state.db,
+        state.writer_db(),
         state,
         CreateUserWithRoleInput {
             username,
@@ -65,7 +65,7 @@ pub async fn register(
         ));
     }
 
-    if user_repo::count_all(&state.db).await? == 0 {
+    if user_repo::count_all(state.writer_db()).await? == 0 {
         return create_first_admin(state, username, email, password)
             .await
             .map(AuthUserInfo::from);
@@ -73,7 +73,7 @@ pub async fn register(
 
     let policy = RuntimeContactVerificationPolicy::from_runtime_config(&state.runtime_config);
     let site_name = branding::title_or_default(&state.runtime_config);
-    let txn = crate::db::transaction::begin(&state.db).await?;
+    let txn = crate::db::transaction::begin(state.writer_db()).await?;
     let email_verified_at = (!auth_policy.register_activation_enabled).then_some(Utc::now());
     let user = create_user_with_role(
         &txn,
@@ -125,7 +125,7 @@ pub async fn resend_register_activation(
     state: &PrimaryAppState,
     identifier: &str,
 ) -> Result<Option<UserAuditInfo>> {
-    let Some(user) = find_user_by_identifier(&state.db, identifier).await? else {
+    let Some(user) = find_user_by_identifier(state.writer_db(), identifier).await? else {
         return Ok(None);
     };
 
@@ -135,7 +135,7 @@ pub async fn resend_register_activation(
 
     if !resend_allowed(
         state,
-        &state.db,
+        state.writer_db(),
         user.id,
         VerificationPurpose::RegisterActivation,
     )
@@ -150,7 +150,7 @@ pub async fn resend_register_activation(
     let policy = RuntimeContactVerificationPolicy::from_runtime_config(&state.runtime_config);
     let site_name = branding::title_or_default(&state.runtime_config);
 
-    let txn = crate::db::transaction::begin(&state.db).await?;
+    let txn = crate::db::transaction::begin(state.writer_db()).await?;
     let token = match issue_contact_verification_token(
         &txn,
         user.id,
@@ -177,7 +177,7 @@ pub async fn resend_register_activation(
 }
 
 pub async fn check_auth_state(state: &PrimaryAppState) -> Result<bool> {
-    Ok(user_repo::count_all(&state.db).await? > 0)
+    Ok(user_repo::count_all(state.writer_db()).await? > 0)
 }
 
 pub async fn setup(
@@ -187,7 +187,7 @@ pub async fn setup(
     password: &str,
 ) -> Result<AuthUserInfo> {
     tracing::debug!("running initial setup");
-    if user_repo::count_all(&state.db).await? > 0 {
+    if user_repo::count_all(state.writer_db()).await? > 0 {
         return Err(validation_error_with_subcode(
             ApiSubcode::ValidationSystemAlreadyInitialized,
             "system already initialized",

--- a/src/services/auth_service/session.rs
+++ b/src/services/auth_service/session.rs
@@ -22,7 +22,7 @@ pub async fn get_auth_snapshot(state: &PrimaryAppState, user_id: i64) -> Result<
         return Ok(snapshot);
     }
 
-    let user = user_repo::find_by_id(&state.db, user_id).await?;
+    let user = user_repo::find_by_id(state.reader_db(), user_id).await?;
     let snapshot = AuthSnapshot::from_user(&user);
     state
         .cache

--- a/src/services/auth_service/session.rs
+++ b/src/services/auth_service/session.rs
@@ -49,7 +49,7 @@ pub async fn list_auth_sessions(
     user_id: i64,
     current_refresh_jti: Option<&str>,
 ) -> Result<Vec<AuthSessionInfo>> {
-    auth_session_repo::list_active_for_user(&state.db, user_id)
+    auth_session_repo::list_active_for_user(state.writer_db(), user_id)
         .await
         .map(|sessions| {
             sessions
@@ -74,7 +74,7 @@ pub async fn revoke_auth_session(
     session_id: &str,
     current_refresh_jti: Option<&str>,
 ) -> Result<bool> {
-    let txn = crate::db::transaction::begin(&state.db).await?;
+    let txn = crate::db::transaction::begin(state.writer_db()).await?;
     let result = async {
         let session = auth_session_repo::find_by_id_for_user(&txn, user_id, session_id)
             .await?
@@ -104,7 +104,7 @@ pub async fn revoke_other_auth_sessions(
     user_id: i64,
     current_refresh_jti: &str,
 ) -> Result<u64> {
-    let txn = crate::db::transaction::begin(&state.db).await?;
+    let txn = crate::db::transaction::begin(state.writer_db()).await?;
     let result = async {
         let current_session = auth_session_repo::find_by_refresh_jti(&txn, current_refresh_jti)
             .await?
@@ -142,12 +142,12 @@ pub async fn revoke_other_auth_sessions(
 }
 
 pub async fn cleanup_expired_auth_sessions(state: &PrimaryAppState) -> Result<u64> {
-    auth_session_repo::delete_expired(&state.db).await
+    auth_session_repo::delete_expired(state.writer_db()).await
 }
 
 pub async fn revoke_user_sessions(state: &PrimaryAppState, user_id: i64) -> Result<UserAuditInfo> {
     tracing::debug!(user_id, "revoking user sessions");
-    let txn = crate::db::transaction::begin(&state.db).await?;
+    let txn = crate::db::transaction::begin(state.writer_db()).await?;
     let result = async {
         let user = user_repo::find_by_id(&txn, user_id).await?;
         let next_session_version = user.session_version.saturating_add(1);

--- a/src/services/auth_service/shared.rs
+++ b/src/services/auth_service/shared.rs
@@ -264,7 +264,7 @@ pub(super) async fn create_first_admin(
 ) -> Result<user::Model> {
     tracing::info!("first user registered — granting admin role to '{username}'");
     create_user_with_role(
-        &state.db,
+        state.writer_db(),
         state,
         CreateUserWithRoleInput {
             username,

--- a/src/services/auth_service/tokens.rs
+++ b/src/services/auth_service/tokens.rs
@@ -178,7 +178,7 @@ pub async fn issue_tokens_for_session(
     user_agent: Option<&str>,
 ) -> Result<(String, String)> {
     let tokens = issue_tokens_for_session_id(state, user_id, session_version, None)?;
-    persist_auth_session(&state.db, user_id, &tokens, ip_address, user_agent).await?;
+    persist_auth_session(state.writer_db(), user_id, &tokens, ip_address, user_agent).await?;
     Ok((tokens.access_token, tokens.refresh_token))
 }
 
@@ -206,7 +206,7 @@ pub async fn revoke_refresh_token(state: &PrimaryAppState, token: &str) -> Resul
     let Some(jti) = claims.jti else {
         return Ok(false);
     };
-    auth_session_repo::revoke_by_refresh_jti(&state.db, &jti, Utc::now()).await
+    auth_session_repo::revoke_by_refresh_jti(state.writer_db(), &jti, Utc::now()).await
 }
 
 struct CreatedToken {

--- a/src/services/auth_service/tokens.rs
+++ b/src/services/auth_service/tokens.rs
@@ -18,6 +18,8 @@ use super::{AuthSnapshot, Claims};
 mod refresh;
 
 pub use refresh::refresh_tokens;
+#[cfg(debug_assertions)]
+pub use refresh::test_support;
 
 #[derive(Debug)]
 struct IssuedTokens {

--- a/src/services/auth_service/tokens/refresh.rs
+++ b/src/services/auth_service/tokens/refresh.rs
@@ -229,9 +229,11 @@ fn classify_refresh_reuse_session(input: RefreshReuseClassification<'_>) -> Refr
 
     // Without same-process contention, require a same-client fingerprint. This
     // keeps sequential no-evidence replay in the compromise path.
-    if reused_auth_session.is_some_and(|session| {
-        is_stale_refresh_from_same_client(session, user_id, now, ip_address, user_agent)
-    }) {
+    if !matches!(evidence, RefreshReuseEvidence::SameProcessContention)
+        && reused_auth_session.is_some_and(|session| {
+            is_stale_refresh_from_same_client(session, user_id, now, ip_address, user_agent)
+        })
+    {
         return RefreshRejection::StaleRefresh {
             user_id,
             reused_jti: refresh_jti.to_string(),
@@ -591,7 +593,7 @@ async fn finish_refresh_outcome(
             user_agent,
         } => {
             let conflict_outcome =
-                crate::db::transaction::with_transaction(&state.db, async |txn| {
+                crate::db::transaction::with_transaction(state.writer_db(), async |txn| {
                     let outcome = classify_failed_refresh_rotation(
                         txn,
                         claims,
@@ -643,7 +645,7 @@ pub async fn refresh_tokens(
     } else {
         RefreshReuseEvidence::ClientFingerprint
     };
-    let outcome = crate::db::transaction::with_transaction(&state.db, async |txn| {
+    let outcome = crate::db::transaction::with_transaction(state.writer_db(), async |txn| {
         rotate_refresh_in_transaction(
             txn,
             state,

--- a/src/services/auth_service/tokens/refresh.rs
+++ b/src/services/auth_service/tokens/refresh.rs
@@ -210,15 +210,15 @@ fn classify_refresh_reuse_session(input: RefreshReuseClassification<'_>) -> Refr
         evidence,
     } = input;
 
-    // A same-process lock loser is the one case where missing or mismatched
-    // client metadata is still safe to classify as stale. The lock proves the
-    // caller overlapped with the winning rotation on this server process, and
-    // the old JTI can only produce a 401 after the winner commits.
+    // A same-process lock loser still needs the same-client fingerprint before
+    // it can be treated as stale. The lock proves overlap on this server
+    // process, but it does not prove the old JTI came from the same client.
     if evidence == RefreshReuseEvidence::SameProcessContention
         && reused_auth_session.is_some_and(|session| {
             session.user_id == user_id
                 && session.revoked_at.is_none()
                 && is_recent_refresh_rotation(session, now)
+                && is_stale_refresh_from_same_client(session, user_id, now, ip_address, user_agent)
         })
     {
         return RefreshRejection::StaleRefresh {
@@ -893,8 +893,7 @@ mod tests {
     }
 
     #[test]
-    fn classify_refresh_reuse_session_treats_same_process_contention_as_stale_without_client_evidence()
-     {
+    fn same_process_contention_without_client_evidence_is_reuse() {
         let now = Utc::now();
         let session = make_auth_session(now);
 
@@ -906,12 +905,11 @@ mod tests {
             RefreshReuseEvidence::SameProcessContention,
         );
 
-        assert_stale_refresh(outcome, 1, "refresh-jti");
+        assert_reuse_detected(outcome, 1, "refresh-jti");
     }
 
     #[test]
-    fn classify_refresh_reuse_session_treats_same_process_contention_as_stale_even_with_mismatched_client()
-     {
+    fn same_process_contention_with_mismatched_client_is_reuse() {
         let now = Utc::now();
         let session = make_auth_session(now);
 
@@ -920,6 +918,22 @@ mod tests {
             now,
             Some("203.0.113.11"),
             Some("other-browser"),
+            RefreshReuseEvidence::SameProcessContention,
+        );
+
+        assert_reuse_detected(outcome, 1, "refresh-jti");
+    }
+
+    #[test]
+    fn same_process_contention_from_same_client_is_stale() {
+        let now = Utc::now();
+        let session = make_auth_session(now);
+
+        let outcome = classify_refresh_reuse_for_test(
+            &session,
+            now,
+            Some("203.0.113.10"),
+            Some("browser"),
             RefreshReuseEvidence::SameProcessContention,
         );
 

--- a/src/services/auth_service/tokens/refresh.rs
+++ b/src/services/auth_service/tokens/refresh.rs
@@ -1,7 +1,42 @@
+//! Refresh token rotation and reuse handling.
+//!
+//! The security rule here is deliberately strict: a refresh token is single-use.
+//! Once it has been rotated, seeing the old JTI again is treated as a possible
+//! token theft unless we have concrete evidence that it is a harmless stale
+//! retry. The two evidence sources we currently accept are:
+//!
+//! 1. The request waited on this process's per-JTI rotation lock, so it is a
+//!    true same-process loser of an in-flight refresh race.
+//! 2. The old JTI matches `previous_refresh_jti`, the rotation is recent, and
+//!    the stored client fingerprint matches the current request.
+//!
+//! Do not widen the "recent" window into a generic grace period. A sequential
+//! replay with no client evidence must still revoke all sessions by bumping
+//! `session_version`; otherwise a stolen refresh token can probe silently.
+//!
+//! End-to-end flow:
+//!
+//! 1. Decode and validate the incoming refresh JWT, including token type and
+//!    JTI presence.
+//! 2. Acquire the process-local mutex keyed by that JTI. This serializes
+//!    same-process requests before any database mutation and records whether
+//!    the request actually waited behind another refresh.
+//! 3. In a transaction, load the auth session and user, verify the token's
+//!    `session_version`, issue the next token pair, then conditionally update
+//!    `auth_sessions.current_refresh_jti = incoming_jti`.
+//! 4. If the current JTI is already gone, classify the incoming token as stale
+//!    or reuse by looking at `previous_refresh_jti` plus the evidence listed
+//!    above.
+//! 5. A stale retry returns E012 only. A confirmed reuse bumps
+//!    `users.session_version`, purges auth sessions, invalidates cached auth
+//!    snapshots, and records an audit log.
+
 use chrono::Utc;
 use dashmap::{DashMap, mapref::entry::Entry};
 use sea_orm::ConnectionTrait;
 use serde::Serialize;
+#[cfg(debug_assertions)]
+use std::sync::Mutex as StdMutex;
 use std::sync::{Arc, LazyLock, Weak};
 use tokio::sync::{Mutex, OwnedMutexGuard};
 
@@ -19,10 +54,23 @@ use super::super::session::{
 };
 use super::{ensure_token_type, issue_tokens_for_session_id, verify_token};
 
+// This window is only for classifying an already-rotated previous JTI. It does
+// not allow a second successful refresh; stale callers still receive E012.
 const REFRESH_REUSE_GRACE_SECS: i64 = 15;
 
+// Process-local serialization for a single refresh JTI.
+//
+// The database conditional update remains the source of truth. This lock only
+// lets us distinguish a real same-process race loser from a later replay with
+// no client evidence. Values are Weak so completed refreshes do not leak one
+// mutex per historical JTI.
 static REFRESH_ROTATION_LOCKS: LazyLock<DashMap<String, Weak<Mutex<()>>>> =
     LazyLock::new(DashMap::new);
+
+#[cfg(debug_assertions)]
+static REFRESH_ROTATION_TEST_HOOK: LazyLock<
+    StdMutex<Option<test_support::RefreshRotationTestHook>>,
+> = LazyLock::new(|| StdMutex::new(None));
 
 struct RefreshRotationLockGuard {
     refresh_jti: String,
@@ -37,6 +85,10 @@ struct RefreshRotationLock {
 
 impl Drop for RefreshRotationLockGuard {
     fn drop(&mut self) {
+        // Drop the mutex guard before dropping our strong Arc, then remove the
+        // DashMap entry only when the Weak can no longer be upgraded. A live
+        // Weak entry is not treated as security evidence elsewhere because it
+        // may simply be waiting for this cleanup path to run.
         drop(self.guard.take());
         drop(self.lock.take());
         REFRESH_ROTATION_LOCKS.remove_if(&self.refresh_jti, |_, lock| lock.upgrade().is_none());
@@ -45,12 +97,20 @@ impl Drop for RefreshRotationLockGuard {
 
 #[derive(Debug)]
 enum RefreshRotationOutcome {
+    // The normal winner path: the auth_session row was atomically moved from
+    // incoming JTI to next JTI, and the newly issued tokens can be returned.
     Rotated {
         access_token: String,
         refresh_token: String,
         session_version: i64,
     },
+    // The incoming JTI was already recorded as previous_refresh_jti. The
+    // request is rejected either as stale or as reuse; handling is deferred so
+    // side effects such as audit logging happen outside the mutation helper.
     Rejected(RefreshRejection),
+    // The row existed when read, but the conditional update matched zero rows.
+    // That means another actor rotated or revoked the row between read and
+    // update. We intentionally reclassify after this transaction ends.
     RotateConflict {
         ip_address: Option<String>,
         user_agent: Option<String>,
@@ -59,17 +119,25 @@ enum RefreshRotationOutcome {
 
 #[derive(Debug)]
 enum RefreshRejection {
+    // A stale caller never receives new tokens and never changes session state.
+    // This is expected for cross-tab races and same-client retry edges.
     StaleRefresh { user_id: i64, reused_jti: String },
+    // A reuse caller is treated as possible token theft. This path revokes the
+    // whole login family by bumping session_version and deleting sessions.
     ReuseDetected { user_id: i64, reused_jti: String },
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum RefreshReuseEvidence {
+    // Evidence comes from stored request metadata (user agent/IP) only.
     ClientFingerprint,
+    // The request actually waited behind another refresh in this process.
     SameProcessContention,
 }
 
 struct RefreshReuseClassification<'a> {
+    // Session found by previous_refresh_jti. None means the incoming JTI is not
+    // tied to any current session and should remain invalid.
     reused_auth_session: Option<&'a auth_session::Model>,
     user_id: i64,
     refresh_jti: &'a str,
@@ -96,6 +164,10 @@ fn refresh_client_matches(
     ip_address: Option<&str>,
     user_agent: Option<&str>,
 ) -> bool {
+    // User agent is the required fingerprint because it is stable across the
+    // normal browser retry path. IP is a refinement: trusted-proxy handling can
+    // legitimately leave it absent, so absence on either side does not turn a
+    // matching UA into a compromise signal.
     let Some(stored_user_agent) = session.user_agent.as_deref() else {
         return false;
     };
@@ -118,6 +190,9 @@ fn is_stale_refresh_from_same_client(
     ip_address: Option<&str>,
     user_agent: Option<&str>,
 ) -> bool {
+    // Same-client stale requires all three facts: same user, live session, and
+    // a recent rotation. The caller still gets E012; this only decides whether
+    // to avoid global session revocation.
     session.user_id == user_id
         && session.revoked_at.is_none()
         && is_recent_refresh_rotation(session, now)
@@ -135,6 +210,10 @@ fn classify_refresh_reuse_session(input: RefreshReuseClassification<'_>) -> Refr
         evidence,
     } = input;
 
+    // A same-process lock loser is the one case where missing or mismatched
+    // client metadata is still safe to classify as stale. The lock proves the
+    // caller overlapped with the winning rotation on this server process, and
+    // the old JTI can only produce a 401 after the winner commits.
     if evidence == RefreshReuseEvidence::SameProcessContention
         && reused_auth_session.is_some_and(|session| {
             session.user_id == user_id
@@ -148,6 +227,8 @@ fn classify_refresh_reuse_session(input: RefreshReuseClassification<'_>) -> Refr
         };
     }
 
+    // Without same-process contention, require a same-client fingerprint. This
+    // keeps sequential no-evidence replay in the compromise path.
     if reused_auth_session.is_some_and(|session| {
         is_stale_refresh_from_same_client(session, user_id, now, ip_address, user_agent)
     }) {
@@ -164,6 +245,10 @@ fn classify_refresh_reuse_session(input: RefreshReuseClassification<'_>) -> Refr
 }
 
 fn refresh_rotation_lock(refresh_jti: &str) -> Arc<Mutex<()>> {
+    // This map is best-effort process-local coordination, not distributed
+    // locking. If a Weak entry has expired we replace it; if it upgrades we use
+    // the same mutex so only one task in this process can rotate a given JTI at
+    // a time.
     match REFRESH_ROTATION_LOCKS.entry(refresh_jti.to_string()) {
         Entry::Occupied(mut entry) => {
             if let Some(lock) = entry.get().upgrade() {
@@ -185,15 +270,28 @@ fn refresh_rotation_lock(refresh_jti: &str) -> Arc<Mutex<()>> {
 async fn acquire_refresh_rotation_lock(refresh_jti: &str) -> RefreshRotationLock {
     let lock = refresh_rotation_lock(refresh_jti);
     match lock.clone().try_lock_owned() {
-        Ok(guard) => RefreshRotationLock {
-            _guard: RefreshRotationLockGuard {
-                refresh_jti: refresh_jti.to_string(),
-                lock: Some(lock),
-                guard: Some(guard),
-            },
-            was_contended: false,
-        },
+        Ok(guard) => {
+            // A direct acquisition means this task did not wait behind an
+            // already-running same-JTI refresh in this process. Even if a Weak
+            // entry existed, we classify future old-token observations using
+            // client fingerprint evidence only.
+            #[cfg(debug_assertions)]
+            maybe_pause_refresh_rotation_after_lock_acquired(refresh_jti).await;
+            RefreshRotationLock {
+                _guard: RefreshRotationLockGuard {
+                    refresh_jti: refresh_jti.to_string(),
+                    lock: Some(lock),
+                    guard: Some(guard),
+                },
+                was_contended: false,
+            }
+        }
         Err(_) => {
+            // Only this branch is "same-process contention". Seeing an old
+            // Weak entry after the mutex has become available is not enough:
+            // that could be a later sequential replay racing with cleanup.
+            #[cfg(debug_assertions)]
+            maybe_notify_refresh_rotation_lock_contended(refresh_jti).await;
             let guard = lock.clone().lock_owned().await;
             RefreshRotationLock {
                 _guard: RefreshRotationLockGuard {
@@ -207,6 +305,37 @@ async fn acquire_refresh_rotation_lock(refresh_jti: &str) -> RefreshRotationLock
     }
 }
 
+#[cfg(debug_assertions)]
+async fn maybe_pause_refresh_rotation_after_lock_acquired(refresh_jti: &str) {
+    let hook = REFRESH_ROTATION_TEST_HOOK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .clone();
+    let Some(hook) = hook else {
+        return;
+    };
+    if hook.refresh_jti != refresh_jti {
+        return;
+    }
+    hook.lock_acquired.notify_one();
+    hook.release_lock.notified().await;
+}
+
+#[cfg(debug_assertions)]
+async fn maybe_notify_refresh_rotation_lock_contended(refresh_jti: &str) {
+    let hook = REFRESH_ROTATION_TEST_HOOK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .clone();
+    let Some(hook) = hook else {
+        return;
+    };
+    if hook.refresh_jti != refresh_jti {
+        return;
+    }
+    hook.lock_contended.notify_one();
+}
+
 async fn classify_failed_refresh_rotation<C: ConnectionTrait>(
     db: &C,
     claims: &Claims,
@@ -215,6 +344,10 @@ async fn classify_failed_refresh_rotation<C: ConnectionTrait>(
     ip_address: Option<&str>,
     user_agent: Option<&str>,
 ) -> Result<RefreshRejection> {
+    // This path is for DB-level conflicts, usually another process/connection
+    // rotating the same JTI between our read and conditional update. There is
+    // no process-local lock evidence here, so classification must fall back to
+    // client fingerprint rules.
     let reused_auth_session =
         auth_session_repo::find_by_previous_refresh_jti(db, refresh_jti).await?;
     Ok(classify_refresh_reuse_session(RefreshReuseClassification {
@@ -229,6 +362,8 @@ async fn classify_failed_refresh_rotation<C: ConnectionTrait>(
 }
 
 async fn revoke_sessions_in_connection<C: ConnectionTrait>(db: &C, user_id: i64) -> Result<()> {
+    // Keep the version bump and auth_session purge in the caller's transaction
+    // so a reuse detection cannot leave half-revoked state behind.
     user_repo::bump_session_version(db, user_id).await?;
     purge_all_auth_sessions_in_connection(db, user_id).await
 }
@@ -237,6 +372,10 @@ async fn classify_refresh_reuse_in_transaction<C: ConnectionTrait>(
     db: &C,
     input: RefreshReuseClassification<'_>,
 ) -> Result<RefreshRejection> {
+    // Classification is pure except for confirmed reuse. The side effect is
+    // intentionally here, inside the same transaction that observed the reused
+    // JTI, so concurrent access tokens are invalidated atomically with session
+    // cleanup.
     let rejection = classify_refresh_reuse_session(input);
     if let RefreshRejection::ReuseDetected { user_id, .. } = &rejection {
         revoke_sessions_in_connection(db, *user_id).await?;
@@ -253,7 +392,18 @@ async fn rotate_refresh_in_transaction<C: ConnectionTrait>(
     user_agent: Option<&str>,
     reuse_evidence: RefreshReuseEvidence,
 ) -> Result<RefreshRotationOutcome> {
+    // This helper runs under the per-JTI lock and a DB transaction. It returns
+    // an outcome instead of writing cookies/audit logs directly so transaction
+    // boundaries stay explicit: DB mutations happen here, external side effects
+    // happen in finish_* after commit.
     let now = Utc::now();
+
+    // First read both the current and previous-JTI views of the session. These
+    // two lookups partition the important states:
+    //
+    // - current exists: this request may be the rotation winner.
+    // - current missing, previous exists: this is an old-token observation.
+    // - neither exists: the token is invalid or already purged.
     let existing_auth_session = auth_session_repo::find_by_refresh_jti(db, refresh_jti).await?;
     let reused_auth_session = if existing_auth_session.is_none() {
         auth_session_repo::find_by_previous_refresh_jti(db, refresh_jti).await?
@@ -261,6 +411,9 @@ async fn rotate_refresh_in_transaction<C: ConnectionTrait>(
         None
     };
     let user = user_repo::find_by_id(db, claims.user_id).await?;
+    // Validate account and token snapshot before issuing new tokens. A stale
+    // session_version means a previous password/session/security event already
+    // invalidated this refresh token, even if the auth_session row still exists.
     if !user.status.is_active() {
         return Err(auth_forbidden_with_subcode(
             ApiSubcode::AuthAccountDisabled,
@@ -272,6 +425,9 @@ async fn rotate_refresh_in_transaction<C: ConnectionTrait>(
     }
 
     let Some(existing_auth_session) = existing_auth_session else {
+        // The current JTI is gone. If it is recorded as the previous JTI of a
+        // live session, the request is using a rotated token; classify it as a
+        // harmless stale retry only when the evidence rules above allow that.
         if reused_auth_session.as_ref().is_some_and(|session| {
             session.user_id == claims.user_id && session.revoked_at.is_none()
         }) {
@@ -302,6 +458,8 @@ async fn rotate_refresh_in_transaction<C: ConnectionTrait>(
 
     let next_ip_address = ip_address.or(existing_auth_session.ip_address.as_deref());
     let next_user_agent = user_agent.or(existing_auth_session.user_agent.as_deref());
+    // The refresh JTI is generated before the conditional update, but it is not
+    // usable unless the update below wins. Losers never return these tokens.
     let tokens = issue_tokens_for_session_id(
         state,
         user.id,
@@ -320,6 +478,10 @@ async fn rotate_refresh_in_transaction<C: ConnectionTrait>(
     )
     .await?
     {
+        // We held the process-local lock, but the database row no longer
+        // matches. That means a cross-process rotation or an unexpected DB race
+        // won first. Re-read `previous_refresh_jti` in a new transaction after
+        // this one ends, then classify with the stricter fingerprint evidence.
         return Ok(RefreshRotationOutcome::RotateConflict {
             ip_address: next_ip_address.map(str::to_string),
             user_agent: next_user_agent.map(str::to_string),
@@ -339,6 +501,10 @@ async fn record_refresh_reuse_detection(
     reused_jti: &str,
     log_message: &'static str,
 ) -> Result<()> {
+    // `revoke_sessions_in_connection` mutates the DB. This function handles the
+    // non-transactional follow-up after commit: evict cached auth snapshots and
+    // leave an audit trail. Do not call this for stale retries; those are noisy
+    // normal browser races, not confirmed compromise signals.
     invalidate_auth_snapshot_cache(state, user_id).await;
     tracing::warn!(user_id, reused_jti, "{log_message}");
     audit_service::log(
@@ -363,6 +529,8 @@ async fn finish_refresh_rejection(
     rejection: RefreshRejection,
     reuse_log_message: &'static str,
 ) -> Result<(String, String)> {
+    // Both stale and reuse map to E012 at the API boundary, but only reuse has
+    // already changed session state and receives security audit logging.
     match rejection {
         RefreshRejection::StaleRefresh {
             user_id,
@@ -393,6 +561,10 @@ async fn finish_refresh_outcome(
     refresh_jti: &str,
     outcome: RefreshRotationOutcome,
 ) -> Result<(String, String)> {
+    // The transaction that produced `outcome` has committed by the time this
+    // runs. That matters for RotateConflict: reclassification must observe the
+    // winner's committed previous_refresh_jti, not the pre-commit view that
+    // caused earlier race bugs.
     match outcome {
         RefreshRotationOutcome::Rotated {
             access_token,
@@ -451,6 +623,9 @@ pub async fn refresh_tokens(
     ip_address: Option<&str>,
     user_agent: Option<&str>,
 ) -> Result<(String, String)> {
+    // Public service entrypoint used by both HTTP handlers and tests. Keep the
+    // order intact: verify JWT cheaply first, acquire the per-JTI lock second,
+    // then do all authoritative state checks in the transaction.
     tracing::debug!("refreshing auth tokens");
     let claims = verify_token(refresh, &state.config.auth.jwt_secret)?;
     ensure_token_type(&claims, TokenType::Refresh)?;
@@ -460,6 +635,9 @@ pub async fn refresh_tokens(
         .ok_or_else(|| AsterError::auth_token_invalid("refresh token missing jti"))?;
 
     let rotation_lock = acquire_refresh_rotation_lock(&refresh_jti).await;
+    // This boolean is the only bridge between the lock layer and reuse
+    // classification. Do not infer SameProcessContention from timing, map
+    // entries, or recent timestamps alone.
     let reuse_evidence = if rotation_lock.was_contended {
         RefreshReuseEvidence::SameProcessContention
     } else {
@@ -480,6 +658,86 @@ pub async fn refresh_tokens(
     .await?;
 
     finish_refresh_outcome(state, &claims, &refresh_jti, outcome).await
+}
+
+#[cfg(debug_assertions)]
+pub mod test_support {
+    //! Debug-only hooks for integration tests.
+    //!
+    //! `cfg(test)` is not visible to integration tests that depend on the lib
+    //! crate, so this module is guarded by `debug_assertions` instead. Release
+    //! builds do not compile it. Tests use this hook to prove that a request
+    //! actually waits on the server-side rotation lock; a plain async barrier is
+    //! not enough because the first refresh may complete before the second
+    //! reaches the lock, making the request indistinguishable from a sequential
+    //! no-evidence replay.
+
+    use std::sync::Arc;
+
+    use tokio::sync::Notify;
+
+    use crate::errors::{AsterError, Result};
+    use crate::types::TokenType;
+
+    use super::{REFRESH_ROTATION_TEST_HOOK, ensure_token_type, verify_token};
+
+    #[derive(Clone)]
+    pub struct RefreshRotationTestHook {
+        pub(super) refresh_jti: String,
+        pub(super) lock_acquired: Arc<Notify>,
+        pub(super) lock_contended: Arc<Notify>,
+        pub(super) release_lock: Arc<Notify>,
+    }
+
+    impl RefreshRotationTestHook {
+        /// Wait until the first request holds the per-JTI lock and is paused.
+        pub async fn wait_until_lock_acquired(&self) {
+            self.lock_acquired.notified().await;
+        }
+
+        /// Wait until another request has failed `try_lock_owned` and is queued.
+        pub async fn wait_until_lock_contended(&self) {
+            self.lock_contended.notified().await;
+        }
+
+        /// Let the paused lock holder continue through rotation.
+        pub fn release_lock(&self) {
+            self.release_lock.notify_one();
+        }
+    }
+
+    impl Drop for RefreshRotationTestHook {
+        fn drop(&mut self) {
+            self.release_lock.notify_waiters();
+        }
+    }
+
+    pub async fn install_refresh_rotation_test_hook(
+        refresh_token: &str,
+        jwt_secret: &str,
+    ) -> Result<RefreshRotationTestHook> {
+        let claims = verify_token(refresh_token, jwt_secret)?;
+        ensure_token_type(&claims, TokenType::Refresh)?;
+        let refresh_jti = claims
+            .jti
+            .ok_or_else(|| AsterError::auth_token_invalid("refresh token missing jti"))?;
+        let hook = RefreshRotationTestHook {
+            refresh_jti,
+            lock_acquired: Arc::new(Notify::new()),
+            lock_contended: Arc::new(Notify::new()),
+            release_lock: Arc::new(Notify::new()),
+        };
+        *REFRESH_ROTATION_TEST_HOOK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner()) = Some(hook.clone());
+        Ok(hook)
+    }
+
+    pub async fn clear_refresh_rotation_test_hook() {
+        *REFRESH_ROTATION_TEST_HOOK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner()) = None;
+    }
 }
 
 #[cfg(test)]

--- a/src/services/batch_service/delete.rs
+++ b/src/services/batch_service/delete.rs
@@ -107,7 +107,7 @@ pub(crate) async fn batch_delete_in_scope(
         .collect();
     if !root_folder_ids_to_delete.is_empty() {
         let (tree_files, tree_folder_ids) = folder_service::collect_folder_forest_in_scope(
-            &state.db,
+            state.writer_db(),
             scope,
             &root_folder_ids_to_delete,
             false,
@@ -125,7 +125,7 @@ pub(crate) async fn batch_delete_in_scope(
         let total_file_count = file_ids_to_delete.len();
         let total_folder_count = folder_ids_to_delete.len();
 
-        let txn = crate::db::transaction::begin(&state.db).await?;
+        let txn = crate::db::transaction::begin(state.writer_db()).await?;
         file_repo::soft_delete_many(&txn, &file_ids_to_delete, now).await?;
         folder_repo::soft_delete_many(&txn, &folder_ids_to_delete, now).await?;
         crate::db::transaction::commit(txn).await?;

--- a/src/services/batch_service/movement.rs
+++ b/src/services/batch_service/movement.rs
@@ -185,7 +185,7 @@ pub(crate) async fn batch_move_in_scope(
             .flat_map(|folder| [folder.parent_id, target_folder_id])
             .collect();
 
-        let txn = crate::db::transaction::begin(&state.db).await?;
+        let txn = crate::db::transaction::begin(state.writer_db()).await?;
         revalidate_batch_folder_move(&txn, scope, &folder_ids_to_move, target_folder_id).await?;
         file_repo::move_many_to_folder(&txn, &file_ids_to_move, target_folder_id, now).await?;
         folder_repo::move_many_to_parent(&txn, &folder_ids_to_move, target_folder_id, now).await?;

--- a/src/services/batch_service/shared.rs
+++ b/src/services/batch_service/shared.rs
@@ -48,10 +48,10 @@ async fn find_files_by_ids_in_scope(
 ) -> Result<Vec<file::Model>> {
     match scope {
         WorkspaceStorageScope::Personal { user_id } => {
-            file_repo::find_by_ids_in_personal_scope(&state.db, user_id, ids).await
+            file_repo::find_by_ids_in_personal_scope(state.writer_db(), user_id, ids).await
         }
         WorkspaceStorageScope::Team { team_id, .. } => {
-            file_repo::find_by_ids_in_team_scope(&state.db, team_id, ids).await
+            file_repo::find_by_ids_in_team_scope(state.writer_db(), team_id, ids).await
         }
     }
 }
@@ -63,10 +63,10 @@ async fn find_folders_by_ids_in_scope(
 ) -> Result<Vec<folder::Model>> {
     match scope {
         WorkspaceStorageScope::Personal { user_id } => {
-            folder_repo::find_by_ids_in_personal_scope(&state.db, user_id, ids).await
+            folder_repo::find_by_ids_in_personal_scope(state.writer_db(), user_id, ids).await
         }
         WorkspaceStorageScope::Team { team_id, .. } => {
-            folder_repo::find_by_ids_in_team_scope(&state.db, team_id, ids).await
+            folder_repo::find_by_ids_in_team_scope(state.writer_db(), team_id, ids).await
         }
     }
 }
@@ -224,7 +224,7 @@ pub(super) async fn load_folder_ancestor_ids_in_scope(
         workspace_storage_service::ensure_active_folder_scope(&folder, scope)?;
         ancestors.insert(folder.id);
         current = match folder.parent_id {
-            Some(parent_id) => Some(folder_repo::find_by_id(&state.db, parent_id).await?),
+            Some(parent_id) => Some(folder_repo::find_by_id(state.writer_db(), parent_id).await?),
             None => None,
         };
     }

--- a/src/services/config_service/actions.rs
+++ b/src/services/config_service/actions.rs
@@ -115,7 +115,7 @@ async fn execute_mail_action(
 ) -> Result<ConfigActionResult> {
     match action {
         ConfigActionType::SendTestEmail => {
-            let actor = user_repo::find_by_id(&state.db, actor_user_id).await?;
+            let actor = user_repo::find_by_id(state.writer_db(), actor_user_id).await?;
             let requested_target = target_email.unwrap_or(&actor.email);
             let normalized_target = mail::normalize_mail_address_config_value(requested_target)?;
             if normalized_target.is_empty() {

--- a/src/services/config_service/system.rs
+++ b/src/services/config_service/system.rs
@@ -186,7 +186,7 @@ pub async fn set(
     }
 
     let config = apply_system_config_definition(
-        config_repo::upsert(&state.db, key, &normalized_value, updated_by).await?,
+        config_repo::upsert(state.writer_db(), key, &normalized_value, updated_by).await?,
     );
     state.runtime_config.apply(config.clone());
     invalidate_dependent_public_config_caches(key);
@@ -194,7 +194,7 @@ pub async fn set(
 }
 
 pub async fn delete(state: &PrimaryAppState, key: &str) -> Result<()> {
-    config_repo::delete_by_key(&state.db, key).await?;
+    config_repo::delete_by_key(state.writer_db(), key).await?;
     state.runtime_config.remove(key);
     invalidate_dependent_public_config_caches(key);
     tracing::debug!(key, "deleted runtime config");

--- a/src/services/config_service/system.rs
+++ b/src/services/config_service/system.rs
@@ -146,7 +146,7 @@ pub async fn list_paginated(
     offset: u64,
 ) -> Result<OffsetPage<SystemConfig>> {
     let page = load_offset_page(limit, offset, 100, |limit, offset| async move {
-        config_repo::find_paginated(&state.db, limit, offset).await
+        config_repo::find_paginated(state.reader_db(), limit, offset).await
     })
     .await?;
     let items = page
@@ -159,7 +159,7 @@ pub async fn list_paginated(
 }
 
 pub async fn get_by_key(state: &PrimaryAppState, key: &str) -> Result<SystemConfig> {
-    config_repo::find_by_key(&state.db, key)
+    config_repo::find_by_key(state.reader_db(), key)
         .await?
         .map(apply_system_config_definition)
         .map(Into::into)

--- a/src/services/direct_link_service.rs
+++ b/src/services/direct_link_service.rs
@@ -38,7 +38,7 @@ pub(crate) async fn create_token_in_scope(
 }
 
 pub(crate) async fn load_public_file(state: &PrimaryAppState, file_id: i64) -> Result<file::Model> {
-    let file = file_repo::find_by_id(&state.db, file_id).await?;
+    let file = file_repo::find_by_id(state.reader_db(), file_id).await?;
     validate_file_scope(state, &file).await?;
     Ok(file)
 }
@@ -71,7 +71,7 @@ pub(crate) async fn download_file(
     range: Option<ResolvedDownloadRange>,
 ) -> Result<file_service::DownloadOutcome> {
     let file = resolve_file_for_download(state, token, requested_name).await?;
-    let blob = file_repo::find_blob_by_id(&state.db, file.blob_id).await?;
+    let blob = file_repo::find_blob_by_id(state.reader_db(), file.blob_id).await?;
     let disposition = if force_download {
         file_service::DownloadDisposition::Attachment
     } else {
@@ -154,7 +154,7 @@ async fn validate_file_scope(state: &PrimaryAppState, file: &file::Model) -> Res
     }
 
     if let Some(team_id) = file.team_id {
-        match team_repo::find_active_by_id(&state.db, team_id).await {
+        match team_repo::find_active_by_id(state.reader_db(), team_id).await {
             Ok(_) => {}
             Err(AsterError::RecordNotFound(_)) => {
                 return Err(AsterError::share_not_found("direct link team is inactive"));

--- a/src/services/external_auth_service/links.rs
+++ b/src/services/external_auth_service/links.rs
@@ -14,8 +14,8 @@ pub async fn list_links(
     state: &PrimaryAppState,
     user_id: i64,
 ) -> Result<Vec<ExternalAuthLinkInfo>> {
-    let identities = external_auth_identity_repo::list_for_user(&state.db, user_id).await?;
-    let providers = external_auth_provider_repo::find_all(&state.db).await?;
+    let identities = external_auth_identity_repo::list_for_user(state.writer_db(), user_id).await?;
+    let providers = external_auth_provider_repo::find_all(state.writer_db()).await?;
     let provider_lookup = providers
         .into_iter()
         .map(|provider| (provider.id, provider))
@@ -50,13 +50,14 @@ fn link_to_info(
 }
 
 pub async fn delete_link(state: &PrimaryAppState, user_id: i64, id: i64) -> Result<bool> {
-    external_auth_identity_repo::delete_for_user(&state.db, id, user_id).await
+    external_auth_identity_repo::delete_for_user(state.writer_db(), id, user_id).await
 }
 
 pub async fn cleanup_expired_flows(state: &PrimaryAppState) -> Result<u64> {
     let now = Utc::now();
-    let login_flows = external_auth_login_flow_repo::cleanup_expired(&state.db, now).await?;
+    let login_flows =
+        external_auth_login_flow_repo::cleanup_expired(state.writer_db(), now).await?;
     let email_flows =
-        external_auth_email_verification_flow_repo::cleanup_expired(&state.db, now).await?;
+        external_auth_email_verification_flow_repo::cleanup_expired(state.writer_db(), now).await?;
     Ok(login_flows + email_flows)
 }

--- a/src/services/external_auth_service/login.rs
+++ b/src/services/external_auth_service/login.rs
@@ -30,15 +30,18 @@ pub async fn start_login(
     return_path: Option<&str>,
 ) -> Result<ExternalAuthStartLoginResponse> {
     let provider_key = normalize_key(provider_key)?;
-    let provider =
-        external_auth_provider_repo::find_by_kind_key(&state.db, provider_kind, &provider_key)
-            .await?
-            .ok_or_else(|| {
-                AsterError::record_not_found(format!(
-                    "external auth provider '{}:{provider_key}'",
-                    provider_kind.as_str()
-                ))
-            })?;
+    let provider = external_auth_provider_repo::find_by_kind_key(
+        state.writer_db(),
+        provider_kind,
+        &provider_key,
+    )
+    .await?
+    .ok_or_else(|| {
+        AsterError::record_not_found(format!(
+            "external auth provider '{}:{provider_key}'",
+            provider_kind.as_str()
+        ))
+    })?;
     if !provider.enabled {
         return Err(AsterError::auth_forbidden(
             "external auth provider is disabled",
@@ -65,7 +68,7 @@ pub async fn start_login(
         consumed_at: Set(None),
         ..Default::default()
     };
-    external_auth_login_flow_repo::create(&state.db, flow).await?;
+    external_auth_login_flow_repo::create(state.writer_db(), flow).await?;
 
     Ok(ExternalAuthStartLoginResponse {
         authorization_url: auth_start.authorization_url,
@@ -98,7 +101,7 @@ pub async fn finish_callback(
     })?;
 
     let flow = external_auth_login_flow_repo::consume_by_state_hash(
-        &state.db,
+        state.writer_db(),
         &state_hash(state_value),
         Utc::now(),
     )
@@ -106,7 +109,8 @@ pub async fn finish_callback(
     .ok_or_else(|| {
         AsterError::auth_invalid_credentials("external auth state is invalid or expired")
     })?;
-    let provider = external_auth_provider_repo::find_by_id(&state.db, flow.provider_id).await?;
+    let provider =
+        external_auth_provider_repo::find_by_id(state.writer_db(), flow.provider_id).await?;
     if provider.provider_kind != provider_kind {
         return Err(AsterError::auth_invalid_credentials(
             "external auth callback provider kind does not match login flow",
@@ -139,7 +143,8 @@ pub async fn finish_callback(
 
     if external_auth_claims_missing_email(&user_claims) {
         if let Some(resolved) =
-            resolve_existing_external_auth_identity(&state.db, &user_claims, Utc::now()).await?
+            resolve_existing_external_auth_identity(state.writer_db(), &user_claims, Utc::now())
+                .await?
         {
             let (access_token, refresh_token) =
                 auth_service::issue_tokens_for_user(state, &resolved.user, ip_address, user_agent)

--- a/src/services/external_auth_service/password_link.rs
+++ b/src/services/external_auth_service/password_link.rs
@@ -33,7 +33,7 @@ pub async fn link_with_password(
 
     let now = Utc::now();
     let flow = external_auth_email_verification_flow_repo::find_active_by_flow_token_hash(
-        &state.db,
+        state.writer_db(),
         &token_hash(&flow_token),
         now,
     )
@@ -41,14 +41,15 @@ pub async fn link_with_password(
     .ok_or_else(|| {
         AsterError::contact_verification_invalid("external auth email verification flow is invalid")
     })?;
-    let provider = external_auth_provider_repo::find_by_id(&state.db, flow.provider_id).await?;
+    let provider =
+        external_auth_provider_repo::find_by_id(state.writer_db(), flow.provider_id).await?;
     if !provider.enabled {
         return Err(AsterError::auth_forbidden(
             "external auth provider is disabled",
         ));
     }
 
-    let user = auth_service::shared::find_user_by_identifier(&state.db, identifier).await?;
+    let user = auth_service::shared::find_user_by_identifier(state.writer_db(), identifier).await?;
     let password_hash = user
         .as_ref()
         .map(|user| user.password_hash.as_str())
@@ -69,7 +70,7 @@ pub async fn link_with_password(
     }
 
     let claims = claims_without_provider_email(&flow);
-    let txn = crate::db::transaction::begin(&state.db).await?;
+    let txn = crate::db::transaction::begin(state.writer_db()).await?;
     let result = async {
         let consumed =
             external_auth_email_verification_flow_repo::mark_consumed_if_unused(&txn, flow.id, now)

--- a/src/services/external_auth_service/providers.rs
+++ b/src/services/external_auth_service/providers.rs
@@ -189,7 +189,7 @@ fn map_driver_test_result(
 pub async fn list_public_providers(
     state: &PrimaryAppState,
 ) -> Result<Vec<ExternalAuthPublicProvider>> {
-    Ok(external_auth_provider_repo::find_enabled(&state.db)
+    Ok(external_auth_provider_repo::find_enabled(state.writer_db())
         .await?
         .into_iter()
         .filter(|provider| registry::default_registry().contains(provider.provider_kind))
@@ -202,7 +202,7 @@ pub async fn list_public_providers_by_kind(
     provider_kind: ExternalAuthProviderKind,
 ) -> Result<Vec<ExternalAuthPublicProvider>> {
     Ok(
-        external_auth_provider_repo::find_enabled_by_kind(&state.db, provider_kind)
+        external_auth_provider_repo::find_enabled_by_kind(state.writer_db(), provider_kind)
             .await?
             .into_iter()
             .filter(|provider| registry::default_registry().contains(provider.provider_kind))
@@ -218,7 +218,7 @@ pub async fn list_admin_providers(
 ) -> Result<OffsetPage<AdminExternalAuthProviderInfo>> {
     let page = load_offset_page(limit, offset, 100, |limit, offset| async move {
         external_auth_provider_repo::find_paginated(
-            &state.db,
+            state.writer_db(),
             limit,
             offset,
             registry::default_registry().supported_kinds(),
@@ -246,7 +246,7 @@ pub async fn get_admin_provider(
     state: &PrimaryAppState,
     id: i64,
 ) -> Result<AdminExternalAuthProviderInfo> {
-    let provider = external_auth_provider_repo::find_by_id(&state.db, id).await?;
+    let provider = external_auth_provider_repo::find_by_id(state.writer_db(), id).await?;
     if !registry::default_registry().contains(provider.provider_kind) {
         return Err(AsterError::record_not_found(format!(
             "external auth provider #{id}"
@@ -269,7 +269,7 @@ pub async fn create_provider(
         )));
     }
     let key = id::new_best_effort_uuid("external auth provider key", |candidate| {
-        let db = &state.db;
+        let db = state.writer_db();
         let provider_kind = input.provider_kind;
         async move {
             let candidate_key = candidate.to_string();
@@ -358,7 +358,7 @@ pub async fn create_provider(
         updated_at: Set(now),
         ..Default::default()
     };
-    let provider = external_auth_provider_repo::create(&state.db, model).await?;
+    let provider = external_auth_provider_repo::create(state.writer_db(), model).await?;
     provider_to_admin(provider)
 }
 
@@ -367,7 +367,7 @@ pub async fn update_provider(
     id: i64,
     input: UpdateExternalAuthProviderInput,
 ) -> Result<AdminExternalAuthProviderInfo> {
-    let existing = external_auth_provider_repo::find_by_id(&state.db, id).await?;
+    let existing = external_auth_provider_repo::find_by_id(state.writer_db(), id).await?;
     if !registry::default_registry().contains(existing.provider_kind) {
         return Err(AsterError::record_not_found(format!(
             "external auth provider #{id}"
@@ -466,30 +466,30 @@ pub async fn update_provider(
     }
     active.updated_at = Set(Utc::now());
 
-    let provider = external_auth_provider_repo::update(&state.db, active).await?;
+    let provider = external_auth_provider_repo::update(state.writer_db(), active).await?;
     provider_to_admin(provider)
 }
 
 pub async fn delete_provider(state: &PrimaryAppState, id: i64) -> Result<()> {
-    let provider = external_auth_provider_repo::find_by_id(&state.db, id).await?;
+    let provider = external_auth_provider_repo::find_by_id(state.writer_db(), id).await?;
     if !registry::default_registry().contains(provider.provider_kind) {
         return Err(AsterError::record_not_found(format!(
             "external auth provider #{id}"
         )));
     }
-    external_auth_provider_repo::delete(&state.db, id).await
+    external_auth_provider_repo::delete(state.writer_db(), id).await
 }
 
 pub async fn test_provider(
     state: &PrimaryAppState,
     id: i64,
 ) -> Result<ExternalAuthProviderTestResult> {
-    let provider = external_auth_provider_repo::find_by_id(&state.db, id).await?;
+    let provider = external_auth_provider_repo::find_by_id(state.writer_db(), id).await?;
     let result = registry::default_registry()
         .get_driver(provider.provider_kind)?
         .test_provider(&external_auth_provider_config(&provider))
         .await?;
-    external_auth_provider_repo::touch_updated_at(&state.db, id, Utc::now()).await?;
+    external_auth_provider_repo::touch_updated_at(state.writer_db(), id, Utc::now()).await?;
     Ok(map_driver_test_result(result))
 }
 

--- a/src/services/external_auth_service/resolution.rs
+++ b/src/services/external_auth_service/resolution.rs
@@ -263,7 +263,7 @@ async fn create_external_auth_user_and_identity(
         let username = external_auth_username_candidate(&username_base, attempt);
         let password = random_internal_password();
 
-        let txn = crate::db::transaction::begin(&state.db).await?;
+        let txn = crate::db::transaction::begin(state.writer_db()).await?;
         let result = async {
             if user_repo::find_by_email(&txn, email).await?.is_some() {
                 return Err(AsterError::validation_error(
@@ -460,21 +460,21 @@ pub(super) async fn resolve_external_auth_user(
 ) -> Result<Option<ResolvedExternalAuthUser>> {
     let now = Utc::now();
     if let Some(identity) = external_auth_identity_repo::find_by_identity_namespace_subject(
-        &state.db,
+        state.writer_db(),
         &claims.identity_namespace,
         &claims.subject,
     )
     .await?
     {
         external_auth_identity_repo::touch_login(
-            &state.db,
+            state.writer_db(),
             identity.id,
             claims.email.as_deref(),
             claims.display_name.as_deref(),
             now,
         )
         .await?;
-        let user = user_repo::find_by_id(&state.db, identity.user_id).await?;
+        let user = user_repo::find_by_id(state.writer_db(), identity.user_id).await?;
         if !user.status.is_active() {
             return Err(AsterError::auth_forbidden("account is disabled"));
         }
@@ -497,12 +497,12 @@ pub(super) async fn resolve_external_auth_user(
     if provider.auto_link_verified_email_enabled
         && claims.email_verified
         && let Some(email) = claims.email.as_deref()
-        && let Some(user) = user_repo::find_by_email(&state.db, email).await?
+        && let Some(user) = user_repo::find_by_email(state.writer_db(), email).await?
     {
         if !user.status.is_active() {
             return Err(AsterError::auth_forbidden("account is disabled"));
         }
-        create_identity_for_claims(&state.db, user.id, provider, claims, now).await?;
+        create_identity_for_claims(state.writer_db(), user.id, provider, claims, now).await?;
         return Ok(Some(ResolvedExternalAuthUser {
             user,
             linked: true,
@@ -523,7 +523,10 @@ pub(super) async fn resolve_external_auth_user(
         if !auth_policy.allow_user_registration {
             return Ok(None);
         }
-        if user_repo::find_by_email(&state.db, email).await?.is_some() {
+        if user_repo::find_by_email(state.writer_db(), email)
+            .await?
+            .is_some()
+        {
             return Ok(None);
         }
         return create_external_auth_user_and_identity(state, provider, claims, now)

--- a/src/services/external_auth_service/verification.rs
+++ b/src/services/external_auth_service/verification.rs
@@ -54,7 +54,7 @@ pub(super) async fn create_pending_email_verification_flow(
         "external auth email verification flow ttl",
     )?;
     external_auth_email_verification_flow_repo::create(
-        &state.db,
+        state.writer_db(),
         external_auth_email_verification_flow::ActiveModel {
             provider_id: Set(provider.id),
             identity_namespace: Set(claims.identity_namespace.clone()),
@@ -88,7 +88,7 @@ pub async fn start_email_verification(
     let email = normalize_email_for_external_auth(&input.email)?;
     let now = Utc::now();
     let flow = external_auth_email_verification_flow_repo::find_active_by_flow_token_hash(
-        &state.db,
+        state.writer_db(),
         &token_hash(&flow_token),
         now,
     )
@@ -102,7 +102,8 @@ pub async fn start_email_verification(
         ));
     }
 
-    let provider = external_auth_provider_repo::find_by_id(&state.db, flow.provider_id).await?;
+    let provider =
+        external_auth_provider_repo::find_by_id(state.writer_db(), flow.provider_id).await?;
     if !provider.enabled {
         return Err(AsterError::auth_forbidden(
             "external auth provider is disabled",
@@ -114,7 +115,7 @@ pub async fn start_email_verification(
         ));
     }
 
-    match user_repo::find_by_email(&state.db, &email).await? {
+    match user_repo::find_by_email(state.writer_db(), &email).await? {
         Some(user) => {
             if !user.status.is_active() {
                 return Err(AsterError::auth_forbidden("account is disabled"));
@@ -140,7 +141,7 @@ pub async fn start_email_verification(
     let provider_name = provider.display_name.clone();
     let site_name = branding::title_or_default(&state.runtime_config);
     let expires_in = format_mail_duration_seconds((flow.expires_at - now).num_seconds());
-    let txn = crate::db::transaction::begin(&state.db).await?;
+    let txn = crate::db::transaction::begin(state.writer_db()).await?;
     let result = async {
         external_auth_email_verification_flow_repo::update_email_request(
             &txn,
@@ -198,7 +199,7 @@ pub async fn confirm_email_verification(
     }
     let now = Utc::now();
     let flow = external_auth_email_verification_flow_repo::find_active_by_verification_token_hash(
-        &state.db,
+        state.writer_db(),
         &token_hash(token),
         now,
     )
@@ -211,7 +212,8 @@ pub async fn confirm_email_verification(
             "external auth email verification target is missing",
         )
     })?;
-    let provider = external_auth_provider_repo::find_by_id(&state.db, flow.provider_id).await?;
+    let provider =
+        external_auth_provider_repo::find_by_id(state.writer_db(), flow.provider_id).await?;
     if !provider.enabled {
         return Err(AsterError::auth_forbidden(
             "external auth provider is disabled",
@@ -219,7 +221,7 @@ pub async fn confirm_email_verification(
     }
 
     let claims = claims_with_verified_local_email(&flow, &email);
-    let txn = crate::db::transaction::begin(&state.db).await?;
+    let txn = crate::db::transaction::begin(state.writer_db()).await?;
     let result = async {
         let consumed =
             external_auth_email_verification_flow_repo::mark_consumed_if_unused(&txn, flow.id, now)

--- a/src/services/file_service/content.rs
+++ b/src/services/file_service/content.rs
@@ -243,7 +243,7 @@ pub(crate) async fn update_content_in_scope(
     body: Bytes,
     if_match: Option<&str>,
 ) -> Result<(crate::entities::file::Model, String)> {
-    let db = &state.db;
+    let db = state.writer_db();
     tracing::debug!(
         scope = ?scope,
         file_id,
@@ -366,7 +366,7 @@ pub(crate) async fn update_content_stream_in_scope(
     declared_size: Option<i64>,
     if_match: Option<&str>,
 ) -> Result<(crate::entities::file::Model, String)> {
-    let db = &state.db;
+    let db = state.writer_db();
     tracing::debug!(
         scope = ?scope,
         file_id,

--- a/src/services/file_service/content.rs
+++ b/src/services/file_service/content.rs
@@ -19,7 +19,6 @@ use crate::services::{
     },
 };
 
-use super::get_info_in_scope;
 use crate::utils::numbers::usize_to_i64;
 
 pub(crate) struct StreamedTempUpload {
@@ -252,7 +251,7 @@ pub(crate) async fn update_content_in_scope(
         has_if_match = if_match.is_some(),
         "updating file content"
     );
-    let f = get_info_in_scope(state, scope, file_id).await?;
+    let f = workspace_storage_service::verify_file_access(state, scope, file_id).await?;
 
     if f.is_locked {
         let lock = crate::db::repository::lock_repo::find_by_entity(
@@ -375,7 +374,7 @@ pub(crate) async fn update_content_stream_in_scope(
         has_if_match = if_match.is_some(),
         "streaming file content update"
     );
-    let f = get_info_in_scope(state, scope, file_id).await?;
+    let f = workspace_storage_service::verify_file_access(state, scope, file_id).await?;
 
     if f.is_locked {
         let lock = crate::db::repository::lock_repo::find_by_entity(

--- a/src/services/file_service/deletion/blob_cleanup.rs
+++ b/src/services/file_service/deletion/blob_cleanup.rs
@@ -8,7 +8,7 @@ pub(crate) async fn ensure_blob_cleanup_if_unreferenced(
     state: &PrimaryAppState,
     blob_id: i64,
 ) -> bool {
-    let current_blob = match file_repo::find_blob_by_id(&state.db, blob_id).await {
+    let current_blob = match file_repo::find_blob_by_id(state.writer_db(), blob_id).await {
         Ok(current_blob) => current_blob,
         Err(AsterError::RecordNotFound(_)) => return true,
         Err(error) => {
@@ -32,7 +32,7 @@ pub(crate) async fn ensure_blob_cleanup_if_unreferenced(
         return true;
     }
 
-    match file_repo::claim_blob_cleanup(&state.db, current_blob.id).await {
+    match file_repo::claim_blob_cleanup(state.writer_db(), current_blob.id).await {
         Ok(true) => cleanup_claimed_blob(state, &current_blob).await,
         Ok(false) => true,
         Err(error) => {
@@ -49,7 +49,7 @@ pub(crate) async fn cleanup_unreferenced_blob(
     state: &PrimaryAppState,
     blob: &file_blob::Model,
 ) -> bool {
-    let current_blob = match file_repo::find_blob_by_id(&state.db, blob.id).await {
+    let current_blob = match file_repo::find_blob_by_id(state.writer_db(), blob.id).await {
         Ok(current_blob) => current_blob,
         Err(AsterError::RecordNotFound(_)) => return true,
         Err(error) => {
@@ -78,7 +78,7 @@ pub(crate) async fn cleanup_unreferenced_blob(
         return false;
     }
 
-    match file_repo::claim_blob_cleanup(&state.db, current_blob.id).await {
+    match file_repo::claim_blob_cleanup(state.writer_db(), current_blob.id).await {
         Ok(true) => {}
         Ok(false) => {
             tracing::warn!(
@@ -101,7 +101,7 @@ pub(crate) async fn cleanup_unreferenced_blob(
 
 async fn cleanup_claimed_blob(state: &PrimaryAppState, current_blob: &file_blob::Model) -> bool {
     async fn restore_cleanup_claim(state: &PrimaryAppState, blob_id: i64, reason: &str) {
-        match file_repo::restore_blob_cleanup_claim(&state.db, blob_id).await {
+        match file_repo::restore_blob_cleanup_claim(state.writer_db(), blob_id).await {
             Ok(true) => {}
             Ok(false) => {
                 tracing::warn!(
@@ -184,7 +184,7 @@ async fn cleanup_claimed_blob(state: &PrimaryAppState, current_blob: &file_blob:
         return false;
     }
 
-    match file_repo::delete_blob_if_cleanup_claimed(&state.db, current_blob.id).await {
+    match file_repo::delete_blob_if_cleanup_claimed(state.writer_db(), current_blob.id).await {
         Ok(true) => true,
         Ok(false) => {
             tracing::warn!(

--- a/src/services/file_service/deletion/purge.rs
+++ b/src/services/file_service/deletion/purge.rs
@@ -28,7 +28,7 @@ pub(crate) async fn purge_in_scope(
     scope: WorkspaceStorageScope,
     id: i64,
 ) -> Result<()> {
-    workspace_storage_service::require_scope_access(state, scope).await?;
+    workspace_storage_service::require_scope_access_with_db(state, &state.db, scope).await?;
 
     let file = file_repo::find_by_id(&state.db, id).await?;
     workspace_storage_service::ensure_file_scope(&file, scope)?;

--- a/src/services/file_service/deletion/purge.rs
+++ b/src/services/file_service/deletion/purge.rs
@@ -28,9 +28,10 @@ pub(crate) async fn purge_in_scope(
     scope: WorkspaceStorageScope,
     id: i64,
 ) -> Result<()> {
-    workspace_storage_service::require_scope_access_with_db(state, &state.db, scope).await?;
+    workspace_storage_service::require_scope_access_with_db(state, state.writer_db(), scope)
+        .await?;
 
-    let file = file_repo::find_by_id(&state.db, id).await?;
+    let file = file_repo::find_by_id(state.writer_db(), id).await?;
     workspace_storage_service::ensure_file_scope(&file, scope)?;
 
     batch_purge_in_scope(state, scope, vec![file]).await?;
@@ -99,7 +100,7 @@ async fn batch_purge_in_resource_scope_internal(
     let blob_ids: Vec<i64> = files.iter().map(|file| file.blob_id).collect();
     let count = usize_to_u32(files.len(), "purged file count")?;
 
-    let txn = crate::db::transaction::begin(&state.db).await?;
+    let txn = crate::db::transaction::begin(state.writer_db()).await?;
 
     let version_blob_ids =
         crate::db::repository::version_repo::delete_all_by_file_ids(&txn, &file_ids).await?;

--- a/src/services/file_service/deletion/soft_delete.rs
+++ b/src/services/file_service/deletion/soft_delete.rs
@@ -3,15 +3,14 @@ use crate::errors::{AsterError, Result};
 use crate::runtime::PrimaryAppState;
 use crate::services::{storage_change_service, workspace_storage_service::WorkspaceStorageScope};
 
-use super::super::get_info_in_scope;
-
 pub(crate) async fn delete_in_scope(
     state: &PrimaryAppState,
     scope: WorkspaceStorageScope,
     id: i64,
 ) -> Result<()> {
     tracing::debug!(scope = ?scope, file_id = id, "soft deleting file");
-    let file = get_info_in_scope(state, scope, id).await?;
+    let file =
+        crate::services::workspace_storage_service::verify_file_access(state, scope, id).await?;
     if file.is_locked {
         return Err(AsterError::resource_locked("file is locked"));
     }

--- a/src/services/file_service/deletion/soft_delete.rs
+++ b/src/services/file_service/deletion/soft_delete.rs
@@ -14,7 +14,7 @@ pub(crate) async fn delete_in_scope(
     if file.is_locked {
         return Err(AsterError::resource_locked("file is locked"));
     }
-    file_repo::soft_delete(&state.db, id).await?;
+    file_repo::soft_delete(state.writer_db(), id).await?;
     storage_change_service::publish(
         state,
         storage_change_service::StorageChangeEvent::new(

--- a/src/services/file_service/deletion/tests.rs
+++ b/src/services/file_service/deletion/tests.rs
@@ -183,7 +183,6 @@ async fn build_deletion_test_state() -> (
             crate::config::operations::share_download_rollback_queue_capacity(&runtime_config),
         );
     let state = PrimaryAppState {
-        db: db.clone(),
         db_handles: crate::db::DbHandles::single(db),
         driver_registry,
         runtime_config: runtime_config.clone(),
@@ -272,7 +271,7 @@ async fn set_user_storage_used(
 #[tokio::test]
 async fn ensure_blob_cleanup_if_unreferenced_deletes_zero_ref_blob() {
     let (state, _user, policy, driver) = build_deletion_test_state().await;
-    let blob = create_blob(&state.db, policy.id, "files/orphan.bin", 7, 0).await;
+    let blob = create_blob(state.writer_db(), policy.id, "files/orphan.bin", 7, 0).await;
     driver.insert_object(&blob.storage_path);
 
     let cleaned = ensure_blob_cleanup_if_unreferenced(&state, blob.id).await;
@@ -285,7 +284,7 @@ async fn ensure_blob_cleanup_if_unreferenced_deletes_zero_ref_blob() {
     );
     assert!(
         file_blob::Entity::find_by_id(blob.id)
-            .one(&state.db)
+            .one(state.writer_db())
             .await
             .expect("blob lookup should succeed")
             .is_none(),
@@ -296,7 +295,7 @@ async fn ensure_blob_cleanup_if_unreferenced_deletes_zero_ref_blob() {
 #[tokio::test]
 async fn ensure_blob_cleanup_if_unreferenced_skips_referenced_blob() {
     let (state, _user, policy, driver) = build_deletion_test_state().await;
-    let blob = create_blob(&state.db, policy.id, "files/in-use.bin", 9, 2).await;
+    let blob = create_blob(state.writer_db(), policy.id, "files/in-use.bin", 9, 2).await;
     driver.insert_object(&blob.storage_path);
 
     let cleaned = ensure_blob_cleanup_if_unreferenced(&state, blob.id).await;
@@ -312,7 +311,7 @@ async fn ensure_blob_cleanup_if_unreferenced_skips_referenced_blob() {
     );
     assert!(
         file_blob::Entity::find_by_id(blob.id)
-            .one(&state.db)
+            .one(state.writer_db())
             .await
             .expect("blob lookup should succeed")
             .is_some(),
@@ -324,7 +323,7 @@ async fn ensure_blob_cleanup_if_unreferenced_skips_referenced_blob() {
 async fn ensure_blob_cleanup_if_unreferenced_skips_cleanup_claimed_blob() {
     let (state, _user, policy, driver) = build_deletion_test_state().await;
     let blob = create_blob(
-        &state.db,
+        state.writer_db(),
         policy.id,
         "files/claimed.bin",
         9,
@@ -345,7 +344,7 @@ async fn ensure_blob_cleanup_if_unreferenced_skips_cleanup_claimed_blob() {
         "cleanup-claimed blob must not be deleted by a competing cleanup path"
     );
     let reloaded_blob = file_blob::Entity::find_by_id(blob.id)
-        .one(&state.db)
+        .one(state.writer_db())
         .await
         .expect("blob lookup should succeed")
         .expect("cleanup-claimed blob row should remain");
@@ -359,7 +358,7 @@ async fn ensure_blob_cleanup_if_unreferenced_skips_cleanup_claimed_blob() {
 async fn cleanup_unreferenced_blob_skips_cleanup_claimed_blob() {
     let (state, _user, policy, driver) = build_deletion_test_state().await;
     let blob = create_blob(
-        &state.db,
+        state.writer_db(),
         policy.id,
         "files/reconcile-claimed.bin",
         9,
@@ -380,7 +379,7 @@ async fn cleanup_unreferenced_blob_skips_cleanup_claimed_blob() {
         "cleanup-claimed blob must not be deleted by a competing cleanup path"
     );
     let reloaded_blob = file_blob::Entity::find_by_id(blob.id)
-        .one(&state.db)
+        .one(state.writer_db())
         .await
         .expect("blob lookup should succeed")
         .expect("cleanup-claimed blob row should remain");
@@ -393,10 +392,10 @@ async fn cleanup_unreferenced_blob_skips_cleanup_claimed_blob() {
 #[tokio::test]
 async fn batch_purge_in_scope_deletes_last_blob_reference() {
     let (state, user, policy, driver) = build_deletion_test_state().await;
-    let blob = create_blob(&state.db, policy.id, "files/last-ref.bin", 11, 1).await;
+    let blob = create_blob(state.writer_db(), policy.id, "files/last-ref.bin", 11, 1).await;
     driver.insert_object(&blob.storage_path);
-    let file = create_file(&state.db, user.id, blob.id, 11, "last-ref.bin").await;
-    set_user_storage_used(&state.db, &user, 11).await;
+    let file = create_file(state.writer_db(), user.id, blob.id, 11, "last-ref.bin").await;
+    set_user_storage_used(state.writer_db(), &user, 11).await;
 
     let purged = batch_purge_in_scope(
         &state,
@@ -414,7 +413,7 @@ async fn batch_purge_in_scope_deletes_last_blob_reference() {
     );
     assert!(
         file::Entity::find_by_id(file.id)
-            .one(&state.db)
+            .one(state.writer_db())
             .await
             .expect("file lookup should succeed")
             .is_none(),
@@ -422,14 +421,14 @@ async fn batch_purge_in_scope_deletes_last_blob_reference() {
     );
     assert!(
         file_blob::Entity::find_by_id(blob.id)
-            .one(&state.db)
+            .one(state.writer_db())
             .await
             .expect("blob lookup should succeed")
             .is_none(),
         "blob row should be deleted when the last reference is purged"
     );
     let reloaded_user = user::Entity::find_by_id(user.id)
-        .one(&state.db)
+        .one(state.writer_db())
         .await
         .expect("user lookup should succeed")
         .expect("user should remain");
@@ -442,11 +441,11 @@ async fn batch_purge_in_scope_deletes_last_blob_reference() {
 #[tokio::test]
 async fn batch_purge_in_scope_keeps_blob_when_other_file_still_references_it() {
     let (state, user, policy, driver) = build_deletion_test_state().await;
-    let blob = create_blob(&state.db, policy.id, "files/shared.bin", 13, 2).await;
+    let blob = create_blob(state.writer_db(), policy.id, "files/shared.bin", 13, 2).await;
     driver.insert_object(&blob.storage_path);
-    let file_a = create_file(&state.db, user.id, blob.id, 13, "shared-a.bin").await;
-    let _file_b = create_file(&state.db, user.id, blob.id, 13, "shared-b.bin").await;
-    set_user_storage_used(&state.db, &user, 26).await;
+    let file_a = create_file(state.writer_db(), user.id, blob.id, 13, "shared-a.bin").await;
+    let _file_b = create_file(state.writer_db(), user.id, blob.id, 13, "shared-b.bin").await;
+    set_user_storage_used(state.writer_db(), &user, 26).await;
 
     let purged = batch_purge_in_scope(
         &state,
@@ -463,7 +462,7 @@ async fn batch_purge_in_scope_keeps_blob_when_other_file_still_references_it() {
         "shared blob must not be deleted while another file still references it"
     );
     let reloaded_blob = file_blob::Entity::find_by_id(blob.id)
-        .one(&state.db)
+        .one(state.writer_db())
         .await
         .expect("blob lookup should succeed")
         .expect("shared blob should remain");
@@ -472,7 +471,7 @@ async fn batch_purge_in_scope_keeps_blob_when_other_file_still_references_it() {
         "shared blob ref_count should decrement to 1"
     );
     let reloaded_user = user::Entity::find_by_id(user.id)
-        .one(&state.db)
+        .one(state.writer_db())
         .await
         .expect("user lookup should succeed")
         .expect("user should remain");

--- a/src/services/file_service/deletion/tests.rs
+++ b/src/services/file_service/deletion/tests.rs
@@ -183,7 +183,8 @@ async fn build_deletion_test_state() -> (
             crate::config::operations::share_download_rollback_queue_capacity(&runtime_config),
         );
     let state = PrimaryAppState {
-        db,
+        db: db.clone(),
+        db_handles: crate::db::DbHandles::single(db),
         driver_registry,
         runtime_config: runtime_config.clone(),
         policy_snapshot,

--- a/src/services/file_service/download/build.rs
+++ b/src/services/file_service/download/build.rs
@@ -39,7 +39,7 @@ pub(crate) async fn download_in_scope_with_range_and_file(
         Some(file) => file,
         None => get_info_in_scope(state, scope, id).await?,
     };
-    let blob = file_repo::find_blob_by_id(&state.db, file.blob_id).await?;
+    let blob = file_repo::find_blob_by_id(state.reader_db(), file.blob_id).await?;
     build_download_outcome(state, &file, &blob, if_none_match, range).await
 }
 
@@ -67,7 +67,7 @@ pub async fn download_raw(
     id: i64,
     if_none_match: Option<&str>,
 ) -> Result<DownloadOutcome> {
-    let db = &state.db;
+    let db = state.reader_db();
     let file = file_repo::find_by_id(db, id).await?;
     ensure_personal_file_scope(&file)?;
     download_raw_unchecked_with_file(state, file, if_none_match).await
@@ -78,7 +78,7 @@ async fn download_raw_unchecked_with_file(
     file: file::Model,
     if_none_match: Option<&str>,
 ) -> Result<DownloadOutcome> {
-    let blob = file_repo::find_blob_by_id(&state.db, file.blob_id).await?;
+    let blob = file_repo::find_blob_by_id(state.reader_db(), file.blob_id).await?;
     build_stream_outcome(state, &file, &blob, if_none_match, None).await
 }
 

--- a/src/services/file_service/download/tests.rs
+++ b/src/services/file_service/download/tests.rs
@@ -243,6 +243,7 @@ async fn build_download_test_state(
 
     let state = PrimaryAppState {
         db: db.clone(),
+        db_handles: crate::db::DbHandles::single(db.clone()),
         driver_registry,
         runtime_config: runtime_config.clone(),
         policy_snapshot,

--- a/src/services/file_service/download/tests.rs
+++ b/src/services/file_service/download/tests.rs
@@ -242,7 +242,6 @@ async fn build_download_test_state(
         );
 
     let state = PrimaryAppState {
-        db: db.clone(),
         db_handles: crate::db::DbHandles::single(db.clone()),
         driver_registry,
         runtime_config: runtime_config.clone(),

--- a/src/services/file_service/lock.rs
+++ b/src/services/file_service/lock.rs
@@ -8,8 +8,6 @@ use crate::services::{
 };
 use crate::types::EntityType;
 
-use super::get_info_in_scope;
-
 pub(crate) async fn set_lock_in_scope(
     state: &PrimaryAppState,
     scope: WorkspaceStorageScope,
@@ -22,7 +20,7 @@ pub(crate) async fn set_lock_in_scope(
         locked,
         "setting file lock state"
     );
-    get_info_in_scope(state, scope, file_id).await?;
+    crate::services::workspace_storage_service::verify_file_access(state, scope, file_id).await?;
 
     if locked {
         lock_service::lock(
@@ -38,7 +36,9 @@ pub(crate) async fn set_lock_in_scope(
         lock_service::unlock(state, EntityType::File, file_id, scope.actor_user_id()).await?;
     }
 
-    let file = get_info_in_scope(state, scope, file_id).await?;
+    let file =
+        crate::services::workspace_storage_service::verify_file_access(state, scope, file_id)
+            .await?;
     tracing::debug!(
         scope = ?scope,
         file_id = file.id,

--- a/src/services/file_service/metadata.rs
+++ b/src/services/file_service/metadata.rs
@@ -19,7 +19,7 @@ pub(crate) async fn get_info_in_scope(
     scope: WorkspaceStorageScope,
     id: i64,
 ) -> Result<file::Model> {
-    workspace_storage_service::verify_file_access(state, scope, id).await
+    workspace_storage_service::verify_file_access_for_read(state, scope, id).await
 }
 
 pub(crate) async fn update_in_scope(
@@ -37,7 +37,7 @@ pub(crate) async fn update_in_scope(
         folder_patch = ?folder_id,
         "updating file metadata"
     );
-    let f = get_info_in_scope(state, scope, id).await?;
+    let f = workspace_storage_service::verify_file_access(state, scope, id).await?;
     if f.is_locked {
         return Err(AsterError::resource_locked("file is locked"));
     }

--- a/src/services/file_service/metadata.rs
+++ b/src/services/file_service/metadata.rs
@@ -29,7 +29,7 @@ pub(crate) async fn update_in_scope(
     name: Option<String>,
     folder_id: NullablePatch<i64>,
 ) -> Result<file::Model> {
-    let db = &state.db;
+    let db = state.writer_db();
     tracing::debug!(
         scope = ?scope,
         file_id = id,

--- a/src/services/file_service/thumbnail.rs
+++ b/src/services/file_service/thumbnail.rs
@@ -30,7 +30,7 @@ pub(crate) async fn get_thumbnail_data_in_scope(
     file_id: i64,
 ) -> Result<Option<ThumbnailResult>> {
     let f = get_info_in_scope(state, scope, file_id).await?;
-    let blob = file_repo::find_blob_by_id(&state.db, f.blob_id).await?;
+    let blob = file_repo::find_blob_by_id(state.reader_db(), f.blob_id).await?;
     let thumbnail =
         media_processing_service::load_thumbnail_if_exists(state, &blob, &f.name, &f.mime_type)
             .await
@@ -65,7 +65,7 @@ pub(crate) async fn image_preview_for_file(
     state: &PrimaryAppState,
     f: &crate::entities::file::Model,
 ) -> Result<ImagePreviewResult> {
-    let blob = file_repo::find_blob_by_id(&state.db, f.blob_id).await?;
+    let blob = file_repo::find_blob_by_id(state.reader_db(), f.blob_id).await?;
     let preview = media_processing_service::generate_and_store_image_preview(
         state,
         &blob,

--- a/src/services/file_service/transfer.rs
+++ b/src/services/file_service/transfer.rs
@@ -39,7 +39,7 @@ pub(crate) async fn copy_file_in_scope(
     src_id: i64,
     dest_folder_id: Option<i64>,
 ) -> Result<file::Model> {
-    let db = &state.db;
+    let db = state.writer_db();
     tracing::debug!(
         scope = ?scope,
         src_file_id = src_id,
@@ -156,7 +156,7 @@ async fn batch_duplicate_file_records_with_specs_in_scope(
     })?;
     let now = chrono::Utc::now();
 
-    let txn = crate::db::transaction::begin(&state.db).await?;
+    let txn = crate::db::transaction::begin(state.writer_db()).await?;
     let created_by_username = load_scope_actor_username(&txn, scope).await?;
 
     // 原子性地增加配额（CAS 语义：如果 quota > 0 且 used + total_size > quota，则失败）
@@ -227,11 +227,11 @@ pub(crate) async fn duplicate_file_record_in_scope(
     dest_folder_id: Option<i64>,
     dest_name: &str,
 ) -> Result<file::Model> {
-    let blob = file_repo::find_blob_by_id(&state.db, src.blob_id).await?;
+    let blob = file_repo::find_blob_by_id(state.writer_db(), src.blob_id).await?;
     let now = Utc::now();
     let blob_size = blob.size;
 
-    let txn = crate::db::transaction::begin(&state.db).await?;
+    let txn = crate::db::transaction::begin(state.writer_db()).await?;
     let created_by_username = load_scope_actor_username(&txn, scope).await?;
     workspace_storage_service::check_quota(&txn, scope, blob_size).await?;
 
@@ -349,9 +349,9 @@ pub(crate) async fn batch_duplicate_file_records_to_mixed_folders_in_scope(
     })?;
     let now = chrono::Utc::now();
 
-    workspace_storage_service::check_quota(&state.db, scope, total_size).await?;
+    workspace_storage_service::check_quota(state.writer_db(), scope, total_size).await?;
 
-    let txn = crate::db::transaction::begin(&state.db).await?;
+    let txn = crate::db::transaction::begin(state.writer_db()).await?;
     let created_by_username = load_scope_actor_username(&txn, scope).await?;
     workspace_storage_service::check_quota(&txn, scope, total_size).await?;
 

--- a/src/services/file_service/transfer.rs
+++ b/src/services/file_service/transfer.rs
@@ -15,8 +15,6 @@ use crate::services::{
     workspace_storage_service::{self, WorkspaceStorageScope, load_scope_actor_username},
 };
 
-use super::get_info_in_scope;
-
 const MAX_COPY_NAME_RETRIES: usize = 32;
 
 fn collect_blob_ref_count_increments(
@@ -48,7 +46,7 @@ pub(crate) async fn copy_file_in_scope(
         dest_folder_id,
         "copying file"
     );
-    let src = get_info_in_scope(state, scope, src_id).await?;
+    let src = workspace_storage_service::verify_file_access(state, scope, src_id).await?;
 
     if let Some(folder_id) = dest_folder_id {
         workspace_storage_service::verify_folder_access(state, scope, folder_id).await?;

--- a/src/services/folder_service/access.rs
+++ b/src/services/folder_service/access.rs
@@ -54,7 +54,7 @@ pub async fn verify_folder_access(
     user_id: i64,
     folder_id: i64,
 ) -> Result<()> {
-    let folder = folder_repo::find_by_id(&state.db, folder_id).await?;
+    let folder = folder_repo::find_by_id(state.writer_db(), folder_id).await?;
     ensure_personal_folder_scope(&folder)?;
     crate::utils::verify_optional_owner(folder.owner_user_id, user_id, "folder")?;
     if folder.deleted_at.is_some() {

--- a/src/services/folder_service/copy.rs
+++ b/src/services/folder_service/copy.rs
@@ -41,7 +41,7 @@ async fn copy_frontier_files_in_scope(
         return Ok(0);
     }
 
-    let db = &state.db;
+    let db = state.writer_db();
     let src_folder_ids: Vec<i64> = frontier.iter().map(|item| item.src_folder_id).collect();
     let dest_by_src: HashMap<i64, i64> = frontier
         .iter()
@@ -98,7 +98,7 @@ async fn load_frontier_child_plans_in_scope(
         return Ok(vec![]);
     }
 
-    let db = &state.db;
+    let db = state.writer_db();
     let src_folder_ids: Vec<i64> = frontier.iter().map(|item| item.src_folder_id).collect();
     let dest_by_src: HashMap<i64, i64> = frontier
         .iter()
@@ -150,7 +150,7 @@ async fn create_frontier_children_from_plans_in_scope(
         return Ok(vec![]);
     }
 
-    let db = &state.db;
+    let db = state.writer_db();
     let mut dest_parent_ids: Vec<i64> =
         child_plans.iter().map(|plan| plan.dest_parent_id).collect();
     dest_parent_ids.sort_unstable();
@@ -221,7 +221,7 @@ pub(crate) async fn copy_folder_tree_in_scope(
     dest_parent_id: Option<i64>,
     dest_name: &str,
 ) -> Result<(folder::Model, i64)> {
-    let db = &state.db;
+    let db = state.writer_db();
     let now = Utc::now();
     let src_folder = folder_repo::find_by_id(db, src_folder_id).await?;
     ensure_folder_model_in_scope(&src_folder, scope)?;
@@ -271,7 +271,7 @@ pub(crate) async fn copy_folder_in_scope(
     src_id: i64,
     dest_parent_id: Option<i64>,
 ) -> Result<folder::Model> {
-    let db = &state.db;
+    let db = state.writer_db();
     tracing::debug!(
         scope = ?scope,
         src_folder_id = src_id,

--- a/src/services/folder_service/hierarchy.rs
+++ b/src/services/folder_service/hierarchy.rs
@@ -159,7 +159,7 @@ pub async fn build_folder_paths_cached(
             .collect();
         chain_ids.sort_unstable();
         chain_ids.dedup();
-        let chain_map = folder_repo::find_by_ids(&state.db, &chain_ids)
+        let chain_map = folder_repo::find_by_ids(state.reader_db(), &chain_ids)
             .await?
             .into_iter()
             .map(|folder| (folder.id, folder))
@@ -202,7 +202,7 @@ pub async fn build_folder_paths_cached(
 
     misses.sort_unstable();
     misses.dedup();
-    let loaded = build_folder_path_entries(&state.db, &misses).await?;
+    let loaded = build_folder_path_entries(state.reader_db(), &misses).await?;
     for (&id, entry) in &loaded {
         state
             .cache
@@ -228,15 +228,16 @@ pub(crate) async fn get_ancestors_in_scope(
     scope: WorkspaceStorageScope,
     folder_id: i64,
 ) -> Result<Vec<FolderAncestorItem>> {
-    let folder = workspace_storage_service::verify_folder_access(state, scope, folder_id).await?;
+    let folder =
+        workspace_storage_service::verify_folder_access_for_read(state, scope, folder_id).await?;
     ensure_folder_model_in_scope(&folder, scope)?;
 
     let ancestors = match scope {
         WorkspaceStorageScope::Personal { user_id } => {
-            folder_repo::find_ancestor_models(&state.db, user_id, folder_id).await?
+            folder_repo::find_ancestor_models(state.reader_db(), user_id, folder_id).await?
         }
         WorkspaceStorageScope::Team { team_id, .. } => {
-            folder_repo::find_team_ancestor_models(&state.db, team_id, folder_id).await?
+            folder_repo::find_team_ancestor_models(state.reader_db(), team_id, folder_id).await?
         }
     };
 

--- a/src/services/folder_service/listing.rs
+++ b/src/services/folder_service/listing.rs
@@ -114,7 +114,7 @@ pub(crate) async fn list_in_scope(
     }
 
     if let Some(parent_id) = parent_id {
-        workspace_storage_service::verify_folder_access(state, scope, parent_id).await?;
+        workspace_storage_service::verify_folder_access_for_read(state, scope, parent_id).await?;
     }
 
     // 目录和文件分开查询，是因为它们的分页策略不同：
@@ -126,7 +126,7 @@ pub(crate) async fn list_in_scope(
                     Ok((
                         vec![],
                         folder_repo::find_children_paginated(
-                            &state.db,
+                            state.reader_db(),
                             user_id,
                             parent_id,
                             0,
@@ -139,7 +139,7 @@ pub(crate) async fn list_in_scope(
                     ))
                 } else {
                     folder_repo::find_children_paginated(
-                        &state.db,
+                        state.reader_db(),
                         user_id,
                         parent_id,
                         params.folder_limit,
@@ -155,7 +155,7 @@ pub(crate) async fn list_in_scope(
                     Ok((
                         vec![],
                         file_repo::find_by_folder_cursor(
-                            &state.db,
+                            state.reader_db(),
                             user_id,
                             parent_id,
                             0,
@@ -168,7 +168,7 @@ pub(crate) async fn list_in_scope(
                     ))
                 } else {
                     file_repo::find_by_folder_cursor(
-                        &state.db,
+                        state.reader_db(),
                         user_id,
                         parent_id,
                         params.file_limit,
@@ -190,7 +190,7 @@ pub(crate) async fn list_in_scope(
                     Ok((
                         vec![],
                         folder_repo::find_team_children_paginated(
-                            &state.db,
+                            state.reader_db(),
                             team_id,
                             parent_id,
                             0,
@@ -203,7 +203,7 @@ pub(crate) async fn list_in_scope(
                     ))
                 } else {
                     folder_repo::find_team_children_paginated(
-                        &state.db,
+                        state.reader_db(),
                         team_id,
                         parent_id,
                         params.folder_limit,
@@ -219,7 +219,7 @@ pub(crate) async fn list_in_scope(
                     Ok((
                         vec![],
                         file_repo::find_by_team_folder_cursor(
-                            &state.db,
+                            state.reader_db(),
                             team_id,
                             parent_id,
                             0,
@@ -232,7 +232,7 @@ pub(crate) async fn list_in_scope(
                     ))
                 } else {
                     file_repo::find_by_team_folder_cursor(
-                        &state.db,
+                        state.reader_db(),
                         team_id,
                         parent_id,
                         params.file_limit,
@@ -306,11 +306,11 @@ pub async fn list_shared(
         sort_order = ?params.sort_order,
         "listing shared folder contents"
     );
-    let folder = folder_repo::find_by_id(&state.db, folder_id).await?;
+    let folder = folder_repo::find_by_id(state.reader_db(), folder_id).await?;
     let contents = if let Some(team_id) = folder.team_id {
         // 公开分享页不再校验“当前用户是不是团队成员”，但数据边界仍然是团队空间。
         let (folders, folders_total) = folder_repo::find_team_children_paginated(
-            &state.db,
+            state.reader_db(),
             team_id,
             Some(folder_id),
             params.folder_limit,
@@ -320,7 +320,7 @@ pub async fn list_shared(
         )
         .await?;
         let (files, files_total) = file_repo::find_by_team_folder_cursor(
-            &state.db,
+            state.reader_db(),
             team_id,
             Some(folder_id),
             params.file_limit,
@@ -348,7 +348,7 @@ pub async fn list_shared(
             crate::errors::AsterError::auth_forbidden("folder has no personal owner")
         })?;
         let (folders, folders_total) = folder_repo::find_children_paginated(
-            &state.db,
+            state.reader_db(),
             owner_user_id,
             Some(folder_id),
             params.folder_limit,
@@ -358,7 +358,7 @@ pub async fn list_shared(
         )
         .await?;
         let (files, files_total) = file_repo::find_by_folder_cursor(
-            &state.db,
+            state.reader_db(),
             owner_user_id,
             Some(folder_id),
             params.file_limit,

--- a/src/services/folder_service/mutation.rs
+++ b/src/services/folder_service/mutation.rs
@@ -37,7 +37,7 @@ pub(crate) async fn create_in_scope(
     {
         workspace_storage_service::require_team_access_with_db(
             state,
-            &state.db,
+            state.writer_db(),
             team_id,
             actor_user_id,
         )
@@ -45,10 +45,10 @@ pub(crate) async fn create_in_scope(
     }
 
     let name = crate::utils::normalize_validate_name(name)?;
-    let created_by_username = load_scope_actor_username(&state.db, scope).await?;
+    let created_by_username = load_scope_actor_username(state.writer_db(), scope).await?;
 
     let now = Utc::now();
-    let created = crate::db::transaction::with_transaction(&state.db, async |txn| {
+    let created = crate::db::transaction::with_transaction(state.writer_db(), async |txn| {
         if let Some(pid) = parent_id {
             let parent = folder_repo::lock_by_id(txn, pid).await?;
             ensure_folder_model_in_scope(&parent, scope)?;
@@ -125,7 +125,7 @@ pub(crate) async fn delete_in_scope(
     let now = Utc::now();
 
     let (folder, file_count, folder_count) =
-        crate::db::transaction::with_transaction(&state.db, async |txn| {
+        crate::db::transaction::with_transaction(state.writer_db(), async |txn| {
             let folder = folder_repo::lock_by_id(txn, folder_id).await?;
             ensure_folder_model_in_scope(&folder, scope)?;
             if folder.is_locked {
@@ -185,7 +185,7 @@ pub(crate) async fn update_in_scope(
     parent_id: NullablePatch<i64>,
     policy_id: NullablePatch<i64>,
 ) -> Result<folder::Model> {
-    let db = &state.db;
+    let db = state.writer_db();
     tracing::debug!(
         scope = ?scope,
         folder_id = id,

--- a/src/services/folder_service/mutation.rs
+++ b/src/services/folder_service/mutation.rs
@@ -168,7 +168,7 @@ pub(crate) async fn get_info_in_scope(
     scope: WorkspaceStorageScope,
     folder_id: i64,
 ) -> Result<folder::Model> {
-    workspace_storage_service::verify_folder_access(state, scope, folder_id).await
+    workspace_storage_service::verify_folder_access_for_read(state, scope, folder_id).await
 }
 
 pub(crate) async fn update_in_scope(

--- a/src/services/folder_service/mutation.rs
+++ b/src/services/folder_service/mutation.rs
@@ -35,7 +35,13 @@ pub(crate) async fn create_in_scope(
         actor_user_id,
     } = scope
     {
-        workspace_storage_service::require_team_access(state, team_id, actor_user_id).await?;
+        workspace_storage_service::require_team_access_with_db(
+            state,
+            &state.db,
+            team_id,
+            actor_user_id,
+        )
+        .await?;
     }
 
     let name = crate::utils::normalize_validate_name(name)?;

--- a/src/services/health_service.rs
+++ b/src/services/health_service.rs
@@ -229,7 +229,7 @@ pub async fn run_primary_system_health_checks<S: PrimaryRuntimeState>(
     state: &S,
 ) -> SystemHealthReport {
     let mut components = Vec::with_capacity(3);
-    components.push(check_database_component(state.db()).await);
+    components.push(check_database_component(state.writer_db()).await);
     components.push(check_cache_component(state).await);
     components.push(check_remote_nodes_component(state).await);
     SystemHealthReport { components }

--- a/src/services/lock_service/cleanup.rs
+++ b/src/services/lock_service/cleanup.rs
@@ -11,7 +11,7 @@ use crate::utils::numbers::usize_to_u64;
 
 /// 清理过期锁（后台任务用）
 pub async fn cleanup_expired(state: &PrimaryAppState) -> Result<u64> {
-    let db = &state.db;
+    let db = state.writer_db();
 
     // 先查出过期锁的 entity 信息（需要重置 is_locked）
     let now = Utc::now();

--- a/src/services/lock_service/lifecycle.rs
+++ b/src/services/lock_service/lifecycle.rs
@@ -28,7 +28,7 @@ pub async fn lock(
     let token = format!("urn:uuid:{}", uuid::Uuid::new_v4());
     let timeout_at = timeout.map(|d| now + d);
     let serialized_owner_info = serialize_resource_lock_owner_info(owner_info.as_ref())?;
-    let txn = crate::db::transaction::begin(&state.db).await?;
+    let txn = crate::db::transaction::begin(state.writer_db()).await?;
 
     let result = async {
         if let Some(existing) = lock_repo::find_by_entity(&txn, entity_type, entity_id).await? {
@@ -105,7 +105,7 @@ pub async fn unlock(
     entity_id: i64,
     user_id: i64,
 ) -> Result<()> {
-    let db = &state.db;
+    let db = state.writer_db();
 
     // 校验归属：只有锁持有者或文件所有者可以解锁
     if let Some(existing) = lock_repo::find_by_entity(db, entity_type, entity_id).await? {
@@ -131,7 +131,7 @@ pub async fn unlock(
 
 /// 按 token 解锁（WebDAV UNLOCK 用）
 pub async fn unlock_by_token(state: &PrimaryAppState, token: &str) -> Result<()> {
-    let db = &state.db;
+    let db = state.writer_db();
     let lock = lock_repo::find_by_token(db, token)
         .await?
         .ok_or_else(|| AsterError::record_not_found("lock not found"))?;
@@ -149,7 +149,7 @@ pub async fn unlock_by_token(state: &PrimaryAppState, token: &str) -> Result<()>
 
 /// 强制解锁（admin 用）
 pub async fn force_unlock(state: &PrimaryAppState, lock_id: i64) -> Result<()> {
-    let db = &state.db;
+    let db = state.writer_db();
     let lock = lock_repo::find_by_id(db, lock_id)
         .await?
         .ok_or_else(|| AsterError::record_not_found("lock not found"))?;
@@ -170,7 +170,7 @@ pub async fn force_unlock_with_audit(
     lock_id: i64,
     audit_ctx: &AuditContext,
 ) -> Result<()> {
-    let lock = lock_repo::find_by_id(&state.db, lock_id)
+    let lock = lock_repo::find_by_id(state.writer_db(), lock_id)
         .await?
         .ok_or_else(|| AsterError::record_not_found("lock not found"))?;
     force_unlock(state, lock_id).await?;
@@ -195,7 +195,7 @@ async fn do_unlock_by_entity(
     entity_type: EntityType,
     entity_id: i64,
 ) -> Result<()> {
-    lock_repo::delete_by_entity(&state.db, entity_type, entity_id).await?;
-    clear_entity_locked_if_unlocked(&state.db, entity_type, entity_id).await?;
+    lock_repo::delete_by_entity(state.writer_db(), entity_type, entity_id).await?;
+    clear_entity_locked_if_unlocked(state.writer_db(), entity_type, entity_id).await?;
     Ok(())
 }

--- a/src/services/lock_service/listing.rs
+++ b/src/services/lock_service/listing.rs
@@ -17,7 +17,8 @@ pub async fn list_paginated(
 ) -> Result<OffsetPage<ResourceLock>> {
     load_offset_page(limit, offset, 100, |limit, offset| async move {
         let (items, total) =
-            lock_repo::find_paginated(&state.db, limit, offset, sort_by, sort_order).await?;
+            lock_repo::find_paginated(state.writer_db(), limit, offset, sort_by, sort_order)
+                .await?;
         let items = build_resource_locks(state, items).await?;
         Ok((items, total))
     })

--- a/src/services/lock_service/tests.rs
+++ b/src/services/lock_service/tests.rs
@@ -150,7 +150,6 @@ async fn build_lock_test_state() -> (PrimaryAppState, user::Model, file::Model) 
         );
 
     let state = PrimaryAppState {
-        db: db.clone(),
         db_handles: crate::db::DbHandles::single(db),
         driver_registry: Arc::new(DriverRegistry::new()),
         runtime_config: runtime_config.clone(),
@@ -258,7 +257,7 @@ async fn lock_replaces_expired_lock_and_keeps_single_row() {
     let (state, user, file) = build_lock_test_state().await;
     let now = Utc::now();
     lock_repo::create(
-        &state.db,
+        state.writer_db(),
         resource_lock::ActiveModel {
             token: Set("expired-lock".to_string()),
             entity_type: Set(EntityType::File),
@@ -287,14 +286,14 @@ async fn lock_replaces_expired_lock_and_keeps_single_row() {
     .await
     .expect("expired lock should be replaced");
 
-    let locks = lock_repo::find_all(&state.db)
+    let locks = lock_repo::find_all(state.writer_db())
         .await
         .expect("locks should load");
     assert_eq!(locks.len(), 1, "only the replacement lock should remain");
     assert_eq!(locks[0].id, replacement.id);
     assert_ne!(locks[0].token, "expired-lock");
 
-    let reloaded_file = file_repo::find_by_id(&state.db, file.id)
+    let reloaded_file = file_repo::find_by_id(state.writer_db(), file.id)
         .await
         .expect("file should reload");
     assert!(
@@ -306,13 +305,13 @@ async fn lock_replaces_expired_lock_and_keeps_single_row() {
 #[tokio::test]
 async fn clear_entity_locked_if_unlocked_keeps_flag_when_replacement_lock_exists() {
     let (state, user, file) = build_lock_test_state().await;
-    set_entity_locked(&state.db, EntityType::File, file.id, true)
+    set_entity_locked(state.writer_db(), EntityType::File, file.id, true)
         .await
         .expect("file should be marked locked");
 
     let now = Utc::now();
     lock_repo::create(
-        &state.db,
+        state.writer_db(),
         resource_lock::ActiveModel {
             token: Set("active-lock".to_string()),
             entity_type: Set(EntityType::File),
@@ -330,11 +329,11 @@ async fn clear_entity_locked_if_unlocked_keeps_flag_when_replacement_lock_exists
     .await
     .expect("active lock should insert");
 
-    clear_entity_locked_if_unlocked(&state.db, EntityType::File, file.id)
+    clear_entity_locked_if_unlocked(state.writer_db(), EntityType::File, file.id)
         .await
         .expect("helper should succeed");
 
-    let reloaded_file = file_repo::find_by_id(&state.db, file.id)
+    let reloaded_file = file_repo::find_by_id(state.writer_db(), file.id)
         .await
         .expect("file should reload");
     assert!(
@@ -346,15 +345,15 @@ async fn clear_entity_locked_if_unlocked_keeps_flag_when_replacement_lock_exists
 #[tokio::test]
 async fn clear_entity_locked_if_unlocked_clears_flag_when_no_lock_remains() {
     let (state, _, file) = build_lock_test_state().await;
-    set_entity_locked(&state.db, EntityType::File, file.id, true)
+    set_entity_locked(state.writer_db(), EntityType::File, file.id, true)
         .await
         .expect("file should be marked locked");
 
-    clear_entity_locked_if_unlocked(&state.db, EntityType::File, file.id)
+    clear_entity_locked_if_unlocked(state.writer_db(), EntityType::File, file.id)
         .await
         .expect("helper should succeed");
 
-    let reloaded_file = file_repo::find_by_id(&state.db, file.id)
+    let reloaded_file = file_repo::find_by_id(state.writer_db(), file.id)
         .await
         .expect("file should reload");
     assert!(

--- a/src/services/lock_service/tests.rs
+++ b/src/services/lock_service/tests.rs
@@ -150,7 +150,8 @@ async fn build_lock_test_state() -> (PrimaryAppState, user::Model, file::Model) 
         );
 
     let state = PrimaryAppState {
-        db,
+        db: db.clone(),
+        db_handles: crate::db::DbHandles::single(db),
         driver_registry: Arc::new(DriverRegistry::new()),
         runtime_config: runtime_config.clone(),
         policy_snapshot: Arc::new(PolicySnapshot::new()),

--- a/src/services/mail_outbox_service.rs
+++ b/src/services/mail_outbox_service.rs
@@ -74,7 +74,7 @@ pub(crate) async fn enqueue<C: ConnectionTrait>(
 }
 
 pub async fn dispatch_due(state: &PrimaryAppState) -> Result<DispatchStats> {
-    dispatch_due_with(&state.db, &state.runtime_config, &state.mail_sender).await
+    dispatch_due_with(state.writer_db(), &state.runtime_config, &state.mail_sender).await
 }
 
 pub async fn dispatch_due_with(
@@ -185,7 +185,7 @@ pub async fn dispatch_due_with(
 }
 
 pub async fn drain(state: &PrimaryAppState) -> Result<DispatchStats> {
-    drain_with(&state.db, &state.runtime_config, &state.mail_sender).await
+    drain_with(state.writer_db(), &state.runtime_config, &state.mail_sender).await
 }
 
 pub async fn drain_with(

--- a/src/services/maintenance_service.rs
+++ b/src/services/maintenance_service.rs
@@ -36,7 +36,7 @@ pub async fn cleanup_expired_completed_upload_sessions(
 
     loop {
         let sessions = upload_session_repo::find_expired_completed_paginated(
-            &state.db,
+            state.writer_db(),
             now,
             last_id.as_deref(),
             COMPLETED_SESSION_BATCH_SIZE,
@@ -55,9 +55,11 @@ pub async fn cleanup_expired_completed_upload_sessions(
             .collect::<HashSet<_>>()
             .into_iter()
             .collect();
-        let tracked_blob_paths =
-            file_repo::find_blob_storage_paths_by_storage_paths(&state.db, &broken_temp_keys)
-                .await?;
+        let tracked_blob_paths = file_repo::find_blob_storage_paths_by_storage_paths(
+            state.writer_db(),
+            &broken_temp_keys,
+        )
+        .await?;
 
         for session in sessions {
             let broken_completed = session.file_id.is_none();
@@ -72,7 +74,7 @@ pub async fn cleanup_expired_completed_upload_sessions(
             );
             crate::utils::cleanup_temp_dir(&temp_dir).await;
 
-            match upload_session_repo::delete(&state.db, &session.id).await {
+            match upload_session_repo::delete(state.writer_db(), &session.id).await {
                 Ok(()) => {
                     stats.completed_sessions_deleted += 1;
                     if broken_completed {
@@ -98,9 +100,12 @@ pub async fn reconcile_blob_state(state: &PrimaryAppState) -> Result<BlobMainten
     let mut stats = BlobMaintenanceStats::default();
 
     loop {
-        let blobs =
-            file_repo::find_blobs_paginated(&state.db, last_blob_id, BLOB_RECONCILE_BATCH_SIZE)
-                .await?;
+        let blobs = file_repo::find_blobs_paginated(
+            state.writer_db(),
+            last_blob_id,
+            BLOB_RECONCILE_BATCH_SIZE,
+        )
+        .await?;
 
         if blobs.is_empty() {
             break;
@@ -150,7 +155,7 @@ async fn reconcile_single_blob_ref_count(
     state: &PrimaryAppState,
     blob_id: i64,
 ) -> Result<Option<ReconciledBlob>> {
-    let txn = crate::db::transaction::begin(&state.db).await?;
+    let txn = crate::db::transaction::begin(state.writer_db()).await?;
     let result = async {
         let mut blob = match file_repo::lock_blob_by_id(&txn, blob_id).await {
             Ok(blob) => blob,
@@ -213,9 +218,9 @@ async fn current_blob_ref_count<C: sea_orm::ConnectionTrait>(db: &C, blob_id: i6
 async fn load_actual_blob_ref_counts(
     state: &PrimaryAppState,
 ) -> Result<std::collections::HashMap<i64, i64>> {
-    let mut actual = file_repo::count_blob_refs_from_files(&state.db).await?;
+    let mut actual = file_repo::count_blob_refs_from_files(state.writer_db()).await?;
 
-    let version_refs = version_repo::count_blob_refs_from_versions(&state.db).await?;
+    let version_refs = version_repo::count_blob_refs_from_versions(state.writer_db()).await?;
     for (blob_id, ref_count) in version_refs {
         *actual.entry(blob_id).or_insert(0) += ref_count;
     }

--- a/src/services/managed_follower_enrollment_service.rs
+++ b/src/services/managed_follower_enrollment_service.rs
@@ -48,9 +48,9 @@ pub async fn create_enrollment_command<S: PrimaryRuntimeState>(
     state: &S,
     remote_node_id: i64,
 ) -> Result<RemoteEnrollmentCommandInfo> {
-    let remote_node = managed_follower_repo::find_by_id(state.db(), remote_node_id).await?;
+    let remote_node = managed_follower_repo::find_by_id(state.writer_db(), remote_node_id).await?;
     if follower_enrollment_session_repo::has_completed_for_managed_follower(
-        state.db(),
+        state.writer_db(),
         remote_node_id,
     )
     .await?
@@ -72,7 +72,7 @@ pub async fn create_enrollment_command<S: PrimaryRuntimeState>(
     let expires_at = Utc::now() + Duration::minutes(DEFAULT_ENROLLMENT_TTL_MINUTES);
     let created_at = Utc::now();
 
-    crate::db::transaction::with_transaction(state.db(), async |txn| {
+    crate::db::transaction::with_transaction(state.writer_db(), async |txn| {
         follower_enrollment_session_repo::invalidate_pending_for_managed_follower(
             txn,
             remote_node_id,
@@ -117,7 +117,7 @@ pub async fn redeem_enrollment_token<S: PrimaryRuntimeState>(
     }
 
     let token_hash = crate::utils::hash::sha256_hex(trimmed.as_bytes());
-    crate::db::transaction::with_transaction(state.db(), async |txn| {
+    crate::db::transaction::with_transaction(state.writer_db(), async |txn| {
         let enrollment = follower_enrollment_session_repo::find_by_token_hash(txn, &token_hash)
             .await?
             .ok_or_else(|| AsterError::validation_error("invalid enrollment token"))?;
@@ -169,7 +169,7 @@ pub async fn ack_enrollment_token<S: PrimaryRuntimeState>(
     }
 
     let ack_token_hash = normalize_ack_token_hash(trimmed);
-    crate::db::transaction::with_transaction(state.db(), async |txn| {
+    crate::db::transaction::with_transaction(state.writer_db(), async |txn| {
         let enrollment =
             follower_enrollment_session_repo::find_by_ack_token_hash(txn, &ack_token_hash)
                 .await?

--- a/src/services/managed_follower_service.rs
+++ b/src/services/managed_follower_service.rs
@@ -125,9 +125,14 @@ pub async fn list_paginated<S: PrimaryRuntimeState>(
     sort_order: SortOrder,
 ) -> Result<OffsetPage<RemoteNodeInfo>> {
     let page = load_offset_page(limit, offset, 100, |limit, offset| async move {
-        let (items, total) =
-            managed_follower_repo::find_paginated(state.db(), limit, offset, sort_by, sort_order)
-                .await?;
+        let (items, total) = managed_follower_repo::find_paginated(
+            state.writer_db(),
+            limit,
+            offset,
+            sort_by,
+            sort_order,
+        )
+        .await?;
         Ok((items, total))
     })
     .await?;
@@ -148,7 +153,7 @@ pub async fn list_paginated<S: PrimaryRuntimeState>(
 }
 
 pub async fn get<S: PrimaryRuntimeState>(state: &S, id: i64) -> Result<RemoteNodeInfo> {
-    let model = managed_follower_repo::find_by_id(state.db(), id).await?;
+    let model = managed_follower_repo::find_by_id(state.writer_db(), id).await?;
     remote_node_info(state, model).await
 }
 
@@ -172,7 +177,7 @@ pub async fn create<S: PrimaryRuntimeState>(
         updated_at: Set(now),
         ..Default::default()
     }
-    .insert(state.db())
+    .insert(state.writer_db())
     .await
     .map_err(map_remote_node_db_err)?;
 
@@ -185,7 +190,7 @@ pub async fn update<S: PrimaryRuntimeState>(
     id: i64,
     input: UpdateRemoteNodeInput,
 ) -> Result<RemoteNodeInfo> {
-    let existing = managed_follower_repo::find_by_id(state.db(), id).await?;
+    let existing = managed_follower_repo::find_by_id(state.writer_db(), id).await?;
     let normalized = normalize_update_input(input)?;
 
     let mut active: managed_follower::ActiveModel = existing.into();
@@ -201,7 +206,7 @@ pub async fn update<S: PrimaryRuntimeState>(
     active.updated_at = Set(Utc::now());
 
     let updated = active
-        .update(state.db())
+        .update(state.writer_db())
         .await
         .map_err(map_remote_node_db_err)?;
     refresh_registry(state).await?;
@@ -219,13 +224,13 @@ pub async fn update<S: PrimaryRuntimeState>(
 
 pub async fn delete<S: PrimaryRuntimeState>(state: &S, id: i64) -> Result<()> {
     tracing::debug!(remote_node_id = id, "deleting remote node");
-    let policy_refs = policy_repo::count_by_remote_node_id(state.db(), id).await?;
+    let policy_refs = policy_repo::count_by_remote_node_id(state.writer_db(), id).await?;
     if policy_refs > 0 {
         return Err(AsterError::validation_error(format!(
             "cannot delete remote node: {policy_refs} storage policy(s) still reference it"
         )));
     }
-    managed_follower_repo::delete(state.db(), id).await?;
+    managed_follower_repo::delete(state.writer_db(), id).await?;
     refresh_registry(state).await?;
     tracing::info!(remote_node_id = id, "deleted remote node");
     Ok(())
@@ -244,7 +249,7 @@ pub async fn require_completed_enrollment<S: PrimaryRuntimeState>(
     state: &S,
     remote_node_id: i64,
 ) -> Result<managed_follower::Model> {
-    let node = managed_follower_repo::find_by_id(state.db(), remote_node_id).await?;
+    let node = managed_follower_repo::find_by_id(state.writer_db(), remote_node_id).await?;
     if enrollment_status_for_node(state, node.id).await? != RemoteNodeEnrollmentStatus::Completed {
         return Err(precondition_failed_with_subcode(
             ApiSubcode::RemoteNodeEnrollmentRequired,
@@ -277,7 +282,7 @@ async fn enrollment_statuses_for_nodes<S: PrimaryRuntimeState>(
     }
 
     let sessions =
-        follower_enrollment_session_repo::find_by_managed_follower_ids(state.db(), node_ids)
+        follower_enrollment_session_repo::find_by_managed_follower_ids(state.writer_db(), node_ids)
             .await?;
     let mut completed_node_ids = HashSet::new();
     let mut latest_by_node = HashMap::new();
@@ -309,15 +314,20 @@ async fn enrollment_status_for_node<S: PrimaryRuntimeState>(
     state: &S,
     node_id: i64,
 ) -> Result<RemoteNodeEnrollmentStatus> {
-    if follower_enrollment_session_repo::has_completed_for_managed_follower(state.db(), node_id)
-        .await?
+    if follower_enrollment_session_repo::has_completed_for_managed_follower(
+        state.writer_db(),
+        node_id,
+    )
+    .await?
     {
         return Ok(RemoteNodeEnrollmentStatus::Completed);
     }
 
-    let latest =
-        follower_enrollment_session_repo::find_latest_for_managed_follower(state.db(), node_id)
-            .await?;
+    let latest = follower_enrollment_session_repo::find_latest_for_managed_follower(
+        state.writer_db(),
+        node_id,
+    )
+    .await?;
     Ok(enrollment_status_from_latest(latest.as_ref(), Utc::now()))
 }
 
@@ -351,7 +361,7 @@ fn enrollment_status_from_latest(
 pub async fn run_health_tests<S: PrimaryRuntimeState>(
     state: &S,
 ) -> Result<RemoteNodeHealthTestStats> {
-    let nodes = managed_follower_repo::find_all(state.db()).await?;
+    let nodes = managed_follower_repo::find_all(state.writer_db()).await?;
     let node_ids = nodes.iter().map(|node| node.id).collect::<Vec<_>>();
     let enrollment_statuses = enrollment_statuses_for_nodes(state, &node_ids).await?;
     let outcomes = stream::iter(nodes.into_iter().map(|node| {
@@ -400,7 +410,7 @@ async fn policy_requirements_for_node<S: PrimaryRuntimeState>(
     state: &S,
     remote_node_id: i64,
 ) -> Result<Vec<(i64, crate::types::StoragePolicyOptions)>> {
-    let policies = policy_repo::find_by_remote_node_id(state.db(), remote_node_id).await?;
+    let policies = policy_repo::find_by_remote_node_id(state.writer_db(), remote_node_id).await?;
     Ok(policies
         .into_iter()
         .map(|policy| {
@@ -459,7 +469,7 @@ async fn probe_and_persist_node<S: PrimaryRuntimeState>(
         ),
     };
     let model = managed_follower_repo::touch_probe_result(
-        state.db(),
+        state.writer_db(),
         node.id,
         last_capabilities,
         last_error,
@@ -468,7 +478,7 @@ async fn probe_and_persist_node<S: PrimaryRuntimeState>(
     .await?;
     state
         .driver_registry()
-        .reload_managed_followers(state.db())
+        .reload_managed_followers(state.writer_db())
         .await?;
     state.driver_registry().invalidate_all();
 
@@ -555,10 +565,10 @@ fn normalize_non_blank(field: &str, value: &str) -> Result<String> {
 }
 
 async fn refresh_registry<S: PrimaryRuntimeState>(state: &S) -> Result<()> {
-    state.policy_snapshot().reload(state.db()).await?;
+    state.policy_snapshot().reload(state.writer_db()).await?;
     state
         .driver_registry()
-        .reload_managed_followers(state.db())
+        .reload_managed_followers(state.writer_db())
         .await?;
     state.driver_registry().invalidate_all();
     Ok(())

--- a/src/services/managed_ingress_profile_service/local_profiles.rs
+++ b/src/services/managed_ingress_profile_service/local_profiles.rs
@@ -19,7 +19,7 @@ pub async fn list<S: FollowerRuntimeState>(
     binding: &master_binding::Model,
 ) -> Result<Vec<RemoteIngressProfileInfo>> {
     Ok(
-        managed_ingress_profile_repo::find_all_by_binding(state.db(), binding.id)
+        managed_ingress_profile_repo::find_all_by_binding(state.writer_db(), binding.id)
             .await?
             .into_iter()
             .map(Into::into)
@@ -33,7 +33,7 @@ pub async fn create<S: FollowerRuntimeState>(
     input: RemoteCreateIngressProfileRequest,
 ) -> Result<RemoteIngressProfileInfo> {
     let normalized = normalize_create_input(input)?;
-    let profile_id = crate::db::transaction::with_transaction(state.db(), async |txn| {
+    let profile_id = crate::db::transaction::with_transaction(state.writer_db(), async |txn| {
         let should_set_default = normalized.is_default == Some(true)
             || managed_ingress_profile_repo::count_by_binding(txn, binding.id).await? == 0;
         let now = Utc::now();
@@ -67,7 +67,7 @@ pub async fn create<S: FollowerRuntimeState>(
         Ok(created.id)
     })
     .await?;
-    let profile = managed_ingress_profile_repo::find_by_id(state.db(), profile_id).await?;
+    let profile = managed_ingress_profile_repo::find_by_id(state.writer_db(), profile_id).await?;
     Ok(reconcile_profile(state, profile).await?.into())
 }
 
@@ -87,7 +87,7 @@ pub async fn update<S: FollowerRuntimeState>(
         ));
     }
 
-    let profile_id = crate::db::transaction::with_transaction(state.db(), async |txn| {
+    let profile_id = crate::db::transaction::with_transaction(state.writer_db(), async |txn| {
         let mut active: managed_ingress_profile::ActiveModel = existing.clone().into();
         active.name = Set(normalized.name);
         active.driver_type = Set(normalized.driver_type);
@@ -110,7 +110,7 @@ pub async fn update<S: FollowerRuntimeState>(
         Ok(updated.id)
     })
     .await?;
-    let profile = managed_ingress_profile_repo::find_by_id(state.db(), profile_id).await?;
+    let profile = managed_ingress_profile_repo::find_by_id(state.writer_db(), profile_id).await?;
     Ok(reconcile_profile(state, profile).await?.into())
 }
 
@@ -126,7 +126,8 @@ pub async fn delete<S: FollowerRuntimeState>(
         is_default = existing.is_default,
         "deleting managed ingress profile"
     );
-    let count = managed_ingress_profile_repo::count_by_binding(state.db(), binding.id).await?;
+    let count =
+        managed_ingress_profile_repo::count_by_binding(state.writer_db(), binding.id).await?;
     if existing.is_default && count > 1 {
         return Err(precondition_failed_with_subcode(
             ApiSubcode::ManagedIngressDefaultDeleteRequiresReplacement,
@@ -134,7 +135,7 @@ pub async fn delete<S: FollowerRuntimeState>(
         ));
     }
     managed_ingress_profile_repo::delete_by_binding_and_profile_key(
-        state.db(),
+        state.writer_db(),
         binding.id,
         &existing.profile_key,
     )
@@ -152,7 +153,7 @@ pub async fn resolve_effective_target<S: FollowerRuntimeState>(
     binding: &master_binding::Model,
 ) -> Result<ResolvedIngressTarget> {
     let profiles =
-        managed_ingress_profile_repo::find_all_by_binding(state.db(), binding.id).await?;
+        managed_ingress_profile_repo::find_all_by_binding(state.writer_db(), binding.id).await?;
     if profiles.is_empty() {
         return Err(precondition_failed_with_subcode(
             ApiSubcode::ManagedIngressRequired,
@@ -160,14 +161,15 @@ pub async fn resolve_effective_target<S: FollowerRuntimeState>(
         ));
     }
 
-    let profile = managed_ingress_profile_repo::find_default_by_binding(state.db(), binding.id)
-        .await?
-        .ok_or_else(|| {
-            precondition_failed_with_subcode(
-                ApiSubcode::ManagedIngressDefaultMissing,
-                "managed ingress profiles exist but no default profile is configured",
-            )
-        })?;
+    let profile =
+        managed_ingress_profile_repo::find_default_by_binding(state.writer_db(), binding.id)
+            .await?
+            .ok_or_else(|| {
+                precondition_failed_with_subcode(
+                    ApiSubcode::ManagedIngressDefaultMissing,
+                    "managed ingress profiles exist but no default profile is configured",
+                )
+            })?;
     if !profile.last_error.trim().is_empty() {
         return Err(precondition_failed_with_subcode(
             ApiSubcode::ManagedIngressDefaultError,
@@ -200,7 +202,7 @@ async fn find_profile_or_err<S: FollowerRuntimeState>(
     profile_key: &str,
 ) -> Result<managed_ingress_profile::Model> {
     managed_ingress_profile_repo::find_by_binding_and_profile_key(
-        state.db(),
+        state.writer_db(),
         master_binding_id,
         profile_key,
     )
@@ -225,5 +227,5 @@ async fn reconcile_profile<S: FollowerRuntimeState>(
         }
     }
     active.updated_at = Set(Utc::now());
-    managed_ingress_profile_repo::update(state.db(), active).await
+    managed_ingress_profile_repo::update(state.writer_db(), active).await
 }

--- a/src/services/managed_ingress_profile_service/tests.rs
+++ b/src/services/managed_ingress_profile_service/tests.rs
@@ -33,6 +33,14 @@ impl SharedRuntimeState for TestFollowerState {
         &self.db
     }
 
+    fn writer_db(&self) -> &DatabaseConnection {
+        &self.db
+    }
+
+    fn reader_db(&self) -> &DatabaseConnection {
+        &self.db
+    }
+
     fn driver_registry(&self) -> &Arc<crate::storage::DriverRegistry> {
         &self.driver_registry
     }

--- a/src/services/managed_ingress_profile_service/tests.rs
+++ b/src/services/managed_ingress_profile_service/tests.rs
@@ -29,10 +29,6 @@ struct TestFollowerState {
 }
 
 impl SharedRuntimeState for TestFollowerState {
-    fn db(&self) -> &DatabaseConnection {
-        &self.db
-    }
-
     fn writer_db(&self) -> &DatabaseConnection {
         &self.db
     }
@@ -102,7 +98,7 @@ async fn setup_state() -> TestFollowerState {
 async fn create_binding(state: &TestFollowerState, access_key: &str) -> master_binding::Model {
     let now = Utc::now();
     master_binding_repo::create(
-        &state.db,
+        state.writer_db(),
         master_binding::ActiveModel {
             name: Set(format!("binding-{access_key}")),
             master_url: Set("https://primary.example.com".to_string()),
@@ -550,7 +546,7 @@ async fn resolve_effective_target_reports_required_default_and_pending_states() 
     .await
     .unwrap();
     let mut stored = managed_ingress_profile_repo::find_by_binding_and_profile_key(
-        &state.db,
+        state.writer_db(),
         binding.id,
         &profile.profile_key,
     )
@@ -559,7 +555,7 @@ async fn resolve_effective_target_reports_required_default_and_pending_states() 
     .unwrap();
     let mut active: managed_ingress_profile::ActiveModel = stored.clone().into();
     active.last_error = Set("path failed".to_string());
-    managed_ingress_profile_repo::update(&state.db, active)
+    managed_ingress_profile_repo::update(state.writer_db(), active)
         .await
         .unwrap();
     let error = expect_aster_err(resolve_effective_target(&state, &binding).await);
@@ -569,7 +565,7 @@ async fn resolve_effective_target_reports_required_default_and_pending_states() 
     );
 
     stored = managed_ingress_profile_repo::find_by_binding_and_profile_key(
-        &state.db,
+        state.writer_db(),
         binding.id,
         &profile.profile_key,
     )
@@ -580,7 +576,7 @@ async fn resolve_effective_target_reports_required_default_and_pending_states() 
     active.last_error = Set(String::new());
     active.applied_revision = Set(0);
     active.desired_revision = Set(1);
-    managed_ingress_profile_repo::update(&state.db, active)
+    managed_ingress_profile_repo::update(state.writer_db(), active)
         .await
         .unwrap();
     let error = expect_aster_err(resolve_effective_target(&state, &binding).await);

--- a/src/services/master_binding_service.rs
+++ b/src/services/master_binding_service.rs
@@ -173,7 +173,7 @@ pub async fn sync_from_primary<S: FollowerRuntimeState>(
     access_key: &str,
     input: SyncMasterBindingInput,
 ) -> Result<master_binding::Model> {
-    let existing = master_binding_repo::find_by_access_key(state.db(), access_key)
+    let existing = master_binding_repo::find_by_access_key(state.writer_db(), access_key)
         .await?
         .ok_or_else(|| AsterError::auth_invalid_credentials("unknown internal access_key"))?;
     let normalized = normalize_sync_input(input)?;
@@ -183,10 +183,10 @@ pub async fn sync_from_primary<S: FollowerRuntimeState>(
     active.is_enabled = Set(normalized.is_enabled);
     active.updated_at = Set(Utc::now());
 
-    let updated = master_binding_repo::update(state.db(), active).await?;
+    let updated = master_binding_repo::update(state.writer_db(), active).await?;
     state
         .driver_registry()
-        .reload_master_bindings(state.db())
+        .reload_master_bindings(state.writer_db())
         .await?;
     Ok(updated)
 }
@@ -333,7 +333,7 @@ pub fn provider_storage_prefix(binding: &master_binding::Model, prefix: &str) ->
 }
 
 pub async fn assert_follower_ready<S: FollowerRuntimeState>(state: &S) -> Result<()> {
-    let bindings = master_binding_repo::find_all(state.db()).await?;
+    let bindings = master_binding_repo::find_all(state.writer_db()).await?;
     let enabled_bindings: Vec<_> = bindings
         .into_iter()
         .filter(|binding| binding.is_enabled)

--- a/src/services/media_metadata_service.rs
+++ b/src/services/media_metadata_service.rs
@@ -218,7 +218,7 @@ pub async fn persist_extracted(
     };
 
     media_metadata_repo::upsert_record(
-        &state.db,
+        state.writer_db(),
         media_metadata_repo::MediaMetadataRecordInput {
             blob_id: blob.id,
             blob_hash: &blob.hash,

--- a/src/services/media_metadata_service.rs
+++ b/src/services/media_metadata_service.rs
@@ -105,7 +105,7 @@ pub async fn get_for_file(state: &PrimaryAppState, f: &file::Model) -> Result<Me
     }
 
     let Some(kind) = metadata_kind_for_file(f) else {
-        let blob = file_repo::find_blob_by_id(&state.db, f.blob_id).await?;
+        let blob = file_repo::find_blob_by_id(state.reader_db(), f.blob_id).await?;
         return Ok(MediaMetadataLookup::Ready(unsupported_file_metadata_info(
             &blob,
             f,
@@ -113,7 +113,7 @@ pub async fn get_for_file(state: &PrimaryAppState, f: &file::Model) -> Result<Me
         )));
     };
 
-    let blob = file_repo::find_blob_by_id(&state.db, f.blob_id).await?;
+    let blob = file_repo::find_blob_by_id(state.reader_db(), f.blob_id).await?;
     if media_metadata_processor_for_file_name(&state.runtime_config, kind, &f.name).is_none() {
         return Ok(MediaMetadataLookup::Ready(unsupported_kind_metadata_info(
             &blob,
@@ -126,7 +126,7 @@ pub async fn get_for_file(state: &PrimaryAppState, f: &file::Model) -> Result<Me
         )));
     }
 
-    if let Some(cached) = media_metadata_repo::find_by_blob_id(&state.db, blob.id).await?
+    if let Some(cached) = media_metadata_repo::find_by_blob_id(state.reader_db(), blob.id).await?
         && cached.blob_hash == blob.hash
         && cached.kind == kind
         && should_use_cached_metadata(state, f, &cached)

--- a/src/services/media_processing_service/tests.rs
+++ b/src/services/media_processing_service/tests.rs
@@ -53,6 +53,7 @@ fn known_thumbnail_cache_paths_include_normalized_namespaces() {
             format!("_thumb/images/1/ab/ca/{hash}.webp"),
             format!("_thumb/vips-cli/1/ab/ca/{hash}.webp"),
             format!("_thumb/ffmpeg-cli/1/ab/ca/{hash}.webp"),
+            format!("_thumb/lofty/1/ab/ca/{hash}.webp"),
             format!("_thumb/storage-native/1/ab/ca/{hash}.webp"),
         ]
     );

--- a/src/services/media_processing_service/thumbnail.rs
+++ b/src/services/media_processing_service/thumbnail.rs
@@ -56,7 +56,7 @@ pub async fn get_or_generate_thumbnail(
     if let Err(error) = ctx.driver.put(&thumbnail_path, &webp_bytes).await {
         tracing::warn!("failed to store thumbnail {thumbnail_path}: {error}");
     } else if let Err(error) = file_repo::set_thumbnail_metadata(
-        &state.db,
+        state.writer_db(),
         blob.id,
         &thumbnail_path,
         &thumbnail_processor,
@@ -145,7 +145,7 @@ async fn generate_and_store_with_context(
     .await?;
     let stored_path = ctx.driver.put(&thumbnail_path, &webp_bytes).await?;
     file_repo::set_thumbnail_metadata(
-        &state.db,
+        state.writer_db(),
         blob.id,
         &stored_path,
         &thumbnail_processor,

--- a/src/services/media_processing_service/thumbnail/cache.rs
+++ b/src/services/media_processing_service/thumbnail/cache.rs
@@ -37,7 +37,7 @@ pub async fn delete_thumbnail(state: &PrimaryAppState, blob: &file_blob::Model) 
         }
     }
 
-    if let Err(error) = file_repo::clear_thumbnail_metadata(&state.db, blob.id).await {
+    if let Err(error) = file_repo::clear_thumbnail_metadata(state.writer_db(), blob.id).await {
         tracing::warn!(
             blob_id = blob.id,
             "failed to clear thumbnail metadata: {error}"
@@ -168,7 +168,7 @@ async fn read_thumbnail_from_path(
 }
 
 async fn clear_thumbnail_metadata(state: &PrimaryAppState, blob: &file_blob::Model) {
-    if let Err(error) = file_repo::clear_thumbnail_metadata(&state.db, blob.id).await {
+    if let Err(error) = file_repo::clear_thumbnail_metadata(state.writer_db(), blob.id).await {
         tracing::warn!(
             blob_id = blob.id,
             "failed to clear stale thumbnail metadata: {error}"
@@ -184,7 +184,8 @@ pub(super) async fn persist_thumbnail_metadata(
     version: &str,
 ) {
     if let Err(error) =
-        file_repo::set_thumbnail_metadata(&state.db, blob.id, path, processor, version).await
+        file_repo::set_thumbnail_metadata(state.writer_db(), blob.id, path, processor, version)
+            .await
     {
         tracing::warn!(
             blob_id = blob.id,

--- a/src/services/passkey_service.rs
+++ b/src/services/passkey_service.rs
@@ -432,7 +432,7 @@ fn map_unique_passkey_err(err: DbErr) -> AsterError {
 }
 
 pub async fn list_passkeys(state: &PrimaryAppState, user_id: i64) -> Result<Vec<PasskeyInfo>> {
-    passkey_repo::list_for_user(&state.db, user_id)
+    passkey_repo::list_for_user(state.writer_db(), user_id)
         .await
         .map(|items| items.into_iter().map(model_to_info).collect())
 }
@@ -443,12 +443,12 @@ pub async fn start_registration(
     name: Option<&str>,
 ) -> Result<PasskeyRegisterStartResp> {
     let webauthn = build_webauthn(state)?;
-    let user = user_repo::find_by_id(&state.db, user_id).await?;
+    let user = user_repo::find_by_id(state.writer_db(), user_id).await?;
     if !user.status.is_active() {
         return Err(AsterError::auth_forbidden("account is disabled"));
     }
-    let existing = passkey_repo::list_for_user(&state.db, user.id).await?;
-    let user_handle = user_handle_for_registration(&state.db, &existing).await?;
+    let existing = passkey_repo::list_for_user(state.writer_db(), user.id).await?;
+    let user_handle = user_handle_for_registration(state.writer_db(), &existing).await?;
     let exclude_credentials = existing
         .iter()
         .map(|item| passkey_from_json(&item.credential).map(|passkey| passkey.cred_id().clone()))
@@ -499,7 +499,7 @@ pub async fn finish_registration(
             "passkey registration challenge does not belong to user",
         ));
     }
-    let user = user_repo::find_by_id(&state.db, user_id).await?;
+    let user = user_repo::find_by_id(state.writer_db(), user_id).await?;
     if !user.status.is_active() {
         return Err(AsterError::auth_forbidden("account is disabled"));
     }
@@ -510,7 +510,7 @@ pub async fn finish_registration(
         .finish_passkey_registration(&credential, &challenge.state)
         .map_err(webauthn_error)?;
     let credential_id = credential_id_to_storage(passkey.cred_id());
-    if passkey_repo::find_by_credential_id(&state.db, &credential_id)
+    if passkey_repo::find_by_credential_id(state.writer_db(), &credential_id)
         .await?
         .is_some()
     {
@@ -542,7 +542,7 @@ pub async fn finish_registration(
         ..Default::default()
     };
     let created = model
-        .insert(&state.db)
+        .insert(state.writer_db())
         .await
         .map_err(map_unique_passkey_err)?;
     Ok(model_to_info(created))
@@ -555,17 +555,17 @@ pub async fn rename_passkey(
     name: &str,
 ) -> Result<PasskeyInfo> {
     let name = normalize_passkey_name(Some(name))?;
-    if !passkey_repo::update_name_for_user(&state.db, id, user_id, &name).await? {
+    if !passkey_repo::update_name_for_user(state.writer_db(), id, user_id, &name).await? {
         return Err(AsterError::record_not_found(format!("passkey #{id}")));
     }
-    let passkey = passkey_repo::find_by_id_for_user(&state.db, id, user_id)
+    let passkey = passkey_repo::find_by_id_for_user(state.writer_db(), id, user_id)
         .await?
         .ok_or_else(|| AsterError::record_not_found(format!("passkey #{id}")))?;
     Ok(model_to_info(passkey))
 }
 
 pub async fn delete_passkey(state: &PrimaryAppState, user_id: i64, id: i64) -> Result<bool> {
-    passkey_repo::delete_for_user(&state.db, id, user_id).await
+    passkey_repo::delete_for_user(state.writer_db(), id, user_id).await
 }
 
 pub async fn start_login(
@@ -615,14 +615,14 @@ pub async fn finish_login(
         ));
     }
     let passkey = passkey_repo::find_by_user_handle_and_credential_id(
-        &state.db,
+        state.writer_db(),
         &user_handle_to_storage(user_handle),
         &credential_id,
     )
     .await?
     .ok_or_else(|| AsterError::auth_invalid_credentials("passkey not found"))?;
 
-    let user = user_repo::find_by_id(&state.db, passkey.user_id).await?;
+    let user = user_repo::find_by_id(state.writer_db(), passkey.user_id).await?;
     if let Some(identifier) = challenge.identifier.as_deref() {
         ensure_login_identifier_matches(&user, identifier)?;
     }
@@ -645,7 +645,7 @@ pub async fn finish_login(
     if changed {
         let credential = stored_passkey_credential(&passkey_to_json(&stored)?)?;
         if !passkey_repo::update_credential_after_auth(
-            &state.db,
+            state.writer_db(),
             passkey.id,
             credential,
             result.backup_eligible(),
@@ -658,7 +658,7 @@ pub async fn finish_login(
             return Err(AsterError::auth_invalid_credentials("passkey not found"));
         }
     } else {
-        if !passkey_repo::touch_last_used(&state.db, passkey.id, now).await? {
+        if !passkey_repo::touch_last_used(state.writer_db(), passkey.id, now).await? {
             return Err(AsterError::auth_invalid_credentials("passkey not found"));
         }
     }

--- a/src/services/policy_service/groups.rs
+++ b/src/services/policy_service/groups.rs
@@ -105,8 +105,14 @@ pub async fn list_groups_paginated(
     sort_order: SortOrder,
 ) -> Result<OffsetPage<StoragePolicyGroupInfo>> {
     let page = load_offset_page(limit, offset, 100, |limit, offset| async move {
-        policy_group_repo::find_groups_paginated(&state.db, limit, offset, sort_by, sort_order)
-            .await
+        policy_group_repo::find_groups_paginated(
+            state.reader_db(),
+            limit,
+            offset,
+            sort_by,
+            sort_order,
+        )
+        .await
     })
     .await?;
     Ok(OffsetPage {
@@ -122,7 +128,7 @@ pub async fn list_groups_paginated(
 }
 
 pub async fn get_group(state: &PrimaryAppState, id: i64) -> Result<StoragePolicyGroupInfo> {
-    let group = policy_group_repo::find_group_by_id(&state.db, id).await?;
+    let group = policy_group_repo::find_group_by_id(state.reader_db(), id).await?;
     Ok(build_group_info(state, &group))
 }
 

--- a/src/services/policy_service/groups.rs
+++ b/src/services/policy_service/groups.rs
@@ -149,9 +149,9 @@ pub async fn create_group(
         ));
     }
 
-    validate_group_items(&state.db, &items).await?;
+    validate_group_items(state.writer_db(), &items).await?;
 
-    let txn = crate::db::transaction::begin(&state.db).await?;
+    let txn = crate::db::transaction::begin(state.writer_db()).await?;
     let now = Utc::now();
     let group = policy_group_repo::create_group(
         &txn,
@@ -172,8 +172,8 @@ pub async fn create_group(
         policy_group_repo::set_only_default_group(&txn, group.id).await?;
     }
     crate::db::transaction::commit(txn).await?;
-    state.policy_snapshot.reload(&state.db).await?;
-    let group = policy_group_repo::find_group_by_id(&state.db, group.id).await?;
+    state.policy_snapshot.reload(state.writer_db()).await?;
+    let group = policy_group_repo::find_group_by_id(state.writer_db(), group.id).await?;
     Ok(build_group_info(state, &group))
 }
 
@@ -189,7 +189,7 @@ pub async fn update_group(
         is_default,
         items,
     } = input;
-    let txn = crate::db::transaction::begin(&state.db).await?;
+    let txn = crate::db::transaction::begin(state.writer_db()).await?;
     let existing = policy_group_repo::find_group_by_id(&txn, id).await?;
     let next_is_enabled = is_enabled.unwrap_or(existing.is_enabled);
     let next_is_default = is_default.unwrap_or(existing.is_default);
@@ -265,13 +265,13 @@ pub async fn update_group(
     }
 
     crate::db::transaction::commit(txn).await?;
-    state.policy_snapshot.reload(&state.db).await?;
-    let group = policy_group_repo::find_group_by_id(&state.db, group.id).await?;
+    state.policy_snapshot.reload(state.writer_db()).await?;
+    let group = policy_group_repo::find_group_by_id(state.writer_db(), group.id).await?;
     Ok(build_group_info(state, &group))
 }
 
 pub async fn delete_group(state: &PrimaryAppState, id: i64) -> Result<()> {
-    let group = policy_group_repo::find_group_by_id(&state.db, id).await?;
+    let group = policy_group_repo::find_group_by_id(state.writer_db(), id).await?;
     tracing::debug!(
         policy_group_id = id,
         policy_group_name = %group.name,
@@ -280,7 +280,7 @@ pub async fn delete_group(state: &PrimaryAppState, id: i64) -> Result<()> {
     );
 
     if group.is_default {
-        let all = policy_group_repo::find_all_groups(&state.db).await?;
+        let all = policy_group_repo::find_all_groups(state.writer_db()).await?;
         let default_count = all.iter().filter(|item| item.is_default).count();
         if default_count <= 1 {
             return Err(AsterError::validation_error(
@@ -290,16 +290,17 @@ pub async fn delete_group(state: &PrimaryAppState, id: i64) -> Result<()> {
     }
 
     let user_assignment_count =
-        policy_group_repo::count_user_group_assignments(&state.db, id).await?;
-    let team_assignment_count = team_repo::count_active_by_policy_group(&state.db, id).await?;
+        policy_group_repo::count_user_group_assignments(state.writer_db(), id).await?;
+    let team_assignment_count =
+        team_repo::count_active_by_policy_group(state.writer_db(), id).await?;
     if let Some(message) =
         format_group_assignment_blocker("delete", user_assignment_count, team_assignment_count)
     {
         return Err(AsterError::validation_error(message));
     }
 
-    policy_group_repo::delete_group(&state.db, id).await?;
-    state.policy_snapshot.reload(&state.db).await?;
+    policy_group_repo::delete_group(state.writer_db(), id).await?;
+    state.policy_snapshot.reload(state.writer_db()).await?;
     tracing::info!(
         policy_group_id = id,
         policy_group_name = %group.name,
@@ -319,14 +320,15 @@ pub async fn migrate_group_users(
         ));
     }
 
-    policy_group_repo::find_group_by_id(&state.db, source_group_id).await?;
-    let target_group = policy_group_repo::find_group_by_id(&state.db, target_group_id).await?;
+    policy_group_repo::find_group_by_id(state.writer_db(), source_group_id).await?;
+    let target_group =
+        policy_group_repo::find_group_by_id(state.writer_db(), target_group_id).await?;
     if !target_group.is_enabled {
         return Err(AsterError::validation_error(
             "cannot migrate users to a disabled storage policy group",
         ));
     }
-    if policy_group_repo::find_group_items(&state.db, target_group_id)
+    if policy_group_repo::find_group_items(state.writer_db(), target_group_id)
         .await?
         .is_empty()
     {
@@ -335,7 +337,7 @@ pub async fn migrate_group_users(
         ));
     }
 
-    let txn = crate::db::transaction::begin(&state.db).await?;
+    let txn = crate::db::transaction::begin(state.writer_db()).await?;
     let migrated_assignments = user_repo::migrate_policy_group_assignments(
         &txn,
         source_group_id,
@@ -354,7 +356,7 @@ pub async fn migrate_group_users(
             migrated_assignments: 0,
         });
     }
-    state.policy_snapshot.reload(&state.db).await?;
+    state.policy_snapshot.reload(state.writer_db()).await?;
 
     Ok(PolicyGroupUserMigrationResult {
         source_group_id,

--- a/src/services/policy_service/policies.rs
+++ b/src/services/policy_service/policies.rs
@@ -82,14 +82,17 @@ pub async fn list_paginated(
 ) -> Result<OffsetPage<StoragePolicy>> {
     load_offset_page(limit, offset, 100, |limit, offset| async move {
         let (items, total) =
-            policy_repo::find_paginated(&state.db, limit, offset, sort_by, sort_order).await?;
+            policy_repo::find_paginated(state.reader_db(), limit, offset, sort_by, sort_order)
+                .await?;
         Ok((items.into_iter().map(Into::into).collect(), total))
     })
     .await
 }
 
 pub async fn get(state: &PrimaryAppState, id: i64) -> Result<StoragePolicy> {
-    policy_repo::find_by_id(&state.db, id).await.map(Into::into)
+    policy_repo::find_by_id(state.reader_db(), id)
+        .await
+        .map(Into::into)
 }
 
 pub async fn create(

--- a/src/services/policy_service/policies.rs
+++ b/src/services/policy_service/policies.rs
@@ -119,14 +119,15 @@ pub async fn create(
     } = connection;
     let (endpoint, bucket) = normalize_connection_fields(driver_type, &endpoint, &bucket)?;
     validate_connection_credentials(driver_type, &access_key, &secret_key)?;
-    let remote_node_id = validate_remote_binding(&state.db, driver_type, remote_node_id).await?;
+    let remote_node_id =
+        validate_remote_binding(state.writer_db(), driver_type, remote_node_id).await?;
     let allowed_types = allowed_types.unwrap_or_default();
     let options = options.unwrap_or_default().normalized();
     let serialized_options = serialize_options(&options)?;
     let chunk_size = chunk_size.unwrap_or(5_242_880);
     ensure_storage_native_thumbnail_supported(driver_type, &options)?;
 
-    let txn = crate::db::transaction::begin(&state.db).await?;
+    let txn = crate::db::transaction::begin(state.writer_db()).await?;
     let now = Utc::now();
     let model = storage_policy::ActiveModel {
         name: Set(name),
@@ -154,15 +155,15 @@ pub async fn create(
         policy_group_repo::set_only_default_group(&txn, default_group_id).await?;
     }
     crate::db::transaction::commit(txn).await?;
-    state.policy_snapshot.reload(&state.db).await?;
+    state.policy_snapshot.reload(state.writer_db()).await?;
     crate::services::config_service::invalidate_public_thumbnail_support_cache();
-    policy_repo::find_by_id(&state.db, result.id)
+    policy_repo::find_by_id(state.writer_db(), result.id)
         .await
         .map(Into::into)
 }
 
 pub async fn delete(state: &PrimaryAppState, id: i64, force: bool) -> Result<()> {
-    let policy = policy_repo::find_by_id(&state.db, id).await?;
+    let policy = policy_repo::find_by_id(state.writer_db(), id).await?;
     tracing::debug!(
         policy_id = id,
         policy_name = %policy.name,
@@ -177,7 +178,7 @@ pub async fn delete(state: &PrimaryAppState, id: i64, force: bool) -> Result<()>
     }
 
     if policy.is_default {
-        let all = policy_repo::find_all(&state.db).await?;
+        let all = policy_repo::find_all(state.writer_db()).await?;
         let default_count = all.iter().filter(|p| p.is_default).count();
         if default_count <= 1 {
             return Err(AsterError::validation_error(
@@ -186,14 +187,16 @@ pub async fn delete(state: &PrimaryAppState, id: i64, force: bool) -> Result<()>
         }
     }
 
-    let blob_count = crate::db::repository::file_repo::count_blobs_by_policy(&state.db, id).await?;
+    let blob_count =
+        crate::db::repository::file_repo::count_blobs_by_policy(state.writer_db(), id).await?;
     if blob_count > 0 {
         return Err(AsterError::validation_error(format!(
             "cannot delete policy: {blob_count} blob(s) still reference it"
         )));
     }
 
-    let group_ref_count = policy_group_repo::count_group_items_by_policy(&state.db, id).await?;
+    let group_ref_count =
+        policy_group_repo::count_group_items_by_policy(state.writer_db(), id).await?;
     if group_ref_count > 0 {
         return Err(AsterError::validation_error(format!(
             "cannot delete policy: {group_ref_count} policy group item(s) still reference it"
@@ -201,7 +204,7 @@ pub async fn delete(state: &PrimaryAppState, id: i64, force: bool) -> Result<()>
     }
 
     let upload_session_count =
-        crate::db::repository::upload_session_repo::count_by_policy(&state.db, id).await?;
+        crate::db::repository::upload_session_repo::count_by_policy(state.writer_db(), id).await?;
     if upload_session_count > 0 {
         if !force {
             return Err(validation_error_with_subcode(
@@ -231,7 +234,8 @@ pub async fn delete(state: &PrimaryAppState, id: i64, force: bool) -> Result<()>
         );
     }
 
-    let blob_count = crate::db::repository::file_repo::count_blobs_by_policy(&state.db, id).await?;
+    let blob_count =
+        crate::db::repository::file_repo::count_blobs_by_policy(state.writer_db(), id).await?;
     if blob_count > 0 {
         return Err(AsterError::validation_error(format!(
             "cannot delete policy: {blob_count} blob(s) still reference it"
@@ -239,17 +243,17 @@ pub async fn delete(state: &PrimaryAppState, id: i64, force: bool) -> Result<()>
     }
 
     let cleared =
-        crate::db::repository::folder_repo::clear_policy_references(&state.db, id).await?;
+        crate::db::repository::folder_repo::clear_policy_references(state.writer_db(), id).await?;
     if cleared > 0 {
         tracing::info!("cleared policy_id on {cleared} folders before deleting policy #{id}");
     }
 
-    policy_repo::delete(&state.db, id).await?;
+    policy_repo::delete(state.writer_db(), id).await?;
 
     // 与 update 一致：先 invalidate driver 再 reload snapshot，
     // 避免"策略行已删除但 driver 仍在缓存里"的窗口。
     state.driver_registry.invalidate(id);
-    state.policy_snapshot.reload(&state.db).await?;
+    state.policy_snapshot.reload(state.writer_db()).await?;
     crate::services::config_service::invalidate_public_thumbnail_support_cache();
     tracing::info!(
         policy_id = id,
@@ -279,7 +283,7 @@ pub async fn update(
         allowed_types,
         options,
     } = input;
-    let txn = crate::db::transaction::begin(&state.db).await?;
+    let txn = crate::db::transaction::begin(state.writer_db()).await?;
     let existing = policy_repo::find_by_id(&txn, id).await?;
     let existing_endpoint = existing.endpoint.clone();
     let existing_bucket = existing.bucket.clone();
@@ -379,10 +383,10 @@ pub async fn update(
     // 如果反过来，中间窗口里读请求可能拿到"新 policy model + 旧 driver cache"，
     // 把写操作发到老的 endpoint/bucket/credential 上——无日志、无报错的静默错路由。
     state.driver_registry.invalidate(id);
-    state.policy_snapshot.reload(&state.db).await?;
+    state.policy_snapshot.reload(state.writer_db()).await?;
     crate::services::config_service::invalidate_public_thumbnail_support_cache();
 
-    policy_repo::find_by_id(&state.db, result.id)
+    policy_repo::find_by_id(state.writer_db(), result.id)
         .await
         .map(Into::into)
 }
@@ -399,7 +403,7 @@ pub async fn test_default_connection<S: PrimaryRuntimeState>(state: &S) -> Resul
 }
 
 pub async fn test_connection<S: PrimaryRuntimeState>(state: &S, id: i64) -> Result<()> {
-    let policy = policy_repo::find_by_id(state.db(), id).await?;
+    let policy = policy_repo::find_by_id(state.writer_db(), id).await?;
     let driver = state.driver_registry().get_driver(&policy)?;
     probe_storage_driver(driver.as_ref(), "write test failed").await
 }
@@ -423,7 +427,8 @@ pub async fn test_connection_params<S: PrimaryRuntimeState>(
     } = input;
     let (endpoint, bucket) = normalize_connection_fields(driver_type, &endpoint, &bucket)?;
     validate_connection_credentials(driver_type, &access_key, &secret_key)?;
-    let remote_node_id = validate_remote_binding(state.db(), driver_type, remote_node_id).await?;
+    let remote_node_id =
+        validate_remote_binding(state.writer_db(), driver_type, remote_node_id).await?;
 
     let fake_policy = storage_policy::Model {
         id: 0,
@@ -450,7 +455,8 @@ pub async fn test_connection_params<S: PrimaryRuntimeState>(
             let remote_node_id = fake_policy.remote_node_id.ok_or_else(|| {
                 AsterError::validation_error("remote storage policy requires remote_node_id")
             })?;
-            let remote_node = managed_follower_repo::find_by_id(state.db(), remote_node_id).await?;
+            let remote_node =
+                managed_follower_repo::find_by_id(state.writer_db(), remote_node_id).await?;
             Box::new(RemoteDriver::new(&fake_policy, &remote_node)?)
         }
         DriverType::S3 => Box::new(S3Driver::new(&fake_policy)?),

--- a/src/services/preview_link_service.rs
+++ b/src/services/preview_link_service.rs
@@ -146,7 +146,7 @@ pub(crate) async fn download_file(
 
     direct_link_service::validate_public_file_name(file, requested_name)?;
 
-    let blob = file_repo::find_blob_by_id(&state.db, file.blob_id).await?;
+    let blob = file_repo::find_blob_by_id(state.reader_db(), file.blob_id).await?;
     if let Some(if_none_match) = if_none_match
         && file_service::if_none_match_matches(if_none_match, &blob.hash)
     {

--- a/src/services/profile_service/avatar.rs
+++ b/src/services/profile_service/avatar.rs
@@ -191,8 +191,8 @@ fn validate_avatar_size(size: u32) -> Result<u32> {
 
 pub async fn get_avatar_bytes(state: &PrimaryAppState, user_id: i64, size: u32) -> Result<Vec<u8>> {
     let size = validate_avatar_size(size)?;
-    user_repo::find_by_id(&state.db, user_id).await?;
-    let profile = user_profile_repo::find_by_user_id(&state.db, user_id)
+    user_repo::find_by_id(state.reader_db(), user_id).await?;
+    let profile = user_profile_repo::find_by_user_id(state.reader_db(), user_id)
         .await?
         .ok_or_else(|| AsterError::record_not_found(format!("profile for user #{user_id}")))?;
 

--- a/src/services/profile_service/avatar.rs
+++ b/src/services/profile_service/avatar.rs
@@ -38,7 +38,7 @@ async fn write_local_avatar(path: &std::path::Path, data: &[u8]) -> Result<()> {
 }
 
 pub async fn cleanup_avatar_upload(state: &PrimaryAppState, user_id: i64) -> Result<()> {
-    let profile = user_profile_repo::find_by_user_id(&state.db, user_id).await?;
+    let profile = user_profile_repo::find_by_user_id(state.writer_db(), user_id).await?;
     if let Some(profile) = profile.as_ref() {
         delete_upload_objects(state, profile).await;
     }
@@ -50,8 +50,8 @@ pub async fn upload_avatar(
     user_id: i64,
     payload: &mut Multipart,
 ) -> Result<UserProfileInfo> {
-    let user = user_repo::find_by_id(&state.db, user_id).await?;
-    let existing = user_profile_repo::find_by_user_id(&state.db, user_id).await?;
+    let user = user_repo::find_by_id(state.writer_db(), user_id).await?;
+    let existing = user_profile_repo::find_by_user_id(state.writer_db(), user_id).await?;
     let upload_data = read_avatar_upload(
         payload,
         operations::avatar_max_upload_size_bytes(&state.runtime_config),
@@ -64,7 +64,7 @@ pub async fn upload_avatar(
     )
     .await?;
     user_repo::check_quota(
-        &state.db,
+        state.writer_db(),
         user_id,
         i64::try_from(processed_avatar.small_bytes.len() + processed_avatar.large_bytes.len())
             .unwrap_or(i64::MAX),
@@ -94,14 +94,14 @@ pub async fn upload_avatar(
             active.avatar_key = Set(Some(prefix_key.clone()));
             active.avatar_version = Set(version);
             active.updated_at = Set(now);
-            user_profile_repo::update(&state.db, active).await
+            user_profile_repo::update(state.writer_db(), active).await
         }
         None => {
             let mut active = default_profile_active_model(user_id, now);
             active.avatar_source = Set(AvatarSource::Upload);
             active.avatar_key = Set(Some(prefix_key.clone()));
             active.avatar_version = Set(version);
-            user_profile_repo::create(&state.db, active).await
+            user_profile_repo::create(state.writer_db(), active).await
         }
     };
 
@@ -137,8 +137,8 @@ pub async fn set_avatar_source(
         ));
     }
 
-    let user = user_repo::find_by_id(&state.db, user_id).await?;
-    let existing = user_profile_repo::find_by_user_id(&state.db, user_id).await?;
+    let user = user_repo::find_by_id(state.writer_db(), user_id).await?;
+    let existing = user_profile_repo::find_by_user_id(state.writer_db(), user_id).await?;
     let gravatar_base_url = resolve_gravatar_base_url(state);
 
     if existing.is_none() && source == AvatarSource::None {
@@ -159,12 +159,12 @@ pub async fn set_avatar_source(
             active.avatar_key = Set(None);
             active.avatar_version = Set(next_version);
             active.updated_at = Set(now);
-            user_profile_repo::update(&state.db, active).await?
+            user_profile_repo::update(state.writer_db(), active).await?
         }
         None => {
             let mut active = default_profile_active_model(user_id, now);
             active.avatar_source = Set(source);
-            user_profile_repo::create(&state.db, active).await?
+            user_profile_repo::create(state.writer_db(), active).await?
         }
     };
 

--- a/src/services/profile_service/info.rs
+++ b/src/services/profile_service/info.rs
@@ -172,7 +172,8 @@ pub async fn get_profile_info_map(
 ) -> crate::errors::Result<HashMap<i64, UserProfileInfo>> {
     let user_ids: Vec<i64> = users.iter().map(|user| user.id).collect();
     let profiles =
-        crate::db::repository::user_profile_repo::find_by_user_ids(&state.db, &user_ids).await?;
+        crate::db::repository::user_profile_repo::find_by_user_ids(state.reader_db(), &user_ids)
+            .await?;
     let gravatar_base_url = resolve_gravatar_base_url(state);
 
     Ok(users

--- a/src/services/profile_service/profile.rs
+++ b/src/services/profile_service/profile.rs
@@ -47,8 +47,8 @@ pub async fn update_profile(
     user_id: i64,
     display_name: Option<String>,
 ) -> Result<UserProfileInfo> {
-    let user = user_repo::find_by_id(&state.db, user_id).await?;
-    let existing = user_profile_repo::find_by_user_id(&state.db, user_id).await?;
+    let user = user_repo::find_by_id(state.writer_db(), user_id).await?;
+    let existing = user_profile_repo::find_by_user_id(state.writer_db(), user_id).await?;
     let gravatar_base_url = resolve_gravatar_base_url(state);
 
     let Some(display_name) = display_name else {
@@ -71,7 +71,7 @@ pub async fn update_profile(
                 let mut active: user_profile::ActiveModel = current.into();
                 active.display_name = Set(normalized);
                 active.updated_at = Set(now);
-                user_profile_repo::update(&state.db, active).await?
+                user_profile_repo::update(state.writer_db(), active).await?
             }
         }
         None => {
@@ -86,7 +86,7 @@ pub async fn update_profile(
 
             let mut active = default_profile_active_model(user_id, now);
             active.display_name = Set(normalized);
-            user_profile_repo::create(&state.db, active).await?
+            user_profile_repo::create(state.writer_db(), active).await?
         }
     };
 
@@ -111,8 +111,8 @@ pub async fn update_wopi_user_info(
     user_id: i64,
     wopi_user_info: String,
 ) -> Result<()> {
-    user_repo::find_by_id(&state.db, user_id).await?;
-    let existing = user_profile_repo::find_by_user_id(&state.db, user_id).await?;
+    user_repo::find_by_id(state.writer_db(), user_id).await?;
+    let existing = user_profile_repo::find_by_user_id(state.writer_db(), user_id).await?;
     let now = Utc::now();
 
     match existing {
@@ -124,12 +124,12 @@ pub async fn update_wopi_user_info(
             let mut active: user_profile::ActiveModel = current.into();
             active.wopi_user_info = Set(Some(wopi_user_info));
             active.updated_at = Set(now);
-            user_profile_repo::update(&state.db, active).await?;
+            user_profile_repo::update(state.writer_db(), active).await?;
         }
         None => {
             let mut active = default_profile_active_model(user_id, now);
             active.wopi_user_info = Set(Some(wopi_user_info));
-            user_profile_repo::create(&state.db, active).await?;
+            user_profile_repo::create(state.writer_db(), active).await?;
         }
     }
 

--- a/src/services/profile_service/profile.rs
+++ b/src/services/profile_service/profile.rs
@@ -32,7 +32,7 @@ pub async fn get_profile_info(
     user: &user::Model,
     audience: AvatarAudience,
 ) -> Result<UserProfileInfo> {
-    let profile = user_profile_repo::find_by_user_id(&state.db, user.id).await?;
+    let profile = user_profile_repo::find_by_user_id(state.reader_db(), user.id).await?;
     let gravatar_base_url = resolve_gravatar_base_url(state);
     Ok(build_profile_info(
         user,
@@ -99,9 +99,11 @@ pub async fn update_profile(
 }
 
 pub async fn get_wopi_user_info(state: &PrimaryAppState, user_id: i64) -> Result<Option<String>> {
-    Ok(user_profile_repo::find_by_user_id(&state.db, user_id)
-        .await?
-        .and_then(|profile| profile.wopi_user_info))
+    Ok(
+        user_profile_repo::find_by_user_id(state.reader_db(), user_id)
+            .await?
+            .and_then(|profile| profile.wopi_user_info),
+    )
 }
 
 pub async fn update_wopi_user_info(

--- a/src/services/property_service.rs
+++ b/src/services/property_service.rs
@@ -67,14 +67,14 @@ async fn verify_ownership(
 ) -> Result<()> {
     match entity_type {
         EntityType::File => {
-            let f = file_repo::find_by_id(&state.db, entity_id).await?;
+            let f = file_repo::find_by_id(state.writer_db(), entity_id).await?;
             file_service::ensure_personal_file_scope(&f)?;
             if f.owner_user_id != Some(user_id) {
                 return Err(AsterError::auth_forbidden("not your file"));
             }
         }
         EntityType::Folder => {
-            let f = folder_repo::find_by_id(&state.db, entity_id).await?;
+            let f = folder_repo::find_by_id(state.writer_db(), entity_id).await?;
             folder_service::ensure_personal_folder_scope(&f)?;
             if f.owner_user_id != Some(user_id) {
                 return Err(AsterError::auth_forbidden("not your folder"));
@@ -93,7 +93,7 @@ pub async fn list(
 ) -> Result<Vec<EntityProperty>> {
     verify_ownership(state, entity_type, entity_id, user_id).await?;
     Ok(
-        property_repo::find_by_entity(&state.db, entity_type, entity_id)
+        property_repo::find_by_entity(state.writer_db(), entity_type, entity_id)
             .await?
             .into_iter()
             .filter(|prop| !is_protected_namespace(&prop.namespace))
@@ -133,9 +133,16 @@ pub async fn set(
         ));
     }
 
-    property_repo::upsert(&state.db, entity_type, entity_id, namespace, name, value)
-        .await
-        .map(Into::into)
+    property_repo::upsert(
+        state.writer_db(),
+        entity_type,
+        entity_id,
+        namespace,
+        name,
+        value,
+    )
+    .await
+    .map(Into::into)
 }
 
 /// 删除单个属性
@@ -151,7 +158,7 @@ pub async fn delete(
 
     ensure_user_namespace_mutable(namespace)?;
 
-    property_repo::delete_prop(&state.db, entity_type, entity_id, namespace, name).await?;
+    property_repo::delete_prop(state.writer_db(), entity_type, entity_id, namespace, name).await?;
     tracing::debug!(
         entity_type = ?entity_type,
         entity_id,

--- a/src/services/search_service.rs
+++ b/src/services/search_service.rs
@@ -256,7 +256,7 @@ pub(crate) async fn search_in_scope(
                         Ok((vec![], 0))
                     } else {
                         search_repo::search_files(
-                            &state.db,
+                            state.reader_db(),
                             user_id,
                             search_repo::FileSearchFilters {
                                 query,
@@ -280,7 +280,7 @@ pub(crate) async fn search_in_scope(
                         Ok((vec![], 0))
                     } else {
                         search_repo::search_folders(
-                            &state.db,
+                            state.reader_db(),
                             user_id,
                             search_repo::FolderSearchFilters {
                                 query,
@@ -323,7 +323,7 @@ pub(crate) async fn search_in_scope(
                         Ok((vec![], 0))
                     } else {
                         search_repo::search_team_files(
-                            &state.db,
+                            state.reader_db(),
                             team_id,
                             search_repo::FileSearchFilters {
                                 query,
@@ -347,7 +347,7 @@ pub(crate) async fn search_in_scope(
                         Ok((vec![], 0))
                     } else {
                         search_repo::search_team_folders(
-                            &state.db,
+                            state.reader_db(),
                             team_id,
                             search_repo::FolderSearchFilters {
                                 query,

--- a/src/services/share_service/access.rs
+++ b/src/services/share_service/access.rs
@@ -76,8 +76,8 @@ async fn resolve_share_owner_info(
     state: &PrimaryAppState,
     share: &share::Model,
 ) -> Result<SharePublicOwnerInfo> {
-    let user = user_repo::find_by_id(&state.db, share.user_id).await?;
-    let profile = user_profile_repo::find_by_user_id(&state.db, share.user_id).await?;
+    let user = user_repo::find_by_id(state.reader_db(), share.user_id).await?;
+    let profile = user_profile_repo::find_by_user_id(state.reader_db(), share.user_id).await?;
     let gravatar_base_url = profile_service::resolve_gravatar_base_url(state);
 
     Ok(SharePublicOwnerInfo {

--- a/src/services/share_service/access.rs
+++ b/src/services/share_service/access.rs
@@ -16,7 +16,7 @@ use super::shared::{
 };
 
 pub async fn get_share_info(state: &PrimaryAppState, token: &str) -> Result<SharePublicInfo> {
-    let db = &state.db;
+    let db = state.writer_db();
     let share = load_valid_share(state, token).await?;
     tracing::debug!(share_id = share.id, "loading public share info");
 

--- a/src/services/share_service/cache.rs
+++ b/src/services/share_service/cache.rs
@@ -118,7 +118,7 @@ pub(super) async fn load_share_record_by_token(
 ) -> Result<share::Model> {
     let cache_key = share_token_lookup_cache_key(token);
     if let Some(cached) = state.cache.get::<CachedShareTokenLookup>(&cache_key).await {
-        match share_repo::find_by_id(&state.db, cached.id).await {
+        match share_repo::find_by_id(state.reader_db(), cached.id).await {
             Ok(share) if share.token == token => {
                 tracing::debug!(share_id = share.id, "share token lookup cache hit");
                 return Ok(share);
@@ -142,7 +142,7 @@ pub(super) async fn load_share_record_by_token(
         }
     }
 
-    let share = share_repo::find_by_token(&state.db, token)
+    let share = share_repo::find_by_token(state.reader_db(), token)
         .await?
         .ok_or_else(|| AsterError::share_not_found(format!("token={token}")))?;
 
@@ -240,16 +240,16 @@ async fn load_active_ids_from_database(
 ) -> Result<HashSet<i64>> {
     match (scope, kind) {
         (WorkspaceResourceScope::Personal { user_id }, ShareTargetKind::File) => {
-            share_repo::find_active_file_ids(&state.db, user_id, ids).await
+            share_repo::find_active_file_ids(state.reader_db(), user_id, ids).await
         }
         (WorkspaceResourceScope::Personal { user_id }, ShareTargetKind::Folder) => {
-            share_repo::find_active_folder_ids(&state.db, user_id, ids).await
+            share_repo::find_active_folder_ids(state.reader_db(), user_id, ids).await
         }
         (WorkspaceResourceScope::Team { team_id }, ShareTargetKind::File) => {
-            share_repo::find_active_team_file_ids(&state.db, team_id, ids).await
+            share_repo::find_active_team_file_ids(state.reader_db(), team_id, ids).await
         }
         (WorkspaceResourceScope::Team { team_id }, ShareTargetKind::Folder) => {
-            share_repo::find_active_team_folder_ids(&state.db, team_id, ids).await
+            share_repo::find_active_team_folder_ids(state.reader_db(), team_id, ids).await
         }
     }
 }

--- a/src/services/share_service/content.rs
+++ b/src/services/share_service/content.rs
@@ -339,7 +339,7 @@ async fn load_or_enqueue_thumbnail(
     state: &PrimaryAppState,
     file: &file::Model,
 ) -> Result<Option<file_service::ThumbnailResult>> {
-    let blob = file_repo::find_blob_by_id(&state.db, file.blob_id).await?;
+    let blob = file_repo::find_blob_by_id(state.writer_db(), file.blob_id).await?;
     let thumbnail = media_processing_service::load_thumbnail_if_exists(
         state,
         &blob,
@@ -543,7 +543,7 @@ async fn download_share_resource_with_disposition(
         has_if_none_match = if_none_match.is_some(),
         "starting shared file download"
     );
-    let blob = file_repo::find_blob_by_id(&state.db, file.blob_id).await?;
+    let blob = file_repo::find_blob_by_id(state.writer_db(), file.blob_id).await?;
 
     if let Some(if_none_match) = if_none_match
         && file_service::if_none_match_matches(if_none_match, &blob.hash)
@@ -564,7 +564,7 @@ async fn download_share_resource_with_disposition(
         .await;
     }
 
-    match share_repo::increment_download_count(&state.db, share.id).await {
+    match share_repo::increment_download_count(state.writer_db(), share.id).await {
         Ok(true) => {
             invalidate_share_token_record_cache_for_share(state, share).await;
             if share.max_downloads > 0
@@ -614,7 +614,7 @@ async fn download_share_resource_with_disposition(
             Ok(outcome)
         }
         Err(error) => {
-            match share_repo::decrement_download_count(&state.db, share.id).await {
+            match share_repo::decrement_download_count(state.writer_db(), share.id).await {
                 Ok(true) => {}
                 Ok(false) => {
                     tracing::warn!(

--- a/src/services/share_service/management.rs
+++ b/src/services/share_service/management.rs
@@ -146,13 +146,15 @@ pub(crate) async fn list_shares_paginated_in_scope(
     let page = load_offset_page(limit, offset, 100, |limit, offset| async move {
         let (shares, total) = match scope {
             WorkspaceStorageScope::Personal { user_id } => {
-                share_repo::find_by_user_paginated(&state.db, user_id, limit, offset).await?
+                share_repo::find_by_user_paginated(state.reader_db(), user_id, limit, offset)
+                    .await?
             }
             WorkspaceStorageScope::Team { team_id, .. } => {
-                share_repo::find_by_team_paginated(&state.db, team_id, limit, offset).await?
+                share_repo::find_by_team_paginated(state.reader_db(), team_id, limit, offset)
+                    .await?
             }
         };
-        let items = build_my_share_infos(&state.db, shares).await?;
+        let items = build_my_share_infos(state.reader_db(), shares).await?;
         Ok((items, total))
     })
     .await?;
@@ -459,7 +461,8 @@ pub async fn list_paginated(
 ) -> Result<OffsetPage<ShareInfo>> {
     load_offset_page(limit, offset, 100, |limit, offset| async move {
         let (items, total) =
-            share_repo::find_paginated(&state.db, limit, offset, sort_by, sort_order).await?;
+            share_repo::find_paginated(state.reader_db(), limit, offset, sort_by, sort_order)
+                .await?;
         let items = share_infos_from_models(state, items).await?;
         Ok((items, total))
     })

--- a/src/services/share_service/management.rs
+++ b/src/services/share_service/management.rs
@@ -50,7 +50,7 @@ pub(crate) async fn create_share_in_scope(
         max_downloads,
         "creating share"
     );
-    workspace_storage_service::require_scope_access(state, scope).await?;
+    workspace_storage_service::require_scope_access_with_db(state, db, scope).await?;
 
     validate_max_downloads(max_downloads)?;
 
@@ -142,7 +142,7 @@ pub(crate) async fn list_shares_paginated_in_scope(
         offset,
         "listing paginated shares"
     );
-    workspace_storage_service::require_scope_access(state, scope).await?;
+    workspace_storage_service::require_scope_access_with_db(state, &state.db, scope).await?;
     let page = load_offset_page(limit, offset, 100, |limit, offset| async move {
         let (shares, total) = match scope {
             WorkspaceStorageScope::Personal { user_id } => {

--- a/src/services/share_service/management.rs
+++ b/src/services/share_service/management.rs
@@ -40,7 +40,7 @@ pub(crate) async fn create_share_in_scope(
     expires_at: Option<chrono::DateTime<Utc>>,
     max_downloads: i64,
 ) -> Result<ShareInfo> {
-    let db = &state.db;
+    let db = state.writer_db();
     let (file_id, folder_id) = target.into_ids();
     tracing::debug!(
         scope = ?scope,
@@ -142,7 +142,8 @@ pub(crate) async fn list_shares_paginated_in_scope(
         offset,
         "listing paginated shares"
     );
-    workspace_storage_service::require_scope_access_with_db(state, &state.db, scope).await?;
+    workspace_storage_service::require_scope_access_with_db(state, state.writer_db(), scope)
+        .await?;
     let page = load_offset_page(limit, offset, 100, |limit, offset| async move {
         let (shares, total) = match scope {
             WorkspaceStorageScope::Personal { user_id } => {
@@ -176,7 +177,7 @@ pub(crate) async fn delete_share_in_scope(
 ) -> Result<()> {
     tracing::debug!(scope = ?scope, share_id, "deleting share");
     let share = load_share_in_scope(state, scope, share_id).await?;
-    share_repo::delete(&state.db, share_id).await?;
+    share_repo::delete(state.writer_db(), share_id).await?;
     invalidate_active_share_target_cache_for_scope(state, scope).await;
     invalidate_share_token_record_cache_for_share(state, &share).await;
     tracing::debug!(scope = ?scope, share_id, "deleted share");
@@ -221,9 +222,11 @@ pub(crate) async fn update_share_in_scope(
     active.max_downloads = Set(max_downloads);
     active.updated_at = Set(Utc::now());
 
-    let updated =
-        share_info_from_model_with_user(state, share_repo::update(&state.db, active).await?)
-            .await?;
+    let updated = share_info_from_model_with_user(
+        state,
+        share_repo::update(state.writer_db(), active).await?,
+    )
+    .await?;
     invalidate_active_share_target_cache_for_scope(state, scope).await;
     invalidate_share_token_record_cache(state, &existing_token).await;
     tracing::debug!(
@@ -258,10 +261,10 @@ pub(crate) async fn batch_delete_shares_in_scope(
 
     let scoped_shares = match scope {
         WorkspaceStorageScope::Personal { user_id } => {
-            share_repo::find_by_ids_in_personal_scope(&state.db, user_id, share_ids).await?
+            share_repo::find_by_ids_in_personal_scope(state.writer_db(), user_id, share_ids).await?
         }
         WorkspaceStorageScope::Team { team_id, .. } => {
-            share_repo::find_by_ids_in_team_scope(&state.db, team_id, share_ids).await?
+            share_repo::find_by_ids_in_team_scope(state.writer_db(), team_id, share_ids).await?
         }
     };
     let share_map: HashMap<i64, share::Model> = scoped_shares
@@ -286,7 +289,7 @@ pub(crate) async fn batch_delete_shares_in_scope(
     }
 
     if !ids_to_delete.is_empty() {
-        let txn = crate::db::transaction::begin(&state.db).await?;
+        let txn = crate::db::transaction::begin(state.writer_db()).await?;
         share_repo::delete_many(&txn, &ids_to_delete).await?;
         crate::db::transaction::commit(txn).await?;
         invalidate_active_share_target_cache_for_scope(state, scope).await;
@@ -470,8 +473,8 @@ pub async fn list_paginated(
 }
 
 pub async fn admin_delete_share(state: &PrimaryAppState, share_id: i64) -> Result<()> {
-    let share = share_repo::find_by_id(&state.db, share_id).await?;
-    share_repo::delete(&state.db, share_id).await?;
+    let share = share_repo::find_by_id(state.writer_db(), share_id).await?;
+    share_repo::delete(state.writer_db(), share_id).await?;
     invalidate_active_share_target_cache_for_share(state, &share).await;
     invalidate_share_token_record_cache_for_share(state, &share).await;
     Ok(())

--- a/src/services/share_service/shared.rs
+++ b/src/services/share_service/shared.rs
@@ -114,7 +114,7 @@ pub(super) async fn load_share_record(
     // 团队分享如果指向的团队已被归档 / 删除，对外表现应当像 share 不存在，
     // 不再向匿名访问者暴露“token 有效但团队没了”这种内部状态。
     if let Some(team_id) = share.team_id {
-        match team_repo::find_active_by_id(&state.db, team_id).await {
+        match team_repo::find_active_by_id(state.reader_db(), team_id).await {
             Ok(_) => {}
             Err(AsterError::RecordNotFound(_)) => {
                 return Err(AsterError::share_not_found(format!("token={token}")));
@@ -179,7 +179,7 @@ pub(super) async fn load_share_file_resource(
             ));
         }
     };
-    let file = file_repo::find_by_id(&state.db, file_id).await?;
+    let file = file_repo::find_by_id(state.reader_db(), file_id).await?;
     ensure_share_matches_file(share, &file)?;
     if file.deleted_at.is_some() {
         return Err(AsterError::file_not_found(format!(
@@ -207,7 +207,7 @@ pub(super) async fn load_share_folder_resource(
             ));
         }
     };
-    let folder = folder_repo::find_by_id(&state.db, folder_id).await?;
+    let folder = folder_repo::find_by_id(state.reader_db(), folder_id).await?;
     ensure_share_matches_folder(share, &folder)?;
     if folder.deleted_at.is_some() {
         return Err(AsterError::folder_not_found(format!(
@@ -241,7 +241,7 @@ pub(super) async fn load_shared_folder_file_target(
     file_id: i64,
 ) -> Result<(share::Model, crate::entities::file::Model)> {
     let (share, root_folder_id) = load_valid_folder_share_root(state, token).await?;
-    let file = file_repo::find_by_id(&state.db, file_id).await?;
+    let file = file_repo::find_by_id(state.reader_db(), file_id).await?;
     ensure_share_matches_file(&share, &file)?;
     if file.deleted_at.is_some() {
         return Err(AsterError::file_not_found(format!(
@@ -256,7 +256,8 @@ pub(super) async fn load_shared_folder_file_target(
             "file is outside shared folder scope",
         )
     })?;
-    folder_service::verify_folder_in_scope(&state.db, file_folder_id, root_folder_id).await?;
+    folder_service::verify_folder_in_scope(state.reader_db(), file_folder_id, root_folder_id)
+        .await?;
     Ok((share, file))
 }
 
@@ -267,7 +268,7 @@ pub(crate) async fn load_shared_folder_file_target_ignoring_download_limit(
 ) -> Result<(share::Model, crate::entities::file::Model)> {
     let (share, root_folder_id) =
         load_usable_folder_share_root_ignoring_download_limit(state, token).await?;
-    let file = file_repo::find_by_id(&state.db, file_id).await?;
+    let file = file_repo::find_by_id(state.reader_db(), file_id).await?;
     ensure_share_matches_file(&share, &file)?;
     if file.deleted_at.is_some() {
         return Err(AsterError::file_not_found(format!(
@@ -280,7 +281,8 @@ pub(crate) async fn load_shared_folder_file_target_ignoring_download_limit(
             "file is outside shared folder scope",
         )
     })?;
-    folder_service::verify_folder_in_scope(&state.db, file_folder_id, root_folder_id).await?;
+    folder_service::verify_folder_in_scope(state.reader_db(), file_folder_id, root_folder_id)
+        .await?;
     Ok((share, file))
 }
 
@@ -290,14 +292,14 @@ pub(super) async fn load_shared_subfolder_target(
     folder_id: i64,
 ) -> Result<(share::Model, crate::entities::folder::Model)> {
     let (share, root_folder_id) = load_valid_folder_share_root(state, token).await?;
-    let target = folder_repo::find_by_id(&state.db, folder_id).await?;
+    let target = folder_repo::find_by_id(state.reader_db(), folder_id).await?;
     ensure_share_matches_folder(&share, &target)?;
     if target.deleted_at.is_some() {
         return Err(AsterError::folder_not_found(format!(
             "folder #{folder_id} is in trash"
         )));
     }
-    folder_service::verify_folder_in_scope(&state.db, folder_id, root_folder_id).await?;
+    folder_service::verify_folder_in_scope(state.reader_db(), folder_id, root_folder_id).await?;
     Ok((share, target))
 }
 

--- a/src/services/share_service/shared.rs
+++ b/src/services/share_service/shared.rs
@@ -86,7 +86,7 @@ pub(super) async fn load_share_in_scope(
     share_id: i64,
 ) -> Result<share::Model> {
     workspace_storage_service::require_scope_access(state, scope).await?;
-    let share = share_repo::find_by_id(&state.db, share_id).await?;
+    let share = share_repo::find_by_id(state.writer_db(), share_id).await?;
     ensure_share_scope(&share, scope)?;
     Ok(share)
 }

--- a/src/services/share_stream_service.rs
+++ b/src/services/share_stream_service.rs
@@ -137,11 +137,11 @@ pub(crate) async fn stream_file(
     };
     direct_link_service::validate_public_file_name(&file, requested_name)?;
 
-    let blob = file_repo::find_blob_by_id(&state.db, file.blob_id).await?;
+    let blob = file_repo::find_blob_by_id(state.writer_db(), file.blob_id).await?;
     let count_reservation = ensure_counted_once(state, session_token, &payload).await?;
 
     if matches!(count_reservation, CountReservation::Reserved) {
-        match share_repo::increment_download_count(&state.db, share.id).await {
+        match share_repo::increment_download_count(state.writer_db(), share.id).await {
             Ok(true) => {
                 mark_counted(state, session_token, &payload).await?;
                 share_service::invalidate_all_share_token_record_cache(state).await;
@@ -175,7 +175,7 @@ pub(crate) async fn stream_file(
         Err(error) => {
             if matches!(count_reservation, CountReservation::Reserved) {
                 release_counted_marker(state, session_token).await;
-                match share_repo::decrement_download_count(&state.db, share.id).await {
+                match share_repo::decrement_download_count(state.writer_db(), share.id).await {
                     Ok(true) | Ok(false) => {}
                     Err(rollback_error) => {
                         tracing::warn!(

--- a/src/services/task_service/archive/common.rs
+++ b/src/services/task_service/archive/common.rs
@@ -130,12 +130,12 @@ pub(super) async fn create_folder_exact_in_scope(
     let name = crate::utils::normalize_validate_name(name)?;
     let exists = match scope {
         WorkspaceStorageScope::Personal { user_id } => {
-            folder_repo::find_by_name_in_parent(&state.db, user_id, parent_id, &name)
+            folder_repo::find_by_name_in_parent(state.writer_db(), user_id, parent_id, &name)
                 .await?
                 .is_some()
         }
         WorkspaceStorageScope::Team { team_id, .. } => {
-            folder_repo::find_by_name_in_team_parent(&state.db, team_id, parent_id, &name)
+            folder_repo::find_by_name_in_team_parent(state.writer_db(), team_id, parent_id, &name)
                 .await?
                 .is_some()
         }
@@ -145,9 +145,9 @@ pub(super) async fn create_folder_exact_in_scope(
     }
 
     let now = Utc::now();
-    let created_by_username = load_scope_actor_username(&state.db, scope).await?;
+    let created_by_username = load_scope_actor_username(state.writer_db(), scope).await?;
     folder_repo::create(
-        &state.db,
+        state.writer_db(),
         folder::ActiveModel {
             name: Set(name),
             parent_id: Set(parent_id),
@@ -174,12 +174,22 @@ async fn resolve_unique_folder_name_in_scope(
     loop {
         let exists = match scope {
             WorkspaceStorageScope::Personal { user_id } => {
-                folder_repo::find_by_name_in_parent(&state.db, user_id, parent_id, &candidate)
-                    .await?
+                folder_repo::find_by_name_in_parent(
+                    state.writer_db(),
+                    user_id,
+                    parent_id,
+                    &candidate,
+                )
+                .await?
             }
             WorkspaceStorageScope::Team { team_id, .. } => {
-                folder_repo::find_by_name_in_team_parent(&state.db, team_id, parent_id, &candidate)
-                    .await?
+                folder_repo::find_by_name_in_team_parent(
+                    state.writer_db(),
+                    team_id,
+                    parent_id,
+                    &candidate,
+                )
+                .await?
             }
         };
         if exists.is_none() {

--- a/src/services/task_service/archive/compress.rs
+++ b/src/services/task_service/archive/compress.rs
@@ -123,7 +123,8 @@ pub(super) async fn process_archive_compress_task(
     let total_bytes = collected.total_source_bytes();
     let estimated_output_bytes = collected.estimated_output_bytes();
     if estimated_output_bytes > 0 {
-        workspace_storage_service::check_quota(&state.db, scope, estimated_output_bytes).await?;
+        workspace_storage_service::check_quota(state.writer_db(), scope, estimated_output_bytes)
+            .await?;
     }
     let entries = collected.into_entries();
     let progress_total = total_bytes.max(0);
@@ -154,7 +155,7 @@ pub(super) async fn process_archive_compress_task(
     let archive_temp_path_string = archive_temp_path.to_string_lossy().into_owned();
     let archive_temp_path_for_worker = archive_temp_path.clone();
     let handle = tokio::runtime::Handle::current();
-    let db = state.db.clone();
+    let db = state.writer_db().clone();
     let driver_registry = state.driver_registry.clone();
     let policy_snapshot = state.policy_snapshot.clone();
     let lease_guard_for_worker = lease_guard.clone();
@@ -262,7 +263,8 @@ pub(super) async fn process_archive_compress_task(
         target_file_id: stored.id,
         target_file_name: stored.name.clone(),
         target_folder_id: stored.folder_id,
-        target_path: build_file_display_path(&state.db, stored.folder_id, &stored.name).await?,
+        target_path: build_file_display_path(state.writer_db(), stored.folder_id, &stored.name)
+            .await?,
     };
     let result_json = serialize_task_result(&result)?;
     mark_task_succeeded(

--- a/src/services/task_service/archive/extract/mod.rs
+++ b/src/services/task_service/archive/extract/mod.rs
@@ -46,7 +46,7 @@ pub(crate) async fn create_archive_extract_task_in_scope(
     file_id: i64,
     params: CreateArchiveExtractTaskParams,
 ) -> Result<super::super::TaskInfo> {
-    workspace_storage_service::require_scope_access(state, scope).await?;
+    workspace_storage_service::require_scope_access_with_db(state, &state.db, scope).await?;
     let source_file = workspace_storage_service::verify_file_access(state, scope, file_id).await?;
     workspace_storage_service::ensure_active_file_scope(&source_file, scope)?;
     ensure_extract_source_supported(&source_file)?;

--- a/src/services/task_service/archive/extract/mod.rs
+++ b/src/services/task_service/archive/extract/mod.rs
@@ -46,7 +46,8 @@ pub(crate) async fn create_archive_extract_task_in_scope(
     file_id: i64,
     params: CreateArchiveExtractTaskParams,
 ) -> Result<super::super::TaskInfo> {
-    workspace_storage_service::require_scope_access_with_db(state, &state.db, scope).await?;
+    workspace_storage_service::require_scope_access_with_db(state, state.writer_db(), scope)
+        .await?;
     let source_file = workspace_storage_service::verify_file_access(state, scope, file_id).await?;
     workspace_storage_service::ensure_active_file_scope(&source_file, scope)?;
     ensure_extract_source_supported(&source_file)?;
@@ -139,7 +140,7 @@ pub(super) async fn process_archive_extract_task(
         )?;
         let steps_for_worker = steps.clone();
 
-        let db = state.db.clone();
+        let db = state.writer_db().clone();
         let policy_snapshot = state.policy_snapshot.clone();
         let handle = tokio::runtime::Handle::current();
         let lease_guard_for_worker = lease_guard.clone();
@@ -242,7 +243,7 @@ pub(super) async fn process_archive_extract_task(
         let result = ArchiveExtractTaskResult {
             target_folder_id: created_root.id,
             target_folder_name: created_root.name.clone(),
-            target_path: build_folder_display_path(&state.db, created_root.id).await?,
+            target_path: build_folder_display_path(state.writer_db(), created_root.id).await?,
             extracted_file_count: staged.file_count,
             extracted_folder_count: staged.directory_count,
         };
@@ -291,7 +292,7 @@ async fn cleanup_created_extract_root_after_import_error(
     }
 
     let lease = lease_guard.lease();
-    match background_task_repo::find_by_id(&state.db, lease.task_id).await {
+    match background_task_repo::find_by_id(state.writer_db(), lease.task_id).await {
         Ok(current_task)
             if should_cleanup_created_extract_root_for_lease_error(&current_task, lease) =>
         {
@@ -332,7 +333,7 @@ async fn cleanup_created_extract_root(
     root_folder_id: i64,
 ) {
     match crate::services::folder_service::collect_folder_tree_in_scope(
-        &state.db,
+        state.writer_db(),
         scope,
         root_folder_id,
         true,
@@ -349,7 +350,7 @@ async fn cleanup_created_extract_root(
                 );
             }
             if let Err(error) = crate::db::repository::property_repo::delete_all_for_entities(
-                &state.db,
+                state.writer_db(),
                 crate::types::EntityType::Folder,
                 &folder_ids,
             )
@@ -360,9 +361,11 @@ async fn cleanup_created_extract_root(
                     "failed to delete partially imported archive folder properties: {error}"
                 );
             }
-            if let Err(error) =
-                crate::db::repository::share_repo::delete_by_folder_ids(&state.db, &folder_ids)
-                    .await
+            if let Err(error) = crate::db::repository::share_repo::delete_by_folder_ids(
+                state.writer_db(),
+                &folder_ids,
+            )
+            .await
             {
                 tracing::warn!(
                     root_folder_id,
@@ -371,7 +374,8 @@ async fn cleanup_created_extract_root(
             }
             crate::services::folder_service::invalidate_folder_path_cache(state).await;
             if let Err(error) =
-                crate::db::repository::folder_repo::delete_many(&state.db, &folder_ids).await
+                crate::db::repository::folder_repo::delete_many(state.writer_db(), &folder_ids)
+                    .await
             {
                 tracing::warn!(
                     root_folder_id,

--- a/src/services/task_service/archive/extract/staging.rs
+++ b/src/services/task_service/archive/extract/staging.rs
@@ -141,7 +141,7 @@ pub(super) async fn download_file_to_temp(
     source_file: &file::Model,
     temp_path: &Path,
 ) -> Result<()> {
-    let blob = file_repo::find_blob_by_id(&state.db, source_file.blob_id).await?;
+    let blob = file_repo::find_blob_by_id(state.writer_db(), source_file.blob_id).await?;
     let policy = state.policy_snapshot.get_policy_or_err(blob.policy_id)?;
     let driver = state.driver_registry.get_driver(&policy)?;
     let mut stream = driver.get_stream(&blob.storage_path).await?;

--- a/src/services/task_service/archive/preview.rs
+++ b/src/services/task_service/archive/preview.rs
@@ -30,7 +30,7 @@ pub(crate) async fn ensure_archive_preview_task(
         archive_preview_task_display_name(source_file.id, blob.id, &blob.hash, limit_signature);
     if let Some(existing) =
         crate::db::repository::background_task_repo::find_latest_by_kind_and_display_name(
-            &state.db,
+            state.writer_db(),
             BackgroundTaskKind::ArchivePreviewGenerate,
             &display_name,
         )
@@ -121,7 +121,7 @@ pub(super) async fn process_archive_preview_task(
             Some("Worker claimed task"),
             None,
         )?;
-        let source_file = file_repo::find_by_id(&state.db, payload.file_id).await?;
+        let source_file = file_repo::find_by_id(state.writer_db(), payload.file_id).await?;
         ensure_source_file_matches_payload(&source_file, &payload)?;
         archive_preview_service::ensure_archive_preview_source_supported(&source_file)?;
         let limits = archive_preview_service::ArchivePreviewLimits::from_runtime_config(
@@ -142,7 +142,7 @@ pub(super) async fn process_archive_preview_task(
                 ),
             ));
         }
-        let blob = file_repo::find_blob_by_id(&state.db, source_file.blob_id).await?;
+        let blob = file_repo::find_blob_by_id(state.writer_db(), source_file.blob_id).await?;
         ensure_source_blob_matches_payload(&blob, &payload)?;
 
         let policy = state.policy_snapshot.get_policy_or_err(blob.policy_id)?;

--- a/src/services/task_service/archive/selection.rs
+++ b/src/services/task_service/archive/selection.rs
@@ -102,7 +102,7 @@ pub(crate) async fn stream_archive_download_in_scope(
 
     let (reader, writer) = tokio::io::duplex(64 * 1024);
     let handle = tokio::runtime::Handle::current();
-    let db = state.db.clone();
+    let db = state.writer_db().clone();
     let driver_registry = state.driver_registry.clone();
     let policy_snapshot = state.policy_snapshot.clone();
     let archive_name_for_worker = archive_name.clone();
@@ -198,10 +198,11 @@ async fn ensure_archive_selection_request_in_scope(
     file_ids: &[i64],
     folder_ids: &[i64],
 ) -> Result<()> {
-    workspace_storage_service::require_scope_access_with_db(state, &state.db, scope).await?;
+    workspace_storage_service::require_scope_access_with_db(state, state.writer_db(), scope)
+        .await?;
     batch_service::validate_batch_ids(file_ids, folder_ids)?;
 
-    let file_map: HashMap<i64, file::Model> = file_repo::find_by_ids(&state.db, file_ids)
+    let file_map: HashMap<i64, file::Model> = file_repo::find_by_ids(state.writer_db(), file_ids)
         .await?
         .into_iter()
         .map(|file| (file.id, file))
@@ -213,11 +214,12 @@ async fn ensure_archive_selection_request_in_scope(
         workspace_storage_service::ensure_active_file_scope(file, scope)?;
     }
 
-    let folder_map: HashMap<i64, folder::Model> = folder_repo::find_by_ids(&state.db, folder_ids)
-        .await?
-        .into_iter()
-        .map(|folder| (folder.id, folder))
-        .collect();
+    let folder_map: HashMap<i64, folder::Model> =
+        folder_repo::find_by_ids(state.writer_db(), folder_ids)
+            .await?
+            .into_iter()
+            .map(|folder| (folder.id, folder))
+            .collect();
     for &folder_id in folder_ids {
         let folder = folder_map
             .get(&folder_id)
@@ -284,9 +286,13 @@ pub(super) async fn collect_archive_entries_from_selection_in_scope(
         let archive_root =
             batch_service::reserve_unique_name(&mut reserved_root_names, &folder.name);
 
-        let (tree_files, tree_folder_ids) =
-            folder_service::collect_folder_tree_in_scope(&state.db, scope, folder_id, false)
-                .await?;
+        let (tree_files, tree_folder_ids) = folder_service::collect_folder_tree_in_scope(
+            state.writer_db(),
+            scope,
+            folder_id,
+            false,
+        )
+        .await?;
         let folder_paths =
             folder_service::build_folder_paths_cached(state, &tree_folder_ids).await?;
         let root_path = folder_paths

--- a/src/services/task_service/archive/selection.rs
+++ b/src/services/task_service/archive/selection.rs
@@ -198,7 +198,7 @@ async fn ensure_archive_selection_request_in_scope(
     file_ids: &[i64],
     folder_ids: &[i64],
 ) -> Result<()> {
-    workspace_storage_service::require_scope_access(state, scope).await?;
+    workspace_storage_service::require_scope_access_with_db(state, &state.db, scope).await?;
     batch_service::validate_batch_ids(file_ids, folder_ids)?;
 
     let file_map: HashMap<i64, file::Model> = file_repo::find_by_ids(&state.db, file_ids)

--- a/src/services/task_service/dispatch/claim.rs
+++ b/src/services/task_service/dispatch/claim.rs
@@ -37,7 +37,7 @@ pub(super) async fn claim_due_for_lane(
     let now = Utc::now();
     let stale_before = now - Duration::seconds(TASK_PROCESSING_STALE_SECS);
     let due = background_task_repo::list_claimable_by_kinds(
-        &state.db,
+        state.writer_db(),
         now,
         stale_before,
         lane_config.kinds(),
@@ -48,9 +48,12 @@ pub(super) async fn claim_due_for_lane(
         return Ok(Vec::new());
     }
 
-    let active =
-        background_task_repo::count_active_processing_by_kinds(&state.db, now, lane_config.kinds())
-            .await?;
+    let active = background_task_repo::count_active_processing_by_kinds(
+        state.writer_db(),
+        now,
+        lane_config.kinds(),
+    )
+    .await?;
     let available = available_lane_capacity(lane_config.limit, active);
     if available == 0 {
         tracing::debug!(
@@ -89,7 +92,8 @@ pub(super) async fn claim_due_for_lane(
     }
 
     let claimed =
-        claim_candidates_for_lane(&state.db, lane_config, &candidates, stale_before).await?;
+        claim_candidates_for_lane(state.writer_db(), lane_config, &candidates, stale_before)
+            .await?;
     let mut claimed_tasks = Vec::with_capacity(claimed.len());
     for claim in claimed {
         claimed_tasks.push((

--- a/src/services/task_service/dispatch/execute.rs
+++ b/src/services/task_service/dispatch/execute.rs
@@ -91,7 +91,7 @@ async fn process_claimed_task(
                     {
                         let now = Utc::now();
                         background_task_repo::touch_heartbeat(
-                            &state.db,
+                            state.writer_db(),
                             task.id,
                             lease.processing_token,
                             now,
@@ -137,7 +137,7 @@ async fn process_claimed_task(
             if !should_auto_retry {
                 let finished_at = Utc::now();
                 let failed = background_task_repo::mark_failed(
-                    &state.db,
+                    state.writer_db(),
                     background_task_repo::TaskFailureUpdate {
                         id: task.id,
                         processing_token: lease.processing_token,
@@ -172,7 +172,7 @@ async fn process_claimed_task(
             } else {
                 let retry_at = Utc::now() + Duration::seconds(retry_delay_secs(attempt_count));
                 let retried = background_task_repo::mark_retry(
-                    &state.db,
+                    state.writer_db(),
                     task.id,
                     lease.processing_token,
                     attempt_count,
@@ -250,7 +250,7 @@ async fn build_failed_task_steps_json(
     kind: BackgroundTaskKind,
     error_message: &str,
 ) -> Option<String> {
-    let latest = background_task_repo::find_by_id(&state.db, task_id)
+    let latest = background_task_repo::find_by_id(state.writer_db(), task_id)
         .await
         .ok()?;
     let mut steps =

--- a/src/services/task_service/dispatch/maintenance.rs
+++ b/src/services/task_service/dispatch/maintenance.rs
@@ -21,7 +21,7 @@ pub async fn drain(state: &PrimaryAppState) -> Result<DispatchStats> {
             continue;
         }
 
-        if background_task_repo::count_processing(&state.db).await? == 0 {
+        if background_task_repo::count_processing(state.writer_db()).await? == 0 {
             break;
         }
 
@@ -72,26 +72,27 @@ pub async fn cleanup_expired(state: &PrimaryAppState) -> Result<u64> {
         // 这里只删“产物目录”，不删 background_task 记录：
         // - 终态且 expires_at 已到的任务：删 temp 目录，保留历史行；
         // - 数据库里已经没有任务行的孤儿目录：直接删，避免长期泄露磁盘。
-        let should_cleanup = match background_task_repo::find_by_id(&state.db, task_id).await {
-            Ok(task) => {
-                task.expires_at <= now
-                    && matches!(
-                        task.status,
-                        BackgroundTaskStatus::Succeeded
-                            | BackgroundTaskStatus::Failed
-                            | BackgroundTaskStatus::Canceled
-                    )
-            }
-            Err(AsterError::RecordNotFound(_)) => {
-                tracing::warn!(
-                    task_id,
-                    path = %path_display,
-                    "cleaning orphaned task temp dir without task record"
-                );
-                true
-            }
-            Err(error) => return Err(error),
-        };
+        let should_cleanup =
+            match background_task_repo::find_by_id(state.writer_db(), task_id).await {
+                Ok(task) => {
+                    task.expires_at <= now
+                        && matches!(
+                            task.status,
+                            BackgroundTaskStatus::Succeeded
+                                | BackgroundTaskStatus::Failed
+                                | BackgroundTaskStatus::Canceled
+                        )
+                }
+                Err(AsterError::RecordNotFound(_)) => {
+                    tracing::warn!(
+                        task_id,
+                        path = %path_display,
+                        "cleaning orphaned task temp dir without task record"
+                    );
+                    true
+                }
+                Err(error) => return Err(error),
+            };
         if !should_cleanup {
             continue;
         }

--- a/src/services/task_service/media_metadata.rs
+++ b/src/services/task_service/media_metadata.rs
@@ -55,7 +55,7 @@ pub(crate) async fn ensure_media_metadata_task(
 ) -> Result<()> {
     let display_name = media_metadata_service::task_display_name(blob.id, kind);
     if let Some(existing) = background_task_repo::find_latest_by_kind_and_display_name(
-        &state.db,
+        state.writer_db(),
         BackgroundTaskKind::MediaMetadataExtract,
         &display_name,
     )
@@ -88,7 +88,7 @@ pub(crate) async fn ensure_media_metadata_task(
         BackgroundTaskKind::MediaMetadataExtract,
     ))?;
     background_task_repo::create(
-        &state.db,
+        state.writer_db(),
         background_task::ActiveModel {
             kind: Set(BackgroundTaskKind::MediaMetadataExtract),
             status: Set(BackgroundTaskStatus::Pending),
@@ -158,7 +158,8 @@ pub(super) async fn process_media_metadata_extract_task(
     .await?;
 
     let blob =
-        crate::db::repository::file_repo::find_blob_by_id(&state.db, payload.blob_id).await?;
+        crate::db::repository::file_repo::find_blob_by_id(state.writer_db(), payload.blob_id)
+            .await?;
     if blob.hash != payload.blob_hash {
         return Err(AsterError::validation_error("source blob hash changed"));
     }

--- a/src/services/task_service/mod.rs
+++ b/src/services/task_service/mod.rs
@@ -249,7 +249,7 @@ pub(crate) async fn get_task_in_scope(
     scope: WorkspaceStorageScope,
     task_id: i64,
 ) -> Result<TaskInfo> {
-    workspace_storage_service::require_scope_access(state, scope).await?;
+    workspace_storage_service::require_scope_access_with_db(state, &state.db, scope).await?;
     let task = background_task_repo::find_by_id(&state.db, task_id).await?;
     ensure_task_in_scope(&task, scope)?;
     build_task_info_with_lookup(state, task).await
@@ -260,7 +260,7 @@ pub(crate) async fn retry_task_in_scope(
     scope: WorkspaceStorageScope,
     task_id: i64,
 ) -> Result<TaskInfo> {
-    workspace_storage_service::require_scope_access(state, scope).await?;
+    workspace_storage_service::require_scope_access_with_db(state, &state.db, scope).await?;
     let task = background_task_repo::find_by_id(&state.db, task_id).await?;
     ensure_task_in_scope(&task, scope)?;
 

--- a/src/services/task_service/mod.rs
+++ b/src/services/task_service/mod.rs
@@ -189,10 +189,12 @@ pub(crate) async fn list_tasks_paginated_in_scope(
     let limit = limit.clamp(1, operations::task_list_max_limit(&state.runtime_config));
     let (tasks, total) = match scope {
         WorkspaceStorageScope::Personal { user_id } => {
-            background_task_repo::find_paginated_personal(&state.db, user_id, limit, offset).await?
+            background_task_repo::find_paginated_personal(state.writer_db(), user_id, limit, offset)
+                .await?
         }
         WorkspaceStorageScope::Team { team_id, .. } => {
-            background_task_repo::find_paginated_team(&state.db, team_id, limit, offset).await?
+            background_task_repo::find_paginated_team(state.writer_db(), team_id, limit, offset)
+                .await?
         }
     };
 
@@ -211,7 +213,7 @@ pub(crate) async fn list_tasks_paginated_for_admin(
 ) -> Result<OffsetPage<TaskInfo>> {
     let limit = limit.clamp(1, operations::task_list_max_limit(&state.runtime_config));
     let (tasks, total) = background_task_repo::find_paginated_all_filtered(
-        &state.db,
+        state.writer_db(),
         limit,
         offset,
         &background_task_repo::AdminTaskFilters {
@@ -234,7 +236,7 @@ pub(crate) async fn cleanup_tasks_for_admin(
 ) -> Result<u64> {
     validate_admin_task_cleanup_status(filters.status)?;
     background_task_repo::delete_terminal_by_filters(
-        &state.db,
+        state.writer_db(),
         &background_task_repo::TerminalTaskCleanupFilters {
             finished_before: filters.finished_before,
             kind: filters.kind,
@@ -249,8 +251,9 @@ pub(crate) async fn get_task_in_scope(
     scope: WorkspaceStorageScope,
     task_id: i64,
 ) -> Result<TaskInfo> {
-    workspace_storage_service::require_scope_access_with_db(state, &state.db, scope).await?;
-    let task = background_task_repo::find_by_id(&state.db, task_id).await?;
+    workspace_storage_service::require_scope_access_with_db(state, state.writer_db(), scope)
+        .await?;
+    let task = background_task_repo::find_by_id(state.writer_db(), task_id).await?;
     ensure_task_in_scope(&task, scope)?;
     build_task_info_with_lookup(state, task).await
 }
@@ -260,8 +263,9 @@ pub(crate) async fn retry_task_in_scope(
     scope: WorkspaceStorageScope,
     task_id: i64,
 ) -> Result<TaskInfo> {
-    workspace_storage_service::require_scope_access_with_db(state, &state.db, scope).await?;
-    let task = background_task_repo::find_by_id(&state.db, task_id).await?;
+    workspace_storage_service::require_scope_access_with_db(state, state.writer_db(), scope)
+        .await?;
+    let task = background_task_repo::find_by_id(state.writer_db(), task_id).await?;
     ensure_task_in_scope(&task, scope)?;
 
     if task.status != BackgroundTaskStatus::Failed {
@@ -283,7 +287,7 @@ pub(crate) async fn retry_task_in_scope(
 
     let now = Utc::now();
     if !background_task_repo::reset_for_manual_retry(
-        &state.db,
+        state.writer_db(),
         task.id,
         now,
         max_attempts,
@@ -450,7 +454,7 @@ pub(super) async fn create_task_record<T: Serialize>(
     // 用户可见的新后台任务都应该走这个入口创建，这样 archive / 未来的
     // download_background 一类任务能自动唤醒 dispatcher，而不是等空闲退避 timer。
     let task = background_task_repo::create(
-        &state.db,
+        state.writer_db(),
         background_task::ActiveModel {
             kind: Set(kind),
             status: Set(BackgroundTaskStatus::Pending),
@@ -512,7 +516,15 @@ pub(super) async fn mark_task_progress(
     status_text: Option<&str>,
     steps: &[TaskStepInfo],
 ) -> Result<()> {
-    update_task_progress_db(&state.db, lease_guard, current, total, status_text, steps).await
+    update_task_progress_db(
+        state.writer_db(),
+        lease_guard,
+        current,
+        total,
+        status_text,
+        steps,
+    )
+    .await
 }
 
 pub(super) async fn update_task_progress_db(
@@ -563,7 +575,7 @@ pub(super) async fn mark_task_succeeded(
     let steps_json = serialize_task_steps(steps)?;
     let lease = lease_guard.lease();
     if background_task_repo::mark_succeeded(
-        &state.db,
+        state.writer_db(),
         background_task_repo::TaskSuccessUpdate {
             id: lease.task_id,
             processing_token: lease.processing_token,

--- a/src/services/task_service/runtime.rs
+++ b/src/services/task_service/runtime.rs
@@ -142,12 +142,14 @@ pub async fn record_runtime_task_run(
     })?;
 
     if should_refresh_latest_success(task_name, outcome)
-        && let Some(existing) =
-            background_task_repo::find_latest_system_runtime_by_task_name(&state.db, task_name)
-                .await?
+        && let Some(existing) = background_task_repo::find_latest_system_runtime_by_task_name(
+            state.writer_db(),
+            task_name,
+        )
+        .await?
         && existing.status == BackgroundTaskStatus::Succeeded
         && background_task_repo::refresh_system_runtime_success(
-            &state.db,
+            state.writer_db(),
             background_task_repo::SystemRuntimeSuccessRefresh {
                 id: existing.id,
                 result_json: result_json.as_ref(),
@@ -160,7 +162,7 @@ pub async fn record_runtime_task_run(
         )
         .await?
     {
-        return background_task_repo::find_by_id(&state.db, existing.id)
+        return background_task_repo::find_by_id(state.writer_db(), existing.id)
             .await
             .map(Some);
     }
@@ -169,7 +171,7 @@ pub async fn record_runtime_task_run(
     // 区别在于 runtime 任务的 kind 是 SystemRuntime，它们只是执行事件记录，
     // 不会再被 dispatcher 拿去执行。
     let task = background_task_repo::create(
-        &state.db,
+        state.writer_db(),
         background_task::ActiveModel {
             kind: Set(BackgroundTaskKind::SystemRuntime),
             status: Set(outcome.status()),

--- a/src/services/task_service/storage_policy_cleanup.rs
+++ b/src/services/task_service/storage_policy_cleanup.rs
@@ -71,7 +71,7 @@ pub(crate) async fn create_storage_policy_temp_cleanup_task(
     ))?;
 
     background_task_repo::create(
-        &state.db,
+        state.writer_db(),
         background_task::ActiveModel {
             kind: Set(BackgroundTaskKind::StoragePolicyTempCleanup),
             status: Set(BackgroundTaskStatus::Pending),
@@ -287,7 +287,7 @@ async fn remote_node_snapshot_for_policy(
     let remote_node_id = policy.remote_node_id.ok_or_else(|| {
         AsterError::validation_error("remote storage policy requires remote_node_id")
     })?;
-    let remote = managed_follower_repo::find_by_id(&state.db, remote_node_id).await?;
+    let remote = managed_follower_repo::find_by_id(state.writer_db(), remote_node_id).await?;
     Ok(Some(StoragePolicyCleanupRemoteNodeSnapshot {
         id: remote.id,
         name: remote.name,

--- a/src/services/task_service/thumbnail.rs
+++ b/src/services/task_service/thumbnail.rs
@@ -67,7 +67,7 @@ pub(crate) async fn ensure_thumbnail_task(
     );
     let display_name = thumbnail_task_display_name(blob.id, processor);
     if let Some(existing) = background_task_repo::find_latest_by_kind_and_display_name(
-        &state.db,
+        state.writer_db(),
         BackgroundTaskKind::ThumbnailGenerate,
         &display_name,
     )
@@ -101,7 +101,7 @@ pub(crate) async fn ensure_thumbnail_task(
     let steps_json =
         serialize_task_steps(&initial_task_steps(BackgroundTaskKind::ThumbnailGenerate))?;
     background_task_repo::create(
-        &state.db,
+        state.writer_db(),
         background_task::ActiveModel {
             kind: Set(BackgroundTaskKind::ThumbnailGenerate),
             status: Set(BackgroundTaskStatus::Pending),
@@ -180,7 +180,8 @@ pub(super) async fn process_thumbnail_generate_task(
     .await?;
 
     let blob =
-        crate::db::repository::file_repo::find_blob_by_id(&state.db, payload.blob_id).await?;
+        crate::db::repository::file_repo::find_blob_by_id(state.writer_db(), payload.blob_id)
+            .await?;
     lease_guard.ensure_active()?;
     set_task_step_succeeded(
         &mut steps,

--- a/src/services/task_service/trash.rs
+++ b/src/services/task_service/trash.rs
@@ -22,7 +22,7 @@ pub(crate) async fn create_trash_purge_all_task_in_scope(
     state: &PrimaryAppState,
     scope: WorkspaceStorageScope,
 ) -> Result<TaskInfo> {
-    workspace_storage_service::require_scope_access(state, scope).await?;
+    workspace_storage_service::require_scope_access_with_db(state, &state.db, scope).await?;
     let payload = TrashPurgeAllTaskPayload {};
     let task = create_task_record(
         state,

--- a/src/services/task_service/trash.rs
+++ b/src/services/task_service/trash.rs
@@ -22,7 +22,8 @@ pub(crate) async fn create_trash_purge_all_task_in_scope(
     state: &PrimaryAppState,
     scope: WorkspaceStorageScope,
 ) -> Result<TaskInfo> {
-    workspace_storage_service::require_scope_access_with_db(state, &state.db, scope).await?;
+    workspace_storage_service::require_scope_access_with_db(state, state.writer_db(), scope)
+        .await?;
     let payload = TrashPurgeAllTaskPayload {};
     let task = create_task_record(
         state,

--- a/src/services/team_service/admin.rs
+++ b/src/services/team_service/admin.rs
@@ -108,7 +108,7 @@ pub async fn update_admin_team(
     team_id: i64,
     input: AdminUpdateTeamInput,
 ) -> Result<AdminTeamInfo> {
-    let team = team_repo::find_active_by_id(&state.db, team_id).await?;
+    let team = team_repo::find_active_by_id(state.writer_db(), team_id).await?;
     let updated = update_team_record(
         state,
         team,
@@ -123,12 +123,12 @@ pub async fn update_admin_team(
 }
 
 pub async fn archive_admin_team(state: &PrimaryAppState, team_id: i64) -> Result<()> {
-    let team = team_repo::find_active_by_id(&state.db, team_id).await?;
+    let team = team_repo::find_active_by_id(state.writer_db(), team_id).await?;
     archive_team_record(state, team).await
 }
 
 pub async fn restore_admin_team(state: &PrimaryAppState, team_id: i64) -> Result<AdminTeamInfo> {
-    let team = team_repo::find_archived_by_id(&state.db, team_id).await?;
+    let team = team_repo::find_archived_by_id(state.writer_db(), team_id).await?;
     let restored = restore_team_record(state, team).await?;
     build_admin_team_info(state, &restored).await
 }

--- a/src/services/team_service/admin.rs
+++ b/src/services/team_service/admin.rs
@@ -27,12 +27,24 @@ pub async fn list_admin_teams(
     let page = load_offset_page(limit, offset, 100, |limit, offset| async move {
         if archived {
             team_repo::find_archived_paginated(
-                &state.db, limit, offset, keyword, sort_by, sort_order,
+                state.reader_db(),
+                limit,
+                offset,
+                keyword,
+                sort_by,
+                sort_order,
             )
             .await
         } else {
-            team_repo::find_active_paginated(&state.db, limit, offset, keyword, sort_by, sort_order)
-                .await
+            team_repo::find_active_paginated(
+                state.reader_db(),
+                limit,
+                offset,
+                keyword,
+                sort_by,
+                sort_order,
+            )
+            .await
         }
     })
     .await?;
@@ -54,7 +66,7 @@ pub async fn list_admin_teams(
 }
 
 pub async fn get_admin_team(state: &PrimaryAppState, team_id: i64) -> Result<AdminTeamInfo> {
-    let team = team_repo::find_by_id(&state.db, team_id).await?;
+    let team = team_repo::find_by_id(state.reader_db(), team_id).await?;
     build_admin_team_info(state, &team).await
 }
 

--- a/src/services/team_service/archive.rs
+++ b/src/services/team_service/archive.rs
@@ -143,7 +143,7 @@ async fn purge_archived_team_files(state: &PrimaryAppState, team: &team::Model) 
 
     loop {
         let files = file_repo::find_all_by_team_paginated(
-            &state.db,
+            state.writer_db(),
             team.id,
             after_file_id,
             TEAM_ARCHIVE_BATCH_SIZE,
@@ -192,12 +192,12 @@ async fn force_delete_archived_team(state: &PrimaryAppState, team: team::Model) 
         team_name = %team_name,
         "force deleting archived team"
     );
-    let upload_sessions = upload_session_repo::find_by_team(&state.db, team_id).await?;
+    let upload_sessions = upload_session_repo::find_by_team(state.writer_db(), team_id).await?;
     cleanup_team_upload_sessions(state, &upload_sessions).await?;
 
     purge_archived_team_files(state, &team).await?;
 
-    let txn = crate::db::transaction::begin(&state.db).await?;
+    let txn = crate::db::transaction::begin(state.writer_db()).await?;
     team_repo::lock_archived_by_id(&txn, team_id).await?;
     upload_session_repo::delete_all_by_team(&txn, team_id).await?;
     clear_team_locks(&txn, team_id).await?;
@@ -232,7 +232,7 @@ async fn force_delete_archived_team(state: &PrimaryAppState, team: team::Model) 
 pub async fn cleanup_expired_archived_teams(state: &PrimaryAppState) -> Result<u64> {
     let retention_days = load_team_archive_retention_days(state);
     let cutoff = Utc::now() - chrono::Duration::days(retention_days);
-    let expired = team_repo::find_archived_before(&state.db, cutoff).await?;
+    let expired = team_repo::find_archived_before(state.writer_db(), cutoff).await?;
 
     let mut deleted = 0u64;
     let ctx = audit_service::AuditContext::system();

--- a/src/services/team_service/members.rs
+++ b/src/services/team_service/members.rs
@@ -30,7 +30,7 @@ pub async fn list_admin_members(
     limit: u64,
     offset: u64,
 ) -> Result<TeamMemberPage> {
-    team_repo::find_by_id(&state.db, team_id).await?;
+    team_repo::find_by_id(state.writer_db(), team_id).await?;
     load_team_member_page(state, team_id, &filters, limit, offset).await
 }
 
@@ -39,13 +39,14 @@ pub async fn get_admin_member(
     team_id: i64,
     member_user_id: i64,
 ) -> Result<TeamMemberInfo> {
-    team_repo::find_by_id(&state.db, team_id).await?;
-    let membership = team_member_repo::find_by_team_and_user(&state.db, team_id, member_user_id)
-        .await?
-        .ok_or_else(|| {
-            AsterError::record_not_found(format!("team member user #{member_user_id}"))
-        })?;
-    let user = user_repo::find_by_id(&state.db, member_user_id).await?;
+    team_repo::find_by_id(state.writer_db(), team_id).await?;
+    let membership =
+        team_member_repo::find_by_team_and_user(state.writer_db(), team_id, member_user_id)
+            .await?
+            .ok_or_else(|| {
+                AsterError::record_not_found(format!("team member user #{member_user_id}"))
+            })?;
+    let user = user_repo::find_by_id(state.writer_db(), member_user_id).await?;
     build_team_member_info(state, membership, user).await
 }
 
@@ -63,7 +64,7 @@ pub async fn add_admin_member(
     }
 
     let now = Utc::now();
-    let txn = crate::db::transaction::begin(&state.db).await?;
+    let txn = crate::db::transaction::begin(state.writer_db()).await?;
     team_repo::lock_active_by_id(&txn, team_id).await?;
 
     // 先锁团队再查 membership，避免并发添加把同一用户重复插入 team_members。
@@ -102,7 +103,7 @@ pub async fn update_admin_member_role(
     member_user_id: i64,
     role: TeamMemberRole,
 ) -> Result<TeamMemberInfo> {
-    let txn = crate::db::transaction::begin(&state.db).await?;
+    let txn = crate::db::transaction::begin(state.writer_db()).await?;
     team_repo::lock_active_by_id(&txn, team_id).await?;
 
     let target_membership = team_member_repo::find_by_team_and_user(&txn, team_id, member_user_id)
@@ -138,7 +139,7 @@ pub async fn remove_admin_member(
     team_id: i64,
     member_user_id: i64,
 ) -> Result<()> {
-    let txn = crate::db::transaction::begin(&state.db).await?;
+    let txn = crate::db::transaction::begin(state.writer_db()).await?;
     team_repo::lock_active_by_id(&txn, team_id).await?;
 
     let target_membership = team_member_repo::find_by_team_and_user(&txn, team_id, member_user_id)
@@ -191,12 +192,13 @@ pub async fn get_member(
     member_user_id: i64,
 ) -> Result<TeamMemberInfo> {
     require_team_membership(state, team_id, actor_user_id).await?;
-    let membership = team_member_repo::find_by_team_and_user(&state.db, team_id, member_user_id)
-        .await?
-        .ok_or_else(|| {
-            AsterError::record_not_found(format!("team member user #{member_user_id}"))
-        })?;
-    let user = user_repo::find_by_id(&state.db, member_user_id).await?;
+    let membership =
+        team_member_repo::find_by_team_and_user(state.writer_db(), team_id, member_user_id)
+            .await?
+            .ok_or_else(|| {
+                AsterError::record_not_found(format!("team member user #{member_user_id}"))
+            })?;
+    let user = user_repo::find_by_id(state.writer_db(), member_user_id).await?;
     build_team_member_info(state, membership, user).await
 }
 
@@ -215,7 +217,7 @@ pub async fn add_member(
     }
 
     let now = Utc::now();
-    let txn = crate::db::transaction::begin(&state.db).await?;
+    let txn = crate::db::transaction::begin(state.writer_db()).await?;
     team_repo::lock_active_by_id(&txn, team_id).await?;
 
     let actor_membership = team_member_repo::find_by_team_and_user(&txn, team_id, actor_user_id)
@@ -268,7 +270,7 @@ pub async fn update_member_role(
     member_user_id: i64,
     role: TeamMemberRole,
 ) -> Result<TeamMemberInfo> {
-    let txn = crate::db::transaction::begin(&state.db).await?;
+    let txn = crate::db::transaction::begin(state.writer_db()).await?;
     team_repo::lock_active_by_id(&txn, team_id).await?;
 
     let actor_membership = team_member_repo::find_by_team_and_user(&txn, team_id, actor_user_id)
@@ -321,7 +323,7 @@ pub async fn remove_member(
     actor_user_id: i64,
     member_user_id: i64,
 ) -> Result<()> {
-    let txn = crate::db::transaction::begin(&state.db).await?;
+    let txn = crate::db::transaction::begin(state.writer_db()).await?;
     team_repo::lock_active_by_id(&txn, team_id).await?;
 
     let actor_membership = team_member_repo::find_by_team_and_user(&txn, team_id, actor_user_id)

--- a/src/services/team_service/shared.rs
+++ b/src/services/team_service/shared.rs
@@ -103,7 +103,7 @@ pub(super) async fn build_team_info(
     my_role: TeamMemberRole,
 ) -> Result<TeamInfo> {
     let creator = load_creator_summary(state, team).await?;
-    let member_count = team_member_repo::count_by_team(&state.db, team.id).await?;
+    let member_count = team_member_repo::count_by_team(state.reader_db(), team.id).await?;
 
     Ok(build_team_info_with_metadata(
         team,
@@ -140,7 +140,7 @@ pub(super) async fn build_admin_team_info(
     team: &team::Model,
 ) -> Result<AdminTeamInfo> {
     let creator = load_creator_summary(state, team).await?;
-    let member_count = team_member_repo::count_by_team(&state.db, team.id).await?;
+    let member_count = team_member_repo::count_by_team(state.reader_db(), team.id).await?;
 
     Ok(build_admin_team_info_with_metadata(
         team,
@@ -271,13 +271,13 @@ pub(super) async fn load_team_member_page(
     };
     let ((rows, total), role_counts) = tokio::try_join!(
         team_member_repo::list_page_by_team_with_user(
-            &state.db,
+            state.reader_db(),
             team_id,
             effective_limit,
             offset,
             &repo_filters,
         ),
-        team_member_repo::count_by_team_grouped_by_role(&state.db, team_id),
+        team_member_repo::count_by_team_grouped_by_role(state.reader_db(), team_id),
     )?;
     let mut owner_count = 0;
     let mut admin_count = 0;
@@ -331,10 +331,26 @@ pub(super) async fn require_team_membership(
     team_id: i64,
     user_id: i64,
 ) -> Result<(team::Model, team_member::Model)> {
+    require_team_membership_with_db(&state.db, team_id, user_id).await
+}
+
+pub(super) async fn require_team_membership_for_read(
+    state: &PrimaryAppState,
+    team_id: i64,
+    user_id: i64,
+) -> Result<(team::Model, team_member::Model)> {
+    require_team_membership_with_db(state.reader_db(), team_id, user_id).await
+}
+
+async fn require_team_membership_with_db<C: ConnectionTrait>(
+    db: &C,
+    team_id: i64,
+    user_id: i64,
+) -> Result<(team::Model, team_member::Model)> {
     // 这里故意只接受 active team。
     // 对归档团队的访问需要走专门恢复 / admin 流程，避免普通团队 API 混入 archived 语义。
-    let team = team_repo::find_active_by_id(&state.db, team_id).await?;
-    let membership = team_member_repo::find_by_team_and_user(&state.db, team_id, user_id)
+    let team = team_repo::find_active_by_id(db, team_id).await?;
+    let membership = team_member_repo::find_by_team_and_user(db, team_id, user_id)
         .await?
         .ok_or_else(|| {
             auth_forbidden_with_subcode(ApiSubcode::TeamNotMember, "not a member of this team")
@@ -405,7 +421,7 @@ pub(super) async fn load_team_metadata<'a>(
             &creator_ids,
             profile_service::AvatarAudience::AdminUser,
         ),
-        team_member_repo::count_by_team_ids(&state.db, &team_ids),
+        team_member_repo::count_by_team_ids(state.reader_db(), &team_ids),
     )?;
 
     Ok((creators, member_counts))

--- a/src/services/team_service/shared.rs
+++ b/src/services/team_service/shared.rs
@@ -313,12 +313,12 @@ pub(super) async fn resolve_target_user(
         (None, None) => Err(AsterError::validation_error(
             "user_id or identifier is required",
         )),
-        (Some(user_id), None) => user_repo::find_by_id(&state.db, user_id).await,
+        (Some(user_id), None) => user_repo::find_by_id(state.writer_db(), user_id).await,
         (None, Some(identifier)) => {
-            if let Some(user) = user_repo::find_by_username(&state.db, identifier).await? {
+            if let Some(user) = user_repo::find_by_username(state.writer_db(), identifier).await? {
                 return Ok(user);
             }
-            if let Some(user) = user_repo::find_by_email(&state.db, identifier).await? {
+            if let Some(user) = user_repo::find_by_email(state.writer_db(), identifier).await? {
                 return Ok(user);
             }
             Err(AsterError::record_not_found(format!("user '{identifier}'")))
@@ -331,7 +331,7 @@ pub(super) async fn require_team_membership(
     team_id: i64,
     user_id: i64,
 ) -> Result<(team::Model, team_member::Model)> {
-    require_team_membership_with_db(&state.db, team_id, user_id).await
+    require_team_membership_with_db(state.writer_db(), team_id, user_id).await
 }
 
 pub(super) async fn require_team_membership_for_read(
@@ -431,14 +431,14 @@ pub(super) async fn ensure_assignable_policy_group(
     state: &PrimaryAppState,
     group_id: i64,
 ) -> Result<()> {
-    let group = policy_group_repo::find_group_by_id(&state.db, group_id).await?;
+    let group = policy_group_repo::find_group_by_id(state.writer_db(), group_id).await?;
     if !group.is_enabled {
         return Err(AsterError::validation_error(
             "cannot assign a disabled storage policy group",
         ));
     }
 
-    let items = policy_group_repo::find_group_items(&state.db, group_id).await?;
+    let items = policy_group_repo::find_group_items(state.writer_db(), group_id).await?;
     if items.is_empty() {
         return Err(AsterError::validation_error(
             "cannot assign a storage policy group without policies",
@@ -482,7 +482,7 @@ pub(super) async fn create_team_record(
     let storage_quota = default_team_storage_quota(state);
     let now = Utc::now();
 
-    let txn = crate::db::transaction::begin(&state.db).await?;
+    let txn = crate::db::transaction::begin(state.writer_db()).await?;
     let created_team = team_repo::create(
         &txn,
         team::ActiveModel {
@@ -549,7 +549,7 @@ pub(super) async fn update_team_record(
     }
     active.updated_at = Set(Utc::now());
 
-    let updated = team_repo::update(&state.db, active).await?;
+    let updated = team_repo::update(state.writer_db(), active).await?;
     crate::services::workspace_storage_service::invalidate_team_access_cache_for_team(
         state, updated.id,
     )
@@ -569,7 +569,7 @@ pub(super) async fn archive_team_record(state: &PrimaryAppState, team: team::Mod
     let now = Utc::now();
     active.archived_at = Set(Some(now));
     active.updated_at = Set(now);
-    team_repo::update(&state.db, active).await?;
+    team_repo::update(state.writer_db(), active).await?;
     crate::services::workspace_storage_service::invalidate_team_access_cache_for_team(
         state, team_id,
     )
@@ -593,7 +593,7 @@ pub(super) async fn restore_team_record(
     let now = Utc::now();
     active.archived_at = Set(None);
     active.updated_at = Set(now);
-    let restored = team_repo::update(&state.db, active).await?;
+    let restored = team_repo::update(state.writer_db(), active).await?;
     crate::services::workspace_storage_service::invalidate_team_access_cache_for_team(
         state,
         restored.id,

--- a/src/services/team_service/team.rs
+++ b/src/services/team_service/team.rs
@@ -15,7 +15,8 @@ use crate::types::TeamMemberRole;
 use super::shared::{
     archive_team_record, build_team_info, build_team_info_with_metadata, create_team_record,
     ensure_can_manage_team, load_team_metadata, require_team_membership,
-    resolve_required_policy_group_id, restore_team_record, update_team_record,
+    require_team_membership_for_read, resolve_required_policy_group_id, restore_team_record,
+    update_team_record,
 };
 use super::{CreateTeamInput, TeamInfo, UpdateTeamInput};
 
@@ -84,12 +85,22 @@ async fn list_user_team_memberships(
     // 这样角色信息和 archived 过滤能保持一致，不会出现“能看到 team 但没有 membership”的状态。
     if archived {
         team_member_repo::list_by_user_with_archived_team_filtered(
-            &state.db, user_id, keyword, limit, offset, None,
+            state.reader_db(),
+            user_id,
+            keyword,
+            limit,
+            offset,
+            None,
         )
         .await
     } else {
         team_member_repo::list_by_user_with_team_filtered(
-            &state.db, user_id, keyword, limit, offset, None,
+            state.reader_db(),
+            user_id,
+            keyword,
+            limit,
+            offset,
+            None,
         )
         .await
     }
@@ -116,7 +127,7 @@ pub async fn create_team(
 }
 
 pub async fn get_team(state: &PrimaryAppState, team_id: i64, user_id: i64) -> Result<TeamInfo> {
-    let (team, membership) = require_team_membership(state, team_id, user_id).await?;
+    let (team, membership) = require_team_membership_for_read(state, team_id, user_id).await?;
     build_team_info(state, &team, membership.role).await
 }
 

--- a/src/services/team_service/team.rs
+++ b/src/services/team_service/team.rs
@@ -161,12 +161,13 @@ pub async fn restore_team(
     team_id: i64,
     actor_user_id: i64,
 ) -> Result<TeamInfo> {
-    let team = team_repo::find_archived_by_id(&state.db, team_id).await?;
-    let membership = team_member_repo::find_by_team_and_user(&state.db, team_id, actor_user_id)
-        .await?
-        .ok_or_else(|| {
-            auth_forbidden_with_subcode(ApiSubcode::TeamNotMember, "not a member of this team")
-        })?;
+    let team = team_repo::find_archived_by_id(state.writer_db(), team_id).await?;
+    let membership =
+        team_member_repo::find_by_team_and_user(state.writer_db(), team_id, actor_user_id)
+            .await?
+            .ok_or_else(|| {
+                auth_forbidden_with_subcode(ApiSubcode::TeamNotMember, "not a member of this team")
+            })?;
     ensure_can_manage_team(membership.role)?;
 
     let restored = restore_team_record(state, team).await?;

--- a/src/services/trash_service/cleanup.rs
+++ b/src/services/trash_service/cleanup.rs
@@ -19,7 +19,7 @@ pub async fn cleanup_expired(state: &PrimaryAppState) -> Result<u32> {
     let mut count: u32 = 0;
 
     // 清理过期文件（批量）
-    let expired_files = file_repo::find_expired_deleted(&state.db, cutoff).await?;
+    let expired_files = file_repo::find_expired_deleted(state.writer_db(), cutoff).await?;
     let mut by_user: HashMap<i64, Vec<file::Model>> = HashMap::new();
     let mut by_team: HashMap<i64, Vec<file::Model>> = HashMap::new();
     for file in expired_files {
@@ -66,7 +66,7 @@ pub async fn cleanup_expired(state: &PrimaryAppState) -> Result<u32> {
     }
 
     // 清理过期文件夹，只处理顶层，父文件夹会递归覆盖子项。
-    let expired_folders = folder_repo::find_expired_deleted(&state.db, cutoff).await?;
+    let expired_folders = folder_repo::find_expired_deleted(state.writer_db(), cutoff).await?;
     let expired_folder_ids: HashSet<i64> = expired_folders.iter().map(|folder| folder.id).collect();
     let top_level_folders: Vec<&folder::Model> = expired_folders
         .iter()

--- a/src/services/trash_service/common.rs
+++ b/src/services/trash_service/common.rs
@@ -129,7 +129,7 @@ pub(super) async fn verify_file_in_trash_in_scope(
     scope: WorkspaceStorageScope,
     file_id: i64,
 ) -> Result<file::Model> {
-    workspace_storage_service::require_scope_access(state, scope).await?;
+    workspace_storage_service::require_scope_access_with_db(state, &state.db, scope).await?;
     let file = file_repo::find_by_id(&state.db, file_id).await?;
     workspace_storage_service::ensure_file_scope(&file, scope)?;
     if file.deleted_at.is_none() {
@@ -143,7 +143,7 @@ pub(super) async fn verify_folder_in_trash_in_scope(
     scope: WorkspaceStorageScope,
     folder_id: i64,
 ) -> Result<folder::Model> {
-    workspace_storage_service::require_scope_access(state, scope).await?;
+    workspace_storage_service::require_scope_access_with_db(state, &state.db, scope).await?;
     let folder = folder_repo::find_by_id(&state.db, folder_id).await?;
     workspace_storage_service::ensure_folder_scope(&folder, scope)?;
     if folder.deleted_at.is_none() {

--- a/src/services/trash_service/common.rs
+++ b/src/services/trash_service/common.rs
@@ -129,8 +129,9 @@ pub(super) async fn verify_file_in_trash_in_scope(
     scope: WorkspaceStorageScope,
     file_id: i64,
 ) -> Result<file::Model> {
-    workspace_storage_service::require_scope_access_with_db(state, &state.db, scope).await?;
-    let file = file_repo::find_by_id(&state.db, file_id).await?;
+    workspace_storage_service::require_scope_access_with_db(state, state.writer_db(), scope)
+        .await?;
+    let file = file_repo::find_by_id(state.writer_db(), file_id).await?;
     workspace_storage_service::ensure_file_scope(&file, scope)?;
     if file.deleted_at.is_none() {
         return Err(AsterError::validation_error("file is not in trash"));
@@ -143,8 +144,9 @@ pub(super) async fn verify_folder_in_trash_in_scope(
     scope: WorkspaceStorageScope,
     folder_id: i64,
 ) -> Result<folder::Model> {
-    workspace_storage_service::require_scope_access_with_db(state, &state.db, scope).await?;
-    let folder = folder_repo::find_by_id(&state.db, folder_id).await?;
+    workspace_storage_service::require_scope_access_with_db(state, state.writer_db(), scope)
+        .await?;
+    let folder = folder_repo::find_by_id(state.writer_db(), folder_id).await?;
     workspace_storage_service::ensure_folder_scope(&folder, scope)?;
     if folder.deleted_at.is_none() {
         return Err(AsterError::validation_error("folder is not in trash"));
@@ -238,7 +240,7 @@ pub(super) async fn purge_folder_forest_in_resource_scope(
         root_folder_count = folder_ids.len(),
         "purging folder forest permanently"
     );
-    let root_folders = folder_repo::find_by_ids(&state.db, folder_ids).await?;
+    let root_folders = folder_repo::find_by_ids(state.writer_db(), folder_ids).await?;
     let root_parent_ids: HashMap<i64, Option<i64>> = root_folders
         .iter()
         .map(|folder| (folder.id, folder.parent_id))
@@ -247,15 +249,21 @@ pub(super) async fn purge_folder_forest_in_resource_scope(
         .iter()
         .map(|folder_id| root_parent_ids.get(folder_id).copied().flatten())
         .collect();
-    let (all_files, all_folder_ids) =
-        folder_service::collect_folder_forest_in_resource_scope(&state.db, scope, folder_ids, true)
-            .await?;
+    let (all_files, all_folder_ids) = folder_service::collect_folder_forest_in_resource_scope(
+        state.writer_db(),
+        scope,
+        folder_ids,
+        true,
+    )
+    .await?;
     let file_count = all_files.len();
     let folder_count = all_folder_ids.len();
     let file_summary =
         file_service::batch_purge_in_resource_scope_silent(state, scope, all_files).await?;
-    property_repo::delete_all_for_entities(&state.db, EntityType::Folder, &all_folder_ids).await?;
-    let deleted_shares = share_repo::delete_by_folder_ids(&state.db, &all_folder_ids).await?;
+    property_repo::delete_all_for_entities(state.writer_db(), EntityType::Folder, &all_folder_ids)
+        .await?;
+    let deleted_shares =
+        share_repo::delete_by_folder_ids(state.writer_db(), &all_folder_ids).await?;
     if deleted_shares > 0 {
         crate::services::share_service::invalidate_active_share_target_cache_for_resource_scope(
             state, scope,
@@ -264,7 +272,7 @@ pub(super) async fn purge_folder_forest_in_resource_scope(
         crate::services::share_service::invalidate_all_share_token_record_cache(state).await;
     }
     crate::services::folder_service::invalidate_folder_path_cache(state).await;
-    folder_repo::delete_many(&state.db, &all_folder_ids).await?;
+    folder_repo::delete_many(state.writer_db(), &all_folder_ids).await?;
     if emit_storage_event {
         storage_change_service::publish(
             state,

--- a/src/services/trash_service/common.rs
+++ b/src/services/trash_service/common.rs
@@ -2,7 +2,7 @@
 
 use std::collections::{BTreeSet, HashMap};
 
-use sea_orm::DatabaseConnection;
+use sea_orm::ConnectionTrait;
 
 use crate::db::repository::{file_repo, folder_repo, property_repo, share_repo};
 use crate::entities::{file, folder};
@@ -34,8 +34,8 @@ pub fn load_retention_days(state: &PrimaryAppState) -> i64 {
         })
 }
 
-pub(super) async fn build_trash_path_cache(
-    db: &DatabaseConnection,
+pub(super) async fn build_trash_path_cache<C: ConnectionTrait>(
+    db: &C,
     folders: &[folder::Model],
     files: &[file::Model],
 ) -> Result<HashMap<i64, String>> {

--- a/src/services/trash_service/listing.rs
+++ b/src/services/trash_service/listing.rs
@@ -42,7 +42,7 @@ async fn list_trash_in_scope(
     let (raw_folders, folders_total) = match scope {
         WorkspaceStorageScope::Personal { user_id } => {
             folder_repo::find_top_level_deleted_paginated(
-                &state.db,
+                state.reader_db(),
                 user_id,
                 folder_limit,
                 folder_offset,
@@ -51,7 +51,7 @@ async fn list_trash_in_scope(
         }
         WorkspaceStorageScope::Team { team_id, .. } => {
             folder_repo::find_top_level_deleted_by_team_paginated(
-                &state.db,
+                state.reader_db(),
                 team_id,
                 folder_limit,
                 folder_offset,
@@ -62,12 +62,17 @@ async fn list_trash_in_scope(
 
     let (raw_files, files_total) = match scope {
         WorkspaceStorageScope::Personal { user_id } => {
-            file_repo::find_top_level_deleted_paginated(&state.db, user_id, file_limit, file_cursor)
-                .await?
+            file_repo::find_top_level_deleted_paginated(
+                state.reader_db(),
+                user_id,
+                file_limit,
+                file_cursor,
+            )
+            .await?
         }
         WorkspaceStorageScope::Team { team_id, .. } => {
             file_repo::find_top_level_deleted_by_team_paginated(
-                &state.db,
+                state.reader_db(),
                 team_id,
                 file_limit,
                 file_cursor,
@@ -76,7 +81,7 @@ async fn list_trash_in_scope(
         }
     };
 
-    let folder_paths = build_trash_path_cache(&state.db, &raw_folders, &raw_files).await?;
+    let folder_paths = build_trash_path_cache(state.reader_db(), &raw_folders, &raw_files).await?;
 
     let raw_file_count = usize_to_u64(raw_files.len(), "trash file count")?;
     let next_file_cursor = if file_limit > 0 && raw_file_count == file_limit {

--- a/src/services/trash_service/purge.rs
+++ b/src/services/trash_service/purge.rs
@@ -99,7 +99,8 @@ pub(crate) async fn purge_all_in_scope_silent(
     scope: WorkspaceStorageScope,
 ) -> Result<PurgeAllSummary> {
     tracing::debug!(scope = ?scope, "purging all trash contents");
-    workspace_storage_service::require_scope_access_with_db(state, &state.db, scope).await?;
+    workspace_storage_service::require_scope_access_with_db(state, state.writer_db(), scope)
+        .await?;
     let mut summary = PurgeAllSummary::default();
 
     let mut folder_cursor: Option<(chrono::DateTime<chrono::Utc>, i64)> = None;
@@ -107,7 +108,7 @@ pub(crate) async fn purge_all_in_scope_silent(
         let (top_folders, _) = match scope {
             WorkspaceStorageScope::Personal { user_id } => {
                 folder_repo::find_top_level_deleted_cursor(
-                    &state.db,
+                    state.writer_db(),
                     user_id,
                     PURGE_ALL_BATCH_SIZE,
                     folder_cursor,
@@ -116,7 +117,7 @@ pub(crate) async fn purge_all_in_scope_silent(
             }
             WorkspaceStorageScope::Team { team_id, .. } => {
                 folder_repo::find_top_level_deleted_by_team_cursor(
-                    &state.db,
+                    state.writer_db(),
                     team_id,
                     PURGE_ALL_BATCH_SIZE,
                     folder_cursor,
@@ -154,7 +155,7 @@ pub(crate) async fn purge_all_in_scope_silent(
         let (top_files, _) = match scope {
             WorkspaceStorageScope::Personal { user_id } => {
                 file_repo::find_top_level_deleted_paginated(
-                    &state.db,
+                    state.writer_db(),
                     user_id,
                     PURGE_ALL_BATCH_SIZE,
                     file_cursor,
@@ -163,7 +164,7 @@ pub(crate) async fn purge_all_in_scope_silent(
             }
             WorkspaceStorageScope::Team { team_id, .. } => {
                 file_repo::find_top_level_deleted_by_team_paginated(
-                    &state.db,
+                    state.writer_db(),
                     team_id,
                     PURGE_ALL_BATCH_SIZE,
                     file_cursor,

--- a/src/services/trash_service/purge.rs
+++ b/src/services/trash_service/purge.rs
@@ -99,7 +99,7 @@ pub(crate) async fn purge_all_in_scope_silent(
     scope: WorkspaceStorageScope,
 ) -> Result<PurgeAllSummary> {
     tracing::debug!(scope = ?scope, "purging all trash contents");
-    workspace_storage_service::require_scope_access(state, scope).await?;
+    workspace_storage_service::require_scope_access_with_db(state, &state.db, scope).await?;
     let mut summary = PurgeAllSummary::default();
 
     let mut folder_cursor: Option<(chrono::DateTime<chrono::Utc>, i64)> = None;

--- a/src/services/trash_service/restore.rs
+++ b/src/services/trash_service/restore.rs
@@ -26,7 +26,7 @@ async fn restore_file_in_scope(
     let mut restore_to_root = false;
 
     if let Some(folder_id) = file.folder_id {
-        let parent = folder_repo::find_by_id(&state.db, folder_id).await;
+        let parent = folder_repo::find_by_id(state.writer_db(), folder_id).await;
         if parent_restore_target_unavailable(&parent, scope)? {
             restored_parent_id = None;
             restore_to_root = true;
@@ -34,7 +34,7 @@ async fn restore_file_in_scope(
     }
 
     if restore_to_root {
-        let txn = crate::db::transaction::begin(&state.db).await?;
+        let txn = crate::db::transaction::begin(state.writer_db()).await?;
         let file_name = file.name.clone();
         let mut active: file::ActiveModel = file.into();
         active.folder_id = Set(None);
@@ -45,7 +45,7 @@ async fn restore_file_in_scope(
             .map_err(|err| file_repo::map_name_db_err(err, &file_name))?;
         crate::db::transaction::commit(txn).await?;
     } else {
-        file_repo::restore(&state.db, id).await?;
+        file_repo::restore(state.writer_db(), id).await?;
     }
     storage_change_service::publish(
         state,
@@ -77,18 +77,18 @@ async fn restore_folder_in_scope(
     let mut restored_parent_id = folder.parent_id;
     let mut restore_to_root = false;
     let (files, folder_ids) =
-        folder_service::collect_folder_tree_in_scope(&state.db, scope, id, true).await?;
+        folder_service::collect_folder_tree_in_scope(state.writer_db(), scope, id, true).await?;
     let child_folder_ids: Vec<i64> = folder_ids.into_iter().filter(|&fid| fid != id).collect();
 
     if let Some(parent_id) = folder.parent_id {
-        let parent = folder_repo::find_by_id(&state.db, parent_id).await;
+        let parent = folder_repo::find_by_id(state.writer_db(), parent_id).await;
         if parent_restore_target_unavailable(&parent, scope)? {
             restore_to_root = true;
             restored_parent_id = None;
         }
     }
 
-    let txn = crate::db::transaction::begin(&state.db).await?;
+    let txn = crate::db::transaction::begin(state.writer_db()).await?;
     let mut active: folder::ActiveModel = folder.into();
     let folder_name = active.name.clone().take().unwrap_or_default();
     if restore_to_root {

--- a/src/services/upload_service/chunk.rs
+++ b/src/services/upload_service/chunk.rs
@@ -447,7 +447,7 @@ async fn upload_chunk_impl(
     chunk_number: i32,
     data: Bytes,
 ) -> Result<ChunkUploadResponse> {
-    let db = &state.db;
+    let db = state.writer_db();
     let upload_id = session.id.as_str();
     tracing::debug!(
         upload_id,
@@ -653,7 +653,7 @@ async fn upload_chunk_payload_impl(
     chunk_number: i32,
     mut payload: actix_web::web::Payload,
 ) -> Result<ChunkUploadResponse> {
-    let db = &state.db;
+    let db = state.writer_db();
     let upload_id = session.id.as_str();
     tracing::debug!(
         upload_id,

--- a/src/services/upload_service/complete.rs
+++ b/src/services/upload_service/complete.rs
@@ -65,7 +65,7 @@ async fn complete_upload_impl_with_hints(
     let plan = determine_completion_plan(&session, parts)?;
     let plan_label = completion_plan_label(&plan);
     let result = match plan {
-        CompletionPlan::ReturnCompleted => find_file_by_session(&state.db, &session).await,
+        CompletionPlan::ReturnCompleted => find_file_by_session(state.writer_db(), &session).await,
         CompletionPlan::CompletePresigned => {
             complete_presigned_upload(state, session, hints.actor_username).await
         }

--- a/src/services/upload_service/complete/chunked.rs
+++ b/src/services/upload_service/complete/chunked.rs
@@ -36,7 +36,7 @@ pub(super) async fn complete_chunked_upload_with_actor_username(
     session: upload_session::Model,
     actor_username: Option<&str>,
 ) -> Result<file::Model> {
-    let db = &state.db;
+    let db = state.writer_db();
     let created = run_upload_completion_stage(
         db,
         &session,
@@ -350,7 +350,7 @@ async fn persist_assembled_upload(
 ) -> Result<file::Model> {
     let now = Utc::now();
     let create_result = async {
-        let txn = crate::db::transaction::begin(&state.db).await?;
+        let txn = crate::db::transaction::begin(state.writer_db()).await?;
 
         let blob = match blob_plan {
             AssembledBlobPlan::Dedup {
@@ -408,7 +408,7 @@ async fn persist_preuploaded_chunked_upload(
 ) -> Result<file::Model> {
     let now = Utc::now();
     let create_result = async {
-        let txn = crate::db::transaction::begin(&state.db).await?;
+        let txn = crate::db::transaction::begin(state.writer_db()).await?;
         let blob = workspace_storage_service::persist_preuploaded_blob(&txn, prepared).await?;
         let created = workspace_storage_service::finalize_upload_session_blob_with_actor_username(
             &txn,

--- a/src/services/upload_service/complete/s3.rs
+++ b/src/services/upload_service/complete/s3.rs
@@ -20,7 +20,7 @@ pub(super) async fn complete_presigned_upload(
 ) -> Result<file::Model> {
     // presigned 单文件的 complete 阶段，本质是“确认对象存在且大小正确”，
     // 然后把 temp_key 直接认领成正式 blob。
-    let db = &state.db;
+    let db = state.writer_db();
     let temp_key = session.s3_temp_key.as_deref().ok_or_else(|| {
         upload_assembly_error_with_subcode(
             ApiSubcode::UploadSessionCorrupted,
@@ -120,7 +120,7 @@ pub(super) async fn complete_s3_relay_multipart(
     session: upload_session::Model,
     actor_username: Option<&str>,
 ) -> Result<file::Model> {
-    let db = &state.db;
+    let db = state.writer_db();
     let parts = upload_session_part_repo::list_by_upload(db, &session.id).await?;
     let expected_parts =
         crate::utils::numbers::i32_to_usize(session.total_chunks, "upload session total_chunks")?;
@@ -269,7 +269,7 @@ async fn complete_s3_multipart_upload_session(
     missing_message: &str,
     actor_username: Option<&str>,
 ) -> Result<file::Model> {
-    let db = &state.db;
+    let db = state.writer_db();
     let temp_key = session.s3_temp_key.as_deref().ok_or_else(|| {
         upload_assembly_error_with_subcode(
             ApiSubcode::UploadSessionCorrupted,

--- a/src/services/upload_service/init.rs
+++ b/src/services/upload_service/init.rs
@@ -98,7 +98,7 @@ async fn init_chunked_upload_session(
 
     let upload_id = with_unique_upload_id(|upload_id| async {
         let inserted = try_persist_upload_session(
-            &state.db,
+            state.writer_db(),
             UploadSessionRecordParams {
                 upload_id: &upload_id,
                 scope: ctx.scope,
@@ -124,7 +124,7 @@ async fn init_chunked_upload_session(
 
     if let Err(error) = prepare_chunked_upload_temp_dir(state, &upload_id).await {
         delete_upload_session_record_after_init_error(
-            &state.db,
+            state.writer_db(),
             &upload_id,
             "chunked temp dir initialization error",
         )

--- a/src/services/upload_service/init/context.rs
+++ b/src/services/upload_service/init/context.rs
@@ -163,7 +163,7 @@ async fn resolve_init_upload_policy(
     )
     .await?;
     validate_policy_upload_size(&policy, total_size)?;
-    workspace_storage_service::check_quota(&state.db, scope, total_size).await?;
+    workspace_storage_service::check_quota(state.writer_db(), scope, total_size).await?;
     Ok(policy)
 }
 
@@ -207,7 +207,7 @@ pub(super) async fn init_multipart_session_with_retry(
         let temp_key = format!("files/{upload_id}");
         let multipart_id = multipart.create_multipart_upload(&temp_key).await?;
         let inserted_result = try_persist_upload_session(
-            &state.db,
+            state.writer_db(),
             UploadSessionRecordParams {
                 upload_id: &upload_id,
                 scope: ctx.scope,

--- a/src/services/upload_service/init/remote.rs
+++ b/src/services/upload_service/init/remote.rs
@@ -125,7 +125,7 @@ async fn init_remote_presigned_single_upload(
     with_unique_upload_id(|upload_id| async {
         let temp_key = format!("files/{upload_id}");
         let inserted = try_persist_upload_session(
-            &state.db,
+            state.writer_db(),
             UploadSessionRecordParams {
                 upload_id: &upload_id,
                 scope: ctx.scope,
@@ -150,7 +150,7 @@ async fn init_remote_presigned_single_upload(
             Ok(url) => url,
             Err(error) => {
                 delete_upload_session_record_after_init_error(
-                    &state.db,
+                    state.writer_db(),
                     &upload_id,
                     "remote presigned URL initialization error",
                 )

--- a/src/services/upload_service/init/s3.rs
+++ b/src/services/upload_service/init/s3.rs
@@ -84,7 +84,7 @@ async fn init_presigned_s3_single_upload(
     with_unique_upload_id(|upload_id| async {
         let temp_key = format!("files/{upload_id}");
         let inserted = try_persist_upload_session(
-            &state.db,
+            state.writer_db(),
             UploadSessionRecordParams {
                 upload_id: &upload_id,
                 scope: ctx.scope,
@@ -109,7 +109,7 @@ async fn init_presigned_s3_single_upload(
             Ok(url) => url,
             Err(error) => {
                 delete_upload_session_record_after_init_error(
-                    &state.db,
+                    state.writer_db(),
                     &upload_id,
                     "presigned URL initialization error",
                 )

--- a/src/services/upload_service/lifecycle.rs
+++ b/src/services/upload_service/lifecycle.rs
@@ -169,7 +169,7 @@ async fn defer_upload_session_cleanup(
     reason: &str,
 ) -> Result<()> {
     let expires_at = Utc::now() + Duration::seconds(DEFERRED_UPLOAD_SESSION_CLEANUP_GRACE_SECS);
-    mark_session_failed_with_expiration(&state.db, upload_id, expires_at).await?;
+    mark_session_failed_with_expiration(state.writer_db(), upload_id, expires_at).await?;
     cleanup_upload_temp_dir(state, upload_id).await;
     tracing::debug!(
         upload_id,
@@ -211,7 +211,7 @@ async fn cancel_upload_impl(state: &PrimaryAppState, session: upload_session::Mo
     }
 
     cleanup_upload_temp_dir(state, upload_id).await;
-    upload_session_repo::delete(&state.db, upload_id).await?;
+    upload_session_repo::delete(state.writer_db(), upload_id).await?;
     tracing::debug!(upload_id, "canceled upload session");
     Ok(())
 }
@@ -235,7 +235,7 @@ pub async fn force_cleanup_by_policy(
     state: &PrimaryAppState,
     policy_id: i64,
 ) -> Result<ForceCleanupByPolicyResult> {
-    let sessions = upload_session_repo::find_by_policy(&state.db, policy_id).await?;
+    let sessions = upload_session_repo::find_by_policy(state.writer_db(), policy_id).await?;
     let mut result = ForceCleanupByPolicyResult::default();
 
     for session in &sessions {
@@ -259,7 +259,7 @@ pub async fn force_cleanup_by_policy(
 
     for session in sessions {
         cleanup_upload_temp_dir(state, &session.id).await;
-        upload_session_repo::delete(&state.db, &session.id).await?;
+        upload_session_repo::delete(state.writer_db(), &session.id).await?;
         result.cleaned += 1;
     }
 
@@ -268,7 +268,7 @@ pub async fn force_cleanup_by_policy(
 
 /// 清理过期的上传 session（后台任务调用）
 pub async fn cleanup_expired(state: &PrimaryAppState) -> Result<u32> {
-    let expired = upload_session_repo::find_expired(&state.db).await?;
+    let expired = upload_session_repo::find_expired(state.writer_db()).await?;
     let mut cleaned = 0usize;
     for session in expired {
         if session.status == UploadSessionStatus::Assembling {
@@ -290,7 +290,7 @@ pub async fn cleanup_expired(state: &PrimaryAppState) -> Result<u32> {
             continue;
         }
 
-        if let Err(error) = upload_session_repo::delete(&state.db, &session.id).await {
+        if let Err(error) = upload_session_repo::delete(state.writer_db(), &session.id).await {
             tracing::warn!(
                 "failed to delete expired upload session {}: {error}",
                 session.id

--- a/src/services/upload_service/progress.rs
+++ b/src/services/upload_service/progress.rs
@@ -12,7 +12,7 @@ use crate::services::upload_service::responses::{
     RecoverableUploadPartResponse, RecoverableUploadSessionResponse, UploadProgressResponse,
 };
 use crate::services::upload_service::scope::{
-    load_upload_session_for_read, personal_scope, team_scope,
+    load_upload_session, load_upload_session_for_read, personal_scope, team_scope,
 };
 use crate::services::workspace_storage_service::{self, resolve_policy_upload_transport};
 use crate::types::{UploadMode, UploadSessionStatus};
@@ -279,7 +279,7 @@ pub async fn presign_parts(
     user_id: i64,
     part_numbers: Vec<i32>,
 ) -> Result<HashMap<i32, String>> {
-    let session = load_upload_session_for_read(state, personal_scope(user_id), upload_id).await?;
+    let session = load_upload_session(state, personal_scope(user_id), upload_id).await?;
     presign_parts_impl(state, session, part_numbers).await
 }
 
@@ -290,8 +290,7 @@ pub async fn presign_parts_for_team(
     user_id: i64,
     part_numbers: Vec<i32>,
 ) -> Result<HashMap<i32, String>> {
-    let session =
-        load_upload_session_for_read(state, team_scope(team_id, user_id), upload_id).await?;
+    let session = load_upload_session(state, team_scope(team_id, user_id), upload_id).await?;
     presign_parts_impl(state, session, part_numbers).await
 }
 

--- a/src/services/upload_service/progress.rs
+++ b/src/services/upload_service/progress.rs
@@ -11,7 +11,9 @@ use crate::runtime::PrimaryAppState;
 use crate::services::upload_service::responses::{
     RecoverableUploadPartResponse, RecoverableUploadSessionResponse, UploadProgressResponse,
 };
-use crate::services::upload_service::scope::{load_upload_session, personal_scope, team_scope};
+use crate::services::upload_service::scope::{
+    load_upload_session_for_read, personal_scope, team_scope,
+};
 use crate::services::workspace_storage_service::{self, resolve_policy_upload_transport};
 use crate::types::{UploadMode, UploadSessionStatus};
 use crate::utils::paths;
@@ -52,7 +54,7 @@ async fn get_progress_impl(
     } else if session.s3_multipart_id.is_some() {
         let policy = state.policy_snapshot.get_policy_or_err(session.policy_id)?;
         if is_relay_multipart_policy(&policy) {
-            upload_session_part_repo::list_part_numbers(&state.db, &session.id)
+            upload_session_part_repo::list_part_numbers(state.reader_db(), &session.id)
                 .await?
                 .into_iter()
                 .map(|part_number| part_number - 1)
@@ -104,7 +106,7 @@ async fn recoverable_session_response(
 ) -> Result<RecoverableUploadSessionResponse> {
     let mode = recoverable_mode_for_session(&session);
     let progress = get_progress_impl(state, session.clone()).await?;
-    let completed_parts = upload_session_part_repo::list_by_upload(&state.db, &session.id)
+    let completed_parts = upload_session_part_repo::list_by_upload(state.reader_db(), &session.id)
         .await?
         .into_iter()
         .map(|part| RecoverableUploadPartResponse {
@@ -136,7 +138,7 @@ async fn list_recoverable_sessions_impl(
     team_id: Option<i64>,
 ) -> Result<Vec<RecoverableUploadSessionResponse>> {
     let sessions = upload_session_repo::find_recoverable_by_owner(
-        &state.db,
+        state.reader_db(),
         user_id,
         team_id,
         RECOVERABLE_UPLOAD_SESSIONS_LIMIT,
@@ -156,7 +158,7 @@ pub async fn get_progress(
     upload_id: &str,
     user_id: i64,
 ) -> Result<UploadProgressResponse> {
-    let session = load_upload_session(state, personal_scope(user_id), upload_id).await?;
+    let session = load_upload_session_for_read(state, personal_scope(user_id), upload_id).await?;
     get_progress_impl(state, session).await
 }
 
@@ -173,7 +175,8 @@ pub async fn get_progress_for_team(
     upload_id: &str,
     user_id: i64,
 ) -> Result<UploadProgressResponse> {
-    let session = load_upload_session(state, team_scope(team_id, user_id), upload_id).await?;
+    let session =
+        load_upload_session_for_read(state, team_scope(team_id, user_id), upload_id).await?;
     get_progress_impl(state, session).await
 }
 
@@ -276,7 +279,7 @@ pub async fn presign_parts(
     user_id: i64,
     part_numbers: Vec<i32>,
 ) -> Result<HashMap<i32, String>> {
-    let session = load_upload_session(state, personal_scope(user_id), upload_id).await?;
+    let session = load_upload_session_for_read(state, personal_scope(user_id), upload_id).await?;
     presign_parts_impl(state, session, part_numbers).await
 }
 
@@ -287,7 +290,8 @@ pub async fn presign_parts_for_team(
     user_id: i64,
     part_numbers: Vec<i32>,
 ) -> Result<HashMap<i32, String>> {
-    let session = load_upload_session(state, team_scope(team_id, user_id), upload_id).await?;
+    let session =
+        load_upload_session_for_read(state, team_scope(team_id, user_id), upload_id).await?;
     presign_parts_impl(state, session, part_numbers).await
 }
 

--- a/src/services/upload_service/scope.rs
+++ b/src/services/upload_service/scope.rs
@@ -53,8 +53,13 @@ async fn load_upload_session_with_db<C: ConnectionTrait>(
     // 配额并不会在 init 时预占——只在 complete 时写入，所以这里不会泄漏配额。
     crate::utils::verify_owner(session.user_id, scope.actor_user_id(), "upload session")?;
     if let Some(team_id) = scope.team_id() {
-        workspace_storage_service::require_team_access(state, team_id, scope.actor_user_id())
-            .await?;
+        workspace_storage_service::require_team_access_with_db(
+            state,
+            db,
+            team_id,
+            scope.actor_user_id(),
+        )
+        .await?;
         ensure_team_upload_session_scope(&session, team_id)?;
     } else {
         ensure_personal_upload_session_scope(&session)?;

--- a/src/services/upload_service/scope.rs
+++ b/src/services/upload_service/scope.rs
@@ -5,6 +5,7 @@ use crate::entities::upload_session;
 use crate::errors::{AsterError, Result};
 use crate::runtime::PrimaryAppState;
 use crate::services::workspace_storage_service::{self, WorkspaceStorageScope};
+use sea_orm::ConnectionTrait;
 
 pub(super) fn personal_scope(user_id: i64) -> WorkspaceStorageScope {
     WorkspaceStorageScope::Personal { user_id }
@@ -35,12 +36,13 @@ fn ensure_team_upload_session_scope(session: &upload_session::Model, team_id: i6
     Ok(())
 }
 
-pub(super) async fn load_upload_session(
+async fn load_upload_session_with_db<C: ConnectionTrait>(
     state: &PrimaryAppState,
+    db: &C,
     scope: WorkspaceStorageScope,
     upload_id: &str,
 ) -> Result<upload_session::Model> {
-    let session = upload_session_repo::find_by_id(&state.db, upload_id).await?;
+    let session = upload_session_repo::find_by_id(db, upload_id).await?;
     // 上传 session 始终绑定发起人：complete/cancel 只能由原作者操作。
     // 多写入者会打破分片顺序校验、blob 去重、配额扣减等单写入语义——
     // 即使团队成员之间也不共享 session。团队 scope 额外再校验成员身份，
@@ -58,4 +60,20 @@ pub(super) async fn load_upload_session(
         ensure_personal_upload_session_scope(&session)?;
     }
     Ok(session)
+}
+
+pub(super) async fn load_upload_session(
+    state: &PrimaryAppState,
+    scope: WorkspaceStorageScope,
+    upload_id: &str,
+) -> Result<upload_session::Model> {
+    load_upload_session_with_db(state, state.writer_db(), scope, upload_id).await
+}
+
+pub(super) async fn load_upload_session_for_read(
+    state: &PrimaryAppState,
+    scope: WorkspaceStorageScope,
+    upload_id: &str,
+) -> Result<upload_session::Model> {
+    load_upload_session_with_db(state, state.reader_db(), scope, upload_id).await
 }

--- a/src/services/user_service/admin.rs
+++ b/src/services/user_service/admin.rs
@@ -110,7 +110,7 @@ pub async fn update(
         }
     }
 
-    let existing = user_repo::find_by_id(&state.db, id).await?;
+    let existing = user_repo::find_by_id(state.writer_db(), id).await?;
     let existing_policy_group_id = existing.policy_group_id;
     let existing_email_verified = auth_service::is_email_verified(&existing);
     let email_verified_changed =
@@ -137,14 +137,16 @@ pub async fn update(
     }
     if let Some(group_id) = policy_group_id {
         let group =
-            crate::db::repository::policy_group_repo::find_group_by_id(&state.db, group_id).await?;
+            crate::db::repository::policy_group_repo::find_group_by_id(state.writer_db(), group_id)
+                .await?;
         if !group.is_enabled {
             return Err(AsterError::validation_error(
                 "cannot assign a disabled storage policy group",
             ));
         }
         let items =
-            crate::db::repository::policy_group_repo::find_group_items(&state.db, group_id).await?;
+            crate::db::repository::policy_group_repo::find_group_items(state.writer_db(), group_id)
+                .await?;
         if items.is_empty() {
             return Err(AsterError::validation_error(
                 "cannot assign a storage policy group without policies",
@@ -156,7 +158,7 @@ pub async fn update(
         active.session_version = Set(current_session_version.saturating_add(1));
     }
     active.updated_at = Set(Utc::now());
-    let txn = crate::db::transaction::begin(&state.db).await?;
+    let txn = crate::db::transaction::begin(state.writer_db()).await?;
     let result = async {
         let updated = active
             .update(&txn)
@@ -242,7 +244,7 @@ pub async fn force_delete(
     state: &PrimaryAppState,
     target_user_id: i64,
 ) -> Result<ForceDeleteSummary> {
-    let db = &state.db;
+    let db = state.writer_db();
     let user = user_repo::find_by_id(db, target_user_id).await?;
 
     if target_user_id == 1 {

--- a/src/services/user_service/preferences.rs
+++ b/src/services/user_service/preferences.rs
@@ -35,7 +35,7 @@ pub async fn get_preferences(
     state: &PrimaryAppState,
     user_id: i64,
 ) -> Result<Option<UserPreferences>> {
-    let user = user_repo::find_by_id(&state.db, user_id).await?;
+    let user = user_repo::find_by_id(state.writer_db(), user_id).await?;
     Ok(parse_preferences(&user))
 }
 
@@ -122,7 +122,7 @@ async fn save_user_config(
         Some(StoredUserConfig::from_config(config).map_aster_err(AsterError::internal_error)?)
     });
     active.updated_at = Set(Utc::now());
-    active.save(&state.db).await?;
+    active.save(state.writer_db()).await?;
     Ok(())
 }
 
@@ -145,7 +145,7 @@ pub async fn update_preferences(
         custom,
         remove_custom_keys,
     } = patch;
-    let user = user_repo::find_by_id(&state.db, user_id).await?;
+    let user = user_repo::find_by_id(state.writer_db(), user_id).await?;
     let mut config = parse_user_config(&user).unwrap_or_default();
     let original_config = config.clone();
     let prefs = &mut config.preferences;

--- a/src/services/user_service/queries.rs
+++ b/src/services/user_service/queries.rs
@@ -50,7 +50,7 @@ pub async fn user_summaries_by_ids(
         return Ok(HashMap::new());
     }
 
-    let users = user_repo::find_by_ids(&state.db, &unique_ids).await?;
+    let users = user_repo::find_by_ids(state.reader_db(), &unique_ids).await?;
     let profile_map = profile_service::get_profile_info_map(state, &users, audience).await?;
     let gravatar_base_url = profile_service::resolve_gravatar_base_url(state);
 
@@ -70,7 +70,7 @@ pub async fn user_summary_by_id(
     user_id: i64,
     audience: profile_service::AvatarAudience,
 ) -> Result<Option<UserSummary>> {
-    match user_repo::find_by_id(&state.db, user_id).await {
+    match user_repo::find_by_id(state.reader_db(), user_id).await {
         Ok(user) => Ok(Some(to_user_summary(state, &user, audience).await?)),
         Err(crate::errors::AsterError::RecordNotFound(_)) => Ok(None),
         Err(err) => Err(err),
@@ -135,7 +135,7 @@ pub async fn get_me(
     user_id: i64,
     access_token_expires_at: i64,
 ) -> Result<MeResponse> {
-    let user = user_repo::find_by_id(&state.db, user_id).await?;
+    let user = user_repo::find_by_id(state.reader_db(), user_id).await?;
     let prefs = parse_preferences(&user);
     let core = user_core(&user);
     Ok(MeResponse {
@@ -168,7 +168,7 @@ pub async fn get_me_partial(
     access_token_expires_at: i64,
     fields: MeResponseFields,
 ) -> Result<MePartialResponse> {
-    let user = user_repo::find_by_id(&state.db, user_id).await?;
+    let user = user_repo::find_by_id(state.reader_db(), user_id).await?;
     let prefs = fields.preferences.then(|| parse_preferences(&user));
     let profile = if fields.profile {
         Some(
@@ -203,7 +203,7 @@ pub async fn get_me_partial(
 }
 
 pub async fn get_self_info(state: &PrimaryAppState, user_id: i64) -> Result<UserInfo> {
-    let user = user_repo::find_by_id(&state.db, user_id).await?;
+    let user = user_repo::find_by_id(state.reader_db(), user_id).await?;
     to_user_info(state, &user, profile_service::AvatarAudience::SelfUser).await
 }
 
@@ -221,7 +221,7 @@ pub async fn list_paginated(
             sort_by: filters.sort_by,
             sort_order: filters.sort_order,
         };
-        user_repo::find_paginated(&state.db, limit, offset, &repo_filters).await
+        user_repo::find_paginated(state.reader_db(), limit, offset, &repo_filters).await
     })
     .await?;
 
@@ -239,6 +239,6 @@ pub async fn list_paginated(
 }
 
 pub async fn get(state: &PrimaryAppState, id: i64) -> Result<UserInfo> {
-    let user = user_repo::find_by_id(&state.db, id).await?;
+    let user = user_repo::find_by_id(state.reader_db(), id).await?;
     to_user_info(state, &user, profile_service::AvatarAudience::AdminUser).await
 }

--- a/src/services/version_service.rs
+++ b/src/services/version_service.rs
@@ -212,8 +212,8 @@ async fn list_versions_in_scope(
     scope: WorkspaceStorageScope,
     file_id: i64,
 ) -> Result<Vec<file_version::Model>> {
-    workspace_storage_service::verify_file_access(state, scope, file_id).await?;
-    version_repo::find_by_file_id(&state.db, file_id).await
+    workspace_storage_service::verify_file_access_for_read(state, scope, file_id).await?;
+    version_repo::find_by_file_id(state.reader_db(), file_id).await
 }
 
 async fn restore_version_in_scope(

--- a/src/services/version_service.rs
+++ b/src/services/version_service.rs
@@ -66,7 +66,7 @@ async fn restore_version_inner(
     file: crate::entities::file::Model,
     version: file_version::Model,
 ) -> Result<crate::entities::file::Model> {
-    let db = &state.db;
+    let db = state.writer_db();
     if file.is_locked {
         return Err(AsterError::resource_locked("file is locked"));
     }
@@ -82,7 +82,7 @@ async fn restore_version_inner(
         );
     }
 
-    let txn = crate::db::transaction::begin(&state.db).await?;
+    let txn = crate::db::transaction::begin(state.writer_db()).await?;
 
     let previous_blob_id = current_blob.id;
     let target_blob_id = version.blob_id;
@@ -176,7 +176,7 @@ async fn delete_version_inner(
     let version_number = version.version;
     let blob_id = version.blob_id;
     let size = version.size;
-    let txn = crate::db::transaction::begin(&state.db).await?;
+    let txn = crate::db::transaction::begin(state.writer_db()).await?;
     version_repo::delete_by_id(&txn, version_id).await?;
     version_repo::decrement_versions_after(&txn, file_id, version_number).await?;
     if size != 0 {
@@ -231,7 +231,7 @@ async fn restore_version_in_scope(
         workspace_storage_service::require_team_management_access(state, team_id, actor_user_id)
             .await?;
     }
-    let version = load_version_for_file(&state.db, file_id, version_id).await?;
+    let version = load_version_for_file(state.writer_db(), file_id, version_id).await?;
     restore_version_inner(state, scope, file, version).await
 }
 
@@ -250,7 +250,7 @@ async fn delete_version_in_scope(
         workspace_storage_service::require_team_management_access(state, team_id, actor_user_id)
             .await?;
     }
-    let version = load_version_for_file(&state.db, file_id, version_id).await?;
+    let version = load_version_for_file(state.writer_db(), file_id, version_id).await?;
     delete_version_inner(state, scope, file.folder_id, version).await
 }
 
@@ -392,7 +392,7 @@ pub async fn delete_version_with_audit(
         file_id,
     )
     .await?;
-    let _version = load_version_for_file(&state.db, file_id, version_id).await?;
+    let _version = load_version_for_file(state.writer_db(), file_id, version_id).await?;
     delete_version(state, file_id, version_id, user_id).await?;
     audit_service::log(
         state,
@@ -443,7 +443,7 @@ pub async fn delete_version_for_team_with_audit(
         file_id,
     )
     .await?;
-    let _version = load_version_for_file(&state.db, file_id, version_id).await?;
+    let _version = load_version_for_file(state.writer_db(), file_id, version_id).await?;
     delete_version_for_team(state, team_id, file_id, version_id, user_id).await?;
     audit_service::log(
         state,
@@ -460,7 +460,7 @@ pub async fn delete_version_for_team_with_audit(
 
 /// 超出版本上限时清理最旧版本
 pub async fn cleanup_excess(state: &PrimaryAppState, file_id: i64) -> Result<()> {
-    let db = &state.db;
+    let db = state.writer_db();
     let file = file_repo::find_by_id(db, file_id).await?;
     let scope = resource_scope_from_file(&file)?;
     let max_versions = get_max_versions(state).await;
@@ -474,7 +474,7 @@ pub async fn cleanup_excess(state: &PrimaryAppState, file_id: i64) -> Result<()>
         }
         let oldest = version_repo::find_oldest_by_file_id(db, file_id).await?;
         if let Some(oldest) = oldest {
-            let txn = crate::db::transaction::begin(&state.db).await?;
+            let txn = crate::db::transaction::begin(state.writer_db()).await?;
             version_repo::delete_by_id(&txn, oldest.id).await?;
             version_repo::decrement_versions_after(&txn, file_id, oldest.version).await?;
             if oldest.size != 0 {
@@ -524,7 +524,7 @@ pub async fn cleanup_excess(state: &PrimaryAppState, file_id: i64) -> Result<()>
 
 /// 清理所有版本（文件永久删除时调用）
 pub async fn purge_all_versions(state: &PrimaryAppState, file_id: i64) -> Result<()> {
-    let db = &state.db;
+    let db = state.writer_db();
     let file = file_repo::find_by_id(db, file_id).await?;
     let scope = resource_scope_from_file(&file)?;
     let versions = version_repo::find_by_file_id(db, file_id).await?;
@@ -537,7 +537,7 @@ pub async fn purge_all_versions(state: &PrimaryAppState, file_id: i64) -> Result
         )?;
     }
 
-    let txn = crate::db::transaction::begin(&state.db).await?;
+    let txn = crate::db::transaction::begin(state.writer_db()).await?;
     let blob_ids = version_repo::delete_all_by_file_id(&txn, file_id).await?;
     if reclaimed_bytes != 0 {
         workspace_storage_service::update_storage_used_for_resource_scope(
@@ -565,7 +565,7 @@ pub async fn purge_all_versions(state: &PrimaryAppState, file_id: i64) -> Result
 
 /// 如果 blob 不再被任何文件或版本引用，减 ref_count 并可能删除物理文件
 async fn cleanup_blob_if_unused(state: &PrimaryAppState, blob_id: i64) -> Result<()> {
-    let db = &state.db;
+    let db = state.writer_db();
     let blob = file_repo::find_blob_by_id(db, blob_id).await?;
 
     file_repo::decrement_blob_ref_count(db, blob.id).await?;
@@ -587,7 +587,7 @@ async fn cleanup_blobs_if_unused_by_counts(
         return Ok(());
     }
 
-    file_repo::decrement_blob_ref_counts_by(&state.db, blob_counts).await?;
+    file_repo::decrement_blob_ref_counts_by(state.writer_db(), blob_counts).await?;
     for &(blob_id, _) in blob_counts {
         if !crate::services::file_service::ensure_blob_cleanup_if_unreferenced(state, blob_id).await
         {

--- a/src/services/webdav_account_service.rs
+++ b/src/services/webdav_account_service.rs
@@ -95,7 +95,7 @@ pub async fn create(
     root_folder_id: Option<i64>,
 ) -> Result<WebdavAccountCreated> {
     // 检查用户名是否已存在
-    if webdav_account_repo::find_by_username(&state.db, username)
+    if webdav_account_repo::find_by_username(state.writer_db(), username)
         .await?
         .is_some()
     {
@@ -113,7 +113,7 @@ pub async fn create(
 
     // 如果指定了 root_folder_id，验证文件夹属于该用户
     let root_folder_path = if let Some(fid) = root_folder_id {
-        let folder = folder_repo::find_by_id(&state.db, fid).await?;
+        let folder = folder_repo::find_by_id(state.writer_db(), fid).await?;
         crate::services::folder_service::ensure_personal_folder_scope(&folder)?;
         crate::utils::verify_optional_owner(folder.owner_user_id, user_id, "folder")?;
         crate::services::folder_service::build_folder_paths_cached(state, &[fid])
@@ -135,7 +135,7 @@ pub async fn create(
     };
 
     let created = model
-        .insert(&state.db)
+        .insert(state.writer_db())
         .await
         .map_err(map_webdav_account_create_db_err)?;
     crate::webdav::auth::invalidate_webdav_auth_for_username(state, &created.username).await;
@@ -150,7 +150,7 @@ pub async fn create(
 
 /// 列出用户的所有 WebDAV 账号（带文件夹路径）
 pub async fn list(state: &PrimaryAppState, user_id: i64) -> Result<Vec<WebdavAccountInfo>> {
-    let accounts = webdav_account_repo::find_by_user(&state.db, user_id).await?;
+    let accounts = webdav_account_repo::find_by_user(state.writer_db(), user_id).await?;
     build_account_infos(state, accounts).await
 }
 
@@ -162,7 +162,8 @@ pub async fn list_paginated(
 ) -> Result<OffsetPage<WebdavAccountInfo>> {
     load_offset_page(limit, offset, 100, |limit, offset| async move {
         let (items, total) =
-            webdav_account_repo::find_by_user_paginated(&state.db, user_id, limit, offset).await?;
+            webdav_account_repo::find_by_user_paginated(state.writer_db(), user_id, limit, offset)
+                .await?;
         let items = build_account_infos(state, items).await?;
         Ok((items, total))
     })
@@ -199,9 +200,9 @@ async fn build_account_infos(
 
 /// 删除 WebDAV 账号（需要验证归属）
 pub async fn delete(state: &PrimaryAppState, id: i64, user_id: i64) -> Result<()> {
-    let account = webdav_account_repo::find_by_id(&state.db, id).await?;
+    let account = webdav_account_repo::find_by_id(state.writer_db(), id).await?;
     crate::utils::verify_owner(account.user_id, user_id, "account")?;
-    webdav_account_repo::delete(&state.db, id).await?;
+    webdav_account_repo::delete(state.writer_db(), id).await?;
     crate::webdav::auth::invalidate_webdav_auth_for_username(state, &account.username).await;
     tracing::debug!(
         webdav_account_id = id,
@@ -218,14 +219,14 @@ pub async fn toggle_active(
     id: i64,
     user_id: i64,
 ) -> Result<WebdavAccount> {
-    let account = webdav_account_repo::find_by_id(&state.db, id).await?;
+    let account = webdav_account_repo::find_by_id(state.writer_db(), id).await?;
     crate::utils::verify_owner(account.user_id, user_id, "account")?;
     let new_is_active = !account.is_active;
     let username = account.username.clone();
     let mut active: webdav_account::ActiveModel = account.into();
     active.is_active = Set(new_is_active);
     active.updated_at = Set(Utc::now());
-    let updated = webdav_account_repo::update(&state.db, active)
+    let updated = webdav_account_repo::update(state.writer_db(), active)
         .await
         .map(Into::into)?;
     crate::webdav::auth::invalidate_webdav_auth_for_username(state, &username).await;
@@ -238,7 +239,7 @@ pub async fn test_credentials(
     username: &str,
     password: &str,
 ) -> Result<()> {
-    let account = webdav_account_repo::find_by_username(&state.db, username)
+    let account = webdav_account_repo::find_by_username(state.writer_db(), username)
         .await?
         .ok_or_else(|| AsterError::auth_invalid_credentials("WebDAV account not found"))?;
 
@@ -250,7 +251,8 @@ pub async fn test_credentials(
         return Err(AsterError::auth_invalid_credentials("wrong password"));
     }
 
-    let user = crate::db::repository::user_repo::find_by_id(&state.db, account.user_id).await?;
+    let user =
+        crate::db::repository::user_repo::find_by_id(state.writer_db(), account.user_id).await?;
     if !user.status.is_active() {
         return Err(AsterError::auth_forbidden("user account is disabled"));
     }

--- a/src/services/webdav_service.rs
+++ b/src/services/webdav_service.rs
@@ -36,7 +36,7 @@ pub async fn collect_folder_tree(
     folder_id: i64,
     include_deleted: bool,
 ) -> Result<(Vec<FileInfo>, Vec<i64>)> {
-    collect_folder_tree_models(&state.db, user_id, folder_id, include_deleted)
+    collect_folder_tree_models(state.writer_db(), user_id, folder_id, include_deleted)
         .await
         .map(|(files, folder_ids)| (files.into_iter().map(FileInfo::from).collect(), folder_ids))
 }
@@ -51,16 +51,16 @@ pub async fn recursive_soft_delete(
 ) -> Result<()> {
     let scope = WorkspaceStorageScope::Personal { user_id };
     tracing::debug!(user_id, folder_id, "webdav soft deleting folder tree");
-    let folder = folder_repo::find_by_id(&state.db, folder_id).await?;
+    let folder = folder_repo::find_by_id(state.writer_db(), folder_id).await?;
     let (files, folder_ids) =
-        collect_folder_tree_models(&state.db, user_id, folder_id, false).await?;
+        collect_folder_tree_models(state.writer_db(), user_id, folder_id, false).await?;
 
     let file_ids: Vec<i64> = files.into_iter().map(|f| f.id).collect();
     let file_count = file_ids.len();
     let folder_count = folder_ids.len();
     let now = Utc::now();
 
-    let txn = crate::db::transaction::begin(&state.db).await?;
+    let txn = crate::db::transaction::begin(state.writer_db()).await?;
     file_repo::soft_delete_many(&txn, &file_ids, now).await?;
     folder_repo::soft_delete_many(&txn, &folder_ids, now).await?;
     crate::db::transaction::commit(txn).await?;
@@ -96,7 +96,7 @@ pub async fn purge_folder_tree(
 ) -> Result<()> {
     tracing::debug!(user_id, folder_id, "webdav purging folder tree");
     let (all_files, all_folder_ids) =
-        collect_folder_tree_models(&state.db, user_id, folder_id, true).await?;
+        collect_folder_tree_models(state.writer_db(), user_id, folder_id, true).await?;
     let file_count = all_files.len();
     let folder_count = all_folder_ids.len();
 
@@ -108,13 +108,14 @@ pub async fn purge_folder_tree(
     .await?;
 
     crate::db::repository::property_repo::delete_all_for_entities(
-        &state.db,
+        state.writer_db(),
         crate::types::EntityType::Folder,
         &all_folder_ids,
     )
     .await?;
 
-    let deleted_shares = share_repo::delete_by_folder_ids(&state.db, &all_folder_ids).await?;
+    let deleted_shares =
+        share_repo::delete_by_folder_ids(state.writer_db(), &all_folder_ids).await?;
     if deleted_shares > 0 {
         crate::services::share_service::invalidate_active_share_target_cache_for_scope(
             state,
@@ -124,7 +125,7 @@ pub async fn purge_folder_tree(
         crate::services::share_service::invalidate_all_share_token_record_cache(state).await;
     }
     crate::services::folder_service::invalidate_folder_path_cache(state).await;
-    folder_repo::delete_many(&state.db, &all_folder_ids).await?;
+    folder_repo::delete_many(state.writer_db(), &all_folder_ids).await?;
     tracing::debug!(
         user_id,
         folder_id,

--- a/src/services/wopi_service/locks.rs
+++ b/src/services/wopi_service/locks.rs
@@ -206,9 +206,14 @@ pub async fn unlock_file(
 
     match active_lock.payload {
         Some(payload) if payload.lock == lock_value => {
-            lock_service::set_entity_locked(&state.db, EntityType::File, resolved.file.id, false)
-                .await?;
-            lock_repo::delete_by_id(&state.db, active_lock.lock.id).await?;
+            lock_service::set_entity_locked(
+                state.writer_db(),
+                EntityType::File,
+                resolved.file.id,
+                false,
+            )
+            .await?;
+            lock_repo::delete_by_id(state.writer_db(), active_lock.lock.id).await?;
             log_wopi_lock_action(
                 state,
                 request_info,
@@ -311,15 +316,18 @@ pub(crate) async fn load_active_lock(
     state: &PrimaryAppState,
     file_id: i64,
 ) -> Result<Option<ActiveWopiLock>> {
-    let Some(lock) = lock_repo::find_by_entity(&state.db, EntityType::File, file_id).await? else {
+    let Some(lock) =
+        lock_repo::find_by_entity(state.writer_db(), EntityType::File, file_id).await?
+    else {
         return Ok(None);
     };
 
     if let Some(timeout_at) = lock.timeout_at
         && timeout_at < Utc::now()
     {
-        lock_repo::delete_by_id(&state.db, lock.id).await?;
-        lock_service::set_entity_locked(&state.db, EntityType::File, file_id, false).await?;
+        lock_repo::delete_by_id(state.writer_db(), lock.id).await?;
+        lock_service::set_entity_locked(state.writer_db(), EntityType::File, file_id, false)
+            .await?;
         return Ok(None);
     }
 
@@ -342,7 +350,8 @@ async fn create_wopi_lock(
     file: &file::Model,
     requested_lock: &str,
 ) -> Result<()> {
-    let path = lock_service::resolve_entity_path(&state.db, EntityType::File, file.id).await?;
+    let path =
+        lock_service::resolve_entity_path(state.writer_db(), EntityType::File, file.id).await?;
     let now = Utc::now();
     let timeout_at = now + Duration::seconds(wopi::lock_ttl_secs(&state.runtime_config));
     let owner_info = lock_service::ResourceLockOwnerInfo::Wopi(lock_service::WopiLockOwnerInfo {
@@ -366,8 +375,8 @@ async fn create_wopi_lock(
         ..Default::default()
     };
 
-    lock_repo::create(&state.db, model).await?;
-    lock_service::set_entity_locked(&state.db, EntityType::File, file.id, true).await?;
+    lock_repo::create(state.writer_db(), model).await?;
+    lock_service::set_entity_locked(state.writer_db(), EntityType::File, file.id, true).await?;
     Ok(())
 }
 
@@ -377,7 +386,7 @@ async fn refresh_lock_model(state: &PrimaryAppState, lock: resource_lock::Model)
         Utc::now() + Duration::seconds(wopi::lock_ttl_secs(&state.runtime_config)),
     ));
     active
-        .update(&state.db)
+        .update(state.writer_db())
         .await
         .map_aster_err(AsterError::database_operation)?;
     Ok(())
@@ -402,7 +411,7 @@ async fn replace_wopi_lock_model(
         Utc::now() + Duration::seconds(wopi::lock_ttl_secs(&state.runtime_config)),
     ));
     active
-        .update(&state.db)
+        .update(state.writer_db())
         .await
         .map_aster_err(AsterError::database_operation)?;
     Ok(())

--- a/src/services/wopi_service/operations.rs
+++ b/src/services/wopi_service/operations.rs
@@ -47,7 +47,7 @@ pub async fn check_file_info(
     request_source: WopiRequestSource<'_>,
 ) -> Result<WopiCheckFileInfo> {
     let resolved = resolve_access_token(state, file_id, access_token, request_source).await?;
-    let blob = file_repo::find_blob_by_id(&state.db, resolved.file.blob_id).await?;
+    let blob = file_repo::find_blob_by_id(state.writer_db(), resolved.file.blob_id).await?;
     let user_info =
         profile_service::get_wopi_user_info(state, resolved.payload.actor_user_id).await?;
 
@@ -89,7 +89,7 @@ pub async fn get_file_contents(
     request_source: WopiRequestSource<'_>,
 ) -> Result<WopiGetFileResult> {
     let resolved = resolve_access_token(state, file_id, access_token, request_source).await?;
-    let blob = file_repo::find_blob_by_id(&state.db, resolved.file.blob_id).await?;
+    let blob = file_repo::find_blob_by_id(state.writer_db(), resolved.file.blob_id).await?;
     let max_expected_size = parse_wopi_max_expected_size(max_expected_size)?;
     if let Some(max_expected_size) = max_expected_size
         && resolved.file.size > max_expected_size
@@ -223,9 +223,13 @@ pub async fn put_relative_file(
         } => {
             // RelativeTarget 先找目标名是否已存在，再根据 overwrite / 锁状态决定
             // 冲突、覆盖还是新建。
-            let existing =
-                find_file_by_name_in_scope(&state.db, scope, resolved.file.folder_id, &target_name)
-                    .await?;
+            let existing = find_file_by_name_in_scope(
+                state.writer_db(),
+                scope,
+                resolved.file.folder_id,
+                &target_name,
+            )
+            .await?;
 
             match existing {
                 None => {

--- a/src/services/wopi_service/session.rs
+++ b/src/services/wopi_service/session.rs
@@ -108,7 +108,7 @@ async fn load_wopi_session_by_hash(
         return Ok(Some(cached));
     }
 
-    let session = wopi_session_repo::find_by_token_hash(&state.db, token_hash).await?;
+    let session = wopi_session_repo::find_by_token_hash(state.writer_db(), token_hash).await?;
     if let Some(session) = &session {
         cache_wopi_session(state, session).await;
     }
@@ -121,7 +121,7 @@ async fn delete_wopi_session(
     token_hash: &str,
     session_id: i64,
 ) -> Result<()> {
-    wopi_session_repo::delete_by_id(&state.db, session_id).await?;
+    wopi_session_repo::delete_by_id(state.writer_db(), session_id).await?;
     state
         .cache
         .delete(&wopi_session_cache_key(token_hash))
@@ -351,7 +351,7 @@ async fn create_access_token_session(
         .ok_or_else(|| AsterError::internal_error("invalid WOPI access token expiry"))?;
     let now = Utc::now();
     let session = wopi_session_repo::create(
-        &state.db,
+        state.writer_db(),
         wopi_session::ActiveModel {
             token_hash: Set(token_hash),
             actor_user_id: Set(payload.actor_user_id),
@@ -385,5 +385,5 @@ fn payload_from_session(session: &CachedWopiSession) -> Result<WopiAccessTokenPa
 }
 
 pub async fn cleanup_expired(state: &PrimaryAppState) -> Result<u64> {
-    wopi_session_repo::delete_expired(&state.db).await
+    wopi_session_repo::delete_expired(state.writer_db()).await
 }

--- a/src/services/wopi_service/targets.rs
+++ b/src/services/wopi_service/targets.rs
@@ -303,10 +303,11 @@ pub(crate) async fn suggest_available_relative_target(
 ) -> Result<String> {
     match scope {
         WorkspaceStorageScope::Personal { user_id } => {
-            file_repo::resolve_unique_filename(&state.db, user_id, folder_id, name).await
+            file_repo::resolve_unique_filename(state.writer_db(), user_id, folder_id, name).await
         }
         WorkspaceStorageScope::Team { team_id, .. } => {
-            file_repo::resolve_unique_team_filename(&state.db, team_id, folder_id, name).await
+            file_repo::resolve_unique_team_filename(state.writer_db(), team_id, folder_id, name)
+                .await
         }
     }
 }
@@ -318,7 +319,8 @@ pub(crate) async fn resolve_available_rename_target(
     current_file_id: i64,
     requested_name: &str,
 ) -> Result<String> {
-    let existing = find_file_by_name_in_scope(&state.db, scope, folder_id, requested_name).await?;
+    let existing =
+        find_file_by_name_in_scope(state.writer_db(), scope, folder_id, requested_name).await?;
     if match existing.as_ref() {
         None => true,
         Some(file) => file.id == current_file_id,

--- a/src/services/workspace_scope_service.rs
+++ b/src/services/workspace_scope_service.rs
@@ -161,13 +161,13 @@ async fn load_team_access_from_database(
     user_id: i64,
 ) -> Result<CachedTeamAccess> {
     if let Some(snapshot) =
-        team_member_repo::find_active_team_access(&state.db, team_id, user_id).await?
+        team_member_repo::find_active_team_access(state.reader_db(), team_id, user_id).await?
     {
         return Ok(snapshot.into());
     }
 
     // 保持旧语义：团队不存在或已归档时返回 not found；团队仍活跃但用户不是成员时返回 forbidden。
-    team_repo::find_active_by_id(&state.db, team_id).await?;
+    team_repo::find_active_by_id(state.reader_db(), team_id).await?;
     Err(auth_forbidden_with_subcode(
         ApiSubcode::TeamNotMember,
         "not a member of this team",
@@ -210,7 +210,7 @@ pub(crate) async fn load_scope_actor_username_cached(
         return Ok(username);
     }
 
-    let username = load_scope_actor_username(&state.db, scope).await?;
+    let username = load_scope_actor_username(state.reader_db(), scope).await?;
     state
         .cache
         .set(&cache_key, &username, Some(ACTOR_USERNAME_CACHE_TTL))
@@ -386,10 +386,27 @@ pub(crate) async fn verify_folder_access(
     scope: WorkspaceStorageScope,
     folder_id: i64,
 ) -> Result<folder::Model> {
+    verify_folder_access_with_db(&state.db, state, scope, folder_id).await
+}
+
+pub(crate) async fn verify_folder_access_for_read(
+    state: &PrimaryAppState,
+    scope: WorkspaceStorageScope,
+    folder_id: i64,
+) -> Result<folder::Model> {
+    verify_folder_access_with_db(state.reader_db(), state, scope, folder_id).await
+}
+
+async fn verify_folder_access_with_db<C: ConnectionTrait>(
+    db: &C,
+    state: &PrimaryAppState,
+    scope: WorkspaceStorageScope,
+    folder_id: i64,
+) -> Result<folder::Model> {
     // 先校验当前 scope 还有效，再取实体做归属检查。
     // 这样所有调用方都能拿到“存在 + 属于当前空间 + 未进回收站”的 folder。
     require_scope_access(state, scope).await?;
-    let folder = folder_repo::find_by_id(&state.db, folder_id).await?;
+    let folder = folder_repo::find_by_id(db, folder_id).await?;
     ensure_active_folder_scope(&folder, scope)?;
 
     Ok(folder)
@@ -400,10 +417,27 @@ pub(crate) async fn verify_file_access(
     scope: WorkspaceStorageScope,
     file_id: i64,
 ) -> Result<file::Model> {
+    verify_file_access_with_db(&state.db, state, scope, file_id).await
+}
+
+pub(crate) async fn verify_file_access_for_read(
+    state: &PrimaryAppState,
+    scope: WorkspaceStorageScope,
+    file_id: i64,
+) -> Result<file::Model> {
+    verify_file_access_with_db(state.reader_db(), state, scope, file_id).await
+}
+
+async fn verify_file_access_with_db<C: ConnectionTrait>(
+    db: &C,
+    state: &PrimaryAppState,
+    scope: WorkspaceStorageScope,
+    file_id: i64,
+) -> Result<file::Model> {
     // 文件访问和文件夹访问保持同样语义：返回值一旦成功，就已经完成 scope
     // 校验和 trash 过滤，上层不需要再手写重复判断。
     require_scope_access(state, scope).await?;
-    let file = file_repo::find_by_id(&state.db, file_id).await?;
+    let file = file_repo::find_by_id(db, file_id).await?;
     ensure_active_file_scope(&file, scope)?;
 
     Ok(file)
@@ -416,10 +450,10 @@ pub(crate) async fn list_files_in_folder(
 ) -> Result<Vec<file::Model>> {
     match scope {
         WorkspaceStorageScope::Personal { user_id } => {
-            file_repo::find_by_folder(&state.db, user_id, folder_id).await
+            file_repo::find_by_folder(state.reader_db(), user_id, folder_id).await
         }
         WorkspaceStorageScope::Team { team_id, .. } => {
-            file_repo::find_by_team_folder(&state.db, team_id, folder_id).await
+            file_repo::find_by_team_folder(state.reader_db(), team_id, folder_id).await
         }
     }
 }
@@ -431,10 +465,10 @@ pub(crate) async fn list_folders_in_parent(
 ) -> Result<Vec<folder::Model>> {
     match scope {
         WorkspaceStorageScope::Personal { user_id } => {
-            folder_repo::find_children(&state.db, user_id, parent_id).await
+            folder_repo::find_children(state.reader_db(), user_id, parent_id).await
         }
         WorkspaceStorageScope::Team { team_id, .. } => {
-            folder_repo::find_team_children(&state.db, team_id, parent_id).await
+            folder_repo::find_team_children(state.reader_db(), team_id, parent_id).await
         }
     }
 }
@@ -489,7 +523,8 @@ mod tests {
             );
 
         PrimaryAppState {
-            db,
+            db: db.clone(),
+            db_handles: crate::db::DbHandles::single(db),
             driver_registry: Arc::new(DriverRegistry::new()),
             runtime_config: runtime_config.clone(),
             policy_snapshot: Arc::new(PolicySnapshot::new()),

--- a/src/services/workspace_scope_service.rs
+++ b/src/services/workspace_scope_service.rs
@@ -415,7 +415,7 @@ pub(crate) async fn verify_folder_access(
     scope: WorkspaceStorageScope,
     folder_id: i64,
 ) -> Result<folder::Model> {
-    verify_folder_access_with_db(&state.db, state, scope, folder_id).await
+    verify_folder_access_with_db(state.writer_db(), state, scope, folder_id).await
 }
 
 pub(crate) async fn verify_folder_access_for_read(
@@ -446,7 +446,7 @@ pub(crate) async fn verify_file_access(
     scope: WorkspaceStorageScope,
     file_id: i64,
 ) -> Result<file::Model> {
-    verify_file_access_with_db(&state.db, state, scope, file_id).await
+    verify_file_access_with_db(state.writer_db(), state, scope, file_id).await
 }
 
 pub(crate) async fn verify_file_access_for_read(
@@ -552,7 +552,6 @@ mod tests {
             );
 
         PrimaryAppState {
-            db: db.clone(),
             db_handles: crate::db::DbHandles::single(db),
             driver_registry: Arc::new(DriverRegistry::new()),
             runtime_config: runtime_config.clone(),
@@ -586,7 +585,7 @@ mod tests {
             config: Set(None),
             ..Default::default()
         }
-        .insert(&state.db)
+        .insert(state.writer_db())
         .await
         .expect("test user should insert")
     }
@@ -597,7 +596,7 @@ mod tests {
     ) -> storage_policy_group::Model {
         let now = Utc::now();
         let policy = policy_repo::create(
-            &state.db,
+            state.writer_db(),
             storage_policy::ActiveModel {
                 name: Set(format!("{name} Policy")),
                 driver_type: Set(DriverType::Local),
@@ -620,7 +619,7 @@ mod tests {
         .await
         .expect("test policy should insert");
         let group = policy_group_repo::create_group(
-            &state.db,
+            state.writer_db(),
             storage_policy_group::ActiveModel {
                 name: Set(format!("{name} Group")),
                 description: Set(String::new()),
@@ -634,7 +633,7 @@ mod tests {
         .await
         .expect("test policy group should insert");
         policy_group_repo::create_group_item(
-            &state.db,
+            state.writer_db(),
             storage_policy_group_item::ActiveModel {
                 group_id: Set(group.id),
                 policy_id: Set(policy.id),
@@ -649,7 +648,7 @@ mod tests {
         .expect("test policy group item should insert");
         state
             .policy_snapshot
-            .reload(&state.db)
+            .reload(state.writer_db())
             .await
             .expect("policy snapshot should reload");
         group
@@ -663,7 +662,7 @@ mod tests {
     ) -> (team::Model, team_member::Model) {
         let now = Utc::now();
         let team = team_repo::create(
-            &state.db,
+            state.writer_db(),
             team::ActiveModel {
                 name: Set("Cache Test Team".to_string()),
                 description: Set(String::new()),
@@ -680,7 +679,7 @@ mod tests {
         .await
         .expect("test team should insert");
         team_member_repo::create(
-            &state.db,
+            state.writer_db(),
             team_member::ActiveModel {
                 team_id: Set(team.id),
                 user_id: Set(owner.id),
@@ -693,7 +692,7 @@ mod tests {
         .await
         .expect("test owner membership should insert");
         let membership = team_member_repo::create(
-            &state.db,
+            state.writer_db(),
             team_member::ActiveModel {
                 team_id: Set(team.id),
                 user_id: Set(member.id),
@@ -724,7 +723,7 @@ mod tests {
 
         let mut active = team.clone().into_active_model();
         active.policy_group_id = Set(Some(second_group.id));
-        team_repo::update(&state.db, active)
+        team_repo::update(state.writer_db(), active)
             .await
             .expect("team policy group should update");
         let policy_group_id = require_team_policy_group_id(&state, team.id, member.id)
@@ -732,7 +731,7 @@ mod tests {
             .expect("cached access should refresh policy group from database");
         assert_eq!(policy_group_id, second_group.id);
 
-        team_member_repo::delete(&state.db, membership.id)
+        team_member_repo::delete(state.writer_db(), membership.id)
             .await
             .expect("membership should delete");
         let error = require_team_access(&state, team.id, member.id)
@@ -747,7 +746,7 @@ mod tests {
         let user = create_user(&state, "folder-owner").await;
         let now = Utc::now();
         let parent = crate::db::repository::folder_repo::create(
-            &state.db,
+            state.writer_db(),
             crate::entities::folder::ActiveModel {
                 name: Set("Parent".to_string()),
                 parent_id: Set(None),
@@ -766,7 +765,7 @@ mod tests {
         .await
         .expect("parent folder should insert");
         let child = crate::db::repository::folder_repo::create(
-            &state.db,
+            state.writer_db(),
             crate::entities::folder::ActiveModel {
                 name: Set("Child".to_string()),
                 parent_id: Set(Some(parent.id)),
@@ -797,7 +796,7 @@ mod tests {
         active.name = Set("Renamed".to_string());
         active.updated_at = Set(Utc::now());
         active
-            .update(&state.db)
+            .update(state.writer_db())
             .await
             .expect("parent should rename");
 
@@ -825,7 +824,7 @@ mod tests {
         let team_id = team.id;
         let mut active = team.into_active_model();
         active.archived_at = Set(Some(Utc::now()));
-        team_repo::update(&state.db, active)
+        team_repo::update(state.writer_db(), active)
             .await
             .expect("team should archive");
 

--- a/src/services/workspace_scope_service.rs
+++ b/src/services/workspace_scope_service.rs
@@ -115,14 +115,15 @@ impl WorkspaceStorageScope {
     }
 }
 
-async fn load_team_access(
+async fn load_team_access<C: ConnectionTrait>(
     state: &PrimaryAppState,
+    db: &C,
     team_id: i64,
     user_id: i64,
 ) -> Result<CachedTeamAccess> {
     let cache_key = team_access_cache_key(team_id, user_id);
     if let Some(cached) = state.cache.get::<CachedTeamAccess>(&cache_key).await {
-        let access = match load_team_access_from_database(state, team_id, user_id).await {
+        let access = match load_team_access_from_database(db, team_id, user_id).await {
             Ok(access) => access,
             Err(error @ (AsterError::RecordNotFound(_) | AsterError::AuthForbidden(_))) => {
                 state.cache.delete(&cache_key).await;
@@ -146,7 +147,7 @@ async fn load_team_access(
         return Ok(access);
     }
 
-    let access = load_team_access_from_database(state, team_id, user_id).await?;
+    let access = load_team_access_from_database(db, team_id, user_id).await?;
     state
         .cache
         .set(&cache_key, &access, Some(TEAM_ACCESS_CACHE_TTL))
@@ -155,19 +156,17 @@ async fn load_team_access(
     Ok(access)
 }
 
-async fn load_team_access_from_database(
-    state: &PrimaryAppState,
+async fn load_team_access_from_database<C: ConnectionTrait>(
+    db: &C,
     team_id: i64,
     user_id: i64,
 ) -> Result<CachedTeamAccess> {
-    if let Some(snapshot) =
-        team_member_repo::find_active_team_access(state.reader_db(), team_id, user_id).await?
-    {
+    if let Some(snapshot) = team_member_repo::find_active_team_access(db, team_id, user_id).await? {
         return Ok(snapshot.into());
     }
 
     // 保持旧语义：团队不存在或已归档时返回 not found；团队仍活跃但用户不是成员时返回 forbidden。
-    team_repo::find_active_by_id(state.reader_db(), team_id).await?;
+    team_repo::find_active_by_id(db, team_id).await?;
     Err(auth_forbidden_with_subcode(
         ApiSubcode::TeamNotMember,
         "not a member of this team",
@@ -178,6 +177,14 @@ pub(crate) async fn require_scope_access(
     state: &PrimaryAppState,
     scope: WorkspaceStorageScope,
 ) -> Result<()> {
+    require_scope_access_with_db(state, state.reader_db(), scope).await
+}
+
+pub(crate) async fn require_scope_access_with_db<C: ConnectionTrait>(
+    state: &PrimaryAppState,
+    db: &C,
+    scope: WorkspaceStorageScope,
+) -> Result<()> {
     // 个人空间天然只需要“用户正在操作自己的空间”这个前提；
     // 团队空间则必须先确认 actor 当前仍然是团队成员。
     if let WorkspaceStorageScope::Team {
@@ -185,7 +192,7 @@ pub(crate) async fn require_scope_access(
         actor_user_id,
     } = scope
     {
-        require_team_access(state, team_id, actor_user_id).await?;
+        require_team_access_with_db(state, db, team_id, actor_user_id).await?;
     }
 
     Ok(())
@@ -349,7 +356,20 @@ pub(crate) async fn require_team_access(
     team_id: i64,
     user_id: i64,
 ) -> Result<()> {
-    load_team_access(state, team_id, user_id).await.map(|_| ())
+    load_team_access(state, state.reader_db(), team_id, user_id)
+        .await
+        .map(|_| ())
+}
+
+pub(crate) async fn require_team_access_with_db<C: ConnectionTrait>(
+    state: &PrimaryAppState,
+    db: &C,
+    team_id: i64,
+    user_id: i64,
+) -> Result<()> {
+    load_team_access(state, db, team_id, user_id)
+        .await
+        .map(|_| ())
 }
 
 pub(crate) async fn require_team_policy_group_id(
@@ -357,7 +377,16 @@ pub(crate) async fn require_team_policy_group_id(
     team_id: i64,
     user_id: i64,
 ) -> Result<i64> {
-    let access = load_team_access(state, team_id, user_id).await?;
+    require_team_policy_group_id_with_db(state, state.reader_db(), team_id, user_id).await
+}
+
+pub(crate) async fn require_team_policy_group_id_with_db<C: ConnectionTrait>(
+    state: &PrimaryAppState,
+    db: &C,
+    team_id: i64,
+    user_id: i64,
+) -> Result<i64> {
+    let access = load_team_access(state, db, team_id, user_id).await?;
     access.policy_group_id.ok_or_else(|| {
         AsterError::storage_policy_not_found(format!(
             "no storage policy group assigned to team #{}",
@@ -371,7 +400,7 @@ pub(crate) async fn require_team_management_access(
     team_id: i64,
     user_id: i64,
 ) -> Result<()> {
-    let access = load_team_access(state, team_id, user_id).await?;
+    let access = load_team_access(state, state.reader_db(), team_id, user_id).await?;
     if !access.role.can_manage_team() {
         return Err(auth_forbidden_with_subcode(
             ApiSubcode::TeamAdminOrOwnerRequired,
@@ -405,7 +434,7 @@ async fn verify_folder_access_with_db<C: ConnectionTrait>(
 ) -> Result<folder::Model> {
     // 先校验当前 scope 还有效，再取实体做归属检查。
     // 这样所有调用方都能拿到“存在 + 属于当前空间 + 未进回收站”的 folder。
-    require_scope_access(state, scope).await?;
+    require_scope_access_with_db(state, db, scope).await?;
     let folder = folder_repo::find_by_id(db, folder_id).await?;
     ensure_active_folder_scope(&folder, scope)?;
 
@@ -436,7 +465,7 @@ async fn verify_file_access_with_db<C: ConnectionTrait>(
 ) -> Result<file::Model> {
     // 文件访问和文件夹访问保持同样语义：返回值一旦成功，就已经完成 scope
     // 校验和 trash 过滤，上层不需要再手写重复判断。
-    require_scope_access(state, scope).await?;
+    require_scope_access_with_db(state, db, scope).await?;
     let file = file_repo::find_by_id(db, file_id).await?;
     ensure_active_file_scope(&file, scope)?;
 

--- a/src/services/workspace_storage_core/finalize.rs
+++ b/src/services/workspace_storage_core/finalize.rs
@@ -92,7 +92,7 @@ pub(crate) async fn finalize_upload_session_file(
         actor_username,
     } = params;
     let scope = scope_from_session(session);
-    let txn = crate::db::transaction::begin(&state.db).await?;
+    let txn = crate::db::transaction::begin(state.writer_db()).await?;
 
     let blob =
         file_repo::find_or_create_blob(&txn, file_hash, size, policy_id, storage_path).await?;

--- a/src/services/workspace_storage_core/path.rs
+++ b/src/services/workspace_storage_core/path.rs
@@ -72,7 +72,7 @@ pub(crate) async fn ensure_upload_parent_path(
         });
     }
 
-    let txn = crate::db::transaction::begin(&state.db).await?;
+    let txn = crate::db::transaction::begin(state.writer_db()).await?;
     let mut current_parent = parsed.base_folder_id;
     let mut current_folder = parsed.base_folder;
 

--- a/src/services/workspace_storage_core/policy.rs
+++ b/src/services/workspace_storage_core/policy.rs
@@ -13,11 +13,11 @@ pub(crate) async fn load_storage_limits(
 ) -> Result<(i64, i64)> {
     match scope {
         WorkspaceStorageScope::Personal { user_id } => {
-            let user = user_repo::find_by_id(&state.db, user_id).await?;
+            let user = user_repo::find_by_id(state.writer_db(), user_id).await?;
             Ok((user.storage_used, user.storage_quota))
         }
         WorkspaceStorageScope::Team { team_id, .. } => {
-            let team = team_repo::find_active_by_id(&state.db, team_id).await?;
+            let team = team_repo::find_active_by_id(state.writer_db(), team_id).await?;
             Ok((team.storage_used, team.storage_quota))
         }
     }

--- a/src/services/workspace_storage_service/mod.rs
+++ b/src/services/workspace_storage_service/mod.rs
@@ -18,9 +18,10 @@ pub(crate) use crate::services::workspace_scope_service::{
     ensure_active_folder_scope, ensure_file_resource_scope, ensure_file_scope, ensure_folder_scope,
     ensure_personal_file_scope, invalidate_team_access_cache_for_member,
     invalidate_team_access_cache_for_team, list_files_in_folder, list_folders_in_parent,
-    load_scope_actor_username, require_scope_access, require_team_access,
-    require_team_management_access, require_team_policy_group_id, verify_file_access,
-    verify_file_access_for_read, verify_folder_access, verify_folder_access_for_read,
+    load_scope_actor_username, require_scope_access, require_scope_access_with_db,
+    require_team_access, require_team_access_with_db, require_team_management_access,
+    require_team_policy_group_id, verify_file_access, verify_file_access_for_read,
+    verify_folder_access, verify_folder_access_for_read,
 };
 pub(crate) use crate::services::workspace_storage_core::{
     FinalizeUploadSessionFileParams, VerifiedFolderPolicyHint, check_quota,

--- a/src/services/workspace_storage_service/mod.rs
+++ b/src/services/workspace_storage_service/mod.rs
@@ -20,7 +20,7 @@ pub(crate) use crate::services::workspace_scope_service::{
     invalidate_team_access_cache_for_team, list_files_in_folder, list_folders_in_parent,
     load_scope_actor_username, require_scope_access, require_team_access,
     require_team_management_access, require_team_policy_group_id, verify_file_access,
-    verify_folder_access,
+    verify_file_access_for_read, verify_folder_access, verify_folder_access_for_read,
 };
 pub(crate) use crate::services::workspace_storage_core::{
     FinalizeUploadSessionFileParams, VerifiedFolderPolicyHint, check_quota,

--- a/src/services/workspace_storage_service/multipart/streaming_direct.rs
+++ b/src/services/workspace_storage_service/multipart/streaming_direct.rs
@@ -39,7 +39,7 @@ pub(super) async fn upload_streaming_direct(
         )));
     }
 
-    check_quota(&state.db, scope, declared_size).await?;
+    check_quota(state.writer_db(), scope, declared_size).await?;
     let driver = state.driver_registry.get_driver(policy)?;
     let prepared_upload = prepare_non_dedup_blob_upload(policy, declared_size);
     let storage_path = prepared_upload.storage_path().to_string();

--- a/src/services/workspace_storage_service/store.rs
+++ b/src/services/workspace_storage_service/store.rs
@@ -146,7 +146,7 @@ pub(crate) async fn create_empty(
     let should_dedup = local_content_dedup_enabled(&policy);
     let now = Utc::now();
 
-    let txn = crate::db::transaction::begin(&state.db).await?;
+    let txn = crate::db::transaction::begin(state.writer_db()).await?;
     let blob = if should_dedup {
         let storage_path = crate::utils::storage_path_from_blob_key(EMPTY_SHA256);
         let blob = file_repo::find_or_create_blob(
@@ -217,7 +217,7 @@ pub(crate) async fn store_preuploaded_nondedup(
         preuploaded_blob,
         actor_username,
     } = params;
-    let db = &state.db;
+    let db = state.writer_db();
 
     tracing::debug!(
         scope = ?scope,
@@ -277,7 +277,7 @@ pub(crate) async fn store_preuploaded_nondedup(
         .to_string();
 
     let create_result = async {
-        let txn = crate::db::transaction::begin(&state.db).await?;
+        let txn = crate::db::transaction::begin(state.writer_db()).await?;
         if storage_delta > 0 {
             check_quota(&txn, scope, storage_delta).await?;
         }

--- a/src/services/workspace_storage_service/store/persist.rs
+++ b/src/services/workspace_storage_service/store/persist.rs
@@ -36,13 +36,13 @@ pub(super) async fn persist_temp_store(
     let cleanup_blob_plan = blob_plan.clone();
 
     if storage_delta > 0 && !quota_prechecked {
-        check_quota(&state.db, scope, storage_delta).await?;
+        check_quota(state.writer_db(), scope, storage_delta).await?;
     }
     let staged_dedup_target =
         stage_temp_blob_before_transaction(&blob_plan, driver.as_ref(), size, &temp_path).await?;
 
     let create_result = async {
-        let txn = crate::db::transaction::begin(&state.db).await?;
+        let txn = crate::db::transaction::begin(state.writer_db()).await?;
         if storage_delta > 0 {
             check_quota(&txn, scope, storage_delta).await?;
         }
@@ -120,7 +120,7 @@ async fn rollback_staged_dedup_blob(
         return;
     };
 
-    match file_repo::find_blob_by_hash(&state.db, &target.file_hash, policy_id).await {
+    match file_repo::find_blob_by_hash(state.writer_db(), &target.file_hash, policy_id).await {
         Ok(Some(blob)) => {
             tracing::debug!(
                 blob_id = blob.id,

--- a/src/services/workspace_storage_service/store/prepare.rs
+++ b/src/services/workspace_storage_service/store/prepare.rs
@@ -113,7 +113,7 @@ pub(super) async fn prepare_store_from_temp(
 
     let quota_prechecked = storage_delta > 0 && matches!(blob_plan, TempBlobPlan::Preuploaded(_));
     if quota_prechecked {
-        check_quota(&state.db, scope, storage_delta).await?;
+        check_quota(state.writer_db(), scope, storage_delta).await?;
     }
 
     if let TempBlobPlan::Preuploaded(preuploaded_blob) = &blob_plan {
@@ -208,7 +208,7 @@ async fn load_overwrite_context(
         return Err(AsterError::resource_locked("file is locked"));
     }
 
-    let old_blob = file_repo::find_blob_by_id(&state.db, old_file.blob_id).await?;
+    let old_blob = file_repo::find_blob_by_id(state.writer_db(), old_file.blob_id).await?;
     if let Err(err) =
         crate::services::media_processing_service::delete_thumbnail(state, &old_blob).await
     {

--- a/src/services/workspace_storage_service/tests.rs
+++ b/src/services/workspace_storage_service/tests.rs
@@ -481,7 +481,6 @@ async fn build_test_state() -> (PrimaryAppState, PathBuf, storage_policy::Model,
         );
 
     let state = PrimaryAppState {
-        db: db.clone(),
         db_handles: crate::db::DbHandles::single(db),
         driver_registry: Arc::new(DriverRegistry::new()),
         runtime_config: runtime_config.clone(),
@@ -525,7 +524,10 @@ async fn exact_name_conflict_cleans_preuploaded_local_blob() {
     .await
     .unwrap();
 
-    let blob_count_before = file_blob::Entity::find().count(&state.db).await.unwrap();
+    let blob_count_before = file_blob::Entity::find()
+        .count(state.writer_db())
+        .await
+        .unwrap();
     let upload_tree_before = snapshot_dir_tree(&uploads_root).unwrap();
 
     let second_temp = temp_root.join("second.bin");
@@ -555,7 +557,10 @@ async fn exact_name_conflict_cleans_preuploaded_local_blob() {
         err.message()
     );
 
-    let blob_count_after = file_blob::Entity::find().count(&state.db).await.unwrap();
+    let blob_count_after = file_blob::Entity::find()
+        .count(state.writer_db())
+        .await
+        .unwrap();
     let upload_tree_after = snapshot_dir_tree(&uploads_root).unwrap();
     assert_eq!(blob_count_after, blob_count_before);
     assert_eq!(upload_tree_after, upload_tree_before);
@@ -620,7 +625,7 @@ async fn temp_store_silent_exact_name_updates_storage_without_storage_event() {
     .expect("silent temp store should succeed");
     assert_eq!(silent.name, "silent.txt");
 
-    let owner = crate::db::repository::user_repo::find_by_id(&state.db, user.id)
+    let owner = crate::db::repository::user_repo::find_by_id(state.writer_db(), user.id)
         .await
         .expect("owner should still exist");
     assert_eq!(
@@ -654,7 +659,7 @@ async fn temp_preupload_quota_failure_does_not_write_blob() {
 
     let mut active: user::ActiveModel = user.clone().into();
     active.storage_quota = Set((payload.len() as i64) - 1);
-    active.update(&state.db).await.unwrap();
+    active.update(state.writer_db()).await.unwrap();
 
     let upload_tree_before = snapshot_dir_tree(&uploads_root).unwrap();
     let err = store_from_temp_with_hints(
@@ -677,7 +682,13 @@ async fn temp_preupload_quota_failure_does_not_write_blob() {
 
     assert_eq!(err.code(), "E032");
     assert_eq!(driver.put_file_count(), 0);
-    assert_eq!(file_blob::Entity::find().count(&state.db).await.unwrap(), 0);
+    assert_eq!(
+        file_blob::Entity::find()
+            .count(state.writer_db())
+            .await
+            .unwrap(),
+        0
+    );
     assert_eq!(
         snapshot_dir_tree(&uploads_root).unwrap(),
         upload_tree_before
@@ -713,7 +724,7 @@ async fn preuploaded_quota_failure_cleans_local_blob() {
 
     let mut active: user::ActiveModel = user.clone().into();
     active.storage_quota = Set((payload.len() as i64) - 1);
-    active.update(&state.db).await.unwrap();
+    active.update(state.writer_db()).await.unwrap();
 
     let err = store_preuploaded_nondedup(
         &state,
@@ -733,7 +744,13 @@ async fn preuploaded_quota_failure_cleans_local_blob() {
     .expect_err("quota failure should clean preuploaded blob");
 
     assert_eq!(err.code(), "E032");
-    assert_eq!(file_blob::Entity::find().count(&state.db).await.unwrap(), 0);
+    assert_eq!(
+        file_blob::Entity::find()
+            .count(state.writer_db())
+            .await
+            .unwrap(),
+        0
+    );
     assert!(snapshot_dir_tree(&uploads_root).unwrap().is_empty());
 
     drop(state);

--- a/src/services/workspace_storage_service/tests.rs
+++ b/src/services/workspace_storage_service/tests.rs
@@ -481,7 +481,8 @@ async fn build_test_state() -> (PrimaryAppState, PathBuf, storage_policy::Model,
         );
 
     let state = PrimaryAppState {
-        db,
+        db: db.clone(),
+        db_handles: crate::db::DbHandles::single(db),
         driver_registry: Arc::new(DriverRegistry::new()),
         runtime_config: runtime_config.clone(),
         policy_snapshot: Arc::new(PolicySnapshot::new()),

--- a/src/webdav/auth.rs
+++ b/src/webdav/auth.rs
@@ -57,7 +57,7 @@ pub(crate) async fn invalidate_webdav_auth_for_user(
     state: &PrimaryAppState,
     user_id: i64,
 ) -> Result<(), AsterError> {
-    let accounts = webdav_account_repo::find_by_user(&state.db, user_id).await?;
+    let accounts = webdav_account_repo::find_by_user(state.writer_db(), user_id).await?;
     for account in accounts {
         invalidate_webdav_auth_for_username(state, &account.username).await;
     }
@@ -112,7 +112,7 @@ async fn authenticate_basic(
     }
 
     // 查 WebDAV 专用账号
-    let account = webdav_account_repo::find_by_username(&state.db, username)
+    let account = webdav_account_repo::find_by_username(state.writer_db(), username)
         .await?
         .ok_or_else(|| AsterError::auth_invalid_credentials("WebDAV account not found"))?;
 
@@ -128,7 +128,7 @@ async fn authenticate_basic(
     }
 
     // 确认关联用户仍然活跃
-    let user = user_repo::find_by_id(&state.db, account.user_id).await?;
+    let user = user_repo::find_by_id(state.writer_db(), account.user_id).await?;
     if !user.status.is_active() {
         return Err(auth_forbidden_with_subcode(
             ApiSubcode::AuthAccountDisabled,
@@ -198,7 +198,6 @@ mod tests {
             );
 
         PrimaryAppState {
-            db: db.clone(),
             db_handles: crate::db::DbHandles::single(db),
             driver_registry: Arc::new(DriverRegistry::new()),
             runtime_config: runtime_config.clone(),
@@ -232,7 +231,7 @@ mod tests {
             config: Set(None),
             ..Default::default()
         }
-        .insert(&state.db)
+        .insert(state.writer_db())
         .await
         .expect("webdav auth test user should be inserted");
 
@@ -252,7 +251,7 @@ mod tests {
             updated_at: Set(now),
             ..Default::default()
         }
-        .insert(&state.db)
+        .insert(state.writer_db())
         .await
         .expect("webdav auth test account should be inserted");
 

--- a/src/webdav/auth.rs
+++ b/src/webdav/auth.rs
@@ -198,7 +198,8 @@ mod tests {
             );
 
         PrimaryAppState {
-            db,
+            db: db.clone(),
+            db_handles: crate::db::DbHandles::single(db),
             driver_registry: Arc::new(DriverRegistry::new()),
             runtime_config: runtime_config.clone(),
             policy_snapshot: Arc::new(PolicySnapshot::new()),

--- a/src/webdav/db_lock_system.rs
+++ b/src/webdav/db_lock_system.rs
@@ -49,7 +49,7 @@ impl DbLockSystem {
         audit_ctx: AuditContext,
     ) -> Box<Self> {
         Box::new(Self {
-            db: state.db.clone(),
+            db: state.writer_db().clone(),
             user_id,
             root_folder_id,
             audit_state: Some(state),

--- a/src/webdav/file.rs
+++ b/src/webdav/file.rs
@@ -163,7 +163,7 @@ impl AsterDavFile {
                     return Err(FsError::TooLarge);
                 }
                 workspace_storage_service::check_quota(
-                    &state.db,
+                    state.writer_db(),
                     WorkspaceStorageScope::Personal { user_id },
                     size_hint,
                 )
@@ -880,7 +880,6 @@ mod tests {
             );
 
         let state = PrimaryAppState {
-            db: db.clone(),
             db_handles: crate::db::DbHandles::single(db),
             driver_registry,
             runtime_config: runtime_config.clone(),
@@ -929,10 +928,11 @@ mod tests {
             "known-size S3 WebDAV write should not create runtime temp files"
         );
 
-        let stored = file_repo::find_by_name_in_folder(&state.db, user.id, None, "direct-s3.txt")
-            .await
-            .expect("stored file lookup should succeed")
-            .expect("S3 direct WebDAV flush should create a file");
+        let stored =
+            file_repo::find_by_name_in_folder(state.writer_db(), user.id, None, "direct-s3.txt")
+                .await
+                .expect("stored file lookup should succeed")
+                .expect("S3 direct WebDAV flush should create a file");
         assert_eq!(
             stored.size,
             i64::try_from(payload.len()).expect("payload length should fit i64")

--- a/src/webdav/file.rs
+++ b/src/webdav/file.rs
@@ -880,7 +880,8 @@ mod tests {
             );
 
         let state = PrimaryAppState {
-            db,
+            db: db.clone(),
+            db_handles: crate::db::DbHandles::single(db),
             driver_registry,
             runtime_config: runtime_config.clone(),
             policy_snapshot,

--- a/src/webdav/fs.rs
+++ b/src/webdav/fs.rs
@@ -97,7 +97,7 @@ impl AsterDavFs {
             _ => return Err(FsError::Forbidden),
         };
 
-        let blob = file_repo::find_blob_by_id(&self.state.db, file.blob_id)
+        let blob = file_repo::find_blob_by_id(self.state.writer_db(), file.blob_id)
             .await
             .map_err(|_| FsError::GeneralFailure)?;
         let policy = self
@@ -147,7 +147,7 @@ impl DavFileSystem for AsterDavFs {
                 .await?;
 
                 let existing_file = file_repo::find_by_name_in_folder(
-                    &self.state.db,
+                    self.state.writer_db(),
                     self.user_id,
                     parent_id,
                     &filename,
@@ -203,10 +203,11 @@ impl DavFileSystem for AsterDavFs {
                 ResolvedNode::File(_) => return Err(FsError::Forbidden),
             };
 
-            let folders = folder_repo::find_children(&self.state.db, self.user_id, folder_id)
-                .await
-                .map_err(|_| FsError::GeneralFailure)?;
-            let files = file_repo::find_by_folder(&self.state.db, self.user_id, folder_id)
+            let folders =
+                folder_repo::find_children(self.state.writer_db(), self.user_id, folder_id)
+                    .await
+                    .map_err(|_| FsError::GeneralFailure)?;
+            let files = file_repo::find_by_folder(self.state.writer_db(), self.user_id, folder_id)
                 .await
                 .map_err(|_| FsError::GeneralFailure)?;
 
@@ -218,7 +219,7 @@ impl DavFileSystem for AsterDavFs {
 
             // 批量查询所有 blob（1 次查询替代 N 次）
             let blob_ids: Vec<i64> = files.iter().map(|f| f.blob_id).collect();
-            let blobs = file_repo::find_blobs_by_ids(&self.state.db, &blob_ids)
+            let blobs = file_repo::find_blobs_by_ids(self.state.writer_db(), &blob_ids)
                 .await
                 .map_err(|_| FsError::GeneralFailure)?;
 
@@ -247,7 +248,7 @@ impl DavFileSystem for AsterDavFs {
                 ResolvedNode::Root => Box::new(AsterDavMeta::root()),
                 ResolvedNode::Folder(f) => Box::new(AsterDavMeta::from_folder(&f)),
                 ResolvedNode::File(f) => {
-                    let blob = file_repo::find_blob_by_id(&self.state.db, f.blob_id)
+                    let blob = file_repo::find_blob_by_id(self.state.writer_db(), f.blob_id)
                         .await
                         .map_err(|_| FsError::GeneralFailure)?;
                     Box::new(AsterDavMeta::from_file(&f, &blob))
@@ -368,7 +369,7 @@ impl DavFileSystem for AsterDavFs {
                 ResolvedNode::File(f) => {
                     // 如果目标已有同名文件，先删除（WebDAV MOVE 覆盖语义）
                     if let Some(existing) = file_repo::find_by_name_in_folder(
-                        &self.state.db,
+                        self.state.writer_db(),
                         self.user_id,
                         dest_parent_id,
                         &dest_name,
@@ -440,7 +441,7 @@ impl DavFileSystem for AsterDavFs {
                 ResolvedNode::File(f) => {
                     // WebDAV COPY 覆盖语义：目标已存在先删除
                     if let Some(existing) = file_repo::find_by_name_in_folder(
-                        &self.state.db,
+                        self.state.writer_db(),
                         self.user_id,
                         dest_parent_id,
                         &dest_name,
@@ -503,7 +504,7 @@ impl DavFileSystem for AsterDavFs {
 
     fn get_quota(&self) -> FsFuture<'_, (u64, Option<u64>)> {
         Box::pin(async move {
-            let user = user_repo::find_by_id(&self.state.db, self.user_id)
+            let user = user_repo::find_by_id(self.state.writer_db(), self.user_id)
                 .await
                 .map_err(|_| FsError::GeneralFailure)?;
 
@@ -532,7 +533,7 @@ impl DavFileSystem for AsterDavFs {
                     Some(v) => v,
                     None => return false,
                 };
-            property_repo::find_by_entity(&self.state.db, entity_type, entity_id)
+            property_repo::find_by_entity(self.state.writer_db(), entity_type, entity_id)
                 .await
                 .map(|props| {
                     props
@@ -550,9 +551,10 @@ impl DavFileSystem for AsterDavFs {
                     .await
                     .ok_or(FsError::NotFound)?;
 
-            let props = property_repo::find_by_entity(&self.state.db, entity_type, entity_id)
-                .await
-                .map_err(|_| FsError::GeneralFailure)?;
+            let props =
+                property_repo::find_by_entity(self.state.writer_db(), entity_type, entity_id)
+                    .await
+                    .map_err(|_| FsError::GeneralFailure)?;
 
             Ok(props
                 .into_iter()
@@ -600,7 +602,7 @@ impl DavFileSystem for AsterDavFs {
                 let status = if set {
                     let value = prop.xml.as_ref().map(|x| String::from_utf8_lossy(x));
                     match property_repo::upsert(
-                        &self.state.db,
+                        self.state.writer_db(),
                         entity_type,
                         entity_id,
                         ns,
@@ -614,7 +616,7 @@ impl DavFileSystem for AsterDavFs {
                     }
                 } else {
                     match property_repo::delete_prop(
-                        &self.state.db,
+                        self.state.writer_db(),
                         entity_type,
                         entity_id,
                         ns,

--- a/src/webdav/mod.rs
+++ b/src/webdav/mod.rs
@@ -114,13 +114,25 @@ pub async fn webdav_handler(
         "OPTIONS" => handle_options(),
         "REPORT" => match collect_xml_payload(&mut payload, webdav.xml_payload_limit).await {
             Ok(body) => {
-                deltav::handle_report(req.uri(), &body, &state.db, &auth_result, &webdav.prefix)
-                    .await
+                deltav::handle_report(
+                    req.uri(),
+                    &body,
+                    state.writer_db(),
+                    &auth_result,
+                    &webdav.prefix,
+                )
+                .await
             }
             Err(resp) => resp,
         },
         "VERSION-CONTROL" => {
-            deltav::handle_version_control(req.uri(), &state.db, &auth_result, &webdav.prefix).await
+            deltav::handle_version_control(
+                req.uri(),
+                state.writer_db(),
+                &auth_result,
+                &webdav.prefix,
+            )
+            .await
         }
         "PROPFIND" => match collect_xml_payload(&mut payload, webdav.xml_payload_limit).await {
             Ok(body) => {
@@ -1738,7 +1750,6 @@ mod tests {
             );
 
         let state = PrimaryAppState {
-            db: db.clone(),
             db_handles: crate::db::DbHandles::single(db.clone()),
             driver_registry,
             runtime_config: runtime_config.clone(),
@@ -1765,7 +1776,7 @@ mod tests {
     ) -> (file::Model, file_blob::Model) {
         let now = Utc::now();
         let blob = file_repo::create_blob(
-            &state.db,
+            state.writer_db(),
             file_blob::ActiveModel {
                 hash: Set(format!("webdav-blob-{}", uuid::Uuid::new_v4())),
                 size: Set(size),
@@ -1781,7 +1792,7 @@ mod tests {
         .expect("webdav handler blob should be inserted");
 
         let file = file_repo::create(
-            &state.db,
+            state.writer_db(),
             file::ActiveModel {
                 name: Set(filename.to_string()),
                 folder_id: Set(None),
@@ -2237,10 +2248,11 @@ mod tests {
             "known-size WebDAV PUT should not fall back to StorageDriver::put_file()"
         );
 
-        let stored = file_repo::find_by_name_in_folder(&state.db, user.id, None, "direct.txt")
-            .await
-            .expect("stored WebDAV file lookup should succeed")
-            .expect("direct WebDAV PUT should create a file");
+        let stored =
+            file_repo::find_by_name_in_folder(state.writer_db(), user.id, None, "direct.txt")
+                .await
+                .expect("stored WebDAV file lookup should succeed")
+                .expect("direct WebDAV PUT should create a file");
         assert_eq!(
             stored.size,
             i64::try_from(body.len()).expect("request body length should fit i64")

--- a/src/webdav/mod.rs
+++ b/src/webdav/mod.rs
@@ -1739,6 +1739,7 @@ mod tests {
 
         let state = PrimaryAppState {
             db: db.clone(),
+            db_handles: crate::db::DbHandles::single(db.clone()),
             driver_registry,
             runtime_config: runtime_config.clone(),
             policy_snapshot,

--- a/src/webdav/path_resolver.rs
+++ b/src/webdav/path_resolver.rs
@@ -149,7 +149,8 @@ async fn validate_cached_folder_path(
     folder_id: i64,
     segments: &[String],
 ) -> Result<bool, FsError> {
-    let chain = match folder_repo::find_ancestor_models(&state.db, user_id, folder_id).await {
+    let chain = match folder_repo::find_ancestor_models(state.writer_db(), user_id, folder_id).await
+    {
         Ok(chain) => chain,
         Err(error) if is_missing_entity(&error) => return Ok(false),
         Err(_) => return Err(FsError::GeneralFailure),
@@ -194,7 +195,7 @@ async fn load_cached_resolved_node(
             parent_id,
             name,
         } => {
-            let folder = match folder_repo::find_by_id(&state.db, id).await {
+            let folder = match folder_repo::find_by_id(state.writer_db(), id).await {
                 Ok(folder) => folder,
                 Err(error) if is_missing_entity(&error) => {
                     state.cache.delete(cache_key).await;
@@ -227,7 +228,7 @@ async fn load_cached_resolved_node(
             folder_id,
             name,
         } => {
-            let file = match file_repo::find_by_id(&state.db, id).await {
+            let file = match file_repo::find_by_id(state.writer_db(), id).await {
                 Ok(file) => file,
                 Err(error) if is_missing_entity(&error) => {
                     state.cache.delete(cache_key).await;
@@ -334,7 +335,7 @@ pub async fn resolve_path_cached(
         return Ok(node);
     }
 
-    let node = resolve_path(&state.db, user_id, path, root_folder_id).await?;
+    let node = resolve_path(state.writer_db(), user_id, path, root_folder_id).await?;
     state
         .cache
         .set(
@@ -422,7 +423,8 @@ pub async fn resolve_parent_cached(
         state.cache.delete(&cache_key).await;
     }
 
-    let (parent_id, name) = resolve_parent(&state.db, user_id, path, root_folder_id).await?;
+    let (parent_id, name) =
+        resolve_parent(state.writer_db(), user_id, path, root_folder_id).await?;
     state
         .cache
         .set(

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -848,6 +848,7 @@ pub async fn setup_with_memory_cache() -> PrimaryAppState {
 
     PrimaryAppState {
         db: base.db,
+        db_handles: base.db_handles,
         driver_registry: base.driver_registry,
         runtime_config: base.runtime_config,
         policy_snapshot: base.policy_snapshot,
@@ -1093,7 +1094,10 @@ pub async fn setup_with_database_url(database_url: &str) -> PrimaryAppState {
         );
 
     PrimaryAppState {
-        db,
+        db: db.clone(),
+        db_handles: aster_drive::db::connect_reader_for_writer(&db_cfg, db.clone())
+            .await
+            .unwrap(),
         driver_registry: std::sync::Arc::new(aster_drive::storage::DriverRegistry::new()),
         runtime_config,
         policy_snapshot,

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -847,7 +847,6 @@ pub async fn setup_with_memory_cache() -> PrimaryAppState {
     let cache = aster_drive::cache::create_cache(&cache_config).await;
 
     PrimaryAppState {
-        db: base.db,
         db_handles: base.db_handles,
         driver_registry: base.driver_registry,
         runtime_config: base.runtime_config,
@@ -1094,7 +1093,6 @@ pub async fn setup_with_database_url(database_url: &str) -> PrimaryAppState {
         );
 
     PrimaryAppState {
-        db: db.clone(),
         db_handles: aster_drive::db::connect_reader_for_writer(&db_cfg, db.clone())
             .await
             .unwrap(),
@@ -1113,7 +1111,7 @@ pub async fn setup_with_database_url(database_url: &str) -> PrimaryAppState {
 
 #[allow(dead_code)]
 pub async fn flush_mail_outbox(state: &PrimaryAppState) {
-    flush_mail_outbox_with(&state.db, &state.runtime_config, &state.mail_sender).await;
+    flush_mail_outbox_with(state.writer_db(), &state.runtime_config, &state.mail_sender).await;
 }
 
 #[allow(dead_code)]
@@ -1257,7 +1255,7 @@ macro_rules! create_test_app {
         use actix_web::{App, test, web};
 
         let state = $state;
-        let db = state.db.clone();
+        let db = state.writer_db().clone();
         test::init_service(
             App::new()
                 .wrap(aster_drive::api::middleware::security_headers::default_headers())
@@ -1519,8 +1517,8 @@ macro_rules! setup_with_webdav {
         use actix_web::{App, test, web};
 
         let state = common::setup().await;
-        let db1 = state.db.clone();
-        let db2 = state.db.clone();
+        let db1 = state.writer_db().clone();
+        let db2 = state.writer_db().clone();
         let webdav_config = aster_drive::config::WebDavConfig::default();
         let app = test::init_service(
             App::new()
@@ -1544,10 +1542,10 @@ macro_rules! setup_with_webdav_and_mail {
         use actix_web::{App, test, web};
 
         let state = common::setup().await;
-        let db = state.db.clone();
+        let db = state.writer_db().clone();
         let mail_sender = state.mail_sender.clone();
-        let db1 = state.db.clone();
-        let db2 = state.db.clone();
+        let db1 = state.writer_db().clone();
+        let db2 = state.writer_db().clone();
         let webdav_config = aster_drive::config::WebDavConfig::default();
         let app = test::init_service(
             App::new()

--- a/tests/external_auth/oidc/mod.rs
+++ b/tests/external_auth/oidc/mod.rs
@@ -398,11 +398,14 @@ pub async fn latest_oidc_email_verification_token(
 
 pub async fn disable_user(state: &aster_drive::runtime::PrimaryAppState, user_id: i64) {
     let user = user::Entity::find_by_id(user_id)
-        .one(&state.db)
+        .one(state.writer_db())
         .await
         .expect("user should query")
         .expect("user should exist");
     let mut active = user.into_active_model();
     active.status = Set(aster_drive::types::UserStatus::Disabled);
-    active.update(&state.db).await.expect("user should update");
+    active
+        .update(state.writer_db())
+        .await
+        .expect("user should update");
 }

--- a/tests/test_admin.rs
+++ b/tests/test_admin.rs
@@ -427,11 +427,12 @@ async fn test_admin_team_crud() {
         .system_default_policy_group()
         .expect("default policy group should exist")
         .id;
-    let default_policy_id = aster_drive::db::repository::policy_repo::find_default(&state.db)
-        .await
-        .unwrap()
-        .expect("default policy should exist")
-        .id;
+    let default_policy_id =
+        aster_drive::db::repository::policy_repo::find_default(state.writer_db())
+            .await
+            .unwrap()
+            .expect("default policy should exist")
+            .id;
     let alternate_group_id = aster_drive::services::policy_service::create_group(
         &state,
         aster_drive::services::policy_service::CreateStoragePolicyGroupInput {
@@ -1112,7 +1113,7 @@ async fn test_admin_policies_support_explicit_sorting() {
 #[actix_web::test]
 async fn test_admin_policy_groups_support_explicit_sorting() {
     let state = common::setup().await;
-    let default_policy_id = policy_repo::find_default(&state.db)
+    let default_policy_id = policy_repo::find_default(state.writer_db())
         .await
         .unwrap()
         .expect("default policy should exist")
@@ -1272,7 +1273,7 @@ async fn test_admin_locks_support_explicit_sorting() {
     .enumerate()
     {
         lock_repo::create(
-            &state.db,
+            state.writer_db(),
             resource_lock::ActiveModel {
                 token: Set(format!("urn:uuid:{}", uuid::Uuid::new_v4())),
                 entity_type: Set(EntityType::File),
@@ -1324,7 +1325,7 @@ async fn test_admin_tasks_support_explicit_sorting_and_id_tiebreaker() {
 
     for display_name in ["Task Sort Zeta", "Task Sort Alpha", "Task Sort Beta"] {
         let task = background_task_repo::create(
-            &state.db,
+            state.writer_db(),
             background_task::ActiveModel {
                 kind: Set(BackgroundTaskKind::SystemRuntime),
                 status: Set(BackgroundTaskStatus::Pending),
@@ -1397,7 +1398,7 @@ async fn test_admin_audit_logs_support_explicit_sorting() {
         (format!("Audit Sort {marker} Beta"), "10.0.0.2"),
     ] {
         audit_log_repo::create(
-            &state.db,
+            state.writer_db(),
             audit_log::ActiveModel {
                 user_id: Set(1),
                 action: Set(AuditAction::AdminUpdateUser),
@@ -1473,7 +1474,7 @@ async fn test_admin_audit_logs_skip_invalid_entity_type_rows() {
         ("file", format!("Audit Valid {marker}")),
     ] {
         audit_log_repo::create(
-            &state.db,
+            state.writer_db(),
             audit_log::ActiveModel {
                 user_id: Set(1),
                 action: Set(AuditAction::FileUpload),
@@ -1528,7 +1529,7 @@ async fn test_admin_overview() {
     assert_eq!(resp.status(), 201);
 
     background_task_repo::create(
-        &state.db,
+        state.writer_db(),
         background_task::ActiveModel {
             kind: Set(BackgroundTaskKind::SystemRuntime),
             status: Set(BackgroundTaskStatus::Succeeded),
@@ -1562,7 +1563,7 @@ async fn test_admin_overview() {
     .expect("background task event should be inserted");
 
     background_task_repo::create(
-        &state.db,
+        state.writer_db(),
         background_task::ActiveModel {
             kind: Set(BackgroundTaskKind::SystemRuntime),
             status: Set(BackgroundTaskStatus::Failed),
@@ -1761,7 +1762,7 @@ async fn test_admin_tasks_lists_all_recorded_tasks() {
     let team_id = team_body["data"]["id"].as_i64().unwrap();
 
     let system_task = background_task_repo::create(
-        &state.db,
+        state.writer_db(),
         background_task::ActiveModel {
             kind: Set(BackgroundTaskKind::SystemRuntime),
             status: Set(BackgroundTaskStatus::Succeeded),
@@ -1795,7 +1796,7 @@ async fn test_admin_tasks_lists_all_recorded_tasks() {
     .expect("system task should be inserted");
 
     let team_task = background_task_repo::create(
-        &state.db,
+        state.writer_db(),
         background_task::ActiveModel {
             kind: Set(BackgroundTaskKind::ArchiveCompress),
             status: Set(BackgroundTaskStatus::Failed),
@@ -1830,7 +1831,7 @@ async fn test_admin_tasks_lists_all_recorded_tasks() {
     .expect("team task should be inserted");
 
     let personal_task = background_task_repo::create(
-        &state.db,
+        state.writer_db(),
         background_task::ActiveModel {
             kind: Set(BackgroundTaskKind::ArchiveExtract),
             status: Set(BackgroundTaskStatus::Processing),
@@ -1959,7 +1960,7 @@ async fn test_admin_tasks_cleanup_uses_explicit_finished_before() {
         };
 
         background_task_repo::create(
-            &state.db,
+            state.writer_db(),
             background_task::ActiveModel {
                 kind: Set(kind),
                 status: Set(status),

--- a/tests/test_archive_preview.rs
+++ b/tests/test_archive_preview.rs
@@ -195,12 +195,13 @@ where
 async fn archive_preview_tasks(
     state: &aster_drive::runtime::PrimaryAppState,
 ) -> Vec<background_task::Model> {
-    let mut tasks = aster_drive::db::repository::background_task_repo::list_recent(&state.db, 50)
-        .await
-        .expect("task list should load")
-        .into_iter()
-        .filter(|task| task.kind == BackgroundTaskKind::ArchivePreviewGenerate)
-        .collect::<Vec<_>>();
+    let mut tasks =
+        aster_drive::db::repository::background_task_repo::list_recent(state.writer_db(), 50)
+            .await
+            .expect("task list should load")
+            .into_iter()
+            .filter(|task| task.kind == BackgroundTaskKind::ArchivePreviewGenerate)
+            .collect::<Vec<_>>();
     tasks.sort_by_key(|task| task.id);
     tasks
 }
@@ -286,9 +287,10 @@ async fn test_archive_preview_returns_manifest_and_caches_it() {
     let body: Value = test::read_body_json(resp).await;
     assert_eq!(body["code"], 0);
 
-    let tasks = aster_drive::db::repository::background_task_repo::list_recent(&state.db, 10)
-        .await
-        .expect("task list should load");
+    let tasks =
+        aster_drive::db::repository::background_task_repo::list_recent(state.writer_db(), 10)
+            .await
+            .expect("task list should load");
     let task = tasks
         .iter()
         .find(|task| task.kind == BackgroundTaskKind::ArchivePreviewGenerate)
@@ -298,9 +300,10 @@ async fn test_archive_preview_returns_manifest_and_caches_it() {
     aster_drive::services::task_service::drain(&state)
         .await
         .expect("archive preview task should drain");
-    let tasks = aster_drive::db::repository::background_task_repo::list_recent(&state.db, 10)
-        .await
-        .expect("task list should load");
+    let tasks =
+        aster_drive::db::repository::background_task_repo::list_recent(state.writer_db(), 10)
+            .await
+            .expect("task list should load");
     let task = tasks
         .iter()
         .find(|task| task.kind == BackgroundTaskKind::ArchivePreviewGenerate)
@@ -378,7 +381,7 @@ async fn test_archive_preview_returns_manifest_and_caches_it() {
     );
 
     let cached = property_repo::find_by_key(
-        &state.db,
+        state.writer_db(),
         EntityType::File,
         file_id,
         "system.archive_preview",
@@ -793,7 +796,7 @@ async fn test_archive_preview_caps_high_manifest_limit_to_cache_storage_limit() 
     );
 
     let cached = property_repo::find_by_key(
-        &state.db,
+        state.writer_db(),
         EntityType::File,
         file_id,
         "system.archive_preview",

--- a/tests/test_audit.rs
+++ b/tests/test_audit.rs
@@ -66,7 +66,7 @@ async fn test_audit_log_persists_long_entity_type_values() {
 
     let entry = audit_log::Entity::find()
         .filter(audit_log::Column::Action.eq(AuditAction::AdminTestExternalAuthProvider))
-        .one(&state.db)
+        .one(state.writer_db())
         .await
         .expect("audit log query should succeed")
         .expect("long entity_type audit log should persist");
@@ -802,7 +802,7 @@ async fn test_audit_log_recorded_on_team_archive_cleanup() {
     use sea_orm::{IntoActiveModel, Set};
 
     let state = common::setup().await;
-    let db = state.db.clone();
+    let db = state.writer_db().clone();
     let state = web::Data::new(state);
     let app = test::init_service(
         App::new()
@@ -836,14 +836,15 @@ async fn test_audit_log_recorded_on_team_archive_cleanup() {
     let resp = test::call_service(&app, req).await;
     assert_eq!(resp.status(), 200);
 
-    let mut archived_team = aster_drive::db::repository::team_repo::find_by_id(&state.db, team_id)
-        .await
-        .unwrap()
-        .into_active_model();
+    let mut archived_team =
+        aster_drive::db::repository::team_repo::find_by_id(state.writer_db(), team_id)
+            .await
+            .unwrap()
+            .into_active_model();
     let archived_at = Utc::now() - Duration::days(10);
     archived_team.archived_at = Set(Some(archived_at));
     archived_team.updated_at = Set(archived_at);
-    aster_drive::db::repository::team_repo::update(&state.db, archived_team)
+    aster_drive::db::repository::team_repo::update(state.writer_db(), archived_team)
         .await
         .unwrap();
 

--- a/tests/test_auth.rs
+++ b/tests/test_auth.rs
@@ -550,7 +550,7 @@ async fn test_register_and_login() {
     )
     .expect("refresh token should verify");
     let refresh_jti = refresh_claims.jti.expect("refresh token should carry jti");
-    let auth_session = auth_session_repo::find_by_refresh_jti(&state.db, &refresh_jti)
+    let auth_session = auth_session_repo::find_by_refresh_jti(state.writer_db(), &refresh_jti)
         .await
         .unwrap()
         .expect("auth session row should exist");
@@ -807,7 +807,7 @@ async fn test_refresh_accepts_matching_csrf_token_and_rotates_cookie() {
         .jti
         .clone()
         .expect("rotated refresh token should carry jti");
-    let rotated_session = auth_session_repo::find_by_refresh_jti(&state.db, &rotated_jti)
+    let rotated_session = auth_session_repo::find_by_refresh_jti(state.writer_db(), &rotated_jti)
         .await
         .unwrap()
         .expect("rotated auth session should exist");
@@ -838,7 +838,7 @@ async fn test_refresh_accepts_matching_csrf_token_and_rotates_cookie() {
         .jti
         .clone()
         .expect("next refresh token should carry jti");
-    let next_session = auth_session_repo::find_by_refresh_jti(&state.db, &next_jti)
+    let next_session = auth_session_repo::find_by_refresh_jti(state.writer_db(), &next_jti)
         .await
         .unwrap()
         .expect("next auth session should exist");
@@ -905,7 +905,7 @@ async fn test_refresh_reuse_detected_revokes_all_sessions() {
         .clone()
         .expect("refresh token should carry jti");
     assert!(
-        auth_session_repo::find_by_refresh_jti(&state.db, &original_jti)
+        auth_session_repo::find_by_refresh_jti(state.writer_db(), &original_jti)
             .await
             .unwrap()
             .is_some()
@@ -926,18 +926,18 @@ async fn test_refresh_reuse_detected_revokes_all_sessions() {
         .clone()
         .expect("rotated refresh token should carry jti");
     assert!(
-        auth_session_repo::find_by_refresh_jti(&state.db, &original_jti)
+        auth_session_repo::find_by_refresh_jti(state.writer_db(), &original_jti)
             .await
             .unwrap()
             .is_none()
     );
-    let rotated_session = auth_session_repo::find_by_refresh_jti(&state.db, &rotated_jti)
+    let rotated_session = auth_session_repo::find_by_refresh_jti(state.writer_db(), &rotated_jti)
         .await
         .unwrap()
         .expect("rotated auth session should exist");
     let mut active = rotated_session.into_active_model();
     active.last_seen_at = Set(chrono::Utc::now() - chrono::Duration::seconds(60));
-    active.update(&state.db).await.unwrap();
+    active.update(state.writer_db()).await.unwrap();
 
     let req = test::TestRequest::post()
         .uri("/api/v1/auth/refresh")
@@ -946,13 +946,13 @@ async fn test_refresh_reuse_detected_revokes_all_sessions() {
         .to_request();
     assert_service_status!(app, req, 401, "refresh token reuse should be rejected");
 
-    let user = user_repo::find_by_username(&state.db, "testuser")
+    let user = user_repo::find_by_username(state.writer_db(), "testuser")
         .await
         .unwrap()
         .expect("user should exist");
     assert_eq!(user.session_version, 2);
     assert!(
-        auth_session_repo::list_active_for_user(&state.db, user.id)
+        auth_session_repo::list_active_for_user(state.writer_db(), user.id)
             .await
             .unwrap()
             .is_empty()
@@ -1059,13 +1059,13 @@ async fn test_concurrent_refresh_same_token_has_single_winner() {
     let loser = first.as_ref().err().or(second.as_ref().err()).unwrap();
     assert_eq!(loser.code(), "E012");
 
-    let user = user_repo::find_by_username(&state.db, "testuser")
+    let user = user_repo::find_by_username(state.writer_db(), "testuser")
         .await
         .unwrap()
         .expect("user should exist");
     assert_eq!(user.session_version, 1);
     assert!(
-        auth_session_repo::list_active_for_user(&state.db, user.id)
+        auth_session_repo::list_active_for_user(state.writer_db(), user.id)
             .await
             .unwrap()
             .len()
@@ -1110,13 +1110,13 @@ async fn test_recent_refresh_reuse_from_different_client_revokes_all_sessions() 
         "recent refresh reuse from a different client should be treated as compromise"
     );
 
-    let user = user_repo::find_by_username(&state.db, "testuser")
+    let user = user_repo::find_by_username(state.writer_db(), "testuser")
         .await
         .unwrap()
         .expect("user should exist");
     assert_eq!(user.session_version, 2);
     assert!(
-        auth_session_repo::list_active_for_user(&state.db, user.id)
+        auth_session_repo::list_active_for_user(state.writer_db(), user.id)
             .await
             .unwrap()
             .is_empty()
@@ -1180,13 +1180,13 @@ async fn test_recent_refresh_reuse_from_spoofed_forwarded_ip_stays_stale() {
         "untrusted forwarded IP changes should not make same-client stale refresh look compromised"
     );
 
-    let user = user_repo::find_by_username(&state.db, "testuser")
+    let user = user_repo::find_by_username(state.writer_db(), "testuser")
         .await
         .unwrap()
         .expect("user should exist");
     assert_eq!(user.session_version, 1);
     assert_eq!(
-        auth_session_repo::list_active_for_user(&state.db, user.id)
+        auth_session_repo::list_active_for_user(state.writer_db(), user.id)
             .await
             .unwrap()
             .len(),
@@ -1221,13 +1221,13 @@ async fn test_recent_refresh_reuse_without_client_evidence_revokes_all_sessions(
         "recent refresh reuse without client evidence should be treated as compromise"
     );
 
-    let user = user_repo::find_by_username(&state.db, "testuser")
+    let user = user_repo::find_by_username(state.writer_db(), "testuser")
         .await
         .unwrap()
         .expect("user should exist");
     assert_eq!(user.session_version, 2);
     assert!(
-        auth_session_repo::list_active_for_user(&state.db, user.id)
+        auth_session_repo::list_active_for_user(state.writer_db(), user.id)
             .await
             .unwrap()
             .is_empty()
@@ -1295,7 +1295,7 @@ async fn test_setup_bootstraps_public_site_url_from_request_origin() {
     assert_eq!(resp.status(), 201);
 
     let stored = aster_drive::db::repository::config_repo::find_by_key(
-        &state.db,
+        state.writer_db(),
         aster_drive::config::site_url::PUBLIC_SITE_URL_KEY,
     )
     .await
@@ -1332,7 +1332,7 @@ async fn test_setup_does_not_overwrite_existing_public_site_url() {
     assert_eq!(resp.status(), 201);
 
     let stored = aster_drive::db::repository::config_repo::find_by_key(
-        &state.db,
+        state.writer_db(),
         aster_drive::config::site_url::PUBLIC_SITE_URL_KEY,
     )
     .await
@@ -1432,7 +1432,7 @@ async fn test_register_is_blocked_when_public_registration_is_disabled() {
 #[actix_web::test]
 async fn test_register_requires_activation_until_confirmed() {
     let state = common::setup().await;
-    let db = state.db.clone();
+    let db = state.writer_db().clone();
     let mail_sender = state.mail_sender.clone();
     let runtime_config = state.runtime_config.clone();
     let app = create_test_app!(state);
@@ -1492,7 +1492,7 @@ async fn test_register_requires_activation_until_confirmed() {
 #[actix_web::test]
 async fn test_register_skips_activation_when_register_activation_is_disabled() {
     let state = common::setup().await;
-    let db = state.db.clone();
+    let db = state.writer_db().clone();
     let mail_sender = state.mail_sender.clone();
     let runtime_config = state.runtime_config.clone();
     state.runtime_config.apply(common::system_config_model(
@@ -1528,7 +1528,7 @@ async fn test_register_skips_activation_when_register_activation_is_disabled() {
 #[actix_web::test]
 async fn test_register_resend_is_generic_for_unknown_identifier_and_cooldown() {
     let state = common::setup().await;
-    let db = state.db.clone();
+    let db = state.writer_db().clone();
     let mail_sender = state.mail_sender.clone();
     let runtime_config = state.runtime_config.clone();
     let app = create_test_app!(state);
@@ -1576,7 +1576,7 @@ async fn test_register_resend_is_generic_for_unknown_identifier_and_cooldown() {
 #[actix_web::test]
 async fn test_email_change_confirmation_redirects_and_notifies_previous_email() {
     let state = common::setup().await;
-    let db = state.db.clone();
+    let db = state.writer_db().clone();
     let mail_sender = state.mail_sender.clone();
     let runtime_config = state.runtime_config.clone();
     let app = create_test_app!(state);
@@ -1643,7 +1643,7 @@ async fn test_email_change_confirmation_redirects_and_notifies_previous_email() 
 #[actix_web::test]
 async fn test_email_change_resend_returns_generic_success_during_cooldown() {
     let state = common::setup().await;
-    let db = state.db.clone();
+    let db = state.writer_db().clone();
     let mail_sender = state.mail_sender.clone();
     let runtime_config = state.runtime_config.clone();
     let app = create_test_app!(state);
@@ -1710,7 +1710,7 @@ async fn test_password_reset_rotates_session_and_sends_notice_and_records_audit_
     use sea_orm::EntityTrait;
 
     let state = common::setup().await;
-    let db = state.db.clone();
+    let db = state.writer_db().clone();
     let mail_sender = state.mail_sender.clone();
     let runtime_config = state.runtime_config.clone();
     let app = create_test_app!(state);
@@ -1817,7 +1817,7 @@ async fn test_password_reset_rotates_session_and_sends_notice_and_records_audit_
 #[actix_web::test]
 async fn test_password_reset_confirm_rejects_reused_token() {
     let state = common::setup().await;
-    let db = state.db.clone();
+    let db = state.writer_db().clone();
     let mail_sender = state.mail_sender.clone();
     let runtime_config = state.runtime_config.clone();
     let app = create_test_app!(state);
@@ -1873,7 +1873,7 @@ async fn test_password_reset_confirm_rejects_expired_token() {
     use sea_orm::{ActiveModelTrait, ColumnTrait, EntityTrait, IntoActiveModel, QueryFilter, Set};
 
     let state = common::setup().await;
-    let db = state.db.clone();
+    let db = state.writer_db().clone();
     let mail_sender = state.mail_sender.clone();
     let runtime_config = state.runtime_config.clone();
     let app = create_test_app!(state);
@@ -1926,7 +1926,7 @@ async fn test_password_reset_confirm_rejects_expired_token() {
 #[actix_web::test]
 async fn test_contact_verification_confirm_rejects_password_reset_token() {
     let state = common::setup().await;
-    let db = state.db.clone();
+    let db = state.writer_db().clone();
     let mail_sender = state.mail_sender.clone();
     let runtime_config = state.runtime_config.clone();
     let app = create_test_app!(state);
@@ -1970,7 +1970,7 @@ async fn test_contact_verification_confirm_rejects_password_reset_token() {
 #[actix_web::test]
 async fn test_password_reset_request_cooldown_returns_generic_success() {
     let state = common::setup().await;
-    let db = state.db.clone();
+    let db = state.writer_db().clone();
     let mail_sender = state.mail_sender.clone();
     let runtime_config = state.runtime_config.clone();
     let app = create_test_app!(state);
@@ -2006,7 +2006,7 @@ async fn test_contact_verification_tokens_allow_only_one_unconsumed_token_per_pu
     use sea_orm::Set;
 
     let state = common::setup().await;
-    let db = state.db.clone();
+    let db = state.writer_db().clone();
     let app = create_test_app!(state);
     let _ = register_and_login!(app);
 
@@ -2404,7 +2404,7 @@ async fn test_storage_events_stream_closes_on_server_shutdown() {
     let app = {
         use actix_web::{App, test, web};
 
-        let db = state.db.clone();
+        let db = state.writer_db().clone();
         test::init_service(
             App::new()
                 .wrap(aster_drive::api::middleware::security_headers::default_headers())
@@ -2441,7 +2441,7 @@ async fn test_storage_events_stream_rejects_new_connections_after_shutdown() {
     let app = {
         use actix_web::{App, test, web};
 
-        let db = state.db.clone();
+        let db = state.writer_db().clone();
         test::init_service(
             App::new()
                 .wrap(aster_drive::api::middleware::security_headers::default_headers())
@@ -2553,7 +2553,7 @@ async fn test_logout_clears_cookies_and_revokes_refresh_token() {
         .expect("refresh token should verify");
     let refresh_jti = refresh_claims.jti.expect("refresh token should carry jti");
     assert!(
-        auth_session_repo::find_by_refresh_jti(&state.db, &refresh_jti)
+        auth_session_repo::find_by_refresh_jti(state.writer_db(), &refresh_jti)
             .await
             .unwrap()
             .is_some()
@@ -2593,7 +2593,7 @@ async fn test_logout_clears_cookies_and_revokes_refresh_token() {
     );
     assert_eq!(cleared_access_path.as_deref(), Some("/"));
     assert_eq!(cleared_refresh_path.as_deref(), Some("/api/v1/auth"));
-    let revoked_session = auth_session_repo::find_by_refresh_jti(&state.db, &refresh_jti)
+    let revoked_session = auth_session_repo::find_by_refresh_jti(state.writer_db(), &refresh_jti)
         .await
         .unwrap()
         .expect("revoked auth session should remain as tombstone");
@@ -2727,12 +2727,12 @@ async fn test_auth_sessions_list_and_revoke_specific_device() {
     let resp = test::call_service(&app, req).await;
     assert_eq!(resp.status(), 200);
     assert!(
-        auth_session_repo::find_by_refresh_jti(&state.db, &refresh_a_jti)
+        auth_session_repo::find_by_refresh_jti(state.writer_db(), &refresh_a_jti)
             .await
             .unwrap()
             .is_some()
     );
-    let user = user_repo::find_by_username(&state.db, "alice")
+    let user = user_repo::find_by_username(state.writer_db(), "alice")
         .await
         .unwrap()
         .expect("user should exist");
@@ -2840,12 +2840,12 @@ async fn test_auth_sessions_can_revoke_other_devices() {
     let body: Value = test::read_body_json(resp).await;
     assert_eq!(body["data"]["removed"], 2);
     assert!(
-        auth_session_repo::find_by_refresh_jti(&state.db, &refresh_a_jti)
+        auth_session_repo::find_by_refresh_jti(state.writer_db(), &refresh_a_jti)
             .await
             .unwrap()
             .is_some()
     );
-    let user = user_repo::find_by_username(&state.db, "testuser")
+    let user = user_repo::find_by_username(state.writer_db(), "testuser")
         .await
         .unwrap()
         .expect("user should exist");
@@ -2885,7 +2885,7 @@ async fn test_auth_sessions_can_revoke_current_device_and_clear_cookies() {
     let refresh_claims = auth_service::verify_token(&refresh, &state.config.auth.jwt_secret)
         .expect("refresh token should verify");
     let refresh_jti = refresh_claims.jti.expect("refresh token should carry jti");
-    let current_session = auth_session_repo::find_by_refresh_jti(&state.db, &refresh_jti)
+    let current_session = auth_session_repo::find_by_refresh_jti(state.writer_db(), &refresh_jti)
         .await
         .unwrap()
         .expect("current auth session should exist");
@@ -2908,7 +2908,7 @@ async fn test_auth_sessions_can_revoke_current_device_and_clear_cookies() {
         common::extract_cookie(&resp, "aster_refresh").as_deref(),
         Some("")
     );
-    let revoked_session = auth_session_repo::find_by_id(&state.db, &current_session.id)
+    let revoked_session = auth_session_repo::find_by_id(state.writer_db(), &current_session.id)
         .await
         .unwrap()
         .expect("revoked auth session should remain as tombstone");
@@ -2921,7 +2921,7 @@ async fn test_register_auto_assigns_policy() {
     use aster_drive::db::repository::policy_group_repo;
 
     let state = common::setup().await;
-    let expected_default_id = policy_group_repo::find_default_group(&state.db)
+    let expected_default_id = policy_group_repo::find_default_group(state.writer_db())
         .await
         .unwrap()
         .expect("default policy group should exist")
@@ -2981,7 +2981,6 @@ async fn test_user_status_cached_in_auth_middleware() {
 
     let base = common::setup().await;
     let state = aster_drive::runtime::PrimaryAppState {
-        db: base.db,
         db_handles: base.db_handles,
         driver_registry: base.driver_registry,
         runtime_config: base.runtime_config,
@@ -3028,7 +3027,6 @@ async fn test_disable_user_invalidates_status_cache() {
 
     let base = common::setup().await;
     let state = aster_drive::runtime::PrimaryAppState {
-        db: base.db,
         db_handles: base.db_handles,
         driver_registry: base.driver_registry,
         runtime_config: base.runtime_config,
@@ -3402,7 +3400,7 @@ async fn test_change_password_rotates_session_and_updates_login_secret() {
         .jti
         .clone()
         .expect("rotated refresh token should carry jti");
-    let rotated_session = auth_session_repo::find_by_refresh_jti(&state.db, &rotated_jti)
+    let rotated_session = auth_session_repo::find_by_refresh_jti(state.writer_db(), &rotated_jti)
         .await
         .unwrap()
         .expect("rotated auth session should exist");
@@ -3579,11 +3577,12 @@ async fn test_avatar_upload_and_source_switch() {
         .runtime_config
         .get(aster_drive::config::avatar::AVATAR_DIR_KEY)
         .expect("avatar_dir should exist");
-    let shared_policy_base_path = aster_drive::db::repository::policy_repo::find_default(&state.db)
-        .await
-        .unwrap()
-        .expect("default policy should exist")
-        .base_path;
+    let shared_policy_base_path =
+        aster_drive::db::repository::policy_repo::find_default(state.writer_db())
+            .await
+            .unwrap()
+            .expect("default policy should exist")
+            .base_path;
     let app = create_test_app!(state);
     let (token, _) = register_and_login!(app);
 
@@ -3683,7 +3682,7 @@ async fn test_avatar_read_rejects_tampered_stored_key() {
     use sea_orm::{ActiveModelTrait, EntityTrait, IntoActiveModel, Set};
 
     let state = common::setup().await;
-    let db = state.db.clone();
+    let db = state.writer_db().clone();
     let avatar_base_path = state
         .runtime_config
         .get(aster_drive::config::avatar::AVATAR_DIR_KEY)
@@ -3896,9 +3895,9 @@ async fn test_passkey_register_login_and_replay_protection() {
     let (mut softpasskey, passkey) = register_test_passkey(&app, &access, "Laptop").await;
     assert_eq!(passkey["name"], "Laptop");
     assert_eq!(passkey["sign_count"], 0);
-    let user_id = testuser_id(&state.db).await;
+    let user_id = testuser_id(state.writer_db()).await;
     let passkey_id = passkey["id"].as_i64().unwrap();
-    let stored_passkey = passkey_repo::find_by_id_for_user(&state.db, passkey_id, user_id)
+    let stored_passkey = passkey_repo::find_by_id_for_user(state.writer_db(), passkey_id, user_id)
         .await
         .unwrap()
         .unwrap();
@@ -3933,7 +3932,7 @@ async fn test_passkey_register_login_and_replay_protection() {
     let body: Value = test::read_body_json(resp).await;
     assert_eq!(body["code"], 0);
 
-    let sessions = auth_session_repo::list_active_for_user(&state.db, user_id)
+    let sessions = auth_session_repo::list_active_for_user(state.writer_db(), user_id)
         .await
         .unwrap();
     assert_eq!(sessions.len(), 2);
@@ -3955,9 +3954,9 @@ async fn test_passkey_login_without_identifier() {
     let (access, _) = register_and_login!(app);
 
     let (mut softpasskey, passkey) = register_test_passkey(&app, &access, "Laptop").await;
-    let user_id = testuser_id(&state.db).await;
+    let user_id = testuser_id(state.writer_db()).await;
     let passkey_id = passkey["id"].as_i64().unwrap();
-    let stored_passkey = passkey_repo::find_by_id_for_user(&state.db, passkey_id, user_id)
+    let stored_passkey = passkey_repo::find_by_id_for_user(state.writer_db(), passkey_id, user_id)
         .await
         .unwrap()
         .unwrap();
@@ -3995,9 +3994,9 @@ async fn test_passkey_conditional_login_preserves_mediation() {
     let (access, _) = register_and_login!(app);
 
     let (mut softpasskey, passkey) = register_test_passkey(&app, &access, "Laptop").await;
-    let user_id = testuser_id(&state.db).await;
+    let user_id = testuser_id(state.writer_db()).await;
     let passkey_id = passkey["id"].as_i64().unwrap();
-    let stored_passkey = passkey_repo::find_by_id_for_user(&state.db, passkey_id, user_id)
+    let stored_passkey = passkey_repo::find_by_id_for_user(state.writer_db(), passkey_id, user_id)
         .await
         .unwrap()
         .unwrap();
@@ -4039,9 +4038,9 @@ async fn test_passkey_login_rejects_identifier_mismatch() {
     let (access, _) = register_and_login!(app);
 
     let (mut softpasskey, passkey) = register_test_passkey(&app, &access, "Laptop").await;
-    let user_id = testuser_id(&state.db).await;
+    let user_id = testuser_id(state.writer_db()).await;
     let passkey_id = passkey["id"].as_i64().unwrap();
-    let stored_passkey = passkey_repo::find_by_id_for_user(&state.db, passkey_id, user_id)
+    let stored_passkey = passkey_repo::find_by_id_for_user(state.writer_db(), passkey_id, user_id)
         .await
         .unwrap()
         .unwrap();
@@ -4139,9 +4138,9 @@ async fn test_passkey_delete_prevents_future_login() {
     let (access, _) = register_and_login!(app);
 
     let (mut softpasskey, passkey) = register_test_passkey(&app, &access, "Laptop").await;
-    let user_id = testuser_id(&state.db).await;
+    let user_id = testuser_id(state.writer_db()).await;
     let passkey_id = passkey["id"].as_i64().unwrap();
-    let stored_passkey = passkey_repo::find_by_id_for_user(&state.db, passkey_id, user_id)
+    let stored_passkey = passkey_repo::find_by_id_for_user(state.writer_db(), passkey_id, user_id)
         .await
         .unwrap()
         .unwrap();
@@ -4200,18 +4199,18 @@ async fn test_passkey_disabled_user_cannot_login() {
     let (access, _) = register_and_login!(app);
 
     let (mut softpasskey, passkey) = register_test_passkey(&app, &access, "Laptop").await;
-    let user_id = testuser_id(&state.db).await;
+    let user_id = testuser_id(state.writer_db()).await;
     let passkey_id = passkey["id"].as_i64().unwrap();
-    let stored_passkey = passkey_repo::find_by_id_for_user(&state.db, passkey_id, user_id)
+    let stored_passkey = passkey_repo::find_by_id_for_user(state.writer_db(), passkey_id, user_id)
         .await
         .unwrap()
         .unwrap();
-    let mut user = user_repo::find_by_id(&state.db, 1)
+    let mut user = user_repo::find_by_id(state.writer_db(), 1)
         .await
         .unwrap()
         .into_active_model();
     user.status = Set(UserStatus::Disabled);
-    user.update(&state.db).await.unwrap();
+    user.update(state.writer_db()).await.unwrap();
 
     let req = test::TestRequest::post()
         .uri("/api/v1/auth/passkeys/login/start")

--- a/tests/test_auth.rs
+++ b/tests/test_auth.rs
@@ -14,7 +14,6 @@ use aster_drive::types::UserStatus;
 use base64::Engine as _;
 use serde_json::Value;
 use std::io::Cursor;
-use std::sync::Arc;
 use std::time::Duration;
 use tokio_util::sync::CancellationToken;
 use webauthn_authenticator_rs::prelude::{Url, WebauthnAuthenticator};
@@ -984,25 +983,38 @@ async fn test_concurrent_refresh_same_token_has_single_winner() {
     let app = create_test_app!(state.clone());
 
     let (_, refresh) = register_and_login!(app);
-    let barrier = Arc::new(tokio::sync::Barrier::new(2));
+    let hook = auth_service::test_support::install_refresh_rotation_test_hook(
+        &refresh,
+        &state.config.auth.jwt_secret,
+    )
+    .await
+    .unwrap();
 
     let first_state = state.clone();
     let first_refresh = refresh.clone();
-    let first_barrier = barrier.clone();
+    let first_task = tokio::spawn(async move {
+        auth_service::refresh_tokens(&first_state, &first_refresh, None, None).await
+    });
+
+    tokio::time::timeout(Duration::from_secs(2), hook.wait_until_lock_acquired())
+        .await
+        .expect("first refresh should acquire rotation lock");
+
     let second_state = state.clone();
     let second_refresh = refresh.clone();
-    let second_barrier = barrier.clone();
+    let second_task = tokio::spawn(async move {
+        auth_service::refresh_tokens(&second_state, &second_refresh, None, None).await
+    });
 
-    let (first, second) = tokio::join!(
-        async move {
-            first_barrier.wait().await;
-            auth_service::refresh_tokens(&first_state, &first_refresh, None, None).await
-        },
-        async move {
-            second_barrier.wait().await;
-            auth_service::refresh_tokens(&second_state, &second_refresh, None, None).await
-        }
-    );
+    tokio::time::timeout(Duration::from_secs(2), hook.wait_until_lock_contended())
+        .await
+        .expect("second refresh should wait on the same rotation lock");
+    hook.release_lock();
+
+    let (first, second) = tokio::join!(first_task, second_task);
+    let first = first.expect("first refresh task should not panic");
+    let second = second.expect("second refresh task should not panic");
+    auth_service::test_support::clear_refresh_rotation_test_hook().await;
 
     assert_eq!(usize::from(first.is_ok()) + usize::from(second.is_ok()), 1);
     assert_eq!(
@@ -2940,6 +2952,7 @@ async fn test_user_status_cached_in_auth_middleware() {
     let base = common::setup().await;
     let state = aster_drive::runtime::PrimaryAppState {
         db: base.db,
+        db_handles: base.db_handles,
         driver_registry: base.driver_registry,
         runtime_config: base.runtime_config,
         policy_snapshot: base.policy_snapshot,
@@ -2986,6 +2999,7 @@ async fn test_disable_user_invalidates_status_cache() {
     let base = common::setup().await;
     let state = aster_drive::runtime::PrimaryAppState {
         db: base.db,
+        db_handles: base.db_handles,
         driver_registry: base.driver_registry,
         runtime_config: base.runtime_config,
         policy_snapshot: base.policy_snapshot,

--- a/tests/test_auth.rs
+++ b/tests/test_auth.rs
@@ -24,6 +24,24 @@ use webauthn_rs_proto::{AllowCredentials, Mediation, ResidentKeyRequirement};
 const TEST_BROWSER_ORIGIN: &str = "http://localhost:8080";
 const TEST_PUBLIC_SITE_ORIGIN: &str = "https://pan.esaps.net";
 
+struct RefreshHookGuard {
+    _hook: auth_service::test_support::RefreshRotationTestHook,
+}
+
+impl RefreshHookGuard {
+    fn new(hook: auth_service::test_support::RefreshRotationTestHook) -> Self {
+        Self { _hook: hook }
+    }
+}
+
+impl Drop for RefreshHookGuard {
+    fn drop(&mut self) {
+        tokio::spawn(async {
+            auth_service::test_support::clear_refresh_rotation_test_hook().await;
+        });
+    }
+}
+
 macro_rules! login_user_with_credentials {
     ($app:expr, $identifier:expr, $password:expr) => {{
         let req = test::TestRequest::post()
@@ -989,11 +1007,18 @@ async fn test_concurrent_refresh_same_token_has_single_winner() {
     )
     .await
     .unwrap();
+    let _hook_guard = RefreshHookGuard::new(hook.clone());
 
     let first_state = state.clone();
     let first_refresh = refresh.clone();
     let first_task = tokio::spawn(async move {
-        auth_service::refresh_tokens(&first_state, &first_refresh, None, None).await
+        auth_service::refresh_tokens(
+            &first_state,
+            &first_refresh,
+            Some("127.0.0.1"),
+            Some("AsterDrive Test Client/1.0"),
+        )
+        .await
     });
 
     tokio::time::timeout(Duration::from_secs(2), hook.wait_until_lock_acquired())
@@ -1003,7 +1028,13 @@ async fn test_concurrent_refresh_same_token_has_single_winner() {
     let second_state = state.clone();
     let second_refresh = refresh.clone();
     let second_task = tokio::spawn(async move {
-        auth_service::refresh_tokens(&second_state, &second_refresh, None, None).await
+        auth_service::refresh_tokens(
+            &second_state,
+            &second_refresh,
+            Some("127.0.0.1"),
+            Some("AsterDrive Test Client/1.0"),
+        )
+        .await
     });
 
     tokio::time::timeout(Duration::from_secs(2), hook.wait_until_lock_contended())
@@ -1014,7 +1045,6 @@ async fn test_concurrent_refresh_same_token_has_single_winner() {
     let (first, second) = tokio::join!(first_task, second_task);
     let first = first.expect("first refresh task should not panic");
     let second = second.expect("second refresh task should not panic");
-    auth_service::test_support::clear_refresh_rotation_test_hook().await;
 
     assert_eq!(usize::from(first.is_ok()) + usize::from(second.is_ok()), 1);
     assert_eq!(

--- a/tests/test_batch.rs
+++ b/tests/test_batch.rs
@@ -1007,7 +1007,7 @@ async fn test_batch_copy_preserves_partial_failures_for_quota() {
     use sea_orm::{ActiveModelTrait, Set};
 
     let state = common::setup().await;
-    let db = state.db.clone();
+    let db = state.writer_db().clone();
     let app = create_test_app!(state);
     let (token, _) = register_and_login!(app);
 

--- a/tests/test_cli.rs
+++ b/tests/test_cli.rs
@@ -202,8 +202,8 @@ async fn seed_migration_fixture(database_url: &str) -> i64 {
         .expect("folder id should exist");
 
     let file_id = upload_test_file_to_folder!(app, token, folder_id);
-    seed_passkey_fixture(&state.db).await;
-    seed_remote_node_fixture(&state.db).await;
+    seed_passkey_fixture(state.writer_db()).await;
+    seed_remote_node_fixture(state.writer_db()).await;
     file_id
 }
 
@@ -1043,7 +1043,7 @@ async fn test_migrations_reject_existing_schema_with_empty_history() {
 async fn test_root_binary_doctor_deep_fix_repairs_counters() {
     let database_url = setup_database_url().await;
     let state = common::setup_with_database_url(&database_url).await;
-    let db = state.db.clone();
+    let db = state.writer_db().clone();
     let app = create_test_app!(state);
     let (token, _) = register_and_login!(app);
     let file_id = upload_test_file!(app, token);
@@ -1107,7 +1107,7 @@ async fn test_root_binary_doctor_deep_fix_repairs_counters() {
 async fn test_root_binary_doctor_scope_and_policy_filter_limit_deep_checks() {
     let database_url = setup_database_url().await;
     let state = common::setup_with_database_url(&database_url).await;
-    let db = state.db.clone();
+    let db = state.writer_db().clone();
     let policy = policy_repo::find_default(&db)
         .await
         .unwrap()

--- a/tests/test_cors.rs
+++ b/tests/test_cors.rs
@@ -12,7 +12,7 @@ const EXPECTED_EXPOSE_HEADERS: &str = "accept-ranges, content-length, content-ra
 macro_rules! create_test_app_with_cors {
     ($state:expr) => {{
         let state = $state;
-        let db = state.db.clone();
+        let db = state.writer_db().clone();
         test::init_service(
             App::new()
                 .wrap(aster_drive::api::middleware::cors::RuntimeCors)

--- a/tests/test_database_backends.rs
+++ b/tests/test_database_backends.rs
@@ -294,12 +294,12 @@ async fn exercise_backend_smoke(database_url: &str, backend: DbBackend) {
 
     let state = common::setup_with_database_url(database_url).await;
     match backend {
-        DbBackend::Postgres => assert_postgres_search_objects(&state.db).await,
-        DbBackend::MySql => assert_mysql_search_objects(&state.db).await,
+        DbBackend::Postgres => assert_postgres_search_objects(state.writer_db()).await,
+        DbBackend::MySql => assert_mysql_search_objects(state.writer_db()).await,
         _ => unreachable!("only postgres/mysql smoke tests use this helper"),
     }
-    assert_background_task_display_name_column_len(&state.db, backend).await;
-    assert_background_task_display_name_accepts_expanded_len(&state.db).await;
+    assert_background_task_display_name_column_len(state.writer_db(), backend).await;
+    assert_background_task_display_name_accepts_expanded_len(state.writer_db()).await;
 
     let app = create_test_app!(state);
     let (token, _) = register_and_login!(app);

--- a/tests/test_db_indexes.rs
+++ b/tests/test_db_indexes.rs
@@ -61,12 +61,12 @@ fn assert_uses_virtual_table(plan: &[String], virtual_table: &str, base_table: &
 #[actix_web::test]
 async fn test_directory_lookup_indexes_cover_listing_and_duplicate_name_queries() {
     let state = common::setup().await;
-    if !skip_unless_sqlite(&state.db) {
+    if !skip_unless_sqlite(state.writer_db()) {
         return;
     }
 
     let folder_listing = explain_query_plan(
-        &state.db,
+        state.writer_db(),
         "SELECT * FROM folders \
          WHERE owner_user_id = 1 AND deleted_at IS NULL AND parent_id = 2 \
          ORDER BY name",
@@ -80,7 +80,7 @@ async fn test_directory_lookup_indexes_cover_listing_and_duplicate_name_queries(
     assert_no_temp_btree(&folder_listing);
 
     let file_listing = explain_query_plan(
-        &state.db,
+        state.writer_db(),
         "SELECT * FROM files \
          WHERE owner_user_id = 1 AND deleted_at IS NULL AND folder_id = 2 \
          ORDER BY name",
@@ -94,7 +94,7 @@ async fn test_directory_lookup_indexes_cover_listing_and_duplicate_name_queries(
     assert_no_temp_btree(&file_listing);
 
     let folder_duplicate = explain_query_plan(
-        &state.db,
+        state.writer_db(),
         "SELECT * FROM folders \
          WHERE owner_user_id = 1 AND name = 'dup' AND deleted_at IS NULL AND parent_id = 2",
     )
@@ -106,7 +106,7 @@ async fn test_directory_lookup_indexes_cover_listing_and_duplicate_name_queries(
     );
 
     let file_duplicate = explain_query_plan(
-        &state.db,
+        state.writer_db(),
         "SELECT * FROM files \
          WHERE owner_user_id = 1 AND name = 'dup' AND deleted_at IS NULL AND folder_id = 2",
     )
@@ -121,12 +121,12 @@ async fn test_directory_lookup_indexes_cover_listing_and_duplicate_name_queries(
 #[actix_web::test]
 async fn test_trash_pagination_indexes_cover_deleted_item_queries() {
     let state = common::setup().await;
-    if !skip_unless_sqlite(&state.db) {
+    if !skip_unless_sqlite(state.writer_db()) {
         return;
     }
 
     let folder_trash = explain_query_plan(
-        &state.db,
+        state.writer_db(),
         "SELECT * FROM folders \
          WHERE owner_user_id = 1 \
            AND deleted_at IS NOT NULL \
@@ -142,7 +142,7 @@ async fn test_trash_pagination_indexes_cover_deleted_item_queries() {
     assert_no_temp_btree(&folder_trash);
 
     let file_trash = explain_query_plan(
-        &state.db,
+        state.writer_db(),
         "SELECT * FROM files \
          WHERE owner_user_id = 1 \
            AND deleted_at IS NOT NULL \
@@ -161,12 +161,12 @@ async fn test_trash_pagination_indexes_cover_deleted_item_queries() {
 #[actix_web::test]
 async fn test_sqlite_file_type_filter_indexes_cover_search_queries() {
     let state = common::setup().await;
-    if !skip_unless_sqlite(&state.db) {
+    if !skip_unless_sqlite(state.writer_db()) {
         return;
     }
 
     let personal_category = explain_query_plan(
-        &state.db,
+        state.writer_db(),
         "SELECT id FROM files \
          WHERE owner_user_id = 1 \
            AND team_id IS NULL \
@@ -184,7 +184,7 @@ async fn test_sqlite_file_type_filter_indexes_cover_search_queries() {
     );
 
     let personal_compound = explain_query_plan(
-        &state.db,
+        state.writer_db(),
         "SELECT id FROM files \
          WHERE owner_user_id = 1 \
            AND team_id IS NULL \
@@ -200,7 +200,7 @@ async fn test_sqlite_file_type_filter_indexes_cover_search_queries() {
     );
 
     let team_category = explain_query_plan(
-        &state.db,
+        state.writer_db(),
         "SELECT id FROM files \
          WHERE team_id = 7 \
            AND deleted_at IS NULL \
@@ -219,7 +219,7 @@ async fn test_sqlite_file_type_filter_indexes_cover_search_queries() {
 #[actix_web::test]
 async fn test_sqlite_search_fts_objects_exist() {
     let state = common::setup().await;
-    if !skip_unless_sqlite(&state.db) {
+    if !skip_unless_sqlite(state.writer_db()) {
         return;
     }
 
@@ -283,12 +283,12 @@ async fn test_sqlite_search_fts_objects_exist() {
 #[actix_web::test]
 async fn test_sqlite_search_fts_query_plan_uses_virtual_tables() {
     let state = common::setup().await;
-    if !skip_unless_sqlite(&state.db) {
+    if !skip_unless_sqlite(state.writer_db()) {
         return;
     }
 
     let file_search_count_plan = explain_query_plan(
-        &state.db,
+        state.writer_db(),
         "SELECT COUNT(*) \
          FROM files \
          WHERE files.deleted_at IS NULL \
@@ -303,7 +303,7 @@ async fn test_sqlite_search_fts_query_plan_uses_virtual_tables() {
     assert_uses_virtual_table(&file_search_count_plan, "files_name_fts", "files");
 
     let file_search_plan = explain_query_plan(
-        &state.db,
+        state.writer_db(),
         "SELECT \
              files.id, files.name, file_blobs.size \
          FROM files \
@@ -322,7 +322,7 @@ async fn test_sqlite_search_fts_query_plan_uses_virtual_tables() {
     assert_uses_virtual_table(&file_search_plan, "files_name_fts", "files");
 
     let folder_search_plan = explain_query_plan(
-        &state.db,
+        state.writer_db(),
         "SELECT \
              folders.id, folders.name \
          FROM folders \
@@ -339,7 +339,7 @@ async fn test_sqlite_search_fts_query_plan_uses_virtual_tables() {
     assert_uses_virtual_table(&folder_search_plan, "folders_name_fts", "folders");
 
     let user_search_plan = explain_query_plan(
-        &state.db,
+        state.writer_db(),
         "SELECT users.* \
          FROM users \
          WHERE users.id IN ( \
@@ -354,7 +354,7 @@ async fn test_sqlite_search_fts_query_plan_uses_virtual_tables() {
     assert_uses_virtual_table(&user_search_plan, "users_search_fts", "users");
 
     let team_search_plan = explain_query_plan(
-        &state.db,
+        state.writer_db(),
         "SELECT teams.* \
          FROM teams \
          WHERE teams.archived_at IS NULL \
@@ -368,7 +368,7 @@ async fn test_sqlite_search_fts_query_plan_uses_virtual_tables() {
     assert_uses_virtual_table(&team_search_plan, "teams_search_fts", "teams");
 
     let team_member_search_plan = explain_query_plan(
-        &state.db,
+        state.writer_db(),
         "SELECT team_members.id, users.username \
          FROM team_members \
          JOIN users ON users.id = team_members.user_id \

--- a/tests/test_directory_upload.rs
+++ b/tests/test_directory_upload.rs
@@ -10,7 +10,7 @@ use serde_json::Value;
 #[actix_web::test]
 async fn test_direct_upload_with_relative_path_creates_nested_folders() {
     let state = common::setup().await;
-    let db = state.db.clone();
+    let db = state.writer_db().clone();
     let app = create_test_app!(state);
     let (token, _) = register_and_login!(app);
 
@@ -85,7 +85,7 @@ async fn test_direct_upload_with_relative_path_creates_nested_folders() {
 #[actix_web::test]
 async fn test_init_upload_with_relative_path_reuses_existing_directories() {
     let state = common::setup().await;
-    let db = state.db.clone();
+    let db = state.writer_db().clone();
     let app = create_test_app!(state);
     let (token, _) = register_and_login!(app);
 
@@ -139,7 +139,7 @@ async fn test_init_upload_with_relative_path_uses_parent_folder_policy() {
     use sea_orm::{ActiveModelTrait, Set};
 
     let state = common::setup().await;
-    let db = state.db.clone();
+    let db = state.writer_db().clone();
     let app = create_test_app!(state);
     let (token, _) = register_and_login!(app);
 

--- a/tests/test_edit.rs
+++ b/tests/test_edit.rs
@@ -361,7 +361,7 @@ async fn test_update_content_etag_mismatch() {
 #[actix_web::test]
 async fn test_update_content_locked_by_other() {
     let state = common::setup().await;
-    let db = state.db.clone();
+    let db = state.writer_db().clone();
     let app = create_test_app!(state);
     let (token, _) = register_and_login!(app);
     let file_id = upload_test_file!(app, token);

--- a/tests/test_files.rs
+++ b/tests/test_files.rs
@@ -381,7 +381,7 @@ async fn test_file_preview_link_usage_limit_falls_back_when_cache_backend_does_n
 #[actix_web::test]
 async fn test_file_repo_resolve_unique_filename_prefers_first_gap_and_preserves_suffix() {
     let state = common::setup().await;
-    let db = state.db.clone();
+    let db = state.writer_db().clone();
     let app = create_test_app!(state);
 
     let (token, _) = register_and_login!(app);
@@ -412,7 +412,7 @@ async fn test_file_repo_resolve_unique_filename_prefers_first_gap_and_preserves_
 #[actix_web::test]
 async fn test_file_repo_resolve_unique_filename_treats_nfd_and_nfc_as_same_name() {
     let state = common::setup().await;
-    let db = state.db.clone();
+    let db = state.writer_db().clone();
     let app = create_test_app!(state);
 
     let (token, _) = register_and_login!(app);
@@ -432,7 +432,7 @@ async fn test_file_repo_resolve_unique_filename_treats_nfd_and_nfc_as_same_name(
 #[actix_web::test]
 async fn test_file_repo_resolve_unique_filename_falls_back_after_candidate_batch() {
     let state = common::setup().await;
-    let db = state.db.clone();
+    let db = state.writer_db().clone();
     let app = create_test_app!(state);
 
     let (token, _) = register_and_login!(app);

--- a/tests/test_folders.rs
+++ b/tests/test_folders.rs
@@ -248,7 +248,7 @@ async fn test_folder_name_validation_returns_400() {
 #[actix_web::test]
 async fn test_folder_repo_find_ancestors_returns_full_chain() {
     let state = common::setup().await;
-    let db = state.db.clone();
+    let db = state.writer_db().clone();
     let app = create_test_app!(state);
     let (token, _) = register_and_login!(app);
 
@@ -540,7 +540,7 @@ async fn test_folder_copy_quota_failure_does_not_materialize_nested_descendants(
     use sea_orm::{ActiveModelTrait, Set};
 
     let state = common::setup().await;
-    let db = state.db.clone();
+    let db = state.writer_db().clone();
     let app = create_test_app!(state);
     let (token, _) = register_and_login!(app);
 
@@ -705,7 +705,7 @@ async fn test_folder_patch_can_move_to_root_with_null() {
 #[actix_web::test]
 async fn test_folder_copy_preserves_policy_ids() {
     let state = common::setup().await;
-    let db = state.db.clone();
+    let db = state.writer_db().clone();
     let app = create_test_app!(state);
     let (token, _) = register_and_login!(app);
 

--- a/tests/test_gravatar_config.rs
+++ b/tests/test_gravatar_config.rs
@@ -11,7 +11,9 @@ use aster_drive::services::profile_service;
 use aster_drive::types::AvatarSource;
 
 async fn load_user_model(state: &PrimaryAppState, user_id: i64) -> user::Model {
-    user_repo::find_by_id(&state.db, user_id).await.unwrap()
+    user_repo::find_by_id(state.writer_db(), user_id)
+        .await
+        .unwrap()
 }
 
 #[actix_web::test]
@@ -65,7 +67,7 @@ async fn test_gravatar_custom_base_url() {
 
     // 设置自定义 gravatar base url
     let config = config_repo::upsert(
-        &state.db,
+        state.writer_db(),
         "gravatar_base_url",
         "https://cravatar.cn/avatar",
         user.id,
@@ -108,7 +110,7 @@ async fn test_gravatar_empty_config_fallback() {
     .unwrap();
 
     // 设置空字符串配置
-    let config = config_repo::upsert(&state.db, "gravatar_base_url", "", user.id)
+    let config = config_repo::upsert(state.writer_db(), "gravatar_base_url", "", user.id)
         .await
         .unwrap();
     state.runtime_config.apply(config);
@@ -147,7 +149,7 @@ async fn test_gravatar_trailing_slash_normalization() {
 
     // 配置带末尾斜杠
     let config = config_repo::upsert(
-        &state.db,
+        state.writer_db(),
         "gravatar_base_url",
         "https://mirror.example.com/avatar/",
         user.id,
@@ -195,7 +197,7 @@ async fn test_gravatar_whitespace_only_config_fallback() {
     .unwrap();
 
     // 配置只有空白字符
-    let config = config_repo::upsert(&state.db, "gravatar_base_url", "   ", user.id)
+    let config = config_repo::upsert(state.writer_db(), "gravatar_base_url", "   ", user.id)
         .await
         .unwrap();
     state.runtime_config.apply(config);

--- a/tests/test_health.rs
+++ b/tests/test_health.rs
@@ -40,7 +40,7 @@ async fn test_health_ready() {
 #[actix_web::test]
 async fn test_health_ready_redacts_database_error() {
     let state = common::setup().await;
-    let db = state.db.clone();
+    let db = state.writer_db().clone();
     let app = create_test_app!(state);
 
     db.close_by_ref().await.unwrap();
@@ -60,7 +60,7 @@ async fn test_health_ready_redacts_database_error() {
 #[actix_web::test]
 async fn test_health_ready_returns_503_when_default_storage_is_unavailable() {
     let state = common::setup().await;
-    let default_policy = policy_repo::find_default(&state.db)
+    let default_policy = policy_repo::find_default(state.writer_db())
         .await
         .unwrap()
         .expect("default policy should exist");
@@ -70,10 +70,14 @@ async fn test_health_ready_returns_503_when_default_storage_is_unavailable() {
     let mut active: storage_policy::ActiveModel = default_policy.clone().into();
     active.base_path = Set(blocked_base_path.to_string_lossy().into_owned());
     active.updated_at = Set(Utc::now());
-    active.update(&state.db).await.unwrap();
+    active.update(state.writer_db()).await.unwrap();
 
     state.driver_registry.invalidate(default_policy.id);
-    state.policy_snapshot.reload(&state.db).await.unwrap();
+    state
+        .policy_snapshot
+        .reload(state.writer_db())
+        .await
+        .unwrap();
 
     let app = create_test_app!(state);
 
@@ -91,7 +95,7 @@ async fn test_health_ready_returns_503_when_default_storage_is_unavailable() {
 #[actix_web::test]
 async fn test_health_ready_returns_503_when_default_storage_policy_is_missing() {
     let state = common::setup().await;
-    let default_policy = policy_repo::find_default(&state.db)
+    let default_policy = policy_repo::find_default(state.writer_db())
         .await
         .unwrap()
         .expect("default policy should exist");
@@ -99,10 +103,14 @@ async fn test_health_ready_returns_503_when_default_storage_policy_is_missing() 
     let mut active: storage_policy::ActiveModel = default_policy.clone().into();
     active.is_default = Set(false);
     active.updated_at = Set(Utc::now());
-    active.update(&state.db).await.unwrap();
+    active.update(state.writer_db()).await.unwrap();
 
     state.driver_registry.invalidate(default_policy.id);
-    state.policy_snapshot.reload(&state.db).await.unwrap();
+    state
+        .policy_snapshot
+        .reload(state.writer_db())
+        .await
+        .unwrap();
 
     let app = create_test_app!(state);
 
@@ -121,7 +129,7 @@ async fn test_health_ready_returns_503_when_default_storage_policy_is_missing() 
 #[actix_web::test]
 async fn test_health_ready_does_not_probe_s3_network() {
     let state = common::setup().await;
-    let default_policy = policy_repo::find_default(&state.db)
+    let default_policy = policy_repo::find_default(state.writer_db())
         .await
         .unwrap()
         .expect("default policy should exist");
@@ -137,10 +145,14 @@ async fn test_health_ready_does_not_probe_s3_network() {
             .to_string(),
     ));
     active.updated_at = Set(Utc::now());
-    active.update(&state.db).await.unwrap();
+    active.update(state.writer_db()).await.unwrap();
 
     state.driver_registry.invalidate(default_policy.id);
-    state.policy_snapshot.reload(&state.db).await.unwrap();
+    state
+        .policy_snapshot
+        .reload(state.writer_db())
+        .await
+        .unwrap();
 
     let app = create_test_app!(state);
 

--- a/tests/test_mail_services.rs
+++ b/tests/test_mail_services.rs
@@ -217,7 +217,7 @@ async fn test_mail_outbox_dispatch_sends_due_message_and_clears_payload() {
     .to_stored()
     .unwrap();
     let row = mail_outbox_repo::create(
-        &state.db,
+        state.writer_db(),
         outbox_model(MailOutboxStatus::Pending, 0, Utc::now(), payload),
     )
     .await
@@ -229,7 +229,7 @@ async fn test_mail_outbox_dispatch_sends_due_message_and_clears_payload() {
     assert_eq!(stats.sent, 1);
     assert_eq!(stats.retried, 0);
     assert_eq!(stats.failed, 0);
-    let stored = find_outbox_row(&state.db, row.id).await;
+    let stored = find_outbox_row(state.writer_db(), row.id).await;
     assert_eq!(stored.status, MailOutboxStatus::Sent);
     assert_eq!(
         stored.payload_json.as_ref(),
@@ -257,7 +257,7 @@ async fn test_mail_outbox_dispatch_skips_future_retry_rows() {
     .to_stored()
     .unwrap();
     mail_outbox_repo::create(
-        &state.db,
+        state.writer_db(),
         outbox_model(
             MailOutboxStatus::Retry,
             1,
@@ -292,7 +292,7 @@ async fn test_mail_outbox_dispatch_retries_failed_delivery_with_truncated_error(
     .to_stored()
     .unwrap();
     let row = mail_outbox_repo::create(
-        &state.db,
+        state.writer_db(),
         outbox_model(MailOutboxStatus::Pending, 0, Utc::now(), payload),
     )
     .await
@@ -300,15 +300,16 @@ async fn test_mail_outbox_dispatch_retries_failed_delivery_with_truncated_error(
     let failing = FailingMailSender::new("x".repeat(1_200));
     let sender: Arc<dyn MailSender> = failing.clone();
 
-    let stats = mail_outbox_service::dispatch_due_with(&state.db, &state.runtime_config, &sender)
-        .await
-        .unwrap();
+    let stats =
+        mail_outbox_service::dispatch_due_with(state.writer_db(), &state.runtime_config, &sender)
+            .await
+            .unwrap();
 
     assert_eq!(stats.claimed, 1);
     assert_eq!(stats.retried, 1);
     assert_eq!(stats.failed, 0);
     assert_eq!(failing.attempts(), 1);
-    let stored = find_outbox_row(&state.db, row.id).await;
+    let stored = find_outbox_row(state.writer_db(), row.id).await;
     assert_eq!(stored.status, MailOutboxStatus::Retry);
     assert_eq!(stored.attempt_count, 1);
     assert!(stored.next_attempt_at > Utc::now());
@@ -327,7 +328,7 @@ async fn test_mail_outbox_dispatch_marks_final_failure_and_clears_payload() {
     .to_stored()
     .unwrap();
     let row = mail_outbox_repo::create(
-        &state.db,
+        state.writer_db(),
         outbox_model(MailOutboxStatus::Pending, 5, Utc::now(), payload),
     )
     .await
@@ -335,15 +336,16 @@ async fn test_mail_outbox_dispatch_marks_final_failure_and_clears_payload() {
     let failing = FailingMailSender::new("smtp unavailable");
     let sender: Arc<dyn MailSender> = failing.clone();
 
-    let stats = mail_outbox_service::dispatch_due_with(&state.db, &state.runtime_config, &sender)
-        .await
-        .unwrap();
+    let stats =
+        mail_outbox_service::dispatch_due_with(state.writer_db(), &state.runtime_config, &sender)
+            .await
+            .unwrap();
 
     assert_eq!(stats.claimed, 1);
     assert_eq!(stats.retried, 0);
     assert_eq!(stats.failed, 1);
     assert_eq!(failing.attempts(), 1);
-    let stored = find_outbox_row(&state.db, row.id).await;
+    let stored = find_outbox_row(state.writer_db(), row.id).await;
     assert_eq!(stored.status, MailOutboxStatus::Failed);
     assert_eq!(stored.attempt_count, 6);
     assert_eq!(
@@ -369,9 +371,11 @@ async fn test_mail_outbox_dispatch_reclaims_stale_processing_rows_and_drain_merg
     .unwrap();
     let mut model = outbox_model(MailOutboxStatus::Processing, 0, Utc::now(), payload.clone());
     model.processing_started_at = Set(Some(Utc::now() - Duration::seconds(120)));
-    let stale = mail_outbox_repo::create(&state.db, model).await.unwrap();
+    let stale = mail_outbox_repo::create(state.writer_db(), model)
+        .await
+        .unwrap();
     mail_outbox_repo::create(
-        &state.db,
+        state.writer_db(),
         outbox_model(MailOutboxStatus::Pending, 0, Utc::now(), payload),
     )
     .await
@@ -384,10 +388,15 @@ async fn test_mail_outbox_dispatch_reclaims_stale_processing_rows_and_drain_merg
     assert_eq!(stats.retried, 0);
     assert_eq!(stats.failed, 0);
     assert_eq!(
-        find_outbox_row(&state.db, stale.id).await.status,
+        find_outbox_row(state.writer_db(), stale.id).await.status,
         MailOutboxStatus::Sent
     );
-    assert_eq!(mail_outbox_repo::count_active(&state.db).await.unwrap(), 0);
+    assert_eq!(
+        mail_outbox_repo::count_active(state.writer_db())
+            .await
+            .unwrap(),
+        0
+    );
 }
 
 #[tokio::test]
@@ -395,7 +404,7 @@ async fn test_mail_outbox_dispatch_invalid_payload_schedules_retry_without_sendi
     let state = common::setup().await;
     apply_mail_config(&state);
     let row = mail_outbox_repo::create(
-        &state.db,
+        state.writer_db(),
         outbox_model(
             MailOutboxStatus::Pending,
             0,
@@ -416,7 +425,7 @@ async fn test_mail_outbox_dispatch_invalid_payload_schedules_retry_without_sendi
             .messages()
             .is_empty()
     );
-    let stored = find_outbox_row(&state.db, row.id).await;
+    let stored = find_outbox_row(state.writer_db(), row.id).await;
     assert_eq!(stored.status, MailOutboxStatus::Retry);
     assert!(stored.last_error.unwrap().contains("failed to decode"));
 }
@@ -434,7 +443,9 @@ async fn test_mail_outbox_dispatch_does_not_reclaim_fresh_processing_rows() {
     .unwrap();
     let mut model = outbox_model(MailOutboxStatus::Processing, 0, Utc::now(), payload);
     model.processing_started_at = Set(Some(Utc::now()));
-    mail_outbox_repo::create(&state.db, model).await.unwrap();
+    mail_outbox_repo::create(state.writer_db(), model)
+        .await
+        .unwrap();
 
     let stats = mail_outbox_service::dispatch_due(&state).await.unwrap();
 

--- a/tests/test_maintenance.rs
+++ b/tests/test_maintenance.rs
@@ -40,7 +40,7 @@ impl Drop for DirModeGuard {
 async fn default_policy(
     state: &aster_drive::runtime::PrimaryAppState,
 ) -> aster_drive::entities::storage_policy::Model {
-    aster_drive::db::repository::policy_repo::find_default(&state.db)
+    aster_drive::db::repository::policy_repo::find_default(state.writer_db())
         .await
         .unwrap()
         .expect("default policy should exist in test setup")
@@ -100,7 +100,7 @@ async fn create_upload_session(
     let policy = default_policy(state).await;
     let now = chrono::Utc::now();
     upload_session_repo::create(
-        &state.db,
+        state.writer_db(),
         aster_drive::entities::upload_session::ActiveModel {
             id: Set(spec.upload_id.to_string()),
             user_id: Set(user_id),
@@ -187,7 +187,7 @@ async fn create_blob(
 
     let now = Utc::now();
     file_repo::create_blob(
-        &state.db,
+        state.writer_db(),
         aster_drive::entities::file_blob::ActiveModel {
             hash: Set(hash.to_string()),
             size: Set(bytes.len() as i64),
@@ -213,7 +213,7 @@ async fn create_wopi_session(
     use aster_drive::db::repository::wopi_session_repo;
 
     wopi_session_repo::create(
-        &state.db,
+        state.writer_db(),
         aster_drive::entities::wopi_session::ActiveModel {
             token_hash: Set(aster_drive::utils::hash::sha256_hex(token.as_bytes())),
             actor_user_id: Set(actor_user_id),
@@ -263,7 +263,7 @@ async fn test_cleanup_expired_completed_upload_sessions_removes_broken_temp_obje
     assert_eq!(stats.completed_sessions_deleted, 1);
     assert_eq!(stats.broken_completed_sessions_deleted, 1);
     assert!(
-        upload_session_repo::find_by_id(&state.db, "broken-completed")
+        upload_session_repo::find_by_id(state.writer_db(), "broken-completed")
             .await
             .is_err()
     );
@@ -307,7 +307,7 @@ async fn test_cleanup_expired_completed_upload_sessions_removes_broken_completed
     assert_eq!(stats.completed_sessions_deleted, 1);
     assert_eq!(stats.broken_completed_sessions_deleted, 1);
     assert!(
-        upload_session_repo::find_by_id(&state.db, "broken-completed-multipart")
+        upload_session_repo::find_by_id(state.writer_db(), "broken-completed-multipart")
             .await
             .is_err()
     );
@@ -324,7 +324,7 @@ async fn test_cleanup_expired_completed_upload_sessions_keeps_live_blob() {
         .await
         .unwrap();
     let file = store_test_file(&state, user.id, "kept.txt", b"kept blob").await;
-    let blob = file_repo::find_blob_by_id(&state.db, file.blob_id)
+    let blob = file_repo::find_blob_by_id(state.writer_db(), file.blob_id)
         .await
         .unwrap();
     let policy = default_policy(&state).await;
@@ -350,12 +350,20 @@ async fn test_cleanup_expired_completed_upload_sessions_keeps_live_blob() {
     assert_eq!(stats.completed_sessions_deleted, 1);
     assert_eq!(stats.broken_completed_sessions_deleted, 0);
     assert!(
-        upload_session_repo::find_by_id(&state.db, "completed-with-file")
+        upload_session_repo::find_by_id(state.writer_db(), "completed-with-file")
             .await
             .is_err()
     );
-    assert!(file_repo::find_by_id(&state.db, file.id).await.is_ok());
-    assert!(file_repo::find_blob_by_id(&state.db, blob.id).await.is_ok());
+    assert!(
+        file_repo::find_by_id(state.writer_db(), file.id)
+            .await
+            .is_ok()
+    );
+    assert!(
+        file_repo::find_blob_by_id(state.writer_db(), blob.id)
+            .await
+            .is_ok()
+    );
     assert!(driver.exists(&blob.storage_path).await.unwrap());
 }
 
@@ -393,7 +401,7 @@ async fn test_cleanup_expired_wopi_sessions_removes_only_expired_rows() {
 
     assert!(
         wopi_session_repo::find_by_token_hash(
-            &state.db,
+            state.writer_db(),
             &aster_drive::utils::hash::sha256_hex(b"expired-wopi-token"),
         )
         .await
@@ -402,7 +410,7 @@ async fn test_cleanup_expired_wopi_sessions_removes_only_expired_rows() {
     );
     assert!(
         wopi_session_repo::find_by_token_hash(
-            &state.db,
+            state.writer_db(),
             &aster_drive::utils::hash::sha256_hex(b"live-wopi-token"),
         )
         .await
@@ -411,7 +419,10 @@ async fn test_cleanup_expired_wopi_sessions_removes_only_expired_rows() {
     );
 
     assert_eq!(
-        wopi_session::Entity::find().count(&state.db).await.unwrap(),
+        wopi_session::Entity::find()
+            .count(state.writer_db())
+            .await
+            .unwrap(),
         1
     );
 }
@@ -459,7 +470,13 @@ async fn test_cleanup_expired_completed_upload_sessions_processes_all_batches() 
 
     assert_eq!(stats.completed_sessions_deleted, 1001);
     assert_eq!(stats.broken_completed_sessions_deleted, 501);
-    assert_eq!(UploadSession::find().count(&state.db).await.unwrap(), 0);
+    assert_eq!(
+        UploadSession::find()
+            .count(state.writer_db())
+            .await
+            .unwrap(),
+        0
+    );
 }
 
 #[actix_web::test]
@@ -506,7 +523,7 @@ async fn test_cleanup_expired_completed_upload_sessions_cleans_team_sessions() {
     assert_eq!(stats.completed_sessions_deleted, 1);
     assert_eq!(stats.broken_completed_sessions_deleted, 1);
     assert!(
-        upload_session_repo::find_by_id(&state.db, "team-broken-completed")
+        upload_session_repo::find_by_id(state.writer_db(), "team-broken-completed")
             .await
             .is_err()
     );
@@ -526,14 +543,14 @@ async fn test_reconcile_blob_state_deletes_orphans_and_fixes_ref_counts() {
     let driver = state.driver_registry.get_driver(&policy).unwrap();
 
     let live_file = store_test_file(&state, user.id, "live.txt", b"live blob").await;
-    let live_blob = file_repo::find_blob_by_id(&state.db, live_file.blob_id)
+    let live_blob = file_repo::find_blob_by_id(state.writer_db(), live_file.blob_id)
         .await
         .unwrap();
     let mut live_blob_active: aster_drive::entities::file_blob::ActiveModel =
         live_blob.clone().into();
     live_blob_active.ref_count = Set(7);
     live_blob_active.updated_at = Set(Utc::now());
-    live_blob_active.update(&state.db).await.unwrap();
+    live_blob_active.update(state.writer_db()).await.unwrap();
 
     let version_hash = "b".repeat(64);
     let version_blob = create_blob(
@@ -545,7 +562,7 @@ async fn test_reconcile_blob_state_deletes_orphans_and_fixes_ref_counts() {
     )
     .await;
     version_repo::create(
-        &state.db,
+        state.writer_db(),
         aster_drive::entities::file_version::ActiveModel {
             file_id: Set(live_file.id),
             blob_id: Set(version_blob.id),
@@ -571,18 +588,18 @@ async fn test_reconcile_blob_state_deletes_orphans_and_fixes_ref_counts() {
     assert_eq!(stats.ref_count_fixed, 3);
     assert_eq!(stats.orphan_blobs_deleted, 1);
 
-    let live_blob_after = file_repo::find_blob_by_id(&state.db, live_blob.id)
+    let live_blob_after = file_repo::find_blob_by_id(state.writer_db(), live_blob.id)
         .await
         .unwrap();
     assert_eq!(live_blob_after.ref_count, 1);
 
-    let version_blob_after = file_repo::find_blob_by_id(&state.db, version_blob.id)
+    let version_blob_after = file_repo::find_blob_by_id(state.writer_db(), version_blob.id)
         .await
         .unwrap();
     assert_eq!(version_blob_after.ref_count, 1);
 
     assert!(
-        file_repo::find_blob_by_id(&state.db, orphan_blob.id)
+        file_repo::find_blob_by_id(state.writer_db(), orphan_blob.id)
             .await
             .is_err()
     );
@@ -611,7 +628,7 @@ async fn test_reconcile_blob_state_processes_all_batches_without_skipping() {
 
     assert_eq!(stats.ref_count_fixed, 1001);
     assert_eq!(stats.orphan_blobs_deleted, 1001);
-    assert_eq!(FileBlob::find().count(&state.db).await.unwrap(), 0);
+    assert_eq!(FileBlob::find().count(state.writer_db()).await.unwrap(), 0);
     assert!(!driver.exists("paging/blob-0000.bin").await.unwrap());
     assert!(!driver.exists("paging/blob-1000.bin").await.unwrap());
 }
@@ -640,7 +657,7 @@ async fn test_reconcile_blob_state_skips_fresh_cleanup_claim() {
 
     assert_eq!(stats.ref_count_fixed, 0);
     assert_eq!(stats.orphan_blobs_deleted, 0);
-    let reloaded_blob = file_repo::find_blob_by_id(&state.db, blob.id)
+    let reloaded_blob = file_repo::find_blob_by_id(state.writer_db(), blob.id)
         .await
         .unwrap();
     assert_eq!(
@@ -669,7 +686,7 @@ async fn test_reconcile_blob_state_recovers_stale_cleanup_claim() {
     .await;
     let mut active: aster_drive::entities::file_blob::ActiveModel = blob.clone().into();
     active.updated_at = Set(Utc::now() - Duration::minutes(11));
-    active.update(&state.db).await.unwrap();
+    active.update(state.writer_db()).await.unwrap();
 
     let stats = maintenance_service::reconcile_blob_state(&state)
         .await
@@ -678,7 +695,7 @@ async fn test_reconcile_blob_state_recovers_stale_cleanup_claim() {
     assert_eq!(stats.ref_count_fixed, 1);
     assert_eq!(stats.orphan_blobs_deleted, 1);
     assert!(
-        file_repo::find_blob_by_id(&state.db, blob.id)
+        file_repo::find_blob_by_id(state.writer_db(), blob.id)
             .await
             .is_err()
     );
@@ -699,7 +716,7 @@ async fn test_purge_keeps_blob_row_when_storage_delete_fails_then_maintenance_re
     let driver = state.driver_registry.get_driver(&policy).unwrap();
 
     let file = store_test_file(&state, user.id, "retry.txt", b"retry blob").await;
-    let blob = file_repo::find_blob_by_id(&state.db, file.blob_id)
+    let blob = file_repo::find_blob_by_id(state.writer_db(), file.blob_id)
         .await
         .unwrap();
 
@@ -712,8 +729,12 @@ async fn test_purge_keeps_blob_row_when_storage_delete_fails_then_maintenance_re
 
     file_service::purge(&state, file.id, user.id).await.unwrap();
 
-    assert!(file_repo::find_by_id(&state.db, file.id).await.is_err());
-    let blob_after_purge = file_repo::find_blob_by_id(&state.db, blob.id)
+    assert!(
+        file_repo::find_by_id(state.writer_db(), file.id)
+            .await
+            .is_err()
+    );
+    let blob_after_purge = file_repo::find_blob_by_id(state.writer_db(), blob.id)
         .await
         .unwrap();
     assert_eq!(blob_after_purge.ref_count, 0);
@@ -727,7 +748,7 @@ async fn test_purge_keeps_blob_row_when_storage_delete_fails_then_maintenance_re
 
     assert_eq!(stats.orphan_blobs_deleted, 1);
     assert!(
-        file_repo::find_blob_by_id(&state.db, blob.id)
+        file_repo::find_blob_by_id(state.writer_db(), blob.id)
             .await
             .is_err()
     );
@@ -758,7 +779,9 @@ async fn test_purge_releases_all_versioned_storage_used() {
     .await
     .unwrap();
 
-    let before_purge = user_repo::find_by_id(&state.db, user.id).await.unwrap();
+    let before_purge = user_repo::find_by_id(state.writer_db(), user.id)
+        .await
+        .unwrap();
     assert_eq!(
         before_purge.storage_used,
         initial_bytes.len() as i64 + updated_bytes.len() as i64
@@ -766,7 +789,9 @@ async fn test_purge_releases_all_versioned_storage_used() {
 
     file_service::purge(&state, file.id, user.id).await.unwrap();
 
-    let after_purge = user_repo::find_by_id(&state.db, user.id).await.unwrap();
+    let after_purge = user_repo::find_by_id(state.writer_db(), user.id)
+        .await
+        .unwrap();
     assert_eq!(after_purge.storage_used, 0);
 }
 
@@ -807,13 +832,15 @@ async fn test_batch_purge_releases_all_versioned_storage_used() {
     .await
     .unwrap();
 
-    let before_purge = user_repo::find_by_id(&state.db, user.id).await.unwrap();
+    let before_purge = user_repo::find_by_id(state.writer_db(), user.id)
+        .await
+        .unwrap();
     assert_eq!(
         before_purge.storage_used,
         (file_a_v1.len() + file_a_v2.len() + file_b_v1.len() + file_b_v2.len()) as i64
     );
 
-    let files = file_repo::find_by_ids(&state.db, &[file_a.id, file_b.id])
+    let files = file_repo::find_by_ids(state.writer_db(), &[file_a.id, file_b.id])
         .await
         .unwrap();
     let purged = file_service::batch_purge(&state, files, user.id)
@@ -821,7 +848,9 @@ async fn test_batch_purge_releases_all_versioned_storage_used() {
         .unwrap();
     assert_eq!(purged, 2);
 
-    let after_purge = user_repo::find_by_id(&state.db, user.id).await.unwrap();
+    let after_purge = user_repo::find_by_id(state.writer_db(), user.id)
+        .await
+        .unwrap();
     assert_eq!(after_purge.storage_used, 0);
 }
 
@@ -839,22 +868,22 @@ async fn test_integrity_audit_detects_storage_and_tree_inconsistencies() {
     let driver = state.driver_registry.get_driver(&policy).unwrap();
 
     let live_file = store_test_file(&state, user.id, "audit.txt", b"audit blob").await;
-    let live_blob = file_repo::find_blob_by_id(&state.db, live_file.blob_id)
+    let live_blob = file_repo::find_blob_by_id(state.writer_db(), live_file.blob_id)
         .await
         .unwrap();
 
     let mut user_active: aster_drive::entities::user::ActiveModel =
-        user_repo::find_by_id(&state.db, user.id)
+        user_repo::find_by_id(state.writer_db(), user.id)
             .await
             .unwrap()
             .into();
     user_active.storage_used = Set(999);
-    user_active.update(&state.db).await.unwrap();
+    user_active.update(state.writer_db()).await.unwrap();
 
     let mut blob_active: file_blob::ActiveModel = live_blob.clone().into();
     blob_active.ref_count = Set(7);
     blob_active.updated_at = Set(Utc::now());
-    blob_active.update(&state.db).await.unwrap();
+    blob_active.update(state.writer_db()).await.unwrap();
 
     driver.delete(&live_blob.storage_path).await.unwrap();
     driver.put("stray/untracked.bin", b"stray").await.unwrap();
@@ -866,11 +895,11 @@ async fn test_integrity_audit_detects_storage_and_tree_inconsistencies() {
         .unwrap();
 
     let now = Utc::now();
-    common::set_foreign_key_checks(&state.db, false)
+    common::set_foreign_key_checks(state.writer_db(), false)
         .await
         .unwrap();
     let dangling_folder = folder_repo::create(
-        &state.db,
+        state.writer_db(),
         folder::ActiveModel {
             name: Set("dangling".to_string()),
             parent_id: Set(Some(999_999)),
@@ -886,12 +915,12 @@ async fn test_integrity_audit_detects_storage_and_tree_inconsistencies() {
     )
     .await
     .unwrap();
-    common::set_foreign_key_checks(&state.db, true)
+    common::set_foreign_key_checks(state.writer_db(), true)
         .await
         .unwrap();
 
     let cycle_a = folder_repo::create(
-        &state.db,
+        state.writer_db(),
         folder::ActiveModel {
             name: Set("cycle-a".to_string()),
             parent_id: Set(None),
@@ -909,7 +938,7 @@ async fn test_integrity_audit_detects_storage_and_tree_inconsistencies() {
     .unwrap();
 
     let cycle_b = folder_repo::create(
-        &state.db,
+        state.writer_db(),
         folder::ActiveModel {
             name: Set("cycle-b".to_string()),
             parent_id: Set(Some(cycle_a.id)),
@@ -929,9 +958,9 @@ async fn test_integrity_audit_detects_storage_and_tree_inconsistencies() {
     let mut cycle_a_active: folder::ActiveModel = cycle_a.clone().into();
     cycle_a_active.parent_id = Set(Some(cycle_b.id));
     cycle_a_active.updated_at = Set(Utc::now());
-    cycle_a_active.update(&state.db).await.unwrap();
+    cycle_a_active.update(state.writer_db()).await.unwrap();
 
-    let usage_drifts = integrity_service::audit_storage_usage(&state.db)
+    let usage_drifts = integrity_service::audit_storage_usage(state.writer_db())
         .await
         .unwrap();
     assert!(usage_drifts.iter().any(|drift| {
@@ -940,7 +969,7 @@ async fn test_integrity_audit_detects_storage_and_tree_inconsistencies() {
             && drift.recorded_bytes == 999
     }));
 
-    let blob_drifts = integrity_service::audit_blob_ref_counts(&state.db, None)
+    let blob_drifts = integrity_service::audit_blob_ref_counts(state.writer_db(), None)
         .await
         .unwrap();
     assert!(blob_drifts.iter().any(|drift| {
@@ -949,10 +978,13 @@ async fn test_integrity_audit_detects_storage_and_tree_inconsistencies() {
             && drift.actual_ref_count == 1
     }));
 
-    let storage_report =
-        integrity_service::audit_storage_objects(&state.db, state.driver_registry.as_ref(), None)
-            .await
-            .unwrap();
+    let storage_report = integrity_service::audit_storage_objects(
+        state.writer_db(),
+        state.driver_registry.as_ref(),
+        None,
+    )
+    .await
+    .unwrap();
     assert!(
         storage_report
             .missing_blob_objects
@@ -972,7 +1004,7 @@ async fn test_integrity_audit_detects_storage_and_tree_inconsistencies() {
             .any(|issue| issue.path == current_thumb_path(&orphan_thumb_hash))
     );
 
-    let folder_issues = integrity_service::audit_folder_tree(&state.db)
+    let folder_issues = integrity_service::audit_folder_tree(state.writer_db())
         .await
         .unwrap();
     assert!(folder_issues.iter().any(|issue| {
@@ -997,46 +1029,46 @@ async fn test_integrity_fix_repairs_storage_usage_and_blob_ref_counts() {
         .await
         .unwrap();
     let file = store_test_file(&state, user.id, "repair.txt", b"repair blob").await;
-    let blob = file_repo::find_blob_by_id(&state.db, file.blob_id)
+    let blob = file_repo::find_blob_by_id(state.writer_db(), file.blob_id)
         .await
         .unwrap();
 
     let mut user_active: aster_drive::entities::user::ActiveModel =
-        user_repo::find_by_id(&state.db, user.id)
+        user_repo::find_by_id(state.writer_db(), user.id)
             .await
             .unwrap()
             .into();
     user_active.storage_used = Set(0);
-    user_active.update(&state.db).await.unwrap();
+    user_active.update(state.writer_db()).await.unwrap();
 
     let mut blob_active: file_blob::ActiveModel = blob.clone().into();
     blob_active.ref_count = Set(0);
     blob_active.updated_at = Set(Utc::now());
-    blob_active.update(&state.db).await.unwrap();
+    blob_active.update(state.writer_db()).await.unwrap();
 
-    let usage_drifts = integrity_service::audit_storage_usage(&state.db)
+    let usage_drifts = integrity_service::audit_storage_usage(state.writer_db())
         .await
         .unwrap();
     assert_eq!(usage_drifts.len(), 1);
-    integrity_service::fix_storage_usage_drifts(&state.db, &usage_drifts)
+    integrity_service::fix_storage_usage_drifts(state.writer_db(), &usage_drifts)
         .await
         .unwrap();
     assert!(
-        integrity_service::audit_storage_usage(&state.db)
+        integrity_service::audit_storage_usage(state.writer_db())
             .await
             .unwrap()
             .is_empty()
     );
 
-    let blob_drifts = integrity_service::audit_blob_ref_counts(&state.db, None)
+    let blob_drifts = integrity_service::audit_blob_ref_counts(state.writer_db(), None)
         .await
         .unwrap();
     assert_eq!(blob_drifts.len(), 1);
-    integrity_service::fix_blob_ref_count_drifts(&state.db, &blob_drifts)
+    integrity_service::fix_blob_ref_count_drifts(state.writer_db(), &blob_drifts)
         .await
         .unwrap();
     assert!(
-        integrity_service::audit_blob_ref_counts(&state.db, None)
+        integrity_service::audit_blob_ref_counts(state.writer_db(), None)
             .await
             .unwrap()
             .is_empty()

--- a/tests/test_media_metadata.rs
+++ b/tests/test_media_metadata.rs
@@ -53,21 +53,21 @@ fn tiny_jpeg_with_exif() -> Vec<u8> {
         .unwrap();
 
     let mut entries = vec![
-        (0x010f, TiffValue::Ascii("SONY")),
-        (0x0110, TiffValue::Ascii("ILCE-7CM2")),
-        (0x0112, TiffValue::Short(1)),
-        (0x0131, TiffValue::Ascii("ILCE-7CM2 v1.01")),
-        (0x013b, TiffValue::Ascii("Aaron Liu")),
-        (0x829a, TiffValue::Rational(1, 200)),
-        (0x829d, TiffValue::Rational(28, 10)),
-        (0x8827, TiffValue::Short(100)),
-        (0x9003, TiffValue::Ascii("2024:04:01 05:44:11")),
+        (0x010f, TiffValue::Ascii("NIKON CORPORATION")),
+        (0x0110, TiffValue::Ascii("NIKON D3400")),
+        (0x0112, TiffValue::Short(8)),
+        (0x0131, TiffValue::Ascii("Ver.1.12")),
+        (0x013b, TiffValue::Ascii("Aster Tester")),
+        (0x829a, TiffValue::Rational(1, 320)),
+        (0x829d, TiffValue::Rational(56, 10)),
+        (0x8827, TiffValue::Short(400)),
+        (0x9003, TiffValue::Ascii("2026:03:05 17:19:01")),
         (0x9204, TiffValue::SRational(0, 10)),
-        (0x9209, TiffValue::Short(0)),
-        (0x920a, TiffValue::Rational(28, 1)),
-        (0xa405, TiffValue::Short(28)),
-        (0xa433, TiffValue::Ascii("TAMRON")),
-        (0xa434, TiffValue::Ascii("E 28-200mm F2.8-5.6 A071")),
+        (0x9209, TiffValue::Short(16)),
+        (0x920a, TiffValue::Rational(135, 1)),
+        (0xa405, TiffValue::Short(202)),
+        (0xa433, TiffValue::Ascii("NIKON")),
+        (0xa434, TiffValue::Ascii("55-200mm f/4-5.6")),
     ];
     entries.sort_by_key(|(tag, _)| *tag);
 
@@ -215,11 +215,11 @@ async fn duplicate_file_for_same_blob(
     source_file_id: i64,
     name: &str,
 ) -> i64 {
-    let source = file_repo::find_by_id(&state.db, source_file_id)
+    let source = file_repo::find_by_id(state.writer_db(), source_file_id)
         .await
         .unwrap();
     let now = chrono::Utc::now();
-    file_repo::increment_blob_ref_count(&state.db, source.blob_id)
+    file_repo::increment_blob_ref_count(state.writer_db(), source.blob_id)
         .await
         .unwrap();
     file::ActiveModel {
@@ -241,15 +241,17 @@ async fn duplicate_file_for_same_blob(
         is_locked: Set(false),
         ..Default::default()
     }
-    .insert(&state.db)
+    .insert(state.writer_db())
     .await
     .unwrap()
     .id
 }
 
 async fn set_system_config(state: &aster_drive::runtime::PrimaryAppState, key: &str, value: &str) {
-    config_repo::upsert(&state.db, key, value, 1).await.unwrap();
-    let mut model = config_repo::find_by_key(&state.db, key)
+    config_repo::upsert(state.writer_db(), key, value, 1)
+        .await
+        .unwrap();
+    let mut model = config_repo::find_by_key(state.writer_db(), key)
         .await
         .unwrap()
         .unwrap();
@@ -281,7 +283,7 @@ async fn insert_synthetic_media_file(
     category: FileCategory,
     bytes: &[u8],
 ) -> i64 {
-    let policy = aster_drive::db::repository::policy_repo::find_default(&state.db)
+    let policy = aster_drive::db::repository::policy_repo::find_default(state.writer_db())
         .await
         .unwrap()
         .expect("default policy should exist");
@@ -300,7 +302,7 @@ async fn insert_synthetic_media_file(
         updated_at: Set(now),
         ..Default::default()
     }
-    .insert(&state.db)
+    .insert(state.writer_db())
     .await
     .unwrap();
     file::ActiveModel {
@@ -322,7 +324,7 @@ async fn insert_synthetic_media_file(
         is_locked: Set(false),
         ..Default::default()
     }
-    .insert(&state.db)
+    .insert(state.writer_db())
     .await
     .unwrap()
     .id
@@ -344,7 +346,7 @@ async fn file_media_metadata_extracts_image_and_reuses_blob_cache() {
         Some("2")
     );
 
-    let task = background_task_repo::list_recent(&state.db, 16)
+    let task = background_task_repo::list_recent(state.writer_db(), 16)
         .await
         .unwrap()
         .into_iter()
@@ -370,7 +372,7 @@ async fn file_media_metadata_extracts_image_and_reuses_blob_cache() {
     assert_eq!(body["data"]["metadata"]["height"], 1);
 
     assert_eq!(
-        background_task_repo::list_recent(&state.db, 16)
+        background_task_repo::list_recent(state.writer_db(), 16)
             .await
             .unwrap()
             .into_iter()
@@ -387,7 +389,7 @@ async fn file_media_metadata_extracts_image_and_reuses_blob_cache() {
     assert_eq!(body["data"]["status"], "ready");
     assert_eq!(body["data"]["metadata"]["kind"], "image");
 
-    let tasks = background_task_repo::list_recent(&state.db, 16)
+    let tasks = background_task_repo::list_recent(state.writer_db(), 16)
         .await
         .unwrap();
     assert_eq!(
@@ -449,22 +451,22 @@ async fn file_media_metadata_extracts_image_exif_fields() {
     assert_eq!(metadata["kind"], "image");
     assert_eq!(metadata["width"], 1);
     assert_eq!(metadata["height"], 1);
-    assert_eq!(metadata["camera_make"], "SONY");
-    assert_eq!(metadata["camera_model"], "ILCE-7CM2");
-    assert_eq!(metadata["lens_make"], "TAMRON");
-    assert_eq!(metadata["lens_model"], "E 28-200mm F2.8-5.6 A071");
-    assert_eq!(metadata["f_number"], 2.8);
-    assert_eq!(metadata["exposure_time_seconds"], 0.005);
-    assert_eq!(metadata["iso"], 100);
+    assert_eq!(metadata["camera_make"], "NIKON CORPORATION");
+    assert_eq!(metadata["camera_model"], "NIKON D3400");
+    assert_eq!(metadata["lens_make"], "NIKON");
+    assert_eq!(metadata["lens_model"], "55-200mm f/4-5.6");
+    assert_eq!(metadata["f_number"], 5.6);
+    assert_eq!(metadata["exposure_time_seconds"], 0.003125);
+    assert_eq!(metadata["iso"], 400);
     assert_eq!(metadata["exposure_bias_ev"], 0.0);
     assert_eq!(metadata["flash_fired"], false);
-    assert_eq!(metadata["flash_mode"], 0);
-    assert_eq!(metadata["focal_length_mm"], 28.0);
-    assert_eq!(metadata["focal_length_35mm"], 28);
-    assert_eq!(metadata["taken_at"], "2024-04-01T05:44:11");
-    assert_eq!(metadata["orientation"], 1);
-    assert_eq!(metadata["artist"], "Aaron Liu");
-    assert_eq!(metadata["software"], "ILCE-7CM2 v1.01");
+    assert_eq!(metadata["flash_mode"], 16);
+    assert_eq!(metadata["focal_length_mm"], 135.0);
+    assert_eq!(metadata["focal_length_35mm"], 202);
+    assert_eq!(metadata["taken_at"], "2026-03-05T17:19:01");
+    assert_eq!(metadata["orientation"], 8);
+    assert_eq!(metadata["artist"], "Aster Tester");
+    assert_eq!(metadata["software"], "Ver.1.12");
 }
 
 #[actix_web::test]
@@ -494,13 +496,15 @@ async fn file_media_metadata_returns_unsupported_for_video_when_ffprobe_processo
     assert_eq!(body["data"]["parser"], "unsupported");
     assert!(body["data"]["metadata"].is_null());
 
-    let file = file_repo::find_by_id(&state.db, file_id).await.unwrap();
-    let record = media_metadata_repo::find_by_blob_id(&state.db, file.blob_id)
+    let file = file_repo::find_by_id(state.writer_db(), file_id)
+        .await
+        .unwrap();
+    let record = media_metadata_repo::find_by_blob_id(state.writer_db(), file.blob_id)
         .await
         .unwrap();
     assert!(record.is_none());
     assert_eq!(
-        background_task_repo::list_recent(&state.db, 16)
+        background_task_repo::list_recent(state.writer_db(), 16)
             .await
             .unwrap()
             .into_iter()
@@ -574,7 +578,7 @@ async fn media_metadata_disabled_returns_unsupported_without_task() {
     assert_eq!(body["data"]["parser"], "disabled");
 
     assert_eq!(
-        background_task_repo::list_recent(&state.db, 16)
+        background_task_repo::list_recent(state.writer_db(), 16)
             .await
             .unwrap()
             .into_iter()
@@ -624,7 +628,7 @@ async fn media_metadata_processor_disabled_returns_unsupported_without_task() {
     assert_eq!(body["data"]["parser"], "unsupported");
 
     assert_eq!(
-        background_task_repo::list_recent(&state.db, 16)
+        background_task_repo::list_recent(state.writer_db(), 16)
             .await
             .unwrap()
             .into_iter()

--- a/tests/test_oidc.rs
+++ b/tests/test_oidc.rs
@@ -190,7 +190,7 @@ async fn admin_tests_external_auth_provider_draft_params_without_persisting() {
     assert_eq!(body["data"]["checks"][1]["name"], "jwks");
 
     let providers = external_auth_provider::Entity::find()
-        .all(&state.db)
+        .all(state.writer_db())
         .await
         .expect("providers should query");
     assert!(providers.is_empty());
@@ -198,7 +198,7 @@ async fn admin_tests_external_auth_provider_draft_params_without_persisting() {
     let audit_entry = audit_log::Entity::find()
         .filter(audit_log::Column::Action.eq(AuditAction::AdminTestExternalAuthProvider))
         .order_by_desc(audit_log::Column::Id)
-        .one(&state.db)
+        .one(state.writer_db())
         .await
         .expect("audit log should query")
         .expect("draft test should write an audit log");
@@ -231,7 +231,7 @@ async fn admin_tests_external_auth_provider_draft_params_without_persisting() {
     let audit_entry = audit_log::Entity::find()
         .filter(audit_log::Column::Action.eq(AuditAction::AdminTestExternalAuthProvider))
         .order_by_desc(audit_log::Column::Id)
-        .one(&state.db)
+        .one(state.writer_db())
         .await
         .expect("audit log should query")
         .expect("failed draft test should write an audit log");
@@ -276,7 +276,7 @@ async fn admin_tests_external_auth_provider_draft_params_without_persisting() {
     assert_eq!(body["data"]["issuer"], mock_provider.issuer);
 
     let providers = external_auth_provider::Entity::find()
-        .all(&state.db)
+        .all(state.writer_db())
         .await
         .expect("providers should query");
     assert_eq!(providers.len(), 1);
@@ -397,7 +397,7 @@ async fn start_login_persists_pkce_flow_and_rejects_replayed_state() {
     );
 
     let flows = external_auth_login_flow::Entity::find()
-        .all(&state.db)
+        .all(state.writer_db())
         .await
         .expect("flows should query");
     assert_eq!(flows.len(), 1);
@@ -405,7 +405,7 @@ async fn start_login_persists_pkce_flow_and_rejects_replayed_state() {
     assert_ne!(flows[0].state_hash, authorize_request.state);
 
     let consumed = external_auth_login_flow_repo::consume_by_state_hash(
-        &state.db,
+        state.writer_db(),
         &aster_drive::utils::hash::sha256_hex(authorize_request.state.as_bytes()),
         Utc::now(),
     )
@@ -413,7 +413,7 @@ async fn start_login_persists_pkce_flow_and_rejects_replayed_state() {
     .expect("flow consume should succeed");
     assert!(consumed.is_some());
     let replay = external_auth_login_flow_repo::consume_by_state_hash(
-        &state.db,
+        state.writer_db(),
         &aster_drive::utils::hash::sha256_hex(authorize_request.state.as_bytes()),
         Utc::now(),
     )
@@ -450,7 +450,7 @@ async fn finish_callback_verifies_jwks_and_issues_asterdrive_cookies() {
     assert!(common::extract_cookie(&resp, "aster_csrf").is_some());
 
     let identities = external_auth_identity::Entity::find()
-        .all(&state.db)
+        .all(state.writer_db())
         .await
         .expect("identities should query");
     assert_eq!(identities.len(), 1);
@@ -500,7 +500,7 @@ async fn finish_callback_auto_links_verified_email_to_existing_user() {
     assert!(common::extract_cookie(&resp, "aster_refresh").is_some());
 
     let identities = external_auth_identity::Entity::find()
-        .all(&state.db)
+        .all(state.writer_db())
         .await
         .expect("identities should query");
     assert_eq!(identities.len(), 1);
@@ -545,7 +545,7 @@ async fn finish_callback_falls_back_to_manual_binding_for_unverified_auto_link_e
     let flow_token = oidc_email_required_flow(&resp);
 
     let identities = external_auth_identity::Entity::find()
-        .all(&state.db)
+        .all(state.writer_db())
         .await
         .expect("identities should query");
     assert!(identities.is_empty());
@@ -555,7 +555,7 @@ async fn finish_callback_falls_back_to_manual_binding_for_unverified_auto_link_e
     assert!(common::extract_cookie(&resp, "aster_access").is_some());
 
     let identities = external_auth_identity::Entity::find()
-        .all(&state.db)
+        .all(state.writer_db())
         .await
         .expect("identities should query");
     assert_eq!(identities.len(), 1);
@@ -590,7 +590,7 @@ async fn finish_callback_rejects_disabled_user_with_existing_identity() {
         .as_i64()
         .expect("provider id should be returned");
     external_auth_identity_repo::create_identity(
-        &state.db,
+        state.writer_db(),
         external_auth_identity_repo::CreateExternalAuthIdentityInput {
             user_id: disabled_user_id,
             provider_id,
@@ -636,7 +636,7 @@ async fn finish_callback_allows_existing_identity_without_email_claim() {
         .as_i64()
         .expect("provider id should be returned");
     external_auth_identity_repo::create_identity(
-        &state.db,
+        state.writer_db(),
         external_auth_identity_repo::CreateExternalAuthIdentityInput {
             user_id: linked_user_id,
             provider_id,
@@ -693,12 +693,12 @@ async fn finish_callback_falls_back_to_manual_binding_when_auto_provision_disabl
     let flow_token = oidc_email_required_flow(&resp);
 
     let identities = external_auth_identity::Entity::find()
-        .all(&state.db)
+        .all(state.writer_db())
         .await
         .expect("identities should query");
     assert!(identities.is_empty());
     let users = user::Entity::find()
-        .all(&state.db)
+        .all(state.writer_db())
         .await
         .expect("users should query");
     assert_eq!(users.len(), 2);
@@ -708,7 +708,7 @@ async fn finish_callback_falls_back_to_manual_binding_when_auto_provision_disabl
     assert!(common::extract_cookie(&resp, "aster_access").is_some());
 
     let identities = external_auth_identity::Entity::find()
-        .all(&state.db)
+        .all(state.writer_db())
         .await
         .expect("identities should query");
     assert_eq!(identities.len(), 1);
@@ -756,12 +756,12 @@ async fn finish_callback_respects_global_registration_setting_for_auto_provision
     let flow_token = oidc_email_required_flow(&resp);
 
     let identities = external_auth_identity::Entity::find()
-        .all(&state.db)
+        .all(state.writer_db())
         .await
         .expect("identities should query");
     assert!(identities.is_empty());
     let users = user::Entity::find()
-        .all(&state.db)
+        .all(state.writer_db())
         .await
         .expect("users should query");
     assert_eq!(users.len(), 2);
@@ -771,7 +771,7 @@ async fn finish_callback_respects_global_registration_setting_for_auto_provision
     assert!(common::extract_cookie(&resp, "aster_access").is_some());
 
     let identities = external_auth_identity::Entity::find()
-        .all(&state.db)
+        .all(state.writer_db())
         .await
         .expect("identities should query");
     assert_eq!(identities.len(), 1);
@@ -779,7 +779,7 @@ async fn finish_callback_respects_global_registration_setting_for_auto_provision
     assert_eq!(identities[0].subject, "registration-closed-subject");
     assert_eq!(identities[0].email_snapshot.as_deref(), None);
     let users = user::Entity::find()
-        .all(&state.db)
+        .all(state.writer_db())
         .await
         .expect("users should query");
     assert_eq!(users.len(), 2);
@@ -819,12 +819,12 @@ async fn manual_binding_respects_global_registration_setting_only_when_email_ver
     assert_eq!(resp.status(), 403);
 
     let identities = external_auth_identity::Entity::find()
-        .all(&state.db)
+        .all(state.writer_db())
         .await
         .expect("identities should query");
     assert!(identities.is_empty());
     let users = user::Entity::find()
-        .all(&state.db)
+        .all(state.writer_db())
         .await
         .expect("users should query");
     assert_eq!(users.len(), 1);
@@ -876,7 +876,7 @@ async fn finish_callback_auto_link_by_verified_email_ignores_global_registration
     assert!(common::extract_cookie(&resp, "aster_access").is_some());
 
     let identities = external_auth_identity::Entity::find()
-        .all(&state.db)
+        .all(state.writer_db())
         .await
         .expect("identities should query");
     assert_eq!(identities.len(), 1);
@@ -927,13 +927,13 @@ async fn no_email_claim_can_register_after_local_email_verification() {
 
     let user = user::Entity::find()
         .filter(user::Column::Email.eq("fallback-provision@example.com"))
-        .one(&state.db)
+        .one(state.writer_db())
         .await
         .expect("user should query")
         .expect("OIDC verified email should create user");
     assert!(user.email_verified_at.is_some());
     let identities = external_auth_identity::Entity::find()
-        .all(&state.db)
+        .all(state.writer_db())
         .await
         .expect("identities should query");
     assert_eq!(identities.len(), 1);
@@ -975,7 +975,7 @@ async fn auto_provision_retries_username_collision_with_random_suffix() {
 
     let user = user::Entity::find()
         .filter(user::Column::Email.eq("username-collision@example.com"))
-        .one(&state.db)
+        .one(state.writer_db())
         .await
         .expect("user should query")
         .expect("OIDC auto-provision should create user");
@@ -985,7 +985,7 @@ async fn auto_provision_retries_username_collision_with_random_suffix() {
 
     let identities = external_auth_identity::Entity::find()
         .filter(external_auth_identity::Column::Subject.eq("username-collision-subject"))
-        .all(&state.db)
+        .all(state.writer_db())
         .await
         .expect("identities should query");
     assert_eq!(identities.len(), 1);
@@ -1044,7 +1044,7 @@ async fn no_email_claim_falls_back_to_local_email_verification_for_existing_user
     assert!(common::extract_cookie(&resp, "aster_access").is_some());
 
     let identities = external_auth_identity::Entity::find()
-        .all(&state.db)
+        .all(state.writer_db())
         .await
         .expect("identities should query");
     assert_eq!(identities.len(), 1);
@@ -1096,7 +1096,7 @@ async fn manual_email_verification_can_link_existing_user_without_auto_link_enab
     assert!(common::extract_cookie(&resp, "aster_access").is_some());
 
     let identities = external_auth_identity::Entity::find()
-        .all(&state.db)
+        .all(state.writer_db())
         .await
         .expect("identities should query");
     assert_eq!(identities.len(), 1);
@@ -1147,7 +1147,7 @@ async fn no_email_claim_can_link_after_local_password_login() {
     assert!(body["data"]["expires_in"].as_u64().is_some());
 
     let identities = external_auth_identity::Entity::find()
-        .all(&state.db)
+        .all(state.writer_db())
         .await
         .expect("identities should query");
     assert_eq!(identities.len(), 1);
@@ -1194,12 +1194,12 @@ async fn oidc_password_link_rejects_wrong_password_without_sending_email() {
     assert!(common::extract_cookie(&resp, "aster_access").is_none());
 
     let identities = external_auth_identity::Entity::find()
-        .all(&state.db)
+        .all(state.writer_db())
         .await
         .expect("identities should query");
     assert!(identities.is_empty());
     let email_flows = external_auth_email_verification_flow::Entity::find()
-        .all(&state.db)
+        .all(state.writer_db())
         .await
         .expect("email verification flows should query");
     assert_eq!(email_flows.len(), 1);
@@ -1243,12 +1243,12 @@ async fn oidc_email_verification_respects_global_registration_setting() {
     assert_eq!(resp.status(), 403);
 
     let users = user::Entity::find()
-        .all(&state.db)
+        .all(state.writer_db())
         .await
         .expect("users should query");
     assert_eq!(users.len(), 1);
     let identities = external_auth_identity::Entity::find()
-        .all(&state.db)
+        .all(state.writer_db())
         .await
         .expect("identities should query");
     assert!(identities.is_empty());
@@ -1283,7 +1283,7 @@ async fn oidc_email_verification_enforces_entered_email_domain() {
     let resp = start_oidc_email_verification(&app, &flow_token, "user@example.org").await;
     assert_eq!(resp.status(), 403);
     let users = user::Entity::find()
-        .all(&state.db)
+        .all(state.writer_db())
         .await
         .expect("users should query");
     assert_eq!(users.len(), 1);
@@ -1333,7 +1333,7 @@ async fn oidc_email_verification_rejects_replay() {
     );
     assert!(common::extract_cookie(&resp, "aster_access").is_none());
     let identities = external_auth_identity::Entity::find()
-        .all(&state.db)
+        .all(state.writer_db())
         .await
         .expect("identities should query");
     assert_eq!(identities.len(), 1);
@@ -1365,13 +1365,15 @@ async fn oidc_email_verification_rejects_expired_pending_flow() {
     let resp = finish_oidc_callback(&app, &provider_key, &state_value).await;
     let flow_token = oidc_email_required_flow(&resp);
     let mut flow = external_auth_email_verification_flow::Entity::find()
-        .one(&state.db)
+        .one(state.writer_db())
         .await
         .expect("flow should query")
         .expect("flow should exist")
         .into_active_model();
     flow.expires_at = Set(Utc::now() - Duration::minutes(1));
-    flow.update(&state.db).await.expect("flow should update");
+    flow.update(state.writer_db())
+        .await
+        .expect("flow should update");
 
     let resp =
         start_oidc_email_verification(&app, &flow_token, "fallback-expired@example.com").await;
@@ -1409,7 +1411,7 @@ async fn finish_callback_rejects_flow_after_provider_disabled() {
     let resp = finish_oidc_callback(&app, &provider_key, &state_value).await;
     assert_oidc_error_redirect(&resp);
     let identities = external_auth_identity::Entity::find()
-        .all(&state.db)
+        .all(state.writer_db())
         .await
         .expect("identities should query");
     assert!(identities.is_empty());
@@ -1435,7 +1437,7 @@ async fn finish_callback_rejects_audience_mismatch() {
     assert_oidc_error_redirect(&resp);
 
     let identities = external_auth_identity::Entity::find()
-        .all(&state.db)
+        .all(state.writer_db())
         .await
         .expect("identities should query");
     assert!(identities.is_empty());
@@ -1461,7 +1463,7 @@ async fn finish_callback_rejects_oversized_subject_before_db_write() {
     assert_oidc_error_redirect(&resp);
 
     let identities = external_auth_identity::Entity::find()
-        .all(&state.db)
+        .all(state.writer_db())
         .await
         .expect("identities should query");
     assert!(identities.is_empty());
@@ -1486,7 +1488,7 @@ async fn finish_callback_rejects_nonce_mismatch() {
     assert_oidc_error_redirect(&resp);
 
     let identities = external_auth_identity::Entity::find()
-        .all(&state.db)
+        .all(state.writer_db())
         .await
         .expect("identities should query");
     assert!(identities.is_empty());
@@ -1510,7 +1512,7 @@ async fn finish_callback_rejects_provider_key_mismatch() {
     assert_oidc_error_redirect(&resp);
 
     let identities = external_auth_identity::Entity::find()
-        .all(&state.db)
+        .all(state.writer_db())
         .await
         .expect("identities should query");
     assert!(identities.is_empty());
@@ -1544,12 +1546,12 @@ async fn finish_callback_enforces_allowed_domains() {
     assert_oidc_error_redirect(&resp);
 
     let identities = external_auth_identity::Entity::find()
-        .all(&state.db)
+        .all(state.writer_db())
         .await
         .expect("identities should query");
     assert!(identities.is_empty());
     let users = user::Entity::find()
-        .all(&state.db)
+        .all(state.writer_db())
         .await
         .expect("users should query");
     assert_eq!(users.len(), 1);
@@ -1611,7 +1613,7 @@ async fn oidc_links_can_be_listed_and_deleted_after_login() {
     assert_eq!(body["data"].as_array().unwrap().len(), 0);
 
     let identities = external_auth_identity::Entity::find()
-        .all(&state.db)
+        .all(state.writer_db())
         .await
         .expect("identities should query");
     assert!(identities.is_empty());
@@ -1661,7 +1663,7 @@ async fn finish_callback_rejects_issuer_mismatch_after_id_token_verification() {
     assert!(common::extract_cookie(&resp, "aster_access").is_none());
 
     let identities = external_auth_identity::Entity::find()
-        .all(&state.db)
+        .all(state.writer_db())
         .await
         .expect("identities should query");
     assert!(identities.is_empty());
@@ -1673,13 +1675,13 @@ async fn finish_callback_rejects_issuer_mismatch_after_id_token_verification() {
 async fn external_auth_identity_lookup_uses_namespace_subject_not_provider_id() {
     let state = common::setup().await;
     let provider_a = external_auth_provider_repo::create(
-        &state.db,
+        state.writer_db(),
         external_auth_provider_model("a", "http://issuer.example.test", true),
     )
     .await
     .expect("provider a should create");
     let provider_b = external_auth_provider_repo::create(
-        &state.db,
+        state.writer_db(),
         external_auth_provider_model("b", "http://issuer.example.test", true),
     )
     .await
@@ -1695,7 +1697,7 @@ async fn external_auth_identity_lookup_uses_namespace_subject_not_provider_id() 
     .expect("admin token should verify");
 
     external_auth_identity_repo::create_identity(
-        &state.db,
+        state.writer_db(),
         external_auth_identity_repo::CreateExternalAuthIdentityInput {
             user_id: claims.user_id,
             provider_id: provider_a.id,
@@ -1713,7 +1715,7 @@ async fn external_auth_identity_lookup_uses_namespace_subject_not_provider_id() 
     .expect("identity should create");
 
     let found = external_auth_identity_repo::find_by_identity_namespace_subject(
-        &state.db,
+        state.writer_db(),
         provider_b
             .issuer_url
             .as_deref()
@@ -1726,7 +1728,7 @@ async fn external_auth_identity_lookup_uses_namespace_subject_not_provider_id() 
     assert_eq!(found.provider_id, provider_a.id);
 
     let duplicate = external_auth_identity_repo::create_identity(
-        &state.db,
+        state.writer_db(),
         external_auth_identity_repo::CreateExternalAuthIdentityInput {
             user_id: claims.user_id,
             provider_id: provider_b.id,
@@ -1748,7 +1750,7 @@ async fn external_auth_identity_lookup_uses_namespace_subject_not_provider_id() 
 async fn cleanup_expired_flows_removes_only_expired_rows() {
     let state = common::setup().await;
     let provider = external_auth_provider_repo::create(
-        &state.db,
+        state.writer_db(),
         external_auth_provider_model("cleanup", "http://cleanup.example.test", true),
     )
     .await
@@ -1759,7 +1761,7 @@ async fn cleanup_expired_flows_removes_only_expired_rows() {
         ("active", now + Duration::minutes(5)),
     ] {
         external_auth_login_flow_repo::create(
-            &state.db,
+            state.writer_db(),
             external_auth_login_flow::ActiveModel {
                 provider_id: Set(provider.id),
                 state_hash: Set(state_hash.to_string()),
@@ -1796,7 +1798,7 @@ async fn cleanup_expired_flows_removes_only_expired_rows() {
             consumed_at: Set(None),
             ..Default::default()
         }
-        .insert(&state.db)
+        .insert(state.writer_db())
         .await
         .expect("email verification flow should create");
     }
@@ -1806,13 +1808,13 @@ async fn cleanup_expired_flows_removes_only_expired_rows() {
         .expect("cleanup should succeed");
     assert_eq!(removed, 2);
     let flows = external_auth_login_flow::Entity::find()
-        .all(&state.db)
+        .all(state.writer_db())
         .await
         .expect("flows should query");
     assert_eq!(flows.len(), 1);
     assert_eq!(flows[0].state_hash, "active");
     let email_flows = external_auth_email_verification_flow::Entity::find()
-        .all(&state.db)
+        .all(state.writer_db())
         .await
         .expect("email verification flows should query");
     assert_eq!(email_flows.len(), 1);
@@ -1893,7 +1895,7 @@ async fn dex_container_authorization_code_login_e2e() {
     assert!(common::extract_cookie(&resp, "aster_csrf").is_some());
 
     let identities = external_auth_identity::Entity::find()
-        .all(&state.db)
+        .all(state.writer_db())
         .await
         .expect("identities should query");
     assert_eq!(identities.len(), 1);

--- a/tests/test_policies.rs
+++ b/tests/test_policies.rs
@@ -24,7 +24,7 @@ async fn create_policy_upload_session(
 
     let now = Utc::now();
     upload_session_repo::create(
-        &state.db,
+        state.writer_db(),
         aster_drive::entities::upload_session::ActiveModel {
             id: Set(spec.upload_id.to_string()),
             user_id: Set(spec.user_id),
@@ -153,20 +153,20 @@ async fn test_seed_policy_groups_backfills_missing_users_to_default_group() {
     )
     .await
     .unwrap();
-    let default_group = policy_group_repo::find_default_group(&state.db)
+    let default_group = policy_group_repo::find_default_group(state.writer_db())
         .await
         .unwrap()
         .expect("default group should exist");
 
     let mut user_active: aster_drive::entities::user::ActiveModel = user.into();
     user_active.policy_group_id = Set(None);
-    user_active.update(&state.db).await.unwrap();
+    user_active.update(state.writer_db()).await.unwrap();
 
-    policy_service::ensure_policy_groups_seeded(&state.db)
+    policy_service::ensure_policy_groups_seeded(state.writer_db())
         .await
         .unwrap();
 
-    let updated = user_repo::find_by_email(&state.db, "policy-backfill@example.com")
+    let updated = user_repo::find_by_email(state.writer_db(), "policy-backfill@example.com")
         .await
         .unwrap()
         .expect("user should exist");
@@ -266,7 +266,7 @@ async fn test_policy_delete_rejects_upload_sessions_unless_forced() {
     use aster_drive::db::repository::{policy_repo, upload_session_repo};
 
     let state = common::setup().await;
-    let db = state.db.clone();
+    let db = state.writer_db().clone();
     let app = create_test_app!(state.clone());
     let (token, _) = register_and_login!(app);
 
@@ -379,7 +379,7 @@ async fn test_policy_force_delete_schedules_late_temp_object_cleanup() {
     use sea_orm::{ActiveModelTrait, ColumnTrait, EntityTrait, QueryFilter, Set};
 
     let state = common::setup().await;
-    let db = state.db.clone();
+    let db = state.writer_db().clone();
     let app = create_test_app!(state.clone());
     let (token, _) = register_and_login!(app);
 
@@ -494,7 +494,7 @@ async fn test_policy_force_delete_still_rejects_blob_references() {
     use aster_drive::types::DriverType;
 
     let state = common::setup().await;
-    let db = state.db.clone();
+    let db = state.writer_db().clone();
     let app = create_test_app!(state.clone());
     let (token, _) = register_and_login!(app);
     let user = aster_drive::db::repository::user_repo::find_by_username(&db, "testuser")
@@ -750,7 +750,7 @@ async fn test_system_policy_default_uniqueness() {
     use aster_drive::db::repository::policy_group_repo;
 
     let state = common::setup().await;
-    let db = state.db.clone();
+    let db = state.writer_db().clone();
     let app = create_test_app!(state);
     let (token, _) = register_and_login!(app);
 
@@ -803,7 +803,7 @@ async fn test_patch_policy_promotes_existing_policy_to_default() {
     use aster_drive::db::repository::policy_group_repo;
 
     let state = common::setup().await;
-    let db = state.db.clone();
+    let db = state.writer_db().clone();
     let app = create_test_app!(state);
     let (token, _) = register_and_login!(app);
 
@@ -867,17 +867,17 @@ async fn test_set_only_default_rejects_missing_policy_without_clearing_default()
     use aster_drive::db::repository::policy_repo;
 
     let state = common::setup().await;
-    let original_default = policy_repo::find_default(&state.db)
+    let original_default = policy_repo::find_default(state.writer_db())
         .await
         .unwrap()
         .expect("default policy should exist");
 
-    let err = policy_repo::set_only_default(&state.db, i64::MAX)
+    let err = policy_repo::set_only_default(state.writer_db(), i64::MAX)
         .await
         .unwrap_err();
     assert!(err.message().contains("policy"));
 
-    let current_default = policy_repo::find_default(&state.db)
+    let current_default = policy_repo::find_default(state.writer_db())
         .await
         .unwrap()
         .expect("default policy should still exist");
@@ -1638,12 +1638,18 @@ async fn test_resolve_policy_fails_without_user_policy_group() {
     .await
     .unwrap();
 
-    let model = user_repo::find_by_id(&state.db, user.id).await.unwrap();
+    let model = user_repo::find_by_id(state.writer_db(), user.id)
+        .await
+        .unwrap();
     let mut active: aster_drive::entities::user::ActiveModel = model.into();
     active.policy_group_id = Set(None);
     active.updated_at = Set(chrono::Utc::now());
-    active.update(&state.db).await.unwrap();
-    state.policy_snapshot.reload(&state.db).await.unwrap();
+    active.update(state.writer_db()).await.unwrap();
+    state
+        .policy_snapshot
+        .reload(state.writer_db())
+        .await
+        .unwrap();
 
     let err = file_service::resolve_policy(&state, user.id, None)
         .await
@@ -1668,13 +1674,13 @@ async fn test_resolve_policy_fails_for_disabled_assigned_policy_group() {
     .await
     .unwrap();
 
-    let default_policy = aster_drive::db::repository::policy_repo::find_default(&state.db)
+    let default_policy = aster_drive::db::repository::policy_repo::find_default(state.writer_db())
         .await
         .unwrap()
         .unwrap();
     let now = chrono::Utc::now();
     let group = policy_group_repo::create_group(
-        &state.db,
+        state.writer_db(),
         aster_drive::entities::storage_policy_group::ActiveModel {
             name: Set("Disabled Assigned Group".to_string()),
             description: Set(String::new()),
@@ -1688,7 +1694,7 @@ async fn test_resolve_policy_fails_for_disabled_assigned_policy_group() {
     .await
     .unwrap();
     policy_group_repo::create_group_item(
-        &state.db,
+        state.writer_db(),
         aster_drive::entities::storage_policy_group_item::ActiveModel {
             group_id: Set(group.id),
             policy_id: Set(default_policy.id),
@@ -1702,22 +1708,28 @@ async fn test_resolve_policy_fails_for_disabled_assigned_policy_group() {
     .await
     .unwrap();
 
-    let user_model = user_repo::find_by_id(&state.db, user.id).await.unwrap();
+    let user_model = user_repo::find_by_id(state.writer_db(), user.id)
+        .await
+        .unwrap();
     let mut user_active: aster_drive::entities::user::ActiveModel = user_model.into();
     user_active.policy_group_id = Set(Some(group.id));
     user_active.updated_at = Set(chrono::Utc::now());
-    user_active.update(&state.db).await.unwrap();
+    user_active.update(state.writer_db()).await.unwrap();
 
-    let group_model = policy_group_repo::find_group_by_id(&state.db, group.id)
+    let group_model = policy_group_repo::find_group_by_id(state.writer_db(), group.id)
         .await
         .unwrap();
     let mut group_active: aster_drive::entities::storage_policy_group::ActiveModel =
         group_model.into();
     group_active.is_enabled = Set(false);
     group_active.updated_at = Set(chrono::Utc::now());
-    group_active.update(&state.db).await.unwrap();
+    group_active.update(state.writer_db()).await.unwrap();
 
-    state.policy_snapshot.reload(&state.db).await.unwrap();
+    state
+        .policy_snapshot
+        .reload(state.writer_db())
+        .await
+        .unwrap();
 
     let err = file_service::resolve_policy(&state, user.id, None)
         .await
@@ -1743,7 +1755,10 @@ async fn test_resolve_policy_fails_when_policy_group_has_no_matching_rule() {
     .await
     .unwrap();
 
-    let default_policy = policy_repo::find_default(&state.db).await.unwrap().unwrap();
+    let default_policy = policy_repo::find_default(state.writer_db())
+        .await
+        .unwrap()
+        .unwrap();
     let overflow_path = format!("/tmp/asterdrive-gap-policy-{}", uuid::Uuid::new_v4());
     std::fs::create_dir_all(&overflow_path).unwrap();
     let overflow_policy = policy_service::create(
@@ -1771,7 +1786,7 @@ async fn test_resolve_policy_fails_when_policy_group_has_no_matching_rule() {
 
     let now = chrono::Utc::now();
     let group = policy_group_repo::create_group(
-        &state.db,
+        state.writer_db(),
         aster_drive::entities::storage_policy_group::ActiveModel {
             name: Set("Gap Rule Group".to_string()),
             description: Set(String::new()),
@@ -1789,7 +1804,7 @@ async fn test_resolve_policy_fails_when_policy_group_has_no_matching_rule() {
         (2, overflow_policy.id, 20, 0),
     ] {
         policy_group_repo::create_group_item(
-            &state.db,
+            state.writer_db(),
             aster_drive::entities::storage_policy_group_item::ActiveModel {
                 group_id: Set(group.id),
                 policy_id: Set(policy_id),
@@ -1804,12 +1819,18 @@ async fn test_resolve_policy_fails_when_policy_group_has_no_matching_rule() {
         .unwrap();
     }
 
-    let user_model = user_repo::find_by_id(&state.db, user.id).await.unwrap();
+    let user_model = user_repo::find_by_id(state.writer_db(), user.id)
+        .await
+        .unwrap();
     let mut user_active: aster_drive::entities::user::ActiveModel = user_model.into();
     user_active.policy_group_id = Set(Some(group.id));
     user_active.updated_at = Set(now);
-    user_active.update(&state.db).await.unwrap();
-    state.policy_snapshot.reload(&state.db).await.unwrap();
+    user_active.update(state.writer_db()).await.unwrap();
+    state
+        .policy_snapshot
+        .reload(state.writer_db())
+        .await
+        .unwrap();
 
     let err = file_service::resolve_policy_for_size(&state, user.id, None, 15)
         .await
@@ -1823,7 +1844,7 @@ async fn test_policy_delete_clears_folder_policy_reference() {
     use aster_drive::db::repository::folder_repo;
 
     let state = common::setup().await;
-    let db = state.db.clone();
+    let db = state.writer_db().clone();
     let app = create_test_app!(state);
     let (token, _) = register_and_login!(app);
 
@@ -1884,7 +1905,7 @@ async fn test_folder_patch_can_clear_policy_with_null() {
     use aster_drive::db::repository::folder_repo;
 
     let state = common::setup().await;
-    let db = state.db.clone();
+    let db = state.writer_db().clone();
     let app = create_test_app!(state);
     let (token, _) = register_and_login!(app);
 

--- a/tests/test_preferences.rs
+++ b/tests/test_preferences.rs
@@ -153,7 +153,7 @@ async fn test_preferences_empty_patch_noop() {
 #[actix_web::test]
 async fn test_preferences_patch_preserves_custom_user_config_keys() {
     let state = common::setup().await;
-    let db = state.db.clone();
+    let db = state.writer_db().clone();
     let app = create_test_app!(state);
     let (token, _) = register_and_login!(app);
 
@@ -354,7 +354,7 @@ async fn test_preferences_color_preset_rejects_invalid_color() {
 #[actix_web::test]
 async fn test_preferences_color_preset_normalizes_legacy_names() {
     let state = common::setup().await;
-    let db = state.db.clone();
+    let db = state.writer_db().clone();
     let app = create_test_app!(state);
     let (token, _) = register_and_login!(app);
 

--- a/tests/test_properties.rs
+++ b/tests/test_properties.rs
@@ -92,7 +92,7 @@ async fn test_entity_properties() {
     assert_eq!(resp.status(), 403);
 
     property_repo::upsert(
-        &state.db,
+        state.writer_db(),
         EntityType::File,
         file_id,
         "system.archive_preview",

--- a/tests/test_remote_storage.rs
+++ b/tests/test_remote_storage.rs
@@ -191,7 +191,7 @@ async fn create_remote_policy_with_options(
 ) -> storage_policy::Model {
     let now = Utc::now();
     let policy = policy_repo::create(
-        &state.db,
+        state.writer_db(),
         storage_policy::ActiveModel {
             name: Set(name.to_string()),
             driver_type: Set(DriverType::Remote),
@@ -217,7 +217,7 @@ async fn create_remote_policy_with_options(
 
     state
         .policy_snapshot
-        .reload(&state.db)
+        .reload(state.writer_db())
         .await
         .expect("policy snapshot should reload after creating remote policy");
 
@@ -230,7 +230,7 @@ async fn seed_remote_capabilities(
     capabilities: RemoteStorageCapabilities,
 ) {
     let mut remote_node: aster_drive::entities::managed_follower::ActiveModel =
-        managed_follower_repo::find_by_id(&state.db, remote_node_id)
+        managed_follower_repo::find_by_id(state.writer_db(), remote_node_id)
             .await
             .expect("remote node should exist before seeding capabilities")
             .into();
@@ -240,12 +240,12 @@ async fn seed_remote_capabilities(
     remote_node.last_checked_at = Set(Some(Utc::now()));
     remote_node.updated_at = Set(Utc::now());
     remote_node
-        .update(&state.db)
+        .update(state.writer_db())
         .await
         .expect("remote node capabilities should update");
     state
         .driver_registry
-        .reload_managed_followers(&state.db)
+        .reload_managed_followers(state.writer_db())
         .await
         .expect("driver registry should reload seeded remote capabilities");
     state.driver_registry.invalidate_all();
@@ -260,12 +260,12 @@ async fn set_policy_max_file_size(
     active.max_file_size = Set(max_file_size);
     active.updated_at = Set(Utc::now());
     active
-        .update(&state.db)
+        .update(state.writer_db())
         .await
         .expect("policy max_file_size should update");
     state
         .policy_snapshot
-        .reload(&state.db)
+        .reload(state.writer_db())
         .await
         .expect("policy snapshot should reload after updating max_file_size");
     state.driver_registry.invalidate(policy.id);
@@ -294,16 +294,19 @@ async fn mark_remote_node_enrollment_completed(
     state: &aster_drive::runtime::PrimaryAppState,
     node_id: i64,
 ) {
-    if follower_enrollment_session_repo::has_completed_for_managed_follower(&state.db, node_id)
-        .await
-        .expect("remote node enrollment completion check should succeed")
+    if follower_enrollment_session_repo::has_completed_for_managed_follower(
+        state.writer_db(),
+        node_id,
+    )
+    .await
+    .expect("remote node enrollment completion check should succeed")
     {
         return;
     }
 
     let now = Utc::now();
     follower_enrollment_session_repo::create(
-        &state.db,
+        state.writer_db(),
         follower_enrollment_session::ActiveModel {
             managed_follower_id: Set(node_id),
             token_hash: Set(format!("test-token-{node_id}-{}", uuid::Uuid::new_v4())),
@@ -325,7 +328,7 @@ async fn create_managed_local_ingress_for_binding(
     access_key: &str,
     base_path: &str,
 ) {
-    let binding = master_binding_repo::find_by_access_key(&provider_state.db, access_key)
+    let binding = master_binding_repo::find_by_access_key(&provider_state.writer_db(), access_key)
         .await
         .expect("provider master binding lookup should succeed")
         .expect("provider master binding should exist");
@@ -611,12 +614,12 @@ async fn setup_browser_presigned_cors_fixture(
     .await
     .expect("consumer remote node should be created");
     let consumer_node_model =
-        managed_follower_repo::find_by_id(&consumer_state.db, consumer_node.id)
+        managed_follower_repo::find_by_id(&consumer_state.writer_db(), consumer_node.id)
             .await
             .expect("consumer remote node should be queryable");
 
     master_binding_service::upsert_from_enrollment(
-        &provider_state.db,
+        &provider_state.writer_db(),
         master_binding_service::UpsertMasterBindingInput {
             name: format!("{label}-binding"),
             master_url: master_url.to_string(),
@@ -629,7 +632,7 @@ async fn setup_browser_presigned_cors_fixture(
     .expect("provider master binding should be created");
     provider_state
         .driver_registry
-        .reload_master_bindings(&provider_state.db)
+        .reload_master_bindings(&provider_state.writer_db())
         .await
         .expect("provider binding registry should reload");
     create_managed_local_ingress_for_binding(
@@ -660,7 +663,7 @@ async fn setup_browser_presigned_cors_fixture(
 
     let app = create_test_app!(consumer_state.clone());
     let _ = register_and_login!(app);
-    let user = user_repo::find_by_username(&consumer_state.db, "testuser")
+    let user = user_repo::find_by_username(&consumer_state.writer_db(), "testuser")
         .await
         .expect("test user lookup should succeed")
         .expect("test user should exist");
@@ -722,12 +725,12 @@ async fn test_managed_ingress_profile_handles_remote_writes_without_legacy_bindi
     .await
     .expect("consumer remote node should be created");
     let consumer_node_model =
-        managed_follower_repo::find_by_id(&consumer_state.db, consumer_node.id)
+        managed_follower_repo::find_by_id(&consumer_state.writer_db(), consumer_node.id)
             .await
             .expect("consumer remote node should be queryable");
 
     let (provider_binding, _) = master_binding_service::upsert_from_enrollment(
-        &provider_state.db,
+        &provider_state.writer_db(),
         master_binding_service::UpsertMasterBindingInput {
             name: "managed-ingress-binding".to_string(),
             master_url: "http://master.example.com".to_string(),
@@ -740,7 +743,7 @@ async fn test_managed_ingress_profile_handles_remote_writes_without_legacy_bindi
     .expect("provider binding should be created");
     provider_state
         .driver_registry
-        .reload_master_bindings(&provider_state.db)
+        .reload_master_bindings(&provider_state.writer_db())
         .await
         .expect("provider binding registry should reload");
     create_managed_local_ingress_for_binding(
@@ -804,7 +807,7 @@ async fn test_managed_ingress_profile_api_isolates_multiple_primary_bindings() {
     let provider_server = spawn_internal_storage_server(provider_state.follower_view()).await;
 
     let (binding_a, _) = master_binding_service::upsert_from_enrollment(
-        &provider_state.db,
+        &provider_state.writer_db(),
         master_binding_service::UpsertMasterBindingInput {
             name: "primary-a".to_string(),
             master_url: "http://primary-a.example.com".to_string(),
@@ -816,7 +819,7 @@ async fn test_managed_ingress_profile_api_isolates_multiple_primary_bindings() {
     .await
     .expect("provider binding a should be created");
     let (binding_b, _) = master_binding_service::upsert_from_enrollment(
-        &provider_state.db,
+        &provider_state.writer_db(),
         master_binding_service::UpsertMasterBindingInput {
             name: "primary-b".to_string(),
             master_url: "http://primary-b.example.com".to_string(),
@@ -831,7 +834,7 @@ async fn test_managed_ingress_profile_api_isolates_multiple_primary_bindings() {
 
     provider_state
         .driver_registry
-        .reload_master_bindings(&provider_state.db)
+        .reload_master_bindings(&provider_state.writer_db())
         .await
         .expect("provider binding registry should reload");
 
@@ -964,7 +967,7 @@ async fn test_internal_storage_presigned_put_rejects_payload_exceeding_ingress_l
     let access_key = "limit-access-key";
     let secret_key = "limit-secret-key";
     master_binding_service::upsert_from_enrollment(
-        &provider_state.db,
+        &provider_state.writer_db(),
         master_binding_service::UpsertMasterBindingInput {
             name: "limit-binding".to_string(),
             master_url: "http://master.example.com".to_string(),
@@ -977,7 +980,7 @@ async fn test_internal_storage_presigned_put_rejects_payload_exceeding_ingress_l
     .expect("provider binding should be created");
     provider_state
         .driver_registry
-        .reload_master_bindings(&provider_state.db)
+        .reload_master_bindings(&provider_state.writer_db())
         .await
         .expect("provider binding registry should reload");
     create_managed_local_ingress_for_binding(&provider_state, access_key, access_key).await;
@@ -1023,7 +1026,7 @@ async fn test_internal_storage_presigned_put_ignores_bytes_beyond_declared_conte
     let access_key = "declared-length-access-key";
     let secret_key = "declared-length-secret-key";
     master_binding_service::upsert_from_enrollment(
-        &provider_state.db,
+        &provider_state.writer_db(),
         master_binding_service::UpsertMasterBindingInput {
             name: "declared-length-binding".to_string(),
             master_url: "http://master.example.com".to_string(),
@@ -1036,11 +1039,11 @@ async fn test_internal_storage_presigned_put_ignores_bytes_beyond_declared_conte
     .expect("provider binding should be created");
     provider_state
         .driver_registry
-        .reload_master_bindings(&provider_state.db)
+        .reload_master_bindings(&provider_state.writer_db())
         .await
         .expect("provider binding registry should reload");
     create_managed_local_ingress_for_binding(&provider_state, access_key, access_key).await;
-    let binding = master_binding_repo::find_by_access_key(&provider_state.db, access_key)
+    let binding = master_binding_repo::find_by_access_key(&provider_state.writer_db(), access_key)
         .await
         .expect("provider binding lookup should succeed")
         .expect("provider binding should exist");
@@ -1110,7 +1113,7 @@ async fn test_internal_storage_compose_rejects_expected_size_exceeding_ingress_l
     let access_key = "compose-limit-access-key";
     let secret_key = "compose-limit-secret-key";
     master_binding_service::upsert_from_enrollment(
-        &provider_state.db,
+        &provider_state.writer_db(),
         master_binding_service::UpsertMasterBindingInput {
             name: "compose-limit-binding".to_string(),
             master_url: "http://master.example.com".to_string(),
@@ -1123,7 +1126,7 @@ async fn test_internal_storage_compose_rejects_expected_size_exceeding_ingress_l
     .expect("provider binding should be created");
     provider_state
         .driver_registry
-        .reload_master_bindings(&provider_state.db)
+        .reload_master_bindings(&provider_state.writer_db())
         .await
         .expect("provider binding registry should reload");
     create_managed_local_ingress_for_binding(&provider_state, access_key, access_key).await;
@@ -1198,7 +1201,7 @@ async fn test_remote_node_connection_failure_returns_error_and_persists_last_err
         .expect_err("connection test should surface probe failures");
     assert_eq!(error.code(), "E031");
 
-    let stored = managed_follower_repo::find_by_id(&state.db, node.id)
+    let stored = managed_follower_repo::find_by_id(state.writer_db(), node.id)
         .await
         .expect("remote node should still exist after failed probe");
     assert!(!stored.last_error.is_empty());
@@ -1221,12 +1224,12 @@ async fn test_remote_node_failed_probe_preserves_cached_capabilities() {
     .await
     .expect("consumer remote node should be created");
     let consumer_node_model =
-        managed_follower_repo::find_by_id(&consumer_state.db, consumer_node.id)
+        managed_follower_repo::find_by_id(&consumer_state.writer_db(), consumer_node.id)
             .await
             .expect("consumer remote node should be queryable");
 
     let (provider_binding, _) = master_binding_service::upsert_from_enrollment(
-        &provider_state.db,
+        &provider_state.writer_db(),
         master_binding_service::UpsertMasterBindingInput {
             name: "capability-cache-access".to_string(),
             master_url: "http://master.example.com".to_string(),
@@ -1239,7 +1242,7 @@ async fn test_remote_node_failed_probe_preserves_cached_capabilities() {
     .expect("provider master binding should be created");
     provider_state
         .driver_registry
-        .reload_master_bindings(&provider_state.db)
+        .reload_master_bindings(&provider_state.writer_db())
         .await
         .expect("provider binding registry should reload");
     create_managed_local_ingress_for_binding(
@@ -1251,7 +1254,7 @@ async fn test_remote_node_failed_probe_preserves_cached_capabilities() {
 
     wait_for_remote_probe(&consumer_state, consumer_node.id).await;
     let cached_capabilities =
-        managed_follower_repo::find_by_id(&consumer_state.db, consumer_node.id)
+        managed_follower_repo::find_by_id(&consumer_state.writer_db(), consumer_node.id)
             .await
             .expect("remote node should remain queryable after successful probe")
             .last_capabilities;
@@ -1264,7 +1267,7 @@ async fn test_remote_node_failed_probe_preserves_cached_capabilities() {
         .expect_err("stopped provider should make probe fail");
     assert_eq!(error.code(), "E031");
 
-    let stored = managed_follower_repo::find_by_id(&consumer_state.db, consumer_node.id)
+    let stored = managed_follower_repo::find_by_id(&consumer_state.writer_db(), consumer_node.id)
         .await
         .expect("remote node should remain queryable after failed probe");
     assert!(!stored.last_error.is_empty());
@@ -1305,7 +1308,7 @@ async fn test_remote_node_probe_rejects_incompatible_protocol_version() {
     assert!(error.message().contains("protocol incompatible"));
     assert!(error.message().contains("local supports v2-v2"));
 
-    let stored = managed_follower_repo::find_by_id(&state.db, node.id)
+    let stored = managed_follower_repo::find_by_id(state.writer_db(), node.id)
         .await
         .expect("remote node should remain queryable");
     assert!(stored.last_error.contains("protocol incompatible"));
@@ -1370,7 +1373,7 @@ async fn test_remote_node_probe_rejects_presigned_download_when_range_cors_missi
             .contains("exposed_headers missing Content-Range")
     );
 
-    let stored = managed_follower_repo::find_by_id(&state.db, node.id)
+    let stored = managed_follower_repo::find_by_id(state.writer_db(), node.id)
         .await
         .expect("remote node should remain queryable");
     assert!(
@@ -1394,7 +1397,7 @@ async fn create_internal_hmac_binding(
     let access_key = format!("{label}-access-key");
     let secret_key = format!("{label}-secret-key");
     master_binding_service::upsert_from_enrollment(
-        &provider_state.db,
+        &provider_state.writer_db(),
         master_binding_service::UpsertMasterBindingInput {
             name: format!("{label}-binding"),
             master_url: "http://master.example.com".to_string(),
@@ -1422,7 +1425,7 @@ async fn setup_internal_hmac_binding_state(
     let (access_key, secret_key) = create_internal_hmac_binding(&provider_state, label).await;
     provider_state
         .driver_registry
-        .reload_master_bindings(&provider_state.db)
+        .reload_master_bindings(&provider_state.writer_db())
         .await
         .expect("provider binding registry should reload");
     (provider_state, access_key, secret_key)
@@ -1435,7 +1438,7 @@ async fn test_internal_storage_capabilities_probe_does_not_require_ingress_profi
     let secret_key = "capabilities-no-ingress-secret-key";
 
     master_binding_service::upsert_from_enrollment(
-        &provider_state.db,
+        &provider_state.writer_db(),
         master_binding_service::UpsertMasterBindingInput {
             name: "capabilities-no-ingress-binding".to_string(),
             master_url: "http://master.example.com".to_string(),
@@ -1448,7 +1451,7 @@ async fn test_internal_storage_capabilities_probe_does_not_require_ingress_profi
     .expect("provider binding should be created");
     provider_state
         .driver_registry
-        .reload_master_bindings(&provider_state.db)
+        .reload_master_bindings(&provider_state.writer_db())
         .await
         .expect("provider binding registry should reload");
 
@@ -1573,7 +1576,7 @@ async fn test_internal_storage_hmac_nonce_is_scoped_by_access_key() {
         create_internal_hmac_binding(&provider_state, "capabilities-nonce-scope-b").await;
     provider_state
         .driver_registry
-        .reload_master_bindings(&provider_state.db)
+        .reload_master_bindings(&provider_state.writer_db())
         .await
         .expect("provider binding registry should reload");
 
@@ -1695,12 +1698,12 @@ async fn test_remote_storage_end_to_end_via_internal_api() {
     .await
     .expect("consumer remote node should be created");
     let consumer_node_model =
-        managed_follower_repo::find_by_id(&consumer_state.db, consumer_node.id)
+        managed_follower_repo::find_by_id(&consumer_state.writer_db(), consumer_node.id)
             .await
             .expect("consumer remote node should be queryable");
 
     let (provider_binding, _) = master_binding_service::upsert_from_enrollment(
-        &provider_state.db,
+        &provider_state.writer_db(),
         master_binding_service::UpsertMasterBindingInput {
             name: "consumer-access".to_string(),
             master_url: "http://master.example.com".to_string(),
@@ -1713,7 +1716,7 @@ async fn test_remote_storage_end_to_end_via_internal_api() {
     .expect("provider master binding should be created");
     provider_state
         .driver_registry
-        .reload_master_bindings(&provider_state.db)
+        .reload_master_bindings(&provider_state.writer_db())
         .await
         .expect("provider binding registry should reload");
     create_managed_local_ingress_for_binding(
@@ -1789,12 +1792,13 @@ async fn test_remote_storage_end_to_end_via_internal_api() {
     .expect("remote file upload should succeed");
     aster_drive::utils::cleanup_temp_file(&upload_path_string).await;
 
-    let created_file = file_repo::find_by_id(&consumer_state.db, created.id)
+    let created_file = file_repo::find_by_id(&consumer_state.writer_db(), created.id)
         .await
         .expect("uploaded file should be queryable");
-    let created_blob = file_repo::find_blob_by_id(&consumer_state.db, created_file.blob_id)
-        .await
-        .expect("uploaded blob should be queryable");
+    let created_blob =
+        file_repo::find_blob_by_id(&consumer_state.writer_db(), created_file.blob_id)
+            .await
+            .expect("uploaded blob should be queryable");
 
     assert!(created_blob.hash.starts_with("remote-"));
     assert!(created_blob.storage_path.starts_with("files/"));
@@ -1867,10 +1871,10 @@ async fn test_remote_storage_end_to_end_via_internal_api() {
     )
     .await
     .expect("remote empty file should be created");
-    let empty_file = file_repo::find_by_id(&consumer_state.db, empty_file.id)
+    let empty_file = file_repo::find_by_id(&consumer_state.writer_db(), empty_file.id)
         .await
         .expect("empty remote file should exist");
-    let empty_blob = file_repo::find_blob_by_id(&consumer_state.db, empty_file.blob_id)
+    let empty_blob = file_repo::find_blob_by_id(&consumer_state.writer_db(), empty_file.blob_id)
         .await
         .expect("empty remote blob should exist");
 
@@ -1923,12 +1927,12 @@ async fn test_remote_presigned_download_redirects_to_follower() {
     .await
     .expect("consumer remote node should be created");
     let consumer_node_model =
-        managed_follower_repo::find_by_id(&consumer_state.db, consumer_node.id)
+        managed_follower_repo::find_by_id(&consumer_state.writer_db(), consumer_node.id)
             .await
             .expect("consumer remote node should be queryable");
 
     master_binding_service::upsert_from_enrollment(
-        &provider_state.db,
+        &provider_state.writer_db(),
         master_binding_service::UpsertMasterBindingInput {
             name: "consumer-access".to_string(),
             master_url: "http://master.example.com".to_string(),
@@ -1941,7 +1945,7 @@ async fn test_remote_presigned_download_redirects_to_follower() {
     .expect("provider master binding should be created");
     provider_state
         .driver_registry
-        .reload_master_bindings(&provider_state.db)
+        .reload_master_bindings(&provider_state.writer_db())
         .await
         .expect("provider binding registry should reload");
     create_managed_local_ingress_for_binding(
@@ -1968,7 +1972,7 @@ async fn test_remote_presigned_download_redirects_to_follower() {
 
     let app = create_test_app!(consumer_state.clone());
     let (token, _) = register_and_login!(app);
-    let user = user_repo::find_by_username(&consumer_state.db, "testuser")
+    let user = user_repo::find_by_username(&consumer_state.writer_db(), "testuser")
         .await
         .expect("test user lookup should succeed")
         .expect("test user should exist");
@@ -2113,12 +2117,12 @@ async fn test_disabling_remote_node_syncs_follower_binding_and_blocks_remote_use
     .await
     .expect("consumer remote node should be created");
     let consumer_node_model =
-        managed_follower_repo::find_by_id(&consumer_state.db, consumer_node.id)
+        managed_follower_repo::find_by_id(&consumer_state.writer_db(), consumer_node.id)
             .await
             .expect("consumer remote node should be queryable");
 
     master_binding_service::upsert_from_enrollment(
-        &provider_state.db,
+        &provider_state.writer_db(),
         master_binding_service::UpsertMasterBindingInput {
             name: "consumer-access".to_string(),
             master_url: "http://master.example.com".to_string(),
@@ -2131,7 +2135,7 @@ async fn test_disabling_remote_node_syncs_follower_binding_and_blocks_remote_use
     .expect("provider master binding should be created");
     provider_state
         .driver_registry
-        .reload_master_bindings(&provider_state.db)
+        .reload_master_bindings(&provider_state.writer_db())
         .await
         .expect("provider binding registry should reload");
     create_managed_local_ingress_for_binding(
@@ -2155,7 +2159,7 @@ async fn test_disabling_remote_node_syncs_follower_binding_and_blocks_remote_use
     .expect("disabling remote node should succeed");
 
     let provider_binding = master_binding_repo::find_by_access_key(
-        &provider_state.db,
+        &provider_state.writer_db(),
         &consumer_node_model.access_key,
     )
     .await
@@ -2236,12 +2240,12 @@ async fn test_saved_remote_node_connection_endpoint_returns_precondition_failed_
     .await
     .expect("consumer remote node should be created");
     let consumer_node_model =
-        managed_follower_repo::find_by_id(&consumer_state.db, consumer_node.id)
+        managed_follower_repo::find_by_id(&consumer_state.writer_db(), consumer_node.id)
             .await
             .expect("consumer remote node should be queryable");
 
     master_binding_service::upsert_from_enrollment(
-        &provider_state.db,
+        &provider_state.writer_db(),
         master_binding_service::UpsertMasterBindingInput {
             name: "consumer-access".to_string(),
             master_url: "http://master.example.com".to_string(),
@@ -2254,7 +2258,7 @@ async fn test_saved_remote_node_connection_endpoint_returns_precondition_failed_
     .expect("provider master binding should be created");
     provider_state
         .driver_registry
-        .reload_master_bindings(&provider_state.db)
+        .reload_master_bindings(&provider_state.writer_db())
         .await
         .expect("provider binding registry should reload");
     create_managed_local_ingress_for_binding(
@@ -2333,9 +2337,10 @@ async fn test_disabled_remote_nodes_skip_network_during_health_checks() {
         "disabled remote nodes should not send health-check traffic",
     );
 
-    let remote_node_model = managed_follower_repo::find_by_id(&consumer_state.db, remote_node.id)
-        .await
-        .expect("disabled remote node should remain queryable");
+    let remote_node_model =
+        managed_follower_repo::find_by_id(&consumer_state.writer_db(), remote_node.id)
+            .await
+            .expect("disabled remote node should remain queryable");
     assert_eq!(remote_node_model.last_checked_at, None);
 
     provider_server.stop().await;
@@ -2373,9 +2378,10 @@ async fn test_pending_remote_nodes_skip_network_during_health_checks() {
         "pending remote nodes should not send health-check traffic",
     );
 
-    let remote_node_model = managed_follower_repo::find_by_id(&consumer_state.db, remote_node.id)
-        .await
-        .expect("pending remote node should remain queryable");
+    let remote_node_model =
+        managed_follower_repo::find_by_id(&consumer_state.writer_db(), remote_node.id)
+            .await
+            .expect("pending remote node should remain queryable");
     assert_eq!(remote_node_model.last_checked_at, None);
     assert_eq!(
         remote_node_model.last_error, "",
@@ -2421,9 +2427,10 @@ async fn test_pending_remote_node_connection_test_requires_completed_enrollment_
         "pending remote node connection tests should not send network traffic",
     );
 
-    let remote_node_model = managed_follower_repo::find_by_id(&consumer_state.db, remote_node.id)
-        .await
-        .expect("pending remote node should remain queryable");
+    let remote_node_model =
+        managed_follower_repo::find_by_id(&consumer_state.writer_db(), remote_node.id)
+            .await
+            .expect("pending remote node should remain queryable");
     assert_eq!(remote_node_model.last_checked_at, None);
     assert_eq!(remote_node_model.last_error, "");
 
@@ -2488,12 +2495,13 @@ async fn test_health_checks_only_touch_enabled_remote_nodes_in_mixed_sets() {
     )
     .await
     .expect("enabled remote node should be created");
-    let enabled_node_model = managed_follower_repo::find_by_id(&consumer_state.db, enabled_node.id)
-        .await
-        .expect("enabled remote node should be queryable");
+    let enabled_node_model =
+        managed_follower_repo::find_by_id(&consumer_state.writer_db(), enabled_node.id)
+            .await
+            .expect("enabled remote node should be queryable");
 
     master_binding_service::upsert_from_enrollment(
-        &provider_state.db,
+        &provider_state.writer_db(),
         master_binding_service::UpsertMasterBindingInput {
             name: "enabled-health-check-access".to_string(),
             master_url: "http://master.example.com".to_string(),
@@ -2506,7 +2514,7 @@ async fn test_health_checks_only_touch_enabled_remote_nodes_in_mixed_sets() {
     .expect("provider binding for enabled node should be created");
     provider_state
         .driver_registry
-        .reload_master_bindings(&provider_state.db)
+        .reload_master_bindings(&provider_state.writer_db())
         .await
         .expect("provider binding registry should reload");
     create_managed_local_ingress_for_binding(
@@ -2547,11 +2555,12 @@ async fn test_health_checks_only_touch_enabled_remote_nodes_in_mixed_sets() {
         "disabled remote node should not send any health-check traffic",
     );
 
-    let enabled_node_model = managed_follower_repo::find_by_id(&consumer_state.db, enabled_node.id)
-        .await
-        .expect("enabled remote node should remain queryable");
+    let enabled_node_model =
+        managed_follower_repo::find_by_id(&consumer_state.writer_db(), enabled_node.id)
+            .await
+            .expect("enabled remote node should remain queryable");
     let disabled_node_model =
-        managed_follower_repo::find_by_id(&consumer_state.db, disabled_node.id)
+        managed_follower_repo::find_by_id(&consumer_state.writer_db(), disabled_node.id)
             .await
             .expect("disabled remote node should remain queryable");
     assert!(enabled_node_model.last_checked_at.is_some());
@@ -2578,12 +2587,12 @@ async fn test_thumbnail_endpoint_returns_precondition_failed_when_remote_node_di
     .await
     .expect("consumer remote node should be created");
     let consumer_node_model =
-        managed_follower_repo::find_by_id(&consumer_state.db, consumer_node.id)
+        managed_follower_repo::find_by_id(&consumer_state.writer_db(), consumer_node.id)
             .await
             .expect("consumer remote node should be queryable");
 
     master_binding_service::upsert_from_enrollment(
-        &provider_state.db,
+        &provider_state.writer_db(),
         master_binding_service::UpsertMasterBindingInput {
             name: "consumer-access".to_string(),
             master_url: "http://master.example.com".to_string(),
@@ -2596,7 +2605,7 @@ async fn test_thumbnail_endpoint_returns_precondition_failed_when_remote_node_di
     .expect("provider master binding should be created");
     provider_state
         .driver_registry
-        .reload_master_bindings(&provider_state.db)
+        .reload_master_bindings(&provider_state.writer_db())
         .await
         .expect("provider binding registry should reload");
     create_managed_local_ingress_for_binding(
@@ -2618,7 +2627,7 @@ async fn test_thumbnail_endpoint_returns_precondition_failed_when_remote_node_di
 
     let app = create_test_app!(consumer_state.clone());
     let (token, _) = register_and_login!(app);
-    let user = user_repo::find_by_username(&consumer_state.db, "testuser")
+    let user = user_repo::find_by_username(&consumer_state.writer_db(), "testuser")
         .await
         .expect("test user lookup should succeed")
         .expect("test user should exist");
@@ -2659,12 +2668,13 @@ async fn test_thumbnail_endpoint_returns_precondition_failed_when_remote_node_di
     .expect("remote thumbnail source upload should succeed");
     aster_drive::utils::cleanup_temp_file(&upload_path_string).await;
 
-    let created_file = file_repo::find_by_id(&consumer_state.db, created.id)
+    let created_file = file_repo::find_by_id(&consumer_state.writer_db(), created.id)
         .await
         .expect("uploaded file should be queryable");
-    let created_blob = file_repo::find_blob_by_id(&consumer_state.db, created_file.blob_id)
-        .await
-        .expect("uploaded blob should be queryable");
+    let created_blob =
+        file_repo::find_blob_by_id(&consumer_state.writer_db(), created_file.blob_id)
+            .await
+            .expect("uploaded blob should be queryable");
     aster_drive::services::media_processing_service::generate_and_store_thumbnail(
         &consumer_state,
         &created_blob,
@@ -2716,12 +2726,12 @@ async fn test_remote_presigned_upload_writes_directly_to_provider() {
     .await
     .expect("consumer remote node should be created");
     let consumer_node_model =
-        managed_follower_repo::find_by_id(&consumer_state.db, consumer_node.id)
+        managed_follower_repo::find_by_id(&consumer_state.writer_db(), consumer_node.id)
             .await
             .expect("consumer remote node should be queryable");
 
     let (provider_binding, _) = master_binding_service::upsert_from_enrollment(
-        &provider_state.db,
+        &provider_state.writer_db(),
         master_binding_service::UpsertMasterBindingInput {
             name: "consumer-access".to_string(),
             master_url: "http://master.example.com".to_string(),
@@ -2734,7 +2744,7 @@ async fn test_remote_presigned_upload_writes_directly_to_provider() {
     .expect("provider master binding should be created");
     provider_state
         .driver_registry
-        .reload_master_bindings(&provider_state.db)
+        .reload_master_bindings(&provider_state.writer_db())
         .await
         .expect("provider binding registry should reload");
     create_managed_local_ingress_for_binding(
@@ -2761,7 +2771,7 @@ async fn test_remote_presigned_upload_writes_directly_to_provider() {
 
     let app = create_test_app!(consumer_state.clone());
     let _ = register_and_login!(app);
-    let user = user_repo::find_by_username(&consumer_state.db, "testuser")
+    let user = user_repo::find_by_username(&consumer_state.writer_db(), "testuser")
         .await
         .expect("test user lookup should succeed")
         .expect("test user should exist");
@@ -2805,7 +2815,7 @@ async fn test_remote_presigned_upload_writes_directly_to_provider() {
         response.headers().get(reqwest::header::ETAG).is_some(),
         "remote presigned upload should return ETag header"
     );
-    let session = upload_session_repo::find_by_id(&consumer_state.db, &upload_id)
+    let session = upload_session_repo::find_by_id(&consumer_state.writer_db(), &upload_id)
         .await
         .expect("upload session should exist");
     let temp_key = session
@@ -2850,12 +2860,13 @@ async fn test_remote_presigned_upload_writes_directly_to_provider() {
     let created = upload_service::complete_upload(&consumer_state, &upload_id, user.id, None)
         .await
         .expect("remote presigned upload should complete");
-    let created_file = file_repo::find_by_id(&consumer_state.db, created.id)
+    let created_file = file_repo::find_by_id(&consumer_state.writer_db(), created.id)
         .await
         .expect("uploaded file should be queryable");
-    let created_blob = file_repo::find_blob_by_id(&consumer_state.db, created_file.blob_id)
-        .await
-        .expect("uploaded blob should be queryable");
+    let created_blob =
+        file_repo::find_blob_by_id(&consumer_state.writer_db(), created_file.blob_id)
+            .await
+            .expect("uploaded blob should be queryable");
     assert_ne!(
         created_blob.storage_path, temp_key,
         "completed remote presigned uploads must be copied away from the still-valid PUT key"
@@ -2906,12 +2917,12 @@ async fn test_force_delete_policy_cleans_late_remote_presigned_put_e2e() {
     .await
     .expect("consumer remote node should be created");
     let consumer_node_model =
-        managed_follower_repo::find_by_id(&consumer_state.db, consumer_node.id)
+        managed_follower_repo::find_by_id(&consumer_state.writer_db(), consumer_node.id)
             .await
             .expect("consumer remote node should be queryable");
 
     let (provider_binding, _) = master_binding_service::upsert_from_enrollment(
-        &provider_state.db,
+        &provider_state.writer_db(),
         master_binding_service::UpsertMasterBindingInput {
             name: "late-presigned-consumer-access".to_string(),
             master_url: "http://master.example.com".to_string(),
@@ -2924,7 +2935,7 @@ async fn test_force_delete_policy_cleans_late_remote_presigned_put_e2e() {
     .expect("provider master binding should be created");
     provider_state
         .driver_registry
-        .reload_master_bindings(&provider_state.db)
+        .reload_master_bindings(&provider_state.writer_db())
         .await
         .expect("provider binding registry should reload");
     create_managed_local_ingress_for_binding(
@@ -2950,7 +2961,7 @@ async fn test_force_delete_policy_cleans_late_remote_presigned_put_e2e() {
 
     let app = create_test_app!(consumer_state.clone());
     let _ = register_and_login!(app);
-    let user = user_repo::find_by_username(&consumer_state.db, "testuser")
+    let user = user_repo::find_by_username(&consumer_state.writer_db(), "testuser")
         .await
         .expect("test user lookup should succeed")
         .expect("test user should exist");
@@ -2987,7 +2998,7 @@ async fn test_force_delete_policy_cleans_late_remote_presigned_put_e2e() {
         .presigned_url
         .clone()
         .expect("presigned mode should return presigned_url");
-    let session = upload_session_repo::find_by_id(&consumer_state.db, &upload_id)
+    let session = upload_session_repo::find_by_id(&consumer_state.writer_db(), &upload_id)
         .await
         .expect("upload session should exist");
     let temp_key = session
@@ -3012,13 +3023,13 @@ async fn test_force_delete_policy_cleans_late_remote_presigned_put_e2e() {
         .await
         .expect("force deleting remote policy with pending presigned session should succeed");
     assert!(
-        policy_repo::find_by_id(&consumer_state.db, remote_policy.id)
+        policy_repo::find_by_id(&consumer_state.writer_db(), remote_policy.id)
             .await
             .is_err(),
         "remote policy should be deleted"
     );
     assert!(
-        upload_session_repo::find_by_id(&consumer_state.db, &upload_id)
+        upload_session_repo::find_by_id(&consumer_state.writer_db(), &upload_id)
             .await
             .is_err(),
         "force delete should remove the remote upload session before the old URL expires"
@@ -3037,14 +3048,14 @@ async fn test_force_delete_policy_cleans_late_remote_presigned_put_e2e() {
 
     let cleanup_task = background_task::Entity::find()
         .filter(background_task::Column::Kind.eq(BackgroundTaskKind::StoragePolicyTempCleanup))
-        .one(&consumer_state.db)
+        .one(&consumer_state.writer_db())
         .await
         .expect("cleanup task query should succeed")
         .expect("force delete should schedule delayed cleanup");
     assert_eq!(cleanup_task.status, BackgroundTaskStatus::Pending);
     let mut due_task: background_task::ActiveModel = cleanup_task.clone().into();
     due_task.next_run_at = Set(Utc::now() - ChronoDuration::seconds(1));
-    due_task.update(&consumer_state.db).await.unwrap();
+    due_task.update(&consumer_state.writer_db()).await.unwrap();
 
     let stats = task_service::dispatch_due(&consumer_state)
         .await
@@ -3057,9 +3068,10 @@ async fn test_force_delete_policy_cleans_late_remote_presigned_put_e2e() {
             .expect("provider temp path existence should be readable after cleanup"),
         "delayed cleanup should delete the late remote temp object"
     );
-    let stored_task = background_task_repo::find_by_id(&consumer_state.db, cleanup_task.id)
-        .await
-        .expect("cleanup task should remain queryable");
+    let stored_task =
+        background_task_repo::find_by_id(&consumer_state.writer_db(), cleanup_task.id)
+            .await
+            .expect("cleanup task should remain queryable");
     assert_eq!(stored_task.status, BackgroundTaskStatus::Succeeded);
 
     provider_server.stop().await;
@@ -3082,12 +3094,12 @@ async fn test_remote_relay_stream_direct_upload_e2e() {
     .await
     .expect("consumer remote node should be created");
     let consumer_node_model =
-        managed_follower_repo::find_by_id(&consumer_state.db, consumer_node.id)
+        managed_follower_repo::find_by_id(&consumer_state.writer_db(), consumer_node.id)
             .await
             .expect("consumer remote node should be queryable");
 
     let (provider_binding, _) = master_binding_service::upsert_from_enrollment(
-        &provider_state.db,
+        &provider_state.writer_db(),
         master_binding_service::UpsertMasterBindingInput {
             name: "consumer-access".to_string(),
             master_url: "http://master.example.com".to_string(),
@@ -3100,7 +3112,7 @@ async fn test_remote_relay_stream_direct_upload_e2e() {
     .expect("provider master binding should be created");
     provider_state
         .driver_registry
-        .reload_master_bindings(&provider_state.db)
+        .reload_master_bindings(&provider_state.writer_db())
         .await
         .expect("provider binding registry should reload");
     create_managed_local_ingress_for_binding(
@@ -3200,12 +3212,13 @@ async fn test_remote_relay_stream_direct_upload_e2e() {
         "remote relay direct upload should not create local temp files or upload temp dirs"
     );
 
-    let created_file = file_repo::find_by_id(&consumer_state.db, file_id)
+    let created_file = file_repo::find_by_id(&consumer_state.writer_db(), file_id)
         .await
         .expect("uploaded file should be queryable");
-    let created_blob = file_repo::find_blob_by_id(&consumer_state.db, created_file.blob_id)
-        .await
-        .expect("uploaded blob should be queryable");
+    let created_blob =
+        file_repo::find_blob_by_id(&consumer_state.writer_db(), created_file.blob_id)
+            .await
+            .expect("uploaded blob should be queryable");
     assert!(created_blob.hash.starts_with("remote-"));
     assert!(created_blob.storage_path.starts_with("files/"));
 
@@ -3240,12 +3253,12 @@ async fn test_remote_presigned_upload_browser_cors_follows_bound_master_origin()
     .await
     .expect("consumer remote node should be created");
     let consumer_node_model =
-        managed_follower_repo::find_by_id(&consumer_state.db, consumer_node.id)
+        managed_follower_repo::find_by_id(&consumer_state.writer_db(), consumer_node.id)
             .await
             .expect("consumer remote node should be queryable");
 
     master_binding_service::upsert_from_enrollment(
-        &provider_state.db,
+        &provider_state.writer_db(),
         master_binding_service::UpsertMasterBindingInput {
             name: "consumer-access".to_string(),
             master_url: "http://localhost:3000".to_string(),
@@ -3258,7 +3271,7 @@ async fn test_remote_presigned_upload_browser_cors_follows_bound_master_origin()
     .expect("provider master binding should be created");
     provider_state
         .driver_registry
-        .reload_master_bindings(&provider_state.db)
+        .reload_master_bindings(&provider_state.writer_db())
         .await
         .expect("provider binding registry should reload");
     create_managed_local_ingress_for_binding(
@@ -3289,7 +3302,7 @@ async fn test_remote_presigned_upload_browser_cors_follows_bound_master_origin()
 
     let app = create_test_app!(consumer_state.clone());
     let _ = register_and_login!(app);
-    let user = user_repo::find_by_username(&consumer_state.db, "testuser")
+    let user = user_repo::find_by_username(&consumer_state.writer_db(), "testuser")
         .await
         .expect("test user lookup should succeed")
         .expect("test user should exist");
@@ -3476,12 +3489,12 @@ async fn test_remote_presigned_download_browser_cors_allows_get() {
     .await
     .expect("consumer remote node should be created");
     let consumer_node_model =
-        managed_follower_repo::find_by_id(&consumer_state.db, consumer_node.id)
+        managed_follower_repo::find_by_id(&consumer_state.writer_db(), consumer_node.id)
             .await
             .expect("consumer remote node should be queryable");
 
     master_binding_service::upsert_from_enrollment(
-        &provider_state.db,
+        &provider_state.writer_db(),
         master_binding_service::UpsertMasterBindingInput {
             name: "consumer-access".to_string(),
             master_url: "http://localhost:3000".to_string(),
@@ -3494,7 +3507,7 @@ async fn test_remote_presigned_download_browser_cors_allows_get() {
     .expect("provider master binding should be created");
     provider_state
         .driver_registry
-        .reload_master_bindings(&provider_state.db)
+        .reload_master_bindings(&provider_state.writer_db())
         .await
         .expect("provider binding registry should reload");
     create_managed_local_ingress_for_binding(
@@ -3525,7 +3538,7 @@ async fn test_remote_presigned_download_browser_cors_allows_get() {
 
     let app = create_test_app!(consumer_state.clone());
     let _ = register_and_login!(app);
-    let user = user_repo::find_by_username(&consumer_state.db, "testuser")
+    let user = user_repo::find_by_username(&consumer_state.writer_db(), "testuser")
         .await
         .expect("test user lookup should succeed")
         .expect("test user should exist");
@@ -3675,7 +3688,7 @@ async fn test_internal_storage_get_honors_range_header() {
     let body = b"0123456789abcdef";
 
     master_binding_service::upsert_from_enrollment(
-        &provider_state.db,
+        &provider_state.writer_db(),
         master_binding_service::UpsertMasterBindingInput {
             name: "range-header-binding".to_string(),
             master_url: "http://master.example.com".to_string(),
@@ -3688,11 +3701,11 @@ async fn test_internal_storage_get_honors_range_header() {
     .expect("provider binding should be created");
     provider_state
         .driver_registry
-        .reload_master_bindings(&provider_state.db)
+        .reload_master_bindings(&provider_state.writer_db())
         .await
         .expect("provider binding registry should reload");
     create_managed_local_ingress_for_binding(&provider_state, access_key, access_key).await;
-    let binding = master_binding_repo::find_by_access_key(&provider_state.db, access_key)
+    let binding = master_binding_repo::find_by_access_key(&provider_state.writer_db(), access_key)
         .await
         .expect("provider binding lookup should succeed")
         .expect("provider binding should exist");
@@ -3777,12 +3790,12 @@ async fn test_remote_relay_stream_chunked_upload_e2e() {
     .await
     .expect("consumer remote node should be created");
     let consumer_node_model =
-        managed_follower_repo::find_by_id(&consumer_state.db, consumer_node.id)
+        managed_follower_repo::find_by_id(&consumer_state.writer_db(), consumer_node.id)
             .await
             .expect("consumer remote node should be queryable");
 
     let (provider_binding, _) = master_binding_service::upsert_from_enrollment(
-        &provider_state.db,
+        &provider_state.writer_db(),
         master_binding_service::UpsertMasterBindingInput {
             name: "consumer-access".to_string(),
             master_url: "http://master.example.com".to_string(),
@@ -3795,7 +3808,7 @@ async fn test_remote_relay_stream_chunked_upload_e2e() {
     .expect("provider master binding should be created");
     provider_state
         .driver_registry
-        .reload_master_bindings(&provider_state.db)
+        .reload_master_bindings(&provider_state.writer_db())
         .await
         .expect("provider binding registry should reload");
     create_managed_local_ingress_for_binding(
@@ -3865,7 +3878,7 @@ async fn test_remote_relay_stream_chunked_upload_e2e() {
         .upload_id
         .clone()
         .expect("chunked mode should return upload id");
-    let session = upload_session_repo::find_by_id(&consumer_state.db, &upload_id)
+    let session = upload_session_repo::find_by_id(&consumer_state.writer_db(), &upload_id)
         .await
         .expect("upload session should exist");
     let remote_multipart_id = session
@@ -3898,7 +3911,7 @@ async fn test_remote_relay_stream_chunked_upload_e2e() {
         "remote relay multipart should not create local upload temp dir"
     );
     assert!(
-        upload_session_part_repo::list_by_upload(&consumer_state.db, &upload_id)
+        upload_session_part_repo::list_by_upload(&consumer_state.writer_db(), &upload_id)
             .await
             .expect("multipart parts should be queryable")
             .is_empty()
@@ -3933,7 +3946,7 @@ async fn test_remote_relay_stream_chunked_upload_e2e() {
     assert_eq!(error_body["error"]["internal_code"], "E024");
     assert_eq!(error_body["error"]["subcode"], "upload.chunk_too_large");
     assert!(
-        upload_session_part_repo::list_by_upload(&consumer_state.db, &oversized_upload_id)
+        upload_session_part_repo::list_by_upload(&consumer_state.writer_db(), &oversized_upload_id)
             .await
             .expect("multipart parts should be queryable")
             .is_empty(),
@@ -3976,7 +3989,7 @@ async fn test_remote_relay_stream_chunked_upload_e2e() {
         .expect("remote relay upload progress should be queryable");
     assert_eq!(progress.chunks_on_disk, vec![0]);
 
-    let parts = upload_session_part_repo::list_by_upload(&consumer_state.db, &upload_id)
+    let parts = upload_session_part_repo::list_by_upload(&consumer_state.writer_db(), &upload_id)
         .await
         .expect("remote relay multipart parts should be queryable");
     assert_eq!(parts.len(), 1);
@@ -4011,12 +4024,13 @@ async fn test_remote_relay_stream_chunked_upload_e2e() {
     let created = upload_service::complete_upload(&consumer_state, &upload_id, user.id, None)
         .await
         .expect("remote relay multipart upload should complete");
-    let created_file = file_repo::find_by_id(&consumer_state.db, created.id)
+    let created_file = file_repo::find_by_id(&consumer_state.writer_db(), created.id)
         .await
         .expect("uploaded file should be queryable");
-    let created_blob = file_repo::find_blob_by_id(&consumer_state.db, created_file.blob_id)
-        .await
-        .expect("uploaded blob should be queryable");
+    let created_blob =
+        file_repo::find_blob_by_id(&consumer_state.writer_db(), created_file.blob_id)
+            .await
+            .expect("uploaded blob should be queryable");
     assert_eq!(created_blob.storage_path, format!("files/{upload_id}"));
 
     let stored_path = managed_ingress_object_path(
@@ -4077,12 +4091,12 @@ async fn test_remote_presigned_upload_browser_cors_accepts_master_url_with_path_
     .await
     .expect("consumer remote node should be created");
     let consumer_node_model =
-        managed_follower_repo::find_by_id(&consumer_state.db, consumer_node.id)
+        managed_follower_repo::find_by_id(&consumer_state.writer_db(), consumer_node.id)
             .await
             .expect("consumer remote node should be queryable");
 
     master_binding_service::upsert_from_enrollment(
-        &provider_state.db,
+        &provider_state.writer_db(),
         master_binding_service::UpsertMasterBindingInput {
             name: "consumer-access".to_string(),
             master_url: "http://localhost:3000/admin/settings/general".to_string(),
@@ -4095,7 +4109,7 @@ async fn test_remote_presigned_upload_browser_cors_accepts_master_url_with_path_
     .expect("provider master binding should be created");
     provider_state
         .driver_registry
-        .reload_master_bindings(&provider_state.db)
+        .reload_master_bindings(&provider_state.writer_db())
         .await
         .expect("provider binding registry should reload");
     create_managed_local_ingress_for_binding(
@@ -4126,7 +4140,7 @@ async fn test_remote_presigned_upload_browser_cors_accepts_master_url_with_path_
 
     let app = create_test_app!(consumer_state.clone());
     let _ = register_and_login!(app);
-    let user = user_repo::find_by_username(&consumer_state.db, "testuser")
+    let user = user_repo::find_by_username(&consumer_state.writer_db(), "testuser")
         .await
         .expect("test user lookup should succeed")
         .expect("test user should exist");
@@ -4203,12 +4217,12 @@ async fn test_remote_presigned_upload_browser_cors_rejects_disabled_binding() {
     .await
     .expect("consumer remote node should be created");
     let consumer_node_model =
-        managed_follower_repo::find_by_id(&consumer_state.db, consumer_node.id)
+        managed_follower_repo::find_by_id(&consumer_state.writer_db(), consumer_node.id)
             .await
             .expect("consumer remote node should be queryable");
 
     let binding = master_binding_service::upsert_from_enrollment(
-        &provider_state.db,
+        &provider_state.writer_db(),
         master_binding_service::UpsertMasterBindingInput {
             name: "consumer-access".to_string(),
             master_url: "http://localhost:3000".to_string(),
@@ -4222,7 +4236,7 @@ async fn test_remote_presigned_upload_browser_cors_rejects_disabled_binding() {
     .0;
     provider_state
         .driver_registry
-        .reload_master_bindings(&provider_state.db)
+        .reload_master_bindings(&provider_state.writer_db())
         .await
         .expect("provider binding registry should reload");
     create_managed_local_ingress_for_binding(
@@ -4253,7 +4267,7 @@ async fn test_remote_presigned_upload_browser_cors_rejects_disabled_binding() {
 
     let app = create_test_app!(consumer_state.clone());
     let _ = register_and_login!(app);
-    let user = user_repo::find_by_username(&consumer_state.db, "testuser")
+    let user = user_repo::find_by_username(&consumer_state.writer_db(), "testuser")
         .await
         .expect("test user lookup should succeed")
         .expect("test user should exist");
@@ -4655,12 +4669,12 @@ async fn test_remote_presigned_multipart_upload_composes_on_provider_without_ass
     .await
     .expect("consumer remote node should be created");
     let consumer_node_model =
-        managed_follower_repo::find_by_id(&consumer_state.db, consumer_node.id)
+        managed_follower_repo::find_by_id(&consumer_state.writer_db(), consumer_node.id)
             .await
             .expect("consumer remote node should be queryable");
 
     let (provider_binding, _) = master_binding_service::upsert_from_enrollment(
-        &provider_state.db,
+        &provider_state.writer_db(),
         master_binding_service::UpsertMasterBindingInput {
             name: "consumer-access".to_string(),
             master_url: "http://master.example.com".to_string(),
@@ -4673,7 +4687,7 @@ async fn test_remote_presigned_multipart_upload_composes_on_provider_without_ass
     .expect("provider master binding should be created");
     provider_state
         .driver_registry
-        .reload_master_bindings(&provider_state.db)
+        .reload_master_bindings(&provider_state.writer_db())
         .await
         .expect("provider binding registry should reload");
     create_managed_local_ingress_for_binding(
@@ -4700,7 +4714,7 @@ async fn test_remote_presigned_multipart_upload_composes_on_provider_without_ass
 
     let app = create_test_app!(consumer_state.clone());
     let _ = register_and_login!(app);
-    let user = user_repo::find_by_username(&consumer_state.db, "testuser")
+    let user = user_repo::find_by_username(&consumer_state.writer_db(), "testuser")
         .await
         .expect("test user lookup should succeed")
         .expect("test user should exist");
@@ -4739,7 +4753,7 @@ async fn test_remote_presigned_multipart_upload_composes_on_provider_without_ass
         .upload_id
         .clone()
         .expect("presigned multipart mode should return upload id");
-    let session = upload_session_repo::find_by_id(&consumer_state.db, &upload_id)
+    let session = upload_session_repo::find_by_id(&consumer_state.writer_db(), &upload_id)
         .await
         .expect("upload session should exist");
     let remote_multipart_id = session
@@ -4823,12 +4837,13 @@ async fn test_remote_presigned_multipart_upload_composes_on_provider_without_ass
     )
     .await
     .expect("remote presigned multipart upload should complete");
-    let created_file = file_repo::find_by_id(&consumer_state.db, created.id)
+    let created_file = file_repo::find_by_id(&consumer_state.writer_db(), created.id)
         .await
         .expect("uploaded file should be queryable");
-    let created_blob = file_repo::find_blob_by_id(&consumer_state.db, created_file.blob_id)
-        .await
-        .expect("uploaded blob should be queryable");
+    let created_blob =
+        file_repo::find_blob_by_id(&consumer_state.writer_db(), created_file.blob_id)
+            .await
+            .expect("uploaded blob should be queryable");
 
     let stored_path = managed_ingress_object_path(
         &provider_state,

--- a/tests/test_search.rs
+++ b/tests/test_search.rs
@@ -728,7 +728,7 @@ async fn test_search_excludes_deleted() {
 #[actix_web::test]
 async fn test_search_only_own_files() {
     let state = common::setup().await;
-    let db = state.db.clone();
+    let db = state.writer_db().clone();
     let mail_sender = state.mail_sender.clone();
     let runtime_config = state.runtime_config.clone();
     let app = create_test_app!(state);

--- a/tests/test_security_fixes.rs
+++ b/tests/test_security_fixes.rs
@@ -61,7 +61,7 @@ macro_rules! register_user2 {
 #[actix_web::test]
 async fn test_upload_to_other_users_folder_returns_403() {
     let state = common::setup().await;
-    let db = state.db.clone();
+    let db = state.writer_db().clone();
     let mail_sender = state.mail_sender.clone();
     let app = create_test_app!(state);
     let (token1, _) = register_and_login!(app);
@@ -108,7 +108,7 @@ async fn test_upload_to_other_users_folder_returns_403() {
 #[actix_web::test]
 async fn test_init_upload_to_other_users_folder_returns_403() {
     let state = common::setup().await;
-    let db = state.db.clone();
+    let db = state.writer_db().clone();
     let mail_sender = state.mail_sender.clone();
     let app = create_test_app!(state);
     let (token1, _) = register_and_login!(app);
@@ -148,7 +148,7 @@ async fn test_init_upload_to_other_users_folder_returns_403() {
 #[actix_web::test]
 async fn test_directory_upload_to_other_users_base_folder_returns_403() {
     let state = common::setup().await;
-    let db = state.db.clone();
+    let db = state.writer_db().clone();
     let mail_sender = state.mail_sender.clone();
     let app = create_test_app!(state);
     let (token1, _) = register_and_login!(app);
@@ -199,7 +199,7 @@ async fn test_directory_upload_to_other_users_base_folder_returns_403() {
 #[actix_web::test]
 async fn test_create_folder_in_other_users_folder_returns_403() {
     let state = common::setup().await;
-    let db = state.db.clone();
+    let db = state.writer_db().clone();
     let mail_sender = state.mail_sender.clone();
     let app = create_test_app!(state);
     let (token1, _) = register_and_login!(app);

--- a/tests/test_services.rs
+++ b/tests/test_services.rs
@@ -78,7 +78,7 @@ async fn store_service_file(
 }
 
 async fn user_storage_used(state: &aster_drive::runtime::PrimaryAppState, user_id: i64) -> i64 {
-    aster_drive::db::repository::user_repo::find_by_id(&state.db, user_id)
+    aster_drive::db::repository::user_repo::find_by_id(state.writer_db(), user_id)
         .await
         .unwrap()
         .storage_used
@@ -90,16 +90,17 @@ async fn wait_for_share_download_count(
     expected: i64,
 ) {
     for _ in 0..40 {
-        let reloaded = aster_drive::db::repository::share_repo::find_by_id(&state.db, share_id)
-            .await
-            .unwrap();
+        let reloaded =
+            aster_drive::db::repository::share_repo::find_by_id(state.writer_db(), share_id)
+                .await
+                .unwrap();
         if reloaded.download_count == expected {
             return;
         }
         tokio::time::sleep(std::time::Duration::from_millis(25)).await;
     }
 
-    let reloaded = aster_drive::db::repository::share_repo::find_by_id(&state.db, share_id)
+    let reloaded = aster_drive::db::repository::share_repo::find_by_id(state.writer_db(), share_id)
         .await
         .unwrap();
     panic!(
@@ -334,12 +335,12 @@ async fn test_file_active_model_partial_name_update_refreshes_classification() {
         name: Set("backup.tar.gz".to_string()),
         ..Default::default()
     }
-    .update(&state.db)
+    .update(state.writer_db())
     .await
     .unwrap();
 
     let updated = file::Entity::find_by_id(file_id)
-        .one(&state.db)
+        .one(state.writer_db())
         .await
         .unwrap()
         .unwrap();
@@ -370,12 +371,12 @@ async fn test_file_active_model_partial_mime_update_refreshes_classification() {
         mime_type: Set("image/png".to_string()),
         ..Default::default()
     }
-    .update(&state.db)
+    .update(state.writer_db())
     .await
     .unwrap();
 
     let updated = file::Entity::find_by_id(file_id)
-        .one(&state.db)
+        .one(state.writer_db())
         .await
         .unwrap()
         .unwrap();
@@ -718,7 +719,7 @@ async fn test_lock_service_lock_unlock() {
     assert!(!lock.token.is_empty());
 
     // 锁定后 is_locked 应该为 true
-    let f = aster_drive::db::repository::folder_repo::find_by_id(&state.db, folder.id)
+    let f = aster_drive::db::repository::folder_repo::find_by_id(state.writer_db(), folder.id)
         .await
         .unwrap();
     assert!(f.is_locked);
@@ -750,7 +751,7 @@ async fn test_lock_service_lock_unlock() {
     .unwrap();
 
     // is_locked 应该回到 false
-    let f = aster_drive::db::repository::folder_repo::find_by_id(&state.db, folder.id)
+    let f = aster_drive::db::repository::folder_repo::find_by_id(state.writer_db(), folder.id)
         .await
         .unwrap();
     assert!(!f.is_locked);
@@ -794,7 +795,7 @@ async fn test_lock_service_force_unlock() {
         .await
         .unwrap();
 
-    let f = aster_drive::db::repository::folder_repo::find_by_id(&state.db, folder.id)
+    let f = aster_drive::db::repository::folder_repo::find_by_id(state.writer_db(), folder.id)
         .await
         .unwrap();
     assert!(!f.is_locked);
@@ -834,17 +835,21 @@ async fn test_lock_service_unlock_by_token_clears_file_lock_state() {
     .await
     .unwrap();
 
-    let locked = file_repo::find_by_id(&state.db, file.id).await.unwrap();
+    let locked = file_repo::find_by_id(state.writer_db(), file.id)
+        .await
+        .unwrap();
     assert!(locked.is_locked);
 
     lock_service::unlock_by_token(&state, &lock.token)
         .await
         .unwrap();
 
-    let unlocked = file_repo::find_by_id(&state.db, file.id).await.unwrap();
+    let unlocked = file_repo::find_by_id(state.writer_db(), file.id)
+        .await
+        .unwrap();
     assert!(!unlocked.is_locked);
     assert!(
-        lock_repo::find_by_token(&state.db, &lock.token)
+        lock_repo::find_by_token(state.writer_db(), &lock.token)
             .await
             .unwrap()
             .is_none()
@@ -893,22 +898,22 @@ async fn test_lock_service_cleanup_expired_unlocks_only_expired_resources() {
     let cleaned = lock_service::cleanup_expired(&state).await.unwrap();
     assert_eq!(cleaned, 1);
 
-    let expired = folder_repo::find_by_id(&state.db, expired_folder.id)
+    let expired = folder_repo::find_by_id(state.writer_db(), expired_folder.id)
         .await
         .unwrap();
-    let active = folder_repo::find_by_id(&state.db, active_folder.id)
+    let active = folder_repo::find_by_id(state.writer_db(), active_folder.id)
         .await
         .unwrap();
     assert!(!expired.is_locked);
     assert!(active.is_locked);
     assert!(
-        lock_repo::find_by_token(&state.db, &expired_lock.token)
+        lock_repo::find_by_token(state.writer_db(), &expired_lock.token)
             .await
             .unwrap()
             .is_none()
     );
     assert!(
-        lock_repo::find_by_token(&state.db, &active_lock.token)
+        lock_repo::find_by_token(state.writer_db(), &active_lock.token)
             .await
             .unwrap()
             .is_some()
@@ -1169,11 +1174,13 @@ async fn test_version_cleanup_excess_reclaims_storage_used() {
     .await
     .unwrap();
 
-    let mut max_versions =
-        aster_drive::db::repository::config_repo::find_by_key(&state.db, "max_versions_per_file")
-            .await
-            .unwrap()
-            .unwrap();
+    let mut max_versions = aster_drive::db::repository::config_repo::find_by_key(
+        state.writer_db(),
+        "max_versions_per_file",
+    )
+    .await
+    .unwrap()
+    .unwrap();
     max_versions.value = "1".to_string();
     state.runtime_config.apply(max_versions);
 
@@ -1299,24 +1306,27 @@ async fn test_version_restore_truncates_future_versions_without_deleting_target_
     assert_eq!(versions[0].blob_id, v1.blob_id);
 
     assert!(
-        aster_drive::db::repository::file_repo::find_blob_by_id(&state.db, v1.blob_id)
+        aster_drive::db::repository::file_repo::find_blob_by_id(state.writer_db(), v1.blob_id)
             .await
             .is_ok()
     );
     assert!(
-        aster_drive::db::repository::file_repo::find_blob_by_id(&state.db, v2.blob_id)
+        aster_drive::db::repository::file_repo::find_blob_by_id(state.writer_db(), v2.blob_id)
             .await
             .is_ok()
     );
     assert!(
-        aster_drive::db::repository::file_repo::find_blob_by_id(&state.db, v3.blob_id)
+        aster_drive::db::repository::file_repo::find_blob_by_id(state.writer_db(), v3.blob_id)
             .await
             .is_err()
     );
     assert!(
-        aster_drive::db::repository::file_repo::find_blob_by_id(&state.db, old_current_blob_id)
-            .await
-            .is_err()
+        aster_drive::db::repository::file_repo::find_blob_by_id(
+            state.writer_db(),
+            old_current_blob_id
+        )
+        .await
+        .is_err()
     );
 
     let temp5 = format!("{}/v5.txt", temp_dir);
@@ -1486,23 +1496,26 @@ async fn test_folder_copy_preserves_multi_level_tree_and_storage_used() {
         storage_before_copy * 2
     );
 
-    let copied_root_files =
-        aster_drive::db::repository::file_repo::find_by_folder(&state.db, user.id, Some(copied.id))
-            .await
-            .unwrap();
+    let copied_root_files = aster_drive::db::repository::file_repo::find_by_folder(
+        state.writer_db(),
+        user.id,
+        Some(copied.id),
+    )
+    .await
+    .unwrap();
     assert_eq!(copied_root_files.len(), 1);
     assert_eq!(copied_root_files[0].name, "root.txt");
     assert_ne!(copied_root_files[0].id, root_file_id);
     assert_eq!(
         copied_root_files[0].blob_id,
-        aster_drive::db::repository::file_repo::find_by_id(&state.db, root_file_id)
+        aster_drive::db::repository::file_repo::find_by_id(state.writer_db(), root_file_id)
             .await
             .unwrap()
             .blob_id
     );
 
     let copied_children = aster_drive::db::repository::folder_repo::find_children(
-        &state.db,
+        state.writer_db(),
         user.id,
         Some(copied.id),
     )
@@ -1527,7 +1540,7 @@ async fn test_folder_copy_preserves_multi_level_tree_and_storage_used() {
         .unwrap();
 
     let copied_child_a_files = aster_drive::db::repository::file_repo::find_by_folder(
-        &state.db,
+        state.writer_db(),
         user.id,
         Some(copied_child_a.id),
     )
@@ -1538,7 +1551,7 @@ async fn test_folder_copy_preserves_multi_level_tree_and_storage_used() {
     assert_ne!(copied_child_a_files[0].id, child_a_file_id);
 
     let copied_child_b_files = aster_drive::db::repository::file_repo::find_by_folder(
-        &state.db,
+        state.writer_db(),
         user.id,
         Some(copied_child_b.id),
     )
@@ -1549,7 +1562,7 @@ async fn test_folder_copy_preserves_multi_level_tree_and_storage_used() {
     assert_ne!(copied_child_b_files[0].id, child_b_file_id);
 
     let copied_grandchildren = aster_drive::db::repository::folder_repo::find_children(
-        &state.db,
+        state.writer_db(),
         user.id,
         Some(copied_child_a.id),
     )
@@ -1559,7 +1572,7 @@ async fn test_folder_copy_preserves_multi_level_tree_and_storage_used() {
     assert_eq!(copied_grandchildren[0].name, "Grandchild");
 
     let copied_grandchild_files = aster_drive::db::repository::file_repo::find_by_folder(
-        &state.db,
+        state.writer_db(),
         user.id,
         Some(copied_grandchildren[0].id),
     )
@@ -1570,7 +1583,7 @@ async fn test_folder_copy_preserves_multi_level_tree_and_storage_used() {
     assert_ne!(copied_grandchild_files[0].id, grandchild_file_id);
     assert_eq!(
         copied_grandchild_files[0].blob_id,
-        aster_drive::db::repository::file_repo::find_by_id(&state.db, grandchild_file_id)
+        aster_drive::db::repository::file_repo::find_by_id(state.writer_db(), grandchild_file_id)
             .await
             .unwrap()
             .blob_id
@@ -1582,7 +1595,7 @@ async fn test_folder_copy_quota_failure_does_not_create_descendants() {
     use sea_orm::{ActiveModelTrait, Set};
 
     let state = common::setup().await;
-    let db = state.db.clone();
+    let db = state.writer_db().clone();
 
     let user = aster_drive::services::auth_service::register(
         &state,
@@ -1744,7 +1757,7 @@ async fn test_driver_registry_invalidate_on_policy_update() {
     let state = common::setup().await;
 
     // 获取默认策略
-    let policies = aster_drive::db::repository::policy_repo::find_all(&state.db)
+    let policies = aster_drive::db::repository::policy_repo::find_all(state.writer_db())
         .await
         .unwrap();
     let policy = &policies[0];
@@ -1772,9 +1785,10 @@ async fn test_driver_registry_invalidate_on_policy_update() {
     .unwrap();
 
     // 更新后获取 → 应是新的实例（缓存已失效，重新创建）
-    let updated_policy = aster_drive::db::repository::policy_repo::find_by_id(&state.db, policy.id)
-        .await
-        .unwrap();
+    let updated_policy =
+        aster_drive::db::repository::policy_repo::find_by_id(state.writer_db(), policy.id)
+            .await
+            .unwrap();
     let driver3 = state.driver_registry.get_driver(&updated_policy).unwrap();
     assert!(
         !std::sync::Arc::ptr_eq(&driver1, &driver3),
@@ -1857,12 +1871,13 @@ async fn test_share_download_failure_rolls_back_download_quota() {
     .await
     .unwrap();
 
-    let file = aster_drive::db::repository::file_repo::find_by_id(&state.db, file_id)
+    let file = aster_drive::db::repository::file_repo::find_by_id(state.writer_db(), file_id)
         .await
         .unwrap();
-    let blob = aster_drive::db::repository::file_repo::find_blob_by_id(&state.db, file.blob_id)
-        .await
-        .unwrap();
+    let blob =
+        aster_drive::db::repository::file_repo::find_blob_by_id(state.writer_db(), file.blob_id)
+            .await
+            .unwrap();
     let policy = state
         .policy_snapshot
         .get_policy_or_err(blob.policy_id)
@@ -1876,7 +1891,7 @@ async fn test_share_download_failure_rolls_back_download_quota() {
             .unwrap_err();
     assert_ne!(err.code(), "E053");
 
-    let reloaded = aster_drive::db::repository::share_repo::find_by_id(&state.db, share.id)
+    let reloaded = aster_drive::db::repository::share_repo::find_by_id(state.writer_db(), share.id)
         .await
         .unwrap();
     assert_eq!(reloaded.download_count, 0);
@@ -1887,7 +1902,7 @@ async fn test_share_download_failure_rolls_back_download_quota() {
             .unwrap_err();
     assert_ne!(err.code(), "E053");
 
-    let reloaded = aster_drive::db::repository::share_repo::find_by_id(&state.db, share.id)
+    let reloaded = aster_drive::db::repository::share_repo::find_by_id(state.writer_db(), share.id)
         .await
         .unwrap();
     assert_eq!(reloaded.download_count, 0);
@@ -1982,10 +1997,10 @@ async fn test_share_target_check_constraint_rejects_zero_or_multiple_targets() {
         updated_at: Set(now),
         ..Default::default()
     }
-    .insert(&state.db)
+    .insert(state.writer_db())
     .await
     .unwrap_err();
-    assert_share_target_check_violation(&state.db, &err);
+    assert_share_target_check_violation(state.writer_db(), &err);
 
     let err = aster_drive::entities::share::ActiveModel {
         token: Set(uuid::Uuid::new_v4().simple().to_string()),
@@ -2002,10 +2017,10 @@ async fn test_share_target_check_constraint_rejects_zero_or_multiple_targets() {
         updated_at: Set(now),
         ..Default::default()
     }
-    .insert(&state.db)
+    .insert(state.writer_db())
     .await
     .unwrap_err();
-    assert_share_target_check_violation(&state.db, &err);
+    assert_share_target_check_violation(state.writer_db(), &err);
 }
 
 #[actix_web::test]
@@ -2040,11 +2055,11 @@ async fn test_share_token_length_constraint_rejects_tokens_longer_than_32_chars(
         updated_at: Set(now),
         ..Default::default()
     }
-    .insert(&state.db)
+    .insert(state.writer_db())
     .await
     .unwrap_err();
 
-    assert_share_token_length_violation(&state.db, &err);
+    assert_share_token_length_violation(state.writer_db(), &err);
 }
 
 #[actix_web::test]
@@ -2101,11 +2116,13 @@ async fn test_team_service_clamps_negative_default_storage_quota() {
     .await
     .unwrap();
 
-    let mut updated =
-        aster_drive::db::repository::config_repo::find_by_key(&state.db, "default_storage_quota")
-            .await
-            .unwrap()
-            .unwrap();
+    let mut updated = aster_drive::db::repository::config_repo::find_by_key(
+        state.writer_db(),
+        "default_storage_quota",
+    )
+    .await
+    .unwrap()
+    .unwrap();
     updated.value = "-1".to_string();
     state.runtime_config.apply(updated);
 
@@ -2142,7 +2159,11 @@ async fn test_team_service_rejects_create_without_default_policy_group() {
         .execute_unprepared("UPDATE storage_policy_groups SET is_default = FALSE;")
         .await
         .unwrap();
-    state.policy_snapshot.reload(&state.db).await.unwrap();
+    state
+        .policy_snapshot
+        .reload(state.writer_db())
+        .await
+        .unwrap();
 
     let err = aster_drive::services::team_service::create_team(
         &state,
@@ -2208,18 +2229,19 @@ async fn test_team_service_degrades_missing_creator_rows() {
     .await
     .unwrap();
 
-    common::set_foreign_key_checks(&state.db, false)
+    common::set_foreign_key_checks(state.writer_db(), false)
         .await
         .unwrap();
-    let mut broken_team = aster_drive::db::repository::team_repo::find_by_id(&state.db, team.id)
-        .await
-        .unwrap()
-        .into_active_model();
+    let mut broken_team =
+        aster_drive::db::repository::team_repo::find_by_id(state.writer_db(), team.id)
+            .await
+            .unwrap()
+            .into_active_model();
     broken_team.created_by = Set(i64::MAX);
-    aster_drive::db::repository::team_repo::update(&state.db, broken_team)
+    aster_drive::db::repository::team_repo::update(state.writer_db(), broken_team)
         .await
         .unwrap();
-    common::set_foreign_key_checks(&state.db, true)
+    common::set_foreign_key_checks(state.writer_db(), true)
         .await
         .unwrap();
 
@@ -2262,7 +2284,7 @@ async fn test_folder_repo_find_expired_deleted_includes_team_folders() {
 
     let deleted_at = Utc::now() - Duration::days(10);
     let created = aster_drive::db::repository::folder_repo::create(
-        &state.db,
+        state.writer_db(),
         aster_drive::entities::folder::ActiveModel {
             name: Set("Team Trash".to_string()),
             parent_id: Set(None),
@@ -2281,10 +2303,12 @@ async fn test_folder_repo_find_expired_deleted_includes_team_folders() {
     .await
     .unwrap();
 
-    let expired =
-        aster_drive::db::repository::folder_repo::find_expired_deleted(&state.db, Utc::now())
-            .await
-            .unwrap();
+    let expired = aster_drive::db::repository::folder_repo::find_expired_deleted(
+        state.writer_db(),
+        Utc::now(),
+    )
+    .await
+    .unwrap();
 
     assert!(expired.iter().any(|folder| folder.id == created.id));
 }
@@ -2338,7 +2362,7 @@ async fn test_folder_repo_find_all_by_user_excludes_team_folders() {
 
     let now = Utc::now();
     let personal = aster_drive::db::repository::folder_repo::create(
-        &state.db,
+        state.writer_db(),
         aster_drive::entities::folder::ActiveModel {
             name: Set("Personal".to_string()),
             parent_id: Set(None),
@@ -2357,7 +2381,7 @@ async fn test_folder_repo_find_all_by_user_excludes_team_folders() {
     .await
     .unwrap();
     let team_folder = aster_drive::db::repository::folder_repo::create(
-        &state.db,
+        state.writer_db(),
         aster_drive::entities::folder::ActiveModel {
             name: Set("Team".to_string()),
             parent_id: Set(None),
@@ -2376,9 +2400,10 @@ async fn test_folder_repo_find_all_by_user_excludes_team_folders() {
     .await
     .unwrap();
 
-    let folders = aster_drive::db::repository::folder_repo::find_all_by_user(&state.db, member.id)
-        .await
-        .unwrap();
+    let folders =
+        aster_drive::db::repository::folder_repo::find_all_by_user(state.writer_db(), member.id)
+            .await
+            .unwrap();
     let folder_ids: BTreeSet<i64> = folders.into_iter().map(|folder| folder.id).collect();
 
     assert!(folder_ids.contains(&personal.id));
@@ -2402,7 +2427,7 @@ async fn test_folder_repo_top_level_deleted_pagination_is_stable_for_equal_times
 
     let deleted_at = Utc::now();
     let first = aster_drive::db::repository::folder_repo::create(
-        &state.db,
+        state.writer_db(),
         aster_drive::entities::folder::ActiveModel {
             name: Set("first".to_string()),
             parent_id: Set(None),
@@ -2421,7 +2446,7 @@ async fn test_folder_repo_top_level_deleted_pagination_is_stable_for_equal_times
     .await
     .unwrap();
     let second = aster_drive::db::repository::folder_repo::create(
-        &state.db,
+        state.writer_db(),
         aster_drive::entities::folder::ActiveModel {
             name: Set("second".to_string()),
             parent_id: Set(None),
@@ -2442,12 +2467,18 @@ async fn test_folder_repo_top_level_deleted_pagination_is_stable_for_equal_times
 
     let (page_one, total) =
         aster_drive::db::repository::folder_repo::find_top_level_deleted_paginated(
-            &state.db, user.id, 1, 0,
+            state.writer_db(),
+            user.id,
+            1,
+            0,
         )
         .await
         .unwrap();
     let (page_two, _) = aster_drive::db::repository::folder_repo::find_top_level_deleted_paginated(
-        &state.db, user.id, 1, 1,
+        state.writer_db(),
+        user.id,
+        1,
+        1,
     )
     .await
     .unwrap();
@@ -2613,14 +2644,15 @@ async fn test_team_archive_cleanup_deletes_expired_team_data() {
     .await
     .unwrap();
 
-    let default_policy_id = aster_drive::db::repository::policy_repo::find_default(&state.db)
-        .await
-        .unwrap()
-        .expect("default policy should exist")
-        .id;
+    let default_policy_id =
+        aster_drive::db::repository::policy_repo::find_default(state.writer_db())
+            .await
+            .unwrap()
+            .expect("default policy should exist")
+            .id;
     let now = Utc::now();
     let folder = aster_drive::db::repository::folder_repo::create(
-        &state.db,
+        state.writer_db(),
         aster_drive::entities::folder::ActiveModel {
             name: Set("cleanup-folder".to_string()),
             parent_id: Set(None),
@@ -2640,7 +2672,7 @@ async fn test_team_archive_cleanup_deletes_expired_team_data() {
     .unwrap();
 
     let blob = aster_drive::db::repository::file_repo::create_blob(
-        &state.db,
+        state.writer_db(),
         aster_drive::entities::file_blob::ActiveModel {
             hash: Set(format!("cleanup-blob-{}", uuid::Uuid::new_v4())),
             size: Set(12),
@@ -2655,7 +2687,7 @@ async fn test_team_archive_cleanup_deletes_expired_team_data() {
     .await
     .unwrap();
     let file = aster_drive::db::repository::file_repo::create(
-        &state.db,
+        state.writer_db(),
         aster_drive::entities::file::ActiveModel {
             name: Set("cleanup.txt".to_string()),
             folder_id: Set(Some(folder.id)),
@@ -2677,7 +2709,7 @@ async fn test_team_archive_cleanup_deletes_expired_team_data() {
     .unwrap();
 
     aster_drive::db::repository::property_repo::upsert(
-        &state.db,
+        state.writer_db(),
         aster_drive::types::EntityType::Folder,
         folder.id,
         "test",
@@ -2699,7 +2731,7 @@ async fn test_team_archive_cleanup_deletes_expired_team_data() {
     .unwrap();
 
     aster_drive::db::repository::share_repo::create(
-        &state.db,
+        state.writer_db(),
         aster_drive::entities::share::ActiveModel {
             token: Set(uuid::Uuid::new_v4().simple().to_string()),
             user_id: Set(owner.id),
@@ -2721,7 +2753,7 @@ async fn test_team_archive_cleanup_deletes_expired_team_data() {
 
     let upload_id = uuid::Uuid::new_v4().to_string();
     aster_drive::db::repository::upload_session_repo::create(
-        &state.db,
+        state.writer_db(),
         aster_drive::entities::upload_session::ActiveModel {
             id: Set(upload_id.clone()),
             user_id: Set(owner.id),
@@ -2749,13 +2781,14 @@ async fn test_team_archive_cleanup_deletes_expired_team_data() {
         .await
         .unwrap();
 
-    let mut archived_team = aster_drive::db::repository::team_repo::find_by_id(&state.db, team.id)
-        .await
-        .unwrap()
-        .into_active_model();
+    let mut archived_team =
+        aster_drive::db::repository::team_repo::find_by_id(state.writer_db(), team.id)
+            .await
+            .unwrap()
+            .into_active_model();
     archived_team.archived_at = Set(Some(Utc::now() - Duration::days(8)));
     archived_team.updated_at = Set(Utc::now() - Duration::days(8));
-    aster_drive::db::repository::team_repo::update(&state.db, archived_team)
+    aster_drive::db::repository::team_repo::update(state.writer_db(), archived_team)
         .await
         .unwrap();
 
@@ -2764,43 +2797,45 @@ async fn test_team_archive_cleanup_deletes_expired_team_data() {
         .unwrap();
     assert_eq!(deleted, 1);
     assert!(
-        aster_drive::db::repository::team_repo::find_by_id(&state.db, team.id)
+        aster_drive::db::repository::team_repo::find_by_id(state.writer_db(), team.id)
             .await
             .is_err()
     );
     assert!(
-        aster_drive::db::repository::file_repo::find_by_id(&state.db, file.id)
+        aster_drive::db::repository::file_repo::find_by_id(state.writer_db(), file.id)
             .await
             .is_err()
     );
     assert!(
-        aster_drive::db::repository::folder_repo::find_by_id(&state.db, folder.id)
+        aster_drive::db::repository::folder_repo::find_by_id(state.writer_db(), folder.id)
             .await
             .is_err()
     );
     assert!(
         aster_drive::db::repository::team_member_repo::find_by_team_and_user(
-            &state.db, team.id, owner.id
+            state.writer_db(),
+            team.id,
+            owner.id
         )
         .await
         .unwrap()
         .is_none()
     );
     assert!(
-        aster_drive::db::repository::share_repo::find_by_team(&state.db, team.id)
+        aster_drive::db::repository::share_repo::find_by_team(state.writer_db(), team.id)
             .await
             .unwrap()
             .is_empty()
     );
     assert!(
-        aster_drive::db::repository::upload_session_repo::find_by_team(&state.db, team.id)
+        aster_drive::db::repository::upload_session_repo::find_by_team(state.writer_db(), team.id)
             .await
             .unwrap()
             .is_empty()
     );
     assert!(
         aster_drive::db::repository::lock_repo::find_by_path_prefix(
-            &state.db,
+            state.writer_db(),
             &format!("/teams/{}/", team.id),
         )
         .await
@@ -2809,7 +2844,7 @@ async fn test_team_archive_cleanup_deletes_expired_team_data() {
     );
     assert!(
         aster_drive::db::repository::property_repo::find_by_entity(
-            &state.db,
+            state.writer_db(),
             aster_drive::types::EntityType::Folder,
             folder.id,
         )
@@ -2844,14 +2879,15 @@ async fn test_team_archive_cleanup_processes_multiple_file_and_folder_batches() 
     .await
     .unwrap();
 
-    let default_policy_id = aster_drive::db::repository::policy_repo::find_default(&state.db)
-        .await
-        .unwrap()
-        .expect("default policy should exist")
-        .id;
+    let default_policy_id =
+        aster_drive::db::repository::policy_repo::find_default(state.writer_db())
+            .await
+            .unwrap()
+            .expect("default policy should exist")
+            .id;
     let now = Utc::now();
     let blob = aster_drive::db::repository::file_repo::create_blob(
-        &state.db,
+        state.writer_db(),
         aster_drive::entities::file_blob::ActiveModel {
             hash: Set(format!("batch-cleanup-blob-{}", uuid::Uuid::new_v4())),
             size: Set(1),
@@ -2869,7 +2905,7 @@ async fn test_team_archive_cleanup_processes_multiple_file_and_folder_batches() 
     let mut sample_file_ids = Vec::new();
     for idx in 0..1001 {
         let file = aster_drive::db::repository::file_repo::create(
-            &state.db,
+            state.writer_db(),
             aster_drive::entities::file::ActiveModel {
                 name: Set(format!("batched-file-{idx:04}.txt")),
                 folder_id: Set(None),
@@ -2897,7 +2933,7 @@ async fn test_team_archive_cleanup_processes_multiple_file_and_folder_batches() 
     let mut sample_folder_ids = Vec::new();
     for idx in 0..1001 {
         let folder = aster_drive::db::repository::folder_repo::create(
-            &state.db,
+            state.writer_db(),
             aster_drive::entities::folder::ActiveModel {
                 name: Set(format!("batched-folder-{idx:04}")),
                 parent_id: Set(None),
@@ -2917,7 +2953,7 @@ async fn test_team_archive_cleanup_processes_multiple_file_and_folder_batches() 
         .unwrap();
         if idx == 0 || idx == 1000 {
             aster_drive::db::repository::property_repo::upsert(
-                &state.db,
+                state.writer_db(),
                 aster_drive::types::EntityType::Folder,
                 folder.id,
                 "aster:",
@@ -2934,13 +2970,14 @@ async fn test_team_archive_cleanup_processes_multiple_file_and_folder_batches() 
         .await
         .unwrap();
 
-    let mut archived_team = aster_drive::db::repository::team_repo::find_by_id(&state.db, team.id)
-        .await
-        .unwrap()
-        .into_active_model();
+    let mut archived_team =
+        aster_drive::db::repository::team_repo::find_by_id(state.writer_db(), team.id)
+            .await
+            .unwrap()
+            .into_active_model();
     archived_team.archived_at = Set(Some(Utc::now() - Duration::days(8)));
     archived_team.updated_at = Set(Utc::now() - Duration::days(8));
-    aster_drive::db::repository::team_repo::update(&state.db, archived_team)
+    aster_drive::db::repository::team_repo::update(state.writer_db(), archived_team)
         .await
         .unwrap();
 
@@ -2949,26 +2986,26 @@ async fn test_team_archive_cleanup_processes_multiple_file_and_folder_batches() 
         .unwrap();
     assert_eq!(deleted, 1);
     assert!(
-        aster_drive::db::repository::team_repo::find_by_id(&state.db, team.id)
+        aster_drive::db::repository::team_repo::find_by_id(state.writer_db(), team.id)
             .await
             .is_err()
     );
     for file_id in sample_file_ids {
         assert!(
-            aster_drive::db::repository::file_repo::find_by_id(&state.db, file_id)
+            aster_drive::db::repository::file_repo::find_by_id(state.writer_db(), file_id)
                 .await
                 .is_err()
         );
     }
     for folder_id in sample_folder_ids {
         assert!(
-            aster_drive::db::repository::folder_repo::find_by_id(&state.db, folder_id)
+            aster_drive::db::repository::folder_repo::find_by_id(state.writer_db(), folder_id)
                 .await
                 .is_err()
         );
         assert!(
             aster_drive::db::repository::property_repo::find_by_entity(
-                &state.db,
+                state.writer_db(),
                 aster_drive::types::EntityType::Folder,
                 folder_id,
             )
@@ -2978,7 +3015,7 @@ async fn test_team_archive_cleanup_processes_multiple_file_and_folder_batches() 
         );
     }
     assert!(
-        aster_drive::db::repository::file_repo::find_blob_by_id(&state.db, blob.id)
+        aster_drive::db::repository::file_repo::find_blob_by_id(state.writer_db(), blob.id)
             .await
             .is_err()
     );
@@ -3010,7 +3047,7 @@ async fn test_team_archive_cleanup_respects_configured_retention() {
     .unwrap();
 
     let mut config = aster_drive::db::repository::config_repo::find_by_key(
-        &state.db,
+        state.writer_db(),
         "team_archive_retention_days",
     )
     .await
@@ -3023,13 +3060,14 @@ async fn test_team_archive_cleanup_respects_configured_retention() {
         .await
         .unwrap();
 
-    let mut archived_team = aster_drive::db::repository::team_repo::find_by_id(&state.db, team.id)
-        .await
-        .unwrap()
-        .into_active_model();
+    let mut archived_team =
+        aster_drive::db::repository::team_repo::find_by_id(state.writer_db(), team.id)
+            .await
+            .unwrap()
+            .into_active_model();
     archived_team.archived_at = Set(Some(Utc::now() - Duration::days(8)));
     archived_team.updated_at = Set(Utc::now() - Duration::days(8));
-    aster_drive::db::repository::team_repo::update(&state.db, archived_team)
+    aster_drive::db::repository::team_repo::update(state.writer_db(), archived_team)
         .await
         .unwrap();
 
@@ -3038,8 +3076,9 @@ async fn test_team_archive_cleanup_respects_configured_retention() {
         .unwrap();
     assert_eq!(deleted, 0);
 
-    let archived = aster_drive::db::repository::team_repo::find_archived_by_id(&state.db, team.id)
-        .await
-        .unwrap();
+    let archived =
+        aster_drive::db::repository::team_repo::find_archived_by_id(state.writer_db(), team.id)
+            .await
+            .unwrap();
     assert_eq!(archived.id, team.id);
 }

--- a/tests/test_shares.rs
+++ b/tests/test_shares.rs
@@ -305,9 +305,10 @@ async fn test_shared_folder_file_thumbnail_returns_202_until_background_generati
         .unwrap();
     assert_eq!(stats.succeeded, 1);
 
-    let tasks = aster_drive::db::repository::background_task_repo::list_recent(&state.db, 8)
-        .await
-        .unwrap();
+    let tasks =
+        aster_drive::db::repository::background_task_repo::list_recent(state.writer_db(), 8)
+            .await
+            .unwrap();
     assert!(
         tasks
             .iter()
@@ -627,7 +628,7 @@ async fn test_share_batch_delete_removes_multiple_shares() {
 #[actix_web::test]
 async fn test_share_batch_delete_preserves_partial_failures_for_foreign_and_missing_ids() {
     let state = common::setup().await;
-    let db = state.db.clone();
+    let db = state.writer_db().clone();
     let mail_sender = state.mail_sender.clone();
     let app = create_test_app!(state);
     let (owner_token, _) = register_and_login!(app);

--- a/tests/test_tasks.rs
+++ b/tests/test_tasks.rs
@@ -537,7 +537,7 @@ async fn insert_processing_task(
 ) -> i64 {
     let now = Utc::now();
     background_task_repo::create(
-        &state.db,
+        state.writer_db(),
         background_task::ActiveModel {
             kind: Set(BackgroundTaskKind::ArchiveCompress),
             status: Set(BackgroundTaskStatus::Processing),
@@ -598,7 +598,7 @@ async fn insert_pending_dispatch_task(
         _ => panic!("unsupported dispatch test task kind"),
     };
     background_task_repo::create(
-        &state.db,
+        state.writer_db(),
         background_task::ActiveModel {
             kind: Set(kind),
             status: Set(BackgroundTaskStatus::Pending),
@@ -643,7 +643,7 @@ async fn insert_pending_lane_task(
 ) -> background_task::Model {
     let now = Utc::now();
     background_task_repo::create(
-        &state.db,
+        state.writer_db(),
         background_task::ActiveModel {
             kind: Set(kind),
             status: Set(BackgroundTaskStatus::Pending),
@@ -717,7 +717,7 @@ async fn test_processing_task_claimability_requires_explicit_lease_expiry() {
     )
     .await;
 
-    let claimable = background_task_repo::list_claimable(&state.db, now, stale_before, 10)
+    let claimable = background_task_repo::list_claimable(state.writer_db(), now, stale_before, 10)
         .await
         .expect("claimable task list should load");
     let ids = claimable.iter().map(|task| task.id).collect::<Vec<_>>();
@@ -734,7 +734,7 @@ async fn test_processing_task_claimability_prefers_explicit_lease_expiry_when_pr
     let stale_before = now - Duration::seconds(60);
 
     let fresh_lease = background_task_repo::create(
-        &state.db,
+        state.writer_db(),
         background_task::ActiveModel {
             kind: Set(BackgroundTaskKind::ArchiveCompress),
             status: Set(BackgroundTaskStatus::Processing),
@@ -768,7 +768,7 @@ async fn test_processing_task_claimability_prefers_explicit_lease_expiry_when_pr
     .expect("fresh explicit lease task should be inserted");
 
     let expired_lease = background_task_repo::create(
-        &state.db,
+        state.writer_db(),
         background_task::ActiveModel {
             kind: Set(BackgroundTaskKind::ArchiveCompress),
             status: Set(BackgroundTaskStatus::Processing),
@@ -801,7 +801,7 @@ async fn test_processing_task_claimability_prefers_explicit_lease_expiry_when_pr
     .await
     .expect("expired explicit lease task should be inserted");
 
-    let claimable = background_task_repo::list_claimable(&state.db, now, stale_before, 10)
+    let claimable = background_task_repo::list_claimable(state.writer_db(), now, stale_before, 10)
         .await
         .expect("claimable task list should load");
     let ids = claimable.iter().map(|task| task.id).collect::<Vec<_>>();
@@ -820,7 +820,7 @@ async fn test_touch_heartbeat_refreshes_processing_task_liveness() {
 
     let touched_at = Utc::now();
     let touched = background_task_repo::touch_heartbeat(
-        &state.db,
+        state.writer_db(),
         task_id,
         0,
         touched_at,
@@ -830,7 +830,7 @@ async fn test_touch_heartbeat_refreshes_processing_task_liveness() {
     .expect("heartbeat touch should succeed");
     assert!(touched);
 
-    let task = background_task_repo::find_by_id(&state.db, task_id)
+    let task = background_task_repo::find_by_id(state.writer_db(), task_id)
         .await
         .expect("task should still exist");
     assert!(
@@ -851,7 +851,7 @@ async fn test_processing_token_fences_stale_worker_updates_after_reclaim() {
     let now = Utc::now();
     let stale_before = now - Duration::seconds(60);
     let task = background_task_repo::create(
-        &state.db,
+        state.writer_db(),
         background_task::ActiveModel {
             kind: Set(BackgroundTaskKind::ArchiveCompress),
             status: Set(BackgroundTaskStatus::Processing),
@@ -885,7 +885,7 @@ async fn test_processing_token_fences_stale_worker_updates_after_reclaim() {
     .expect("processing task with token should be inserted");
 
     let reclaimed = background_task_repo::try_claim(
-        &state.db,
+        state.writer_db(),
         task.id,
         task.processing_token,
         Utc::now(),
@@ -898,7 +898,7 @@ async fn test_processing_token_fences_stale_worker_updates_after_reclaim() {
     assert!(reclaimed);
 
     let stale_touched = background_task_repo::touch_heartbeat(
-        &state.db,
+        state.writer_db(),
         task.id,
         task.processing_token,
         Utc::now(),
@@ -909,7 +909,7 @@ async fn test_processing_token_fences_stale_worker_updates_after_reclaim() {
     assert!(!stale_touched);
 
     let stale_progress = background_task_repo::mark_progress(
-        &state.db,
+        state.writer_db(),
         background_task_repo::TaskProgressUpdate {
             id: task.id,
             processing_token: task.processing_token,
@@ -926,7 +926,7 @@ async fn test_processing_token_fences_stale_worker_updates_after_reclaim() {
     assert!(!stale_progress);
 
     let fresh_touched = background_task_repo::touch_heartbeat(
-        &state.db,
+        state.writer_db(),
         task.id,
         task.processing_token + 1,
         Utc::now(),
@@ -936,7 +936,7 @@ async fn test_processing_token_fences_stale_worker_updates_after_reclaim() {
     .expect("current worker heartbeat should still succeed");
     assert!(fresh_touched);
 
-    let stored = background_task_repo::find_by_id(&state.db, task.id)
+    let stored = background_task_repo::find_by_id(state.writer_db(), task.id)
         .await
         .expect("reclaimed task should still exist");
     assert_eq!(stored.status, BackgroundTaskStatus::Processing);
@@ -949,7 +949,7 @@ async fn test_dispatch_due_reclaims_stale_processing_task_with_new_token() {
     let state = common::setup().await;
     let now = Utc::now();
     let task = background_task_repo::create(
-        &state.db,
+        state.writer_db(),
         background_task::ActiveModel {
             kind: Set(BackgroundTaskKind::SystemRuntime),
             status: Set(BackgroundTaskStatus::Processing),
@@ -993,7 +993,7 @@ async fn test_dispatch_due_reclaims_stale_processing_task_with_new_token() {
     assert_eq!(stats.failed, 1);
     assert_eq!(stats.succeeded, 0);
 
-    let stored = background_task_repo::find_by_id(&state.db, task.id)
+    let stored = background_task_repo::find_by_id(state.writer_db(), task.id)
         .await
         .expect("reclaimed task should still exist");
     assert_eq!(stored.status, BackgroundTaskStatus::Failed);
@@ -1073,7 +1073,7 @@ async fn test_cleanup_expired_keeps_terminal_task_records() {
     let state = common::setup().await;
     let now = Utc::now();
     let task = background_task_repo::create(
-        &state.db,
+        state.writer_db(),
         background_task::ActiveModel {
             kind: Set(BackgroundTaskKind::ArchiveCompress),
             status: Set(BackgroundTaskStatus::Succeeded),
@@ -1119,7 +1119,7 @@ async fn test_cleanup_expired_keeps_terminal_task_records() {
         "expired task temp dir should be removed"
     );
 
-    let stored = background_task_repo::find_by_id(&state.db, task.id)
+    let stored = background_task_repo::find_by_id(state.writer_db(), task.id)
         .await
         .expect("expired task record should still exist");
     assert_eq!(stored.status, BackgroundTaskStatus::Succeeded);
@@ -1222,7 +1222,7 @@ async fn test_record_runtime_task_run_skips_quiet_outcome() {
     .expect("quiet runtime task handling should succeed");
 
     assert!(recorded.is_none());
-    let recent = background_task_repo::list_recent(&state.db, 10)
+    let recent = background_task_repo::list_recent(state.writer_db(), 10)
         .await
         .expect("recent background tasks should load");
     assert!(recent.is_empty());
@@ -1270,7 +1270,7 @@ async fn test_record_runtime_task_run_refreshes_latest_healthy_system_check() {
     assert_eq!(second.finished_at, Some(second_finished_at));
     assert_eq!(second.updated_at, second_finished_at);
 
-    let recent = background_task_repo::list_recent(&state.db, 10)
+    let recent = background_task_repo::list_recent(state.writer_db(), 10)
         .await
         .expect("recent background tasks should load");
     assert_eq!(recent.len(), 1);
@@ -1319,7 +1319,7 @@ async fn test_record_runtime_task_run_keeps_health_failure_history_before_recove
     assert_ne!(recovered.id, failed.id);
     assert_eq!(recovered.status, BackgroundTaskStatus::Succeeded);
 
-    let recent = background_task_repo::list_recent(&state.db, 10)
+    let recent = background_task_repo::list_recent(state.writer_db(), 10)
         .await
         .expect("recent background tasks should load");
     assert_eq!(recent.len(), 2);
@@ -1341,7 +1341,7 @@ async fn test_dispatch_due_marks_manual_retryable_task_failed_without_auto_retry
     assert_eq!(stats.failed, 1);
     assert_eq!(stats.succeeded, 0);
 
-    let stored = background_task_repo::find_by_id(&state.db, task.id)
+    let stored = background_task_repo::find_by_id(state.writer_db(), task.id)
         .await
         .expect("failed task should still exist");
     assert_eq!(stored.status, BackgroundTaskStatus::Failed);
@@ -1367,7 +1367,7 @@ async fn test_dispatch_due_marks_task_failed_after_max_attempts() {
     assert_eq!(stats.failed, 1);
     assert_eq!(stats.succeeded, 0);
 
-    let stored = background_task_repo::find_by_id(&state.db, task.id)
+    let stored = background_task_repo::find_by_id(state.writer_db(), task.id)
         .await
         .expect("failed task should still exist");
     assert_eq!(stored.status, BackgroundTaskStatus::Failed);
@@ -1388,7 +1388,7 @@ async fn test_dispatch_due_marks_task_failed_after_max_attempts() {
 #[actix_web::test]
 async fn test_personal_archive_stream_preserves_empty_folders() {
     let state = common::setup().await;
-    let db = state.db.clone();
+    let db = state.writer_db().clone();
     let mail_sender = state.mail_sender.clone();
     let state = web::Data::new(state);
     let app = test::init_service(
@@ -1402,7 +1402,7 @@ async fn test_personal_archive_stream_preserves_empty_folders() {
 
     register_user!(
         app,
-        state.db.clone(),
+        state.writer_db().clone(),
         mail_sender,
         "taskowner",
         "taskowner@example.com",
@@ -1501,7 +1501,7 @@ async fn test_personal_archive_stream_preserves_empty_folders() {
 #[actix_web::test]
 async fn test_team_archive_stream_is_scoped_to_team_routes() {
     let state = common::setup().await;
-    let db = state.db.clone();
+    let db = state.writer_db().clone();
     let mail_sender = state.mail_sender.clone();
     let state = web::Data::new(state);
     let app = test::init_service(
@@ -1515,7 +1515,7 @@ async fn test_team_archive_stream_is_scoped_to_team_routes() {
 
     register_user!(
         app,
-        state.db.clone(),
+        state.writer_db().clone(),
         mail_sender,
         "teamowner",
         "teamowner@example.com",
@@ -1594,7 +1594,7 @@ async fn test_team_archive_stream_is_scoped_to_team_routes() {
 #[actix_web::test]
 async fn test_personal_archive_compress_task_creates_workspace_file() {
     let state = common::setup().await;
-    let db = state.db.clone();
+    let db = state.writer_db().clone();
     let mail_sender = state.mail_sender.clone();
     let state = web::Data::new(state);
     let app = test::init_service(
@@ -1617,7 +1617,7 @@ async fn test_personal_archive_compress_task_creates_workspace_file() {
 
     register_user!(
         app,
-        state.db.clone(),
+        state.writer_db().clone(),
         mail_sender,
         "compressor",
         "compressor@example.com",
@@ -1908,14 +1908,15 @@ async fn test_archive_compress_task_rejects_quota_before_building_archive() {
     let body: Value = test::read_body_json(resp).await;
     let file_id = body["data"]["id"].as_i64().unwrap();
 
-    let owner = aster_drive::db::repository::user_repo::find_by_username(&state.db, "testuser")
-        .await
-        .expect("owner lookup should succeed")
-        .expect("owner should exist");
+    let owner =
+        aster_drive::db::repository::user_repo::find_by_username(state.writer_db(), "testuser")
+            .await
+            .expect("owner lookup should succeed")
+            .expect("owner should exist");
     let mut owner_active = owner.into_active_model();
     owner_active.storage_quota = Set(owner_active.storage_used.clone().unwrap());
     owner_active
-        .update(&state.db)
+        .update(state.writer_db())
         .await
         .expect("owner quota should update");
 
@@ -2059,10 +2060,11 @@ async fn test_retry_task_reloads_max_attempts_from_runtime_config() {
     let state = common::setup().await;
     let app = create_test_app!(state.clone());
     let (token, _) = register_and_login!(app);
-    let owner = aster_drive::db::repository::user_repo::find_by_username(&state.db, "testuser")
-        .await
-        .expect("owner lookup should succeed")
-        .expect("owner should exist");
+    let owner =
+        aster_drive::db::repository::user_repo::find_by_username(state.writer_db(), "testuser")
+            .await
+            .expect("owner lookup should succeed")
+            .expect("owner should exist");
 
     aster_drive::services::config_service::set(&state, "background_task_max_attempts", "4", 1)
         .await
@@ -2079,7 +2081,7 @@ async fn test_retry_task_reloads_max_attempts_from_runtime_config() {
     )
     .expect("archive payload should serialize");
     let task = background_task_repo::create(
-        &state.db,
+        state.writer_db(),
         background_task::ActiveModel {
             kind: Set(BackgroundTaskKind::ArchiveCompress),
             status: Set(BackgroundTaskStatus::Failed),
@@ -2130,7 +2132,7 @@ async fn test_retry_task_reloads_max_attempts_from_runtime_config() {
         .await
         .expect("manual task retry should wake the dispatcher");
 
-    let stored = background_task_repo::find_by_id(&state.db, task.id)
+    let stored = background_task_repo::find_by_id(state.writer_db(), task.id)
         .await
         .expect("retried task should still exist");
     assert_eq!(stored.status, BackgroundTaskStatus::Pending);
@@ -2141,7 +2143,7 @@ async fn test_retry_task_reloads_max_attempts_from_runtime_config() {
 #[actix_web::test]
 async fn test_team_archive_extract_task_creates_team_folder_tree() {
     let state = common::setup().await;
-    let db = state.db.clone();
+    let db = state.writer_db().clone();
     let mail_sender = state.mail_sender.clone();
     let state = web::Data::new(state);
     let app = test::init_service(
@@ -2155,7 +2157,7 @@ async fn test_team_archive_extract_task_creates_team_folder_tree() {
 
     register_user!(
         app,
-        state.db.clone(),
+        state.writer_db().clone(),
         mail_sender,
         "extractor",
         "extractor@example.com",
@@ -2657,17 +2659,18 @@ async fn test_archive_extract_task_fails_before_staging_when_quota_is_insufficie
     let resp = test::call_service(&app, req).await;
     assert_eq!(resp.status(), 200);
 
-    let owner = aster_drive::db::repository::user_repo::find_by_username(&state.db, "testuser")
-        .await
-        .expect("owner lookup should succeed")
-        .expect("owner should exist");
+    let owner =
+        aster_drive::db::repository::user_repo::find_by_username(state.writer_db(), "testuser")
+            .await
+            .expect("owner lookup should succeed")
+            .expect("owner should exist");
     let quota_base = owner.storage_used;
     let mut owner_active = owner.into_active_model();
     owner_active.storage_quota = Set(quota_base
         .checked_add(8)
         .expect("quota adjustment should stay within i64"));
     owner_active
-        .update(&state.db)
+        .update(state.writer_db())
         .await
         .expect("owner quota should update");
 
@@ -3245,13 +3248,13 @@ async fn test_archive_extract_task_fails_when_downloaded_source_exceeds_declared
     assert_eq!(resp.status(), 200);
 
     let source_file =
-        aster_drive::db::repository::file_repo::find_by_id(&state.db, archive_file_id)
+        aster_drive::db::repository::file_repo::find_by_id(state.writer_db(), archive_file_id)
             .await
             .expect("archive file should be loaded");
     let mut file_active = source_file.into_active_model();
     file_active.size = Set(1);
     file_active
-        .update(&state.db)
+        .update(state.writer_db())
         .await
         .expect("archive file declared size should update");
 
@@ -3311,10 +3314,11 @@ async fn test_archive_extract_task_cleans_created_root_after_import_failure() {
         .await
         .expect("background task max attempts config should update");
     let (token, _) = register_and_login!(app);
-    let owner = aster_drive::db::repository::user_repo::find_by_username(&state.db, "testuser")
-        .await
-        .expect("owner lookup should succeed")
-        .expect("owner should exist");
+    let owner =
+        aster_drive::db::repository::user_repo::find_by_username(state.writer_db(), "testuser")
+            .await
+            .expect("owner lookup should succeed")
+            .expect("owner should exist");
 
     let req = test::TestRequest::post()
         .uri("/api/v1/files/new")
@@ -3374,7 +3378,7 @@ async fn test_archive_extract_task_cleans_created_root_after_import_failure() {
     assert_eq!(body["data"]["status"], "failed");
 
     let cleanup_root = aster_drive::db::repository::folder_repo::find_by_name_in_parent(
-        &state.db,
+        state.writer_db(),
         owner.id,
         None,
         "cleanup-root",

--- a/tests/test_team_space.rs
+++ b/tests/test_team_space.rs
@@ -117,20 +117,24 @@ async fn set_default_policy_chunk_size(
 ) {
     use sea_orm::{ActiveModelTrait, Set};
 
-    let policy = aster_drive::db::repository::policy_repo::find_default(&state.db)
+    let policy = aster_drive::db::repository::policy_repo::find_default(state.writer_db())
         .await
         .unwrap()
         .expect("default policy should exist");
     let mut active: aster_drive::entities::storage_policy::ActiveModel = policy.into();
     active.chunk_size = Set(chunk_size);
-    active.update(&state.db).await.unwrap();
-    state.policy_snapshot.reload(&state.db).await.unwrap();
+    active.update(state.writer_db()).await.unwrap();
+    state
+        .policy_snapshot
+        .reload(state.writer_db())
+        .await
+        .unwrap();
 }
 
 #[actix_web::test]
 async fn test_team_space_upload_browse_download_and_personal_separation() {
     let state = common::setup().await;
-    let db = state.db.clone();
+    let db = state.writer_db().clone();
     let mail_sender = state.mail_sender.clone();
     let app = create_test_app!(state);
 
@@ -311,7 +315,7 @@ async fn test_team_space_upload_browse_download_and_personal_separation() {
 #[actix_web::test]
 async fn test_team_space_delete_folder_and_non_member_forbidden() {
     let state = common::setup().await;
-    let db = state.db.clone();
+    let db = state.writer_db().clone();
     let mail_sender = state.mail_sender.clone();
     let app = create_test_app!(state);
 
@@ -430,7 +434,7 @@ async fn test_team_space_delete_folder_and_non_member_forbidden() {
 #[actix_web::test]
 async fn test_team_space_patch_file_and_folder() {
     let state = common::setup().await;
-    let db = state.db.clone();
+    let db = state.writer_db().clone();
     let mail_sender = state.mail_sender.clone();
     let app = create_test_app!(state);
 
@@ -622,7 +626,7 @@ async fn test_team_space_patch_file_and_folder() {
 #[actix_web::test]
 async fn test_team_file_direct_link_supports_public_access_and_team_deactivation() {
     let state = common::setup().await;
-    let db = state.db.clone();
+    let db = state.writer_db().clone();
     let mail_sender = state.mail_sender.clone();
     let app = create_test_app!(state);
 
@@ -711,7 +715,7 @@ async fn test_team_file_direct_link_supports_public_access_and_team_deactivation
 #[actix_web::test]
 async fn test_team_space_copy_file_and_folder() {
     let state = common::setup().await;
-    let db = state.db.clone();
+    let db = state.writer_db().clone();
     let mail_sender = state.mail_sender.clone();
     let app = create_test_app!(state);
 
@@ -900,7 +904,7 @@ async fn test_team_space_copy_file_and_folder() {
 #[actix_web::test]
 async fn test_team_space_content_versions_and_locks() {
     let state = common::setup().await;
-    let db = state.db.clone();
+    let db = state.writer_db().clone();
     let mail_sender = state.mail_sender.clone();
     let app = create_test_app!(state);
 
@@ -1192,7 +1196,7 @@ async fn test_team_space_content_versions_and_locks() {
 #[actix_web::test]
 async fn test_team_update_content_allows_body_larger_than_global_payload_limit() {
     let state = common::setup().await;
-    let db = state.db.clone();
+    let db = state.writer_db().clone();
     let mail_sender = state.mail_sender.clone();
     let app = create_test_app!(state);
 
@@ -1255,7 +1259,7 @@ async fn test_team_update_content_allows_body_larger_than_global_payload_limit()
 #[actix_web::test]
 async fn test_team_versions_enforce_scope_and_membership() {
     let state = common::setup().await;
-    let db = state.db.clone();
+    let db = state.writer_db().clone();
     let mail_sender = state.mail_sender.clone();
     let app = create_test_app!(state);
 
@@ -1384,7 +1388,7 @@ async fn test_team_versions_enforce_scope_and_membership() {
 #[actix_web::test]
 async fn test_team_shares_support_public_folder_access_and_team_management() {
     let state = common::setup().await;
-    let db = state.db.clone();
+    let db = state.writer_db().clone();
     let mail_sender = state.mail_sender.clone();
     let app = create_test_app!(state);
 
@@ -1608,7 +1612,7 @@ async fn test_team_shares_support_public_folder_access_and_team_management() {
 #[actix_web::test]
 async fn test_team_trash_restore_file_to_root_and_purge_deleted_folder_tree() {
     let state = common::setup().await;
-    let db = state.db.clone();
+    let db = state.writer_db().clone();
     let mail_sender = state.mail_sender.clone();
     let app = create_test_app!(state);
 
@@ -1760,7 +1764,7 @@ async fn test_team_trash_restore_file_to_root_and_purge_deleted_folder_tree() {
 #[actix_web::test]
 async fn test_team_trash_purge_all_schedules_background_task() {
     let state = common::setup().await;
-    let db = state.db.clone();
+    let db = state.writer_db().clone();
     let mail_sender = state.mail_sender.clone();
     let app = create_test_app!(state.clone());
 
@@ -1859,7 +1863,7 @@ async fn test_team_trash_purge_all_schedules_background_task() {
 #[actix_web::test]
 async fn test_team_trash_purge_all_rejects_non_member_without_creating_task() {
     let state = common::setup().await;
-    let db = state.db.clone();
+    let db = state.writer_db().clone();
     let mail_sender = state.mail_sender.clone();
     let app = create_test_app!(state);
 
@@ -1944,7 +1948,7 @@ async fn test_team_trash_purge_all_rejects_non_member_without_creating_task() {
 #[actix_web::test]
 async fn test_team_trash_rejects_active_and_out_of_scope_items() {
     let state = common::setup().await;
-    let db = state.db.clone();
+    let db = state.writer_db().clone();
     let mail_sender = state.mail_sender.clone();
     let app = create_test_app!(state);
 
@@ -2056,7 +2060,7 @@ async fn test_team_trash_rejects_active_and_out_of_scope_items() {
 #[actix_web::test]
 async fn test_team_trash_pagination_preserves_totals_and_membership() {
     let state = common::setup().await;
-    let db = state.db.clone();
+    let db = state.writer_db().clone();
     let mail_sender = state.mail_sender.clone();
     let app = create_test_app!(state);
 
@@ -2208,7 +2212,7 @@ async fn test_team_trash_pagination_preserves_totals_and_membership() {
 #[actix_web::test]
 async fn test_team_space_chunked_upload_flow_and_personal_route_rejection() {
     let state = common::setup().await;
-    let db = state.db.clone();
+    let db = state.writer_db().clone();
     set_default_policy_chunk_size(&state, 4).await;
     let mail_sender = state.mail_sender.clone();
     let app = create_test_app!(state);
@@ -2330,7 +2334,7 @@ async fn test_team_space_chunked_upload_flow_and_personal_route_rejection() {
 #[actix_web::test]
 async fn test_team_chunk_upload_endpoint_rejects_oversized_chunk_with_413() {
     let state = common::setup().await;
-    let db = state.db.clone();
+    let db = state.writer_db().clone();
     set_default_policy_chunk_size(&state, 4).await;
     let mail_sender = state.mail_sender.clone();
     let app = create_test_app!(state);
@@ -2394,7 +2398,7 @@ async fn test_team_chunk_upload_endpoint_rejects_oversized_chunk_with_413() {
 #[actix_web::test]
 async fn test_team_chunk_upload_endpoint_keeps_duplicate_size_validation() {
     let state = common::setup().await;
-    let db = state.db.clone();
+    let db = state.writer_db().clone();
     set_default_policy_chunk_size(&state, 4).await;
     let mail_sender = state.mail_sender.clone();
     let app = create_test_app!(state);
@@ -2465,7 +2469,7 @@ async fn test_team_chunk_upload_endpoint_keeps_duplicate_size_validation() {
 #[actix_web::test]
 async fn test_team_empty_upload_flow_uses_direct_and_creates_file() {
     let state = common::setup().await;
-    let db = state.db.clone();
+    let db = state.writer_db().clone();
     let mail_sender = state.mail_sender.clone();
     let app = create_test_app!(state);
 
@@ -2529,7 +2533,7 @@ async fn test_team_empty_upload_flow_uses_direct_and_creates_file() {
 #[actix_web::test]
 async fn test_team_upload_session_enforces_owner_even_for_members() {
     let state = common::setup().await;
-    let db = state.db.clone();
+    let db = state.writer_db().clone();
     set_default_policy_chunk_size(&state, 4).await;
     let mail_sender = state.mail_sender.clone();
     let app = create_test_app!(state);
@@ -2637,7 +2641,7 @@ async fn test_team_upload_session_enforces_owner_even_for_members() {
 #[actix_web::test]
 async fn test_team_search_scopes_results_to_workspace_and_enforces_membership() {
     let state = common::setup().await;
-    let db = state.db.clone();
+    let db = state.writer_db().clone();
     let mail_sender = state.mail_sender.clone();
     let app = create_test_app!(state);
 
@@ -2761,7 +2765,7 @@ async fn test_team_search_scopes_results_to_workspace_and_enforces_membership() 
 #[actix_web::test]
 async fn test_team_search_rejects_invalid_params_via_shared_validation() {
     let state = common::setup().await;
-    let db = state.db.clone();
+    let db = state.writer_db().clone();
     let mail_sender = state.mail_sender.clone();
     let app = create_test_app!(state);
 
@@ -2804,7 +2808,7 @@ async fn test_team_search_rejects_invalid_params_via_shared_validation() {
 #[actix_web::test]
 async fn test_team_search_supports_category_and_extension_filters() {
     let state = common::setup().await;
-    let db = state.db.clone();
+    let db = state.writer_db().clone();
     let mail_sender = state.mail_sender.clone();
     let app = create_test_app!(state);
 
@@ -2898,7 +2902,7 @@ async fn test_team_search_supports_category_and_extension_filters() {
 #[actix_web::test]
 async fn test_team_batch_routes_support_copy_move_and_delete() {
     let state = common::setup().await;
-    let db = state.db.clone();
+    let db = state.writer_db().clone();
     let mail_sender = state.mail_sender.clone();
     let app = create_test_app!(state);
 
@@ -3061,7 +3065,7 @@ async fn test_team_batch_routes_support_copy_move_and_delete() {
 #[actix_web::test]
 async fn test_team_batch_delete_preserves_scope_and_locked_failures() {
     let state = common::setup().await;
-    let db = state.db.clone();
+    let db = state.writer_db().clone();
     let mail_sender = state.mail_sender.clone();
     let app = create_test_app!(state);
 
@@ -3181,7 +3185,7 @@ async fn test_team_batch_delete_preserves_scope_and_locked_failures() {
 #[actix_web::test]
 async fn test_team_share_batch_delete_preserves_partial_failures() {
     let state = common::setup().await;
-    let db = state.db.clone();
+    let db = state.writer_db().clone();
     let mail_sender = state.mail_sender.clone();
     let app = create_test_app!(state);
 

--- a/tests/test_teams.rs
+++ b/tests/test_teams.rs
@@ -45,7 +45,7 @@ macro_rules! login_user {
 #[actix_web::test]
 async fn test_team_crud_and_member_lifecycle() {
     let state = common::setup().await;
-    let db = state.db.clone();
+    let db = state.writer_db().clone();
     let mail_sender = state.mail_sender.clone();
     let app = create_test_app!(state);
 
@@ -195,7 +195,7 @@ async fn test_team_crud_and_member_lifecycle() {
 #[actix_web::test]
 async fn test_team_list_keyword_filters_visible_teams_and_archived_state() {
     let state = common::setup().await;
-    let db = state.db.clone();
+    let db = state.writer_db().clone();
     let mail_sender = state.mail_sender.clone();
     let app = create_test_app!(state);
 
@@ -321,7 +321,7 @@ async fn test_team_list_keyword_filters_visible_teams_and_archived_state() {
 #[actix_web::test]
 async fn test_team_permissions_for_member_and_admin() {
     let state = common::setup().await;
-    let db = state.db.clone();
+    let db = state.writer_db().clone();
     let mail_sender = state.mail_sender.clone();
     let app = create_test_app!(state);
 
@@ -421,7 +421,7 @@ async fn test_team_permissions_for_member_and_admin() {
 #[actix_web::test]
 async fn test_only_system_admin_can_create_team() {
     let state = common::setup().await;
-    let db = state.db.clone();
+    let db = state.writer_db().clone();
     let mail_sender = state.mail_sender.clone();
     let app = create_test_app!(state);
 
@@ -458,7 +458,7 @@ async fn test_only_system_admin_can_create_team() {
 #[actix_web::test]
 async fn test_team_owner_protection_and_archive() {
     let state = common::setup().await;
-    let db = state.db.clone();
+    let db = state.writer_db().clone();
     let mail_sender = state.mail_sender.clone();
     let app = create_test_app!(state);
 
@@ -566,7 +566,7 @@ async fn test_team_owner_protection_and_archive() {
 #[actix_web::test]
 async fn test_team_admin_can_restore_archived_team() {
     let state = common::setup().await;
-    let db = state.db.clone();
+    let db = state.writer_db().clone();
     let mail_sender = state.mail_sender.clone();
     let app = create_test_app!(state);
 

--- a/tests/test_thumbnail.rs
+++ b/tests/test_thumbnail.rs
@@ -175,7 +175,9 @@ async fn thumbnail_task_display_name_for_processor(
     file_id: i64,
     processor: MediaProcessorKind,
 ) -> String {
-    let file = file_repo::find_by_id(&state.db, file_id).await.unwrap();
+    let file = file_repo::find_by_id(state.writer_db(), file_id)
+        .await
+        .unwrap();
     format!(
         "Generate thumbnail for blob #{} via {}",
         file.blob_id,
@@ -195,15 +197,17 @@ async fn blob_for_file(
     state: &PrimaryAppState,
     file_id: i64,
 ) -> aster_drive::entities::file_blob::Model {
-    let file = file_repo::find_by_id(&state.db, file_id).await.unwrap();
-    file_repo::find_blob_by_id(&state.db, file.blob_id)
+    let file = file_repo::find_by_id(state.writer_db(), file_id)
+        .await
+        .unwrap();
+    file_repo::find_blob_by_id(state.writer_db(), file.blob_id)
         .await
         .unwrap()
 }
 
 async fn thumbnail_task_count(state: &PrimaryAppState, file_id: i64) -> usize {
     let display_name = thumbnail_task_display_name(state, file_id).await;
-    background_task_repo::list_recent(&state.db, 32)
+    background_task_repo::list_recent(state.writer_db(), 32)
         .await
         .unwrap()
         .into_iter()
@@ -214,7 +218,7 @@ async fn thumbnail_task_count(state: &PrimaryAppState, file_id: i64) -> usize {
 }
 
 async fn enable_default_policy_storage_native_thumbnail(state: &PrimaryAppState) {
-    let policy = policy_repo::find_default(&state.db)
+    let policy = policy_repo::find_default(state.writer_db())
         .await
         .unwrap()
         .expect("default policy should exist");
@@ -225,8 +229,12 @@ async fn enable_default_policy_storage_native_thumbnail(state: &PrimaryAppState)
         ..Default::default()
     })
     .unwrap());
-    active.update(&state.db).await.unwrap();
-    state.policy_snapshot.reload(&state.db).await.unwrap();
+    active.update(state.writer_db()).await.unwrap();
+    state
+        .policy_snapshot
+        .reload(state.writer_db())
+        .await
+        .unwrap();
 }
 
 async fn latest_thumbnail_task(
@@ -243,7 +251,7 @@ async fn latest_thumbnail_task_for_processor(
 ) -> aster_drive::entities::background_task::Model {
     let display_name = thumbnail_task_display_name_for_processor(state, file_id, processor).await;
     background_task_repo::find_latest_by_kind_and_display_name(
-        &state.db,
+        state.writer_db(),
         BackgroundTaskKind::ThumbnailGenerate,
         &display_name,
     )
@@ -447,7 +455,7 @@ async fn test_thumbnail_non_image_returns_bad_request_without_task() {
     let resp = request_thumbnail!(app, token, file_id);
 
     assert_eq!(resp.status(), 400);
-    let tasks = background_task_repo::list_recent(&state.db, 16)
+    let tasks = background_task_repo::list_recent(state.writer_db(), 16)
         .await
         .unwrap();
     assert!(

--- a/tests/test_trash.rs
+++ b/tests/test_trash.rs
@@ -233,7 +233,7 @@ async fn test_trash_purge_all() {
     let resp = test::call_service(&app, req).await;
     let body: Value = test::read_body_json(resp).await;
     assert_eq!(body["data"]["files"].as_array().unwrap().len(), 2);
-    let owner_before = user_repo::find_by_username(&state.db, "testuser")
+    let owner_before = user_repo::find_by_username(state.writer_db(), "testuser")
         .await
         .unwrap()
         .unwrap();
@@ -338,7 +338,7 @@ async fn test_trash_purge_all() {
     let resp = test::call_service(&app, req).await;
     let body: Value = test::read_body_json(resp).await;
     assert_eq!(body["data"]["files"].as_array().unwrap().len(), 0);
-    let owner_after = user_repo::find_by_username(&state.db, "testuser")
+    let owner_after = user_repo::find_by_username(state.writer_db(), "testuser")
         .await
         .unwrap()
         .unwrap();
@@ -667,7 +667,7 @@ async fn test_restore_file_moves_to_root_when_original_folder_is_deleted() {
     use aster_drive::db::repository::file_repo;
 
     let state = common::setup().await;
-    let db = state.db.clone();
+    let db = state.writer_db().clone();
     let app = create_test_app!(state);
     let (token, _) = register_and_login!(app);
 
@@ -717,7 +717,7 @@ async fn test_restore_folder_moves_to_root_when_parent_is_deleted() {
     use aster_drive::db::repository::{file_repo, folder_repo};
 
     let state = common::setup().await;
-    let db = state.db.clone();
+    let db = state.writer_db().clone();
     let app = create_test_app!(state);
     let (token, _) = register_and_login!(app);
 
@@ -831,49 +831,58 @@ async fn test_cleanup_expired_falls_back_to_default_retention_for_invalid_config
         .await
         .unwrap();
 
-    config_repo::upsert(&state.db, "trash_retention_days", "not-a-number", user.id)
-        .await
-        .unwrap();
+    config_repo::upsert(
+        state.writer_db(),
+        "trash_retention_days",
+        "not-a-number",
+        user.id,
+    )
+    .await
+    .unwrap();
 
     let expired_at = Utc::now() - Duration::days(8);
 
     let mut deleted_root: aster_drive::entities::file::ActiveModel =
-        file_repo::find_by_id(&state.db, root_file.id)
+        file_repo::find_by_id(state.writer_db(), root_file.id)
             .await
             .unwrap()
             .into();
     deleted_root.deleted_at = Set(Some(expired_at));
-    deleted_root.update(&state.db).await.unwrap();
+    deleted_root.update(state.writer_db()).await.unwrap();
 
     let mut deleted_nested: aster_drive::entities::file::ActiveModel =
-        file_repo::find_by_id(&state.db, nested_file.id)
+        file_repo::find_by_id(state.writer_db(), nested_file.id)
             .await
             .unwrap()
             .into();
     deleted_nested.deleted_at = Set(Some(expired_at));
-    deleted_nested.update(&state.db).await.unwrap();
+    deleted_nested.update(state.writer_db()).await.unwrap();
 
     let mut deleted_folder: aster_drive::entities::folder::ActiveModel =
-        folder_repo::find_by_id(&state.db, folder.id)
+        folder_repo::find_by_id(state.writer_db(), folder.id)
             .await
             .unwrap()
             .into();
     deleted_folder.deleted_at = Set(Some(expired_at));
-    deleted_folder.update(&state.db).await.unwrap();
+    deleted_folder.update(state.writer_db()).await.unwrap();
 
     let purged = trash_service::cleanup_expired(&state).await.unwrap();
     assert_eq!(purged, 3);
     assert!(
-        file_repo::find_by_id(&state.db, root_file.id)
+        file_repo::find_by_id(state.writer_db(), root_file.id)
             .await
             .is_err()
     );
     assert!(
-        file_repo::find_by_id(&state.db, nested_file.id)
+        file_repo::find_by_id(state.writer_db(), nested_file.id)
             .await
             .is_err()
     );
-    assert!(folder_repo::find_by_id(&state.db, folder.id).await.is_err());
+    assert!(
+        folder_repo::find_by_id(state.writer_db(), folder.id)
+            .await
+            .is_err()
+    );
 }
 
 #[actix_web::test]
@@ -902,12 +911,12 @@ async fn test_cleanup_expired_only_counts_top_level_deleted_folders() {
     let expired_at = Utc::now() - Duration::days(8);
     for folder_id in [parent.id, child.id] {
         let mut folder: aster_drive::entities::folder::ActiveModel =
-            folder_repo::find_by_id(&state.db, folder_id)
+            folder_repo::find_by_id(state.writer_db(), folder_id)
                 .await
                 .unwrap()
                 .into();
         folder.deleted_at = Set(Some(expired_at));
-        folder.update(&state.db).await.unwrap();
+        folder.update(state.writer_db()).await.unwrap();
     }
 
     let purged = trash_service::cleanup_expired(&state).await.unwrap();
@@ -915,8 +924,16 @@ async fn test_cleanup_expired_only_counts_top_level_deleted_folders() {
         purged, 1,
         "only the top-level expired folder should be counted"
     );
-    assert!(folder_repo::find_by_id(&state.db, parent.id).await.is_err());
-    assert!(folder_repo::find_by_id(&state.db, child.id).await.is_err());
+    assert!(
+        folder_repo::find_by_id(state.writer_db(), parent.id)
+            .await
+            .is_err()
+    );
+    assert!(
+        folder_repo::find_by_id(state.writer_db(), child.id)
+            .await
+            .is_err()
+    );
 }
 
 #[actix_web::test]
@@ -950,7 +967,9 @@ async fn test_cleanup_expired_keeps_recently_deleted_items() {
     let purged = trash_service::cleanup_expired(&state).await.unwrap();
     assert_eq!(purged, 0);
 
-    let trashed = file_repo::find_by_id(&state.db, file.id).await.unwrap();
+    let trashed = file_repo::find_by_id(state.writer_db(), file.id)
+        .await
+        .unwrap();
     assert!(trashed.deleted_at.is_some());
 }
 

--- a/tests/test_upload.rs
+++ b/tests/test_upload.rs
@@ -2470,6 +2470,77 @@ async fn test_upload_service_get_progress_uses_db_parts_for_terminal_relay_multi
 }
 
 #[actix_web::test]
+async fn test_sqlite_reader_routes_do_not_wait_for_busy_writer_pool() {
+    use aster_drive::services::auth_service;
+    use sea_orm::{ConnectionTrait, TransactionTrait};
+
+    let database_url = format!(
+        "sqlite:///tmp/asterdrive-reader-routes-{}.db?mode=rwc",
+        uuid::Uuid::new_v4()
+    );
+    let state = common::setup_with_database_url(&database_url).await;
+    assert!(
+        state.db_handles.sqlite_read_write_split(),
+        "file SQLite test state should enable reader/writer split"
+    );
+
+    let app = create_test_app!(state.clone());
+    let user = auth_service::register(&state, "readerroute", "readerroute@test.com", "password123")
+        .await
+        .unwrap();
+    let (access_token, _) =
+        auth_service::issue_tokens_for_session(&state, user.id, user.session_version, None, None)
+            .await
+            .unwrap();
+    let upload_id = new_test_upload_id();
+    create_upload_session(
+        &state,
+        user.id,
+        UploadSessionSpec::new(
+            &upload_id,
+            aster_drive::types::UploadSessionStatus::Uploading,
+            chrono::Utc::now() + chrono::Duration::hours(1),
+        )
+        .chunks(3, 2),
+    )
+    .await;
+
+    let txn = state.db.begin().await.unwrap();
+    txn.execute_unprepared("UPDATE users SET updated_at = updated_at WHERE id = -1")
+        .await
+        .unwrap();
+
+    let folder_req = test::TestRequest::get()
+        .uri("/api/v1/folders")
+        .insert_header(("Authorization", format!("Bearer {access_token}")))
+        .to_request();
+    let folder_resp = tokio::time::timeout(
+        std::time::Duration::from_millis(500),
+        test::call_service(&app, folder_req),
+    )
+    .await
+    .expect("folder listing should not wait for the busy writer pool");
+    assert_eq!(folder_resp.status(), 200);
+
+    let progress_req = test::TestRequest::get()
+        .uri(&format!("/api/v1/files/upload/{upload_id}"))
+        .insert_header(("Authorization", format!("Bearer {access_token}")))
+        .to_request();
+    let progress_resp = tokio::time::timeout(
+        std::time::Duration::from_millis(500),
+        test::call_service(&app, progress_req),
+    )
+    .await
+    .expect("upload progress should not wait for the busy writer pool");
+    assert_eq!(progress_resp.status(), 200);
+    let progress_body: Value = test::read_body_json(progress_resp).await;
+    assert_eq!(progress_body["data"]["upload_id"], upload_id);
+    assert_eq!(progress_body["data"]["received_count"], 2);
+
+    txn.rollback().await.unwrap();
+}
+
+#[actix_web::test]
 async fn test_upload_service_presign_parts_rejects_non_multipart_session() {
     use aster_drive::services::{auth_service, upload_service};
 

--- a/tests/test_upload.rs
+++ b/tests/test_upload.rs
@@ -18,7 +18,11 @@ fn new_test_upload_id() -> String {
 }
 
 async fn reload_policy_snapshot(state: &aster_drive::runtime::PrimaryAppState) {
-    state.policy_snapshot.reload(&state.db).await.unwrap();
+    state
+        .policy_snapshot
+        .reload(state.writer_db())
+        .await
+        .unwrap();
 }
 
 async fn set_default_local_content_dedup(
@@ -28,7 +32,7 @@ async fn set_default_local_content_dedup(
     use aster_drive::db::repository::policy_repo;
     use sea_orm::{ActiveModelTrait, Set};
 
-    let policy = policy_repo::find_default(&state.db)
+    let policy = policy_repo::find_default(state.writer_db())
         .await
         .unwrap()
         .expect("default policy should exist in test setup");
@@ -41,7 +45,7 @@ async fn set_default_local_content_dedup(
         }
         .to_string(),
     ));
-    active.update(&state.db).await.unwrap();
+    active.update(state.writer_db()).await.unwrap();
     reload_policy_snapshot(state).await;
 }
 
@@ -107,10 +111,10 @@ async fn upload_same_content_direct_and_chunked(
         .await
         .unwrap();
 
-    let direct_blob = file_repo::find_blob_by_id(&state.db, direct_file.blob_id)
+    let direct_blob = file_repo::find_blob_by_id(state.writer_db(), direct_file.blob_id)
         .await
         .unwrap();
-    let chunked_blob = file_repo::find_blob_by_id(&state.db, chunked_file.blob_id)
+    let chunked_blob = file_repo::find_blob_by_id(state.writer_db(), chunked_file.blob_id)
         .await
         .unwrap();
 
@@ -180,14 +184,14 @@ async fn create_upload_session(
     use aster_drive::db::repository::{policy_repo, upload_session_repo};
     use sea_orm::Set;
 
-    let policy = policy_repo::find_default(&state.db)
+    let policy = policy_repo::find_default(state.writer_db())
         .await
         .unwrap()
         .expect("default policy should exist in test setup");
     let policy_id = spec.policy_id.unwrap_or(policy.id);
     let now = chrono::Utc::now();
     upload_session_repo::create(
-        &state.db,
+        state.writer_db(),
         aster_drive::entities::upload_session::ActiveModel {
             id: Set(spec.upload_id.to_string()),
             user_id: Set(user_id),
@@ -226,7 +230,7 @@ async fn test_upload_session_try_create_reports_id_conflict() {
     )
     .await
     .unwrap();
-    let policy = policy_repo::find_default(&state.db)
+    let policy = policy_repo::find_default(state.writer_db())
         .await
         .unwrap()
         .expect("default policy should exist");
@@ -254,12 +258,12 @@ async fn test_upload_session_try_create_reports_id_conflict() {
     };
 
     assert!(
-        upload_session_repo::try_create(&state.db, build_model())
+        upload_session_repo::try_create(state.writer_db(), build_model())
             .await
             .unwrap()
     );
     assert!(
-        !upload_session_repo::try_create(&state.db, build_model())
+        !upload_session_repo::try_create(state.writer_db(), build_model())
             .await
             .unwrap()
     );
@@ -286,7 +290,7 @@ async fn test_upload_session_try_create_preserves_non_id_unique_conflict() {
     )
     .await
     .unwrap();
-    let policy = policy_repo::find_default(&state.db)
+    let policy = policy_repo::find_default(state.writer_db())
         .await
         .unwrap()
         .expect("default policy should exist");
@@ -314,11 +318,11 @@ async fn test_upload_session_try_create_preserves_non_id_unique_conflict() {
     };
 
     assert!(
-        upload_session_repo::try_create(&state.db, build_model(new_test_upload_id()))
+        upload_session_repo::try_create(state.writer_db(), build_model(new_test_upload_id()))
             .await
             .unwrap()
     );
-    let err = upload_session_repo::try_create(&state.db, build_model(new_test_upload_id()))
+    let err = upload_session_repo::try_create(state.writer_db(), build_model(new_test_upload_id()))
         .await
         .expect_err("non-id unique conflict should not be treated as id retry");
     assert_eq!(err.code(), "E002");
@@ -336,7 +340,7 @@ async fn create_dead_remote_policy(
 
     let now = chrono::Utc::now();
     let remote_node = managed_follower_repo::create(
-        &state.db,
+        state.writer_db(),
         managed_follower::ActiveModel {
             name: Set(format!("dead-remote-{}", uuid::Uuid::new_v4())),
             base_url: Set("http://127.0.0.1:9".to_string()),
@@ -358,7 +362,7 @@ async fn create_dead_remote_policy(
     .unwrap();
 
     let policy = policy_repo::create(
-        &state.db,
+        state.writer_db(),
         storage_policy::ActiveModel {
             name: Set(format!("dead-remote-policy-{}", uuid::Uuid::new_v4())),
             driver_type: Set(DriverType::Remote),
@@ -383,12 +387,12 @@ async fn create_dead_remote_policy(
 
     state
         .policy_snapshot
-        .reload(&state.db)
+        .reload(state.writer_db())
         .await
         .expect("policy snapshot should reload after creating dead remote policy");
     state
         .driver_registry
-        .reload_managed_followers(&state.db)
+        .reload_managed_followers(state.writer_db())
         .await
         .expect("driver registry should reload managed followers after creating dead remote node");
     state.driver_registry.invalidate(policy.id);
@@ -591,7 +595,7 @@ async fn create_s3_policy(
 
     let now = Utc::now();
     let policy = aster_drive::db::repository::policy_repo::create(
-        &state.db,
+        state.writer_db(),
         aster_drive::entities::storage_policy::ActiveModel {
             name: Set(name.to_string()),
             driver_type: Set(aster_drive::types::DriverType::S3),
@@ -614,7 +618,11 @@ async fn create_s3_policy(
     )
     .await
     .unwrap();
-    state.policy_snapshot.reload(&state.db).await.unwrap();
+    state
+        .policy_snapshot
+        .reload(state.writer_db())
+        .await
+        .unwrap();
     state.driver_registry.invalidate(policy.id);
     policy
 }
@@ -788,8 +796,12 @@ async fn test_concurrent_store_from_temp_same_name_auto_renames() {
 
     let first = first.unwrap();
     let second = second.unwrap();
-    let first = file_repo::find_by_id(&state.db, first.id).await.unwrap();
-    let second = file_repo::find_by_id(&state.db, second.id).await.unwrap();
+    let first = file_repo::find_by_id(state.writer_db(), first.id)
+        .await
+        .unwrap();
+    let second = file_repo::find_by_id(state.writer_db(), second.id)
+        .await
+        .unwrap();
 
     let mut names = vec![first.name, second.name];
     names.sort();
@@ -1123,7 +1135,7 @@ async fn test_upload_service_init_upload_normalizes_nfd_filename_and_rejects_win
     let upload_id = init
         .upload_id
         .expect("chunked upload should return upload_id");
-    let session = upload_session_repo::find_by_id(&state.db, &upload_id)
+    let session = upload_session_repo::find_by_id(state.writer_db(), &upload_id)
         .await
         .unwrap();
     assert_eq!(session.filename, "caf\u{00e9}.txt");
@@ -1149,7 +1161,7 @@ async fn test_update_storage_used_is_atomic_under_concurrency() {
 
     let mut tasks = JoinSet::new();
     for _ in 0..32 {
-        let db = state.db.clone();
+        let db = state.writer_db().clone();
         let user_id = user.id;
         tasks.spawn(async move { user_repo::update_storage_used(&db, user_id, 1).await });
     }
@@ -1158,12 +1170,14 @@ async fn test_update_storage_used_is_atomic_under_concurrency() {
         result.unwrap().unwrap();
     }
 
-    let updated = user_repo::find_by_id(&state.db, user.id).await.unwrap();
+    let updated = user_repo::find_by_id(state.writer_db(), user.id)
+        .await
+        .unwrap();
     assert_eq!(updated.storage_used, 32);
 
     let mut tasks = JoinSet::new();
     for _ in 0..40 {
-        let db = state.db.clone();
+        let db = state.writer_db().clone();
         let user_id = user.id;
         tasks.spawn(async move { user_repo::update_storage_used(&db, user_id, -1).await });
     }
@@ -1172,7 +1186,9 @@ async fn test_update_storage_used_is_atomic_under_concurrency() {
         result.unwrap().unwrap();
     }
 
-    let updated = user_repo::find_by_id(&state.db, user.id).await.unwrap();
+    let updated = user_repo::find_by_id(state.writer_db(), user.id)
+        .await
+        .unwrap();
     assert_eq!(
         updated.storage_used, 0,
         "storage_used should not go below zero"
@@ -1198,17 +1214,17 @@ async fn test_concurrent_quota_overrun_is_rejected_by_cas() {
 
     // 设 quota = 100 字节，并发提交 20 个 +10 字节请求（总需求 200，超额一倍）
     let model = user::Entity::find_by_id(registered.id)
-        .one(&state.db)
+        .one(state.writer_db())
         .await
         .unwrap()
         .unwrap();
     let mut active = model.into_active_model();
     active.storage_quota = Set(100);
-    active.update(&state.db).await.unwrap();
+    active.update(state.writer_db()).await.unwrap();
 
     let mut tasks = JoinSet::new();
     for _ in 0..20 {
-        let db = state.db.clone();
+        let db = state.writer_db().clone();
         let user_id = registered.id;
         tasks.spawn(async move { user_repo::update_storage_used(&db, user_id, 10).await });
     }
@@ -1228,7 +1244,7 @@ async fn test_concurrent_quota_overrun_is_rejected_by_cas() {
     assert_eq!(succeeded, 10, "exactly 10 requests should fit in quota=100");
     assert_eq!(quota_exceeded, 10, "remaining 10 must be rejected");
 
-    let final_state = user_repo::find_by_id(&state.db, registered.id)
+    let final_state = user_repo::find_by_id(state.writer_db(), registered.id)
         .await
         .unwrap();
     assert_eq!(final_state.storage_used, 100, "must not exceed quota");
@@ -1249,17 +1265,17 @@ async fn test_check_quota_rejects_integer_overflow() {
 
     // 把 storage_used 调到接近 i64::MAX，再传一个会触发溢出的 delta
     let model = user::Entity::find_by_id(registered.id)
-        .one(&state.db)
+        .one(state.writer_db())
         .await
         .unwrap()
         .unwrap();
     let mut active = model.into_active_model();
     active.storage_used = Set(i64::MAX - 100);
     active.storage_quota = Set(0); // 不限，证明检查的是溢出本身而非配额
-    active.update(&state.db).await.unwrap();
+    active.update(state.writer_db()).await.unwrap();
 
     // 不限配额下，i64 加法溢出本来会 wrap 成负数通过 check，现在必须明确拒绝
-    let result = user_repo::check_quota(&state.db, registered.id, 200).await;
+    let result = user_repo::check_quota(state.writer_db(), registered.id, 200).await;
     let err = result.expect_err("overflow must be rejected");
     assert_eq!(err.code(), "E004", "expected internal_error for overflow");
 }
@@ -1552,12 +1568,13 @@ async fn test_chunked_upload_streaming_assembly_preserves_content() {
         .unwrap();
     assert_eq!(file.name, "streamed.txt");
 
-    let blob = file_repo::find_blob_by_id(&state.db, file.blob_id)
+    let blob = file_repo::find_blob_by_id(state.writer_db(), file.blob_id)
         .await
         .unwrap();
-    let policy = aster_drive::db::repository::policy_repo::find_by_id(&state.db, blob.policy_id)
-        .await
-        .unwrap();
+    let policy =
+        aster_drive::db::repository::policy_repo::find_by_id(state.writer_db(), blob.policy_id)
+            .await
+            .unwrap();
     let driver = state.driver_registry.get_driver(&policy).unwrap();
     let stored = driver.get(&blob.storage_path).await.unwrap();
 
@@ -1658,13 +1675,13 @@ async fn test_concurrent_chunked_dedup_complete_reuses_blob_without_overwrite() 
 
     let first = tasks.join_next().await.unwrap().unwrap();
     let second = tasks.join_next().await.unwrap().unwrap();
-    let first_blob = file_repo::find_blob_by_id(&state.db, first.blob_id)
+    let first_blob = file_repo::find_blob_by_id(state.writer_db(), first.blob_id)
         .await
         .unwrap();
-    let second_blob = file_repo::find_blob_by_id(&state.db, second.blob_id)
+    let second_blob = file_repo::find_blob_by_id(state.writer_db(), second.blob_id)
         .await
         .unwrap();
-    let policy = policy_repo::find_by_id(&state.db, first_blob.policy_id)
+    let policy = policy_repo::find_by_id(state.writer_db(), first_blob.policy_id)
         .await
         .unwrap();
     let driver = state.driver_registry.get_driver(&policy).unwrap();
@@ -1680,7 +1697,7 @@ async fn test_local_direct_upload_with_declared_size_avoids_global_temp_dirs_and
 
     let state = common::setup().await;
     set_default_local_content_dedup(&state, true).await;
-    let db = state.db.clone();
+    let db = state.writer_db().clone();
     let driver_registry = state.driver_registry.clone();
     let temp_roots = vec![
         state.config.server.temp_dir.clone(),
@@ -1957,21 +1974,23 @@ async fn test_upload_session_part_upsert_updates_existing_row_without_duplicates
     )
     .await;
 
-    let first = upload_session_part_repo::upsert_part(&state.db, &upload_id, 1, "etag-1", 5)
-        .await
-        .unwrap();
+    let first =
+        upload_session_part_repo::upsert_part(state.writer_db(), &upload_id, 1, "etag-1", 5)
+            .await
+            .unwrap();
     assert!(first.inserted);
     assert_eq!(first.model.etag, "etag-1");
     assert_eq!(first.model.size, 5);
 
-    let second = upload_session_part_repo::upsert_part(&state.db, &upload_id, 1, "etag-2", 7)
-        .await
-        .unwrap();
+    let second =
+        upload_session_part_repo::upsert_part(state.writer_db(), &upload_id, 1, "etag-2", 7)
+            .await
+            .unwrap();
     assert!(!second.inserted);
     assert_eq!(second.model.etag, "etag-2");
     assert_eq!(second.model.size, 7);
 
-    let parts = upload_session_part_repo::list_by_upload(&state.db, &upload_id)
+    let parts = upload_session_part_repo::list_by_upload(state.writer_db(), &upload_id)
         .await
         .unwrap();
     assert_eq!(parts.len(), 1);
@@ -1979,7 +1998,7 @@ async fn test_upload_session_part_upsert_updates_existing_row_without_duplicates
     assert_eq!(parts[0].etag, "etag-2");
     assert_eq!(parts[0].size, 7);
 
-    let session = upload_session_repo::find_by_id(&state.db, &upload_id)
+    let session = upload_session_repo::find_by_id(state.writer_db(), &upload_id)
         .await
         .unwrap();
     assert_eq!(session.received_count, 0);
@@ -2053,7 +2072,7 @@ async fn test_complete_upload_is_idempotent_after_completion() {
     assert_eq!(second.blob_id, first.blob_id);
     assert_eq!(second.name, "idempotent.txt");
 
-    let session = upload_session_repo::find_by_id(&state.db, &upload_id)
+    let session = upload_session_repo::find_by_id(state.writer_db(), &upload_id)
         .await
         .unwrap();
     assert_eq!(
@@ -2102,7 +2121,7 @@ async fn test_complete_upload_marks_session_failed_after_assembly_error() {
     assert_eq!(err.code(), "E057");
     assert!(err.message().contains("open chunk 1"));
 
-    let session = upload_session_repo::find_by_id(&state.db, &upload_id)
+    let session = upload_session_repo::find_by_id(state.writer_db(), &upload_id)
         .await
         .unwrap();
     assert_eq!(
@@ -2162,7 +2181,7 @@ async fn test_complete_upload_keeps_presigned_multipart_session_retryable_after_
         .unwrap_err();
     assert_eq!(err.code(), "E031");
 
-    let session = upload_session_repo::find_by_id(&state.db, &upload_id)
+    let session = upload_session_repo::find_by_id(state.writer_db(), &upload_id)
         .await
         .unwrap();
     assert_eq!(session.status, UploadSessionStatus::Presigned);
@@ -2173,7 +2192,7 @@ async fn test_complete_upload_keeps_presigned_multipart_session_retryable_after_
         .unwrap_err();
     assert_eq!(retry_err.code(), "E031");
 
-    let session_after_retry = upload_session_repo::find_by_id(&state.db, &upload_id)
+    let session_after_retry = upload_session_repo::find_by_id(state.writer_db(), &upload_id)
         .await
         .unwrap();
     assert_eq!(session_after_retry.status, UploadSessionStatus::Presigned);
@@ -2233,7 +2252,7 @@ async fn test_complete_upload_keeps_remote_chunked_session_retryable_after_stora
         .unwrap_err();
     assert_eq!(err.code(), "E031");
 
-    let session = upload_session_repo::find_by_id(&state.db, &upload_id)
+    let session = upload_session_repo::find_by_id(state.writer_db(), &upload_id)
         .await
         .unwrap();
     assert_eq!(session.status, UploadSessionStatus::Uploading);
@@ -2244,7 +2263,7 @@ async fn test_complete_upload_keeps_remote_chunked_session_retryable_after_stora
         .unwrap_err();
     assert_eq!(retry_err.code(), "E031");
 
-    let session_after_retry = upload_session_repo::find_by_id(&state.db, &upload_id)
+    let session_after_retry = upload_session_repo::find_by_id(state.writer_db(), &upload_id)
         .await
         .unwrap();
     assert_eq!(session_after_retry.status, UploadSessionStatus::Uploading);
@@ -2428,7 +2447,7 @@ async fn test_upload_service_get_progress_uses_db_parts_for_terminal_relay_multi
         let upload_id = new_test_upload_id();
         let now = Utc::now();
         upload_session_repo::create(
-            &state.db,
+            state.writer_db(),
             aster_drive::entities::upload_session::ActiveModel {
                 id: Set(upload_id.clone()),
                 user_id: Set(user.id),
@@ -2452,10 +2471,10 @@ async fn test_upload_service_get_progress_uses_db_parts_for_terminal_relay_multi
         .await
         .unwrap();
 
-        upload_session_part_repo::upsert_part(&state.db, &upload_id, 1, "etag-1", 5)
+        upload_session_part_repo::upsert_part(state.writer_db(), &upload_id, 1, "etag-1", 5)
             .await
             .unwrap();
-        upload_session_part_repo::upsert_part(&state.db, &upload_id, 3, "etag-3", 5)
+        upload_session_part_repo::upsert_part(state.writer_db(), &upload_id, 3, "etag-3", 5)
             .await
             .unwrap();
 
@@ -2482,7 +2501,7 @@ async fn test_sqlite_reader_routes_do_not_wait_for_busy_writer_pool() {
     let database_url = format!("sqlite://{}?mode=rwc", temp_dir.join("reader.db").display());
     let state = common::setup_with_database_url(&database_url).await;
     assert!(
-        state.db_handles.sqlite_read_write_split(),
+        state.sqlite_read_write_split(),
         "file SQLite test state should enable reader/writer split"
     );
 
@@ -2507,7 +2526,7 @@ async fn test_sqlite_reader_routes_do_not_wait_for_busy_writer_pool() {
     )
     .await;
 
-    let txn = state.db.begin().await.unwrap();
+    let txn = state.writer_db().begin().await.unwrap();
     txn.execute_unprepared("UPDATE users SET updated_at = updated_at WHERE id = -1")
         .await
         .unwrap();
@@ -2693,17 +2712,17 @@ async fn test_upload_service_cleanup_expired_removes_local_sessions_only() {
     let cleaned = upload_service::cleanup_expired(&state).await.unwrap();
     assert_eq!(cleaned, 1);
     assert!(
-        upload_session_repo::find_by_id(&state.db, &expired_id)
+        upload_session_repo::find_by_id(state.writer_db(), &expired_id)
             .await
             .is_err()
     );
     assert!(
-        upload_session_repo::find_by_id(&state.db, &completed_id)
+        upload_session_repo::find_by_id(state.writer_db(), &completed_id)
             .await
             .is_ok()
     );
     assert!(
-        upload_session_repo::find_by_id(&state.db, &assembling_id)
+        upload_session_repo::find_by_id(state.writer_db(), &assembling_id)
             .await
             .is_ok()
     );
@@ -2760,7 +2779,7 @@ async fn test_upload_service_cleanup_expired_keeps_remote_sessions_when_storage_
     let cleaned = upload_service::cleanup_expired(&state).await.unwrap();
     assert_eq!(cleaned, 0);
 
-    let session = upload_session_repo::find_by_id(&state.db, &upload_id)
+    let session = upload_session_repo::find_by_id(state.writer_db(), &upload_id)
         .await
         .unwrap();
     assert_eq!(session.status, UploadSessionStatus::Uploading);
@@ -2829,7 +2848,7 @@ async fn test_cancel_upload_aborts_presigned_multipart_session_on_rustfs() {
     assert_eq!(init.total_chunks, Some(2));
     let upload_id = init.upload_id.clone().unwrap();
 
-    let session = upload_session_repo::find_by_id(&state.db, &upload_id)
+    let session = upload_session_repo::find_by_id(state.writer_db(), &upload_id)
         .await
         .unwrap();
     let temp_key = session
@@ -2884,7 +2903,7 @@ async fn test_cancel_upload_aborts_presigned_multipart_session_on_rustfs() {
         .unwrap();
 
     assert!(
-        upload_session_repo::find_by_id(&state.db, &upload_id)
+        upload_session_repo::find_by_id(state.writer_db(), &upload_id)
             .await
             .is_err(),
         "canceled multipart upload session should be deleted immediately"
@@ -2956,7 +2975,7 @@ async fn test_cancel_upload_keeps_remote_session_when_object_cleanup_is_unavaila
         .unwrap();
     let cancel_completed_at = chrono::Utc::now();
 
-    let session = upload_session_repo::find_by_id(&state.db, &upload_id)
+    let session = upload_session_repo::find_by_id(state.writer_db(), &upload_id)
         .await
         .unwrap();
     assert_eq!(session.status, UploadSessionStatus::Failed);
@@ -3010,7 +3029,7 @@ async fn test_upload_chunk_returns_session_expired_for_failed_multipart_session(
     assert_eq!(err.code(), "E055");
     assert!(err.message().contains("canceled or failed"));
     assert!(
-        upload_session_part_repo::find_by_upload_and_part(&state.db, &upload_id, 1)
+        upload_session_part_repo::find_by_upload_and_part(state.writer_db(), &upload_id, 1)
             .await
             .unwrap()
             .is_none(),
@@ -3091,18 +3110,19 @@ async fn test_presigned_upload_s3_e2e() {
     assert_eq!(file.name, "hello.txt");
 
     // 4. 验证文件可通过 driver 读取
-    let policy = policy_repo::find_by_id(&state.db, s3_policy.id)
+    let policy = policy_repo::find_by_id(state.writer_db(), s3_policy.id)
         .await
         .unwrap();
     let driver = state.driver_registry.get_driver(&policy).unwrap();
     let completed_session =
-        aster_drive::db::repository::upload_session_repo::find_by_id(&state.db, &upload_id)
+        aster_drive::db::repository::upload_session_repo::find_by_id(state.writer_db(), &upload_id)
             .await
             .unwrap();
     let temp_key = completed_session.s3_temp_key.unwrap();
-    let blob = aster_drive::db::repository::file_repo::find_blob_by_id(&state.db, file.blob_id)
-        .await
-        .unwrap();
+    let blob =
+        aster_drive::db::repository::file_repo::find_blob_by_id(state.writer_db(), file.blob_id)
+            .await
+            .unwrap();
     assert_ne!(
         blob.storage_path, temp_key,
         "completed presigned uploads must be copied away from the still-valid PUT key"
@@ -3137,12 +3157,14 @@ async fn test_presigned_upload_s3_e2e() {
         "S3 presigned skips dedup — each upload creates its own blob"
     );
 
-    let blob1 = aster_drive::db::repository::file_repo::find_blob_by_id(&state.db, file.blob_id)
-        .await
-        .unwrap();
-    let blob2 = aster_drive::db::repository::file_repo::find_blob_by_id(&state.db, file2.blob_id)
-        .await
-        .unwrap();
+    let blob1 =
+        aster_drive::db::repository::file_repo::find_blob_by_id(state.writer_db(), file.blob_id)
+            .await
+            .unwrap();
+    let blob2 =
+        aster_drive::db::repository::file_repo::find_blob_by_id(state.writer_db(), file2.blob_id)
+            .await
+            .unwrap();
     assert_eq!(blob1.ref_count, 1);
     assert_eq!(blob2.ref_count, 1);
 }
@@ -3218,7 +3240,7 @@ async fn test_force_delete_policy_cleans_late_s3_presigned_put_e2e() {
     assert_eq!(init.mode, aster_drive::types::UploadMode::Presigned);
     let upload_id = init.upload_id.unwrap();
     let presigned_url = init.presigned_url.unwrap();
-    let session = upload_session_repo::find_by_id(&state.db, &upload_id)
+    let session = upload_session_repo::find_by_id(state.writer_db(), &upload_id)
         .await
         .unwrap();
     let temp_key = session
@@ -3235,9 +3257,13 @@ async fn test_force_delete_policy_cleans_late_s3_presigned_put_e2e() {
     policy_service::delete(&state, policy.id, true)
         .await
         .expect("force deleting policy with pending presigned session should succeed");
-    assert!(policy_repo::find_by_id(&state.db, policy.id).await.is_err());
     assert!(
-        upload_session_repo::find_by_id(&state.db, &upload_id)
+        policy_repo::find_by_id(state.writer_db(), policy.id)
+            .await
+            .is_err()
+    );
+    assert!(
+        upload_session_repo::find_by_id(state.writer_db(), &upload_id)
             .await
             .is_err(),
         "force delete should remove the upload session before the old URL expires"
@@ -3262,14 +3288,14 @@ async fn test_force_delete_policy_cleans_late_s3_presigned_put_e2e() {
 
     let cleanup_task = background_task::Entity::find()
         .filter(background_task::Column::Kind.eq(BackgroundTaskKind::StoragePolicyTempCleanup))
-        .one(&state.db)
+        .one(state.writer_db())
         .await
         .unwrap()
         .expect("force delete should schedule delayed cleanup");
     assert_eq!(cleanup_task.status, BackgroundTaskStatus::Pending);
     let mut due_task: background_task::ActiveModel = cleanup_task.clone().into();
     due_task.next_run_at = Set(chrono::Utc::now() - chrono::Duration::seconds(1));
-    due_task.update(&state.db).await.unwrap();
+    due_task.update(state.writer_db()).await.unwrap();
 
     let stats = task_service::dispatch_due(&state).await.unwrap();
     assert_eq!(stats.claimed, 1);
@@ -3278,7 +3304,7 @@ async fn test_force_delete_policy_cleans_late_s3_presigned_put_e2e() {
         !s3_object_exists(&s3_client, bucket, &object_key).await,
         "delayed cleanup should delete the late S3 temp object"
     );
-    let stored_task = background_task_repo::find_by_id(&state.db, cleanup_task.id)
+    let stored_task = background_task_repo::find_by_id(state.writer_db(), cleanup_task.id)
         .await
         .unwrap();
     assert_eq!(stored_task.status, BackgroundTaskStatus::Succeeded);
@@ -3404,11 +3430,11 @@ async fn test_presigned_multipart_upload_s3_e2e() {
     .unwrap();
     assert_eq!(file.name, "multipart.bin");
 
-    let policy = policy_repo::find_by_id(&state.db, s3_policy.id)
+    let policy = policy_repo::find_by_id(state.writer_db(), s3_policy.id)
         .await
         .unwrap();
     let driver = state.driver_registry.get_driver(&policy).unwrap();
-    let blob = file_repo::find_blob_by_id(&state.db, file.blob_id)
+    let blob = file_repo::find_blob_by_id(state.writer_db(), file.blob_id)
         .await
         .unwrap();
     let stored = driver.get(&blob.storage_path).await.unwrap();
@@ -3455,7 +3481,7 @@ async fn test_create_empty_file_s3_no_dedup() {
         .unwrap();
     common::seed_csrf_token(&login.access_token);
 
-    let db = state.db.clone();
+    let db = state.writer_db().clone();
     let driver_registry = state.driver_registry.clone();
     let app = create_test_app!(state);
 
@@ -3555,7 +3581,7 @@ async fn test_relay_stream_direct_upload_s3_e2e() {
             .unwrap();
     assert_eq!(init.mode, aster_drive::types::UploadMode::Direct);
 
-    let db = state.db.clone();
+    let db = state.writer_db().clone();
     let driver_registry = state.driver_registry.clone();
     let temp_roots = vec![
         state.config.server.temp_dir.clone(),
@@ -3674,7 +3700,7 @@ async fn test_relay_stream_direct_upload_s3_exact_part_size_e2e() {
         .unwrap();
     common::seed_csrf_token(&login.access_token);
 
-    let db = state.db.clone();
+    let db = state.writer_db().clone();
     let sessions_before = upload_session::Entity::find()
         .filter(upload_session::Column::UserId.eq(user.id))
         .count(&db)
@@ -3863,7 +3889,7 @@ async fn test_relay_stream_chunked_upload_s3_e2e() {
     assert_eq!(body["error"]["internal_code"], "E024");
     assert_eq!(body["error"]["subcode"], "upload.chunk_too_large");
     assert!(
-        upload_session_part_repo::list_by_upload(&state.db, &oversized_upload_id)
+        upload_session_part_repo::list_by_upload(state.writer_db(), &oversized_upload_id)
             .await
             .unwrap()
             .is_empty(),
@@ -3891,7 +3917,7 @@ async fn test_relay_stream_chunked_upload_s3_e2e() {
         "relay_stream should not create local upload temp dir"
     );
     assert!(
-        upload_session_part_repo::list_by_upload(&state.db, &upload_id)
+        upload_session_part_repo::list_by_upload(state.writer_db(), &upload_id)
             .await
             .unwrap()
             .is_empty()
@@ -3929,7 +3955,7 @@ async fn test_relay_stream_chunked_upload_s3_e2e() {
         .unwrap();
     assert_eq!(progress.chunks_on_disk, vec![0]);
 
-    let parts = upload_session_part_repo::list_by_upload(&state.db, &upload_id)
+    let parts = upload_session_part_repo::list_by_upload(state.writer_db(), &upload_id)
         .await
         .unwrap();
     assert_eq!(parts.len(), 1);
@@ -3958,7 +3984,7 @@ async fn test_relay_stream_chunked_upload_s3_e2e() {
         .unwrap();
     assert_eq!(progress.chunks_on_disk, vec![0, 1]);
 
-    let parts = upload_session_part_repo::list_by_upload(&state.db, &upload_id)
+    let parts = upload_session_part_repo::list_by_upload(state.writer_db(), &upload_id)
         .await
         .unwrap();
     assert_eq!(parts.len(), 2);
@@ -3968,7 +3994,7 @@ async fn test_relay_stream_chunked_upload_s3_e2e() {
     assert_eq!(parts[1].size, part2.len() as i64);
     assert!(parts.iter().all(|part| !part.etag.is_empty()));
 
-    let session = upload_session_repo::find_by_id(&state.db, &upload_id)
+    let session = upload_session_repo::find_by_id(state.writer_db(), &upload_id)
         .await
         .unwrap();
     assert_eq!(session.received_count, 2);
@@ -3982,7 +4008,7 @@ async fn test_relay_stream_chunked_upload_s3_e2e() {
         .unwrap();
     assert_eq!(file.name, "relay-multipart.bin");
 
-    let session = upload_session_repo::find_by_id(&state.db, &upload_id)
+    let session = upload_session_repo::find_by_id(state.writer_db(), &upload_id)
         .await
         .unwrap();
     assert_eq!(
@@ -3991,7 +4017,7 @@ async fn test_relay_stream_chunked_upload_s3_e2e() {
     );
     assert_eq!(session.file_id, Some(file.id));
 
-    let blob = file_repo::find_blob_by_id(&state.db, file.blob_id)
+    let blob = file_repo::find_blob_by_id(state.writer_db(), file.blob_id)
         .await
         .unwrap();
     assert_eq!(blob.hash, format!("s3-{upload_id}"));
@@ -4011,7 +4037,7 @@ async fn test_relay_stream_chunked_upload_s3_e2e() {
     );
     assert_eq!(completed_progress.chunks_on_disk, vec![0, 1]);
 
-    let parts = upload_session_part_repo::list_by_upload(&state.db, &upload_id)
+    let parts = upload_session_part_repo::list_by_upload(state.writer_db(), &upload_id)
         .await
         .unwrap();
     assert_eq!(parts.len(), 2);

--- a/tests/test_upload.rs
+++ b/tests/test_upload.rs
@@ -2472,12 +2472,14 @@ async fn test_upload_service_get_progress_uses_db_parts_for_terminal_relay_multi
 #[actix_web::test]
 async fn test_sqlite_reader_routes_do_not_wait_for_busy_writer_pool() {
     use aster_drive::services::auth_service;
+    use aster_drive::utils::raii::TempDirGuard;
     use sea_orm::{ConnectionTrait, TransactionTrait};
 
-    let database_url = format!(
-        "sqlite:///tmp/asterdrive-reader-routes-{}.db?mode=rwc",
-        uuid::Uuid::new_v4()
-    );
+    let temp_dir =
+        std::env::temp_dir().join(format!("asterdrive-reader-routes-{}", uuid::Uuid::new_v4()));
+    std::fs::create_dir_all(&temp_dir).expect("sqlite temp dir should be created");
+    let _temp_dir_guard = TempDirGuard::new(temp_dir.clone(), "sqlite reader route test db");
+    let database_url = format!("sqlite://{}?mode=rwc", temp_dir.join("reader.db").display());
     let state = common::setup_with_database_url(&database_url).await;
     assert!(
         state.db_handles.sqlite_read_write_split(),

--- a/tests/test_user_management.rs
+++ b/tests/test_user_management.rs
@@ -176,7 +176,7 @@ async fn test_force_delete_user() {
 #[actix_web::test]
 async fn test_force_delete_user_preserves_team_upload_and_blob_ref() {
     let state = common::setup().await;
-    let db = state.db.clone();
+    let db = state.writer_db().clone();
     let runtime_config = state.runtime_config.clone();
     let app = create_test_app!(state);
 
@@ -454,7 +454,7 @@ async fn test_admin_create_user_uses_default_quota_and_policy() {
     use aster_drive::db::repository::policy_group_repo;
 
     let state = common::setup().await;
-    let expected_default_id = policy_group_repo::find_default_group(&state.db)
+    let expected_default_id = policy_group_repo::find_default_group(state.writer_db())
         .await
         .unwrap()
         .expect("default policy group should exist")

--- a/tests/test_webdav.rs
+++ b/tests/test_webdav.rs
@@ -79,7 +79,7 @@ async fn setup_with_custom_webdav_config(
     Error = actix_web::Error,
 > {
     let state = common::setup().await;
-    let db = state.db.clone();
+    let db = state.writer_db().clone();
     let rl = RateLimitConfig::default();
     let network_trust = state.config.network_trust.clone();
 
@@ -445,8 +445,8 @@ async fn test_webdav_get_and_head_do_not_create_runtime_temp_files() {
     let state = common::setup().await;
     let runtime_temp_dir =
         aster_drive::utils::paths::runtime_temp_dir(&state.config.server.temp_dir);
-    let db1 = state.db.clone();
-    let db2 = state.db.clone();
+    let db1 = state.writer_db().clone();
+    let db2 = state.writer_db().clone();
     let webdav_config = aster_drive::config::WebDavConfig::default();
     let app = test::init_service(
         App::new()
@@ -510,8 +510,8 @@ async fn test_webdav_put_local_fast_path_avoids_runtime_temp_files() {
     let state = common::setup().await;
     let runtime_temp_dir =
         aster_drive::utils::paths::runtime_temp_dir(&state.config.server.temp_dir);
-    let db1 = state.db.clone();
-    let db2 = state.db.clone();
+    let db1 = state.writer_db().clone();
+    let db2 = state.writer_db().clone();
     let webdav_config = aster_drive::config::WebDavConfig::default();
     let app = test::init_service(
         App::new()
@@ -570,8 +570,8 @@ async fn test_webdav_put_without_content_length_avoids_runtime_temp_files() {
     let runtime_temp_dir =
         aster_drive::utils::paths::runtime_temp_dir(&state.config.server.temp_dir);
     let upload_temp_dir = state.config.server.upload_temp_dir.clone();
-    let db1 = state.db.clone();
-    let db2 = state.db.clone();
+    let db1 = state.writer_db().clone();
+    let db2 = state.writer_db().clone();
     let webdav_config = aster_drive::config::WebDavConfig::default();
     let app = test::init_service(
         App::new()
@@ -637,8 +637,8 @@ async fn test_webdav_runtime_toggle_takes_effect_immediately() {
     use serde_json::Value;
 
     let state = common::setup().await;
-    let db1 = state.db.clone();
-    let db2 = state.db.clone();
+    let db1 = state.writer_db().clone();
+    let db2 = state.writer_db().clone();
     let webdav_config = aster_drive::config::WebDavConfig::default();
     let app = test::init_service(
         App::new()
@@ -1393,8 +1393,8 @@ async fn test_webdav_hides_and_rejects_system_property_namespace() {
     use aster_drive::services::auth_service;
 
     let state = common::setup().await;
-    let db1 = state.db.clone();
-    let db2 = state.db.clone();
+    let db1 = state.writer_db().clone();
+    let db2 = state.writer_db().clone();
     let webdav_config = aster_drive::config::WebDavConfig::default();
     let app = test::init_service(
         App::new()
@@ -1422,13 +1422,17 @@ async fn test_webdav_hides_and_rejects_system_property_namespace() {
     let resp = test::call_service(&app, req).await;
     assert!(resp.status() == 201 || resp.status() == 204);
 
-    let file =
-        file_repo::find_by_name_in_folder(&state.db, claims.user_id, None, "system-props.zip")
-            .await
-            .expect("file lookup should succeed")
-            .expect("uploaded file should exist");
+    let file = file_repo::find_by_name_in_folder(
+        state.writer_db(),
+        claims.user_id,
+        None,
+        "system-props.zip",
+    )
+    .await
+    .expect("file lookup should succeed")
+    .expect("uploaded file should exist");
     property_repo::upsert(
-        &state.db,
+        state.writer_db(),
         EntityType::File,
         file.id,
         "system.archive_preview",
@@ -1484,7 +1488,7 @@ async fn test_webdav_hides_and_rejects_system_property_namespace() {
     );
 
     let cached = property_repo::find_by_key(
-        &state.db,
+        state.writer_db(),
         EntityType::File,
         file.id,
         "system.archive_preview",

--- a/tests/test_webdav_accounts.rs
+++ b/tests/test_webdav_accounts.rs
@@ -222,7 +222,7 @@ async fn test_webdav_account_list_resolves_nested_paths() {
 #[actix_web::test]
 async fn test_webdav_account_rejects_duplicate_username_and_foreign_root_folder() {
     let state = common::setup().await;
-    let db = state.db.clone();
+    let db = state.writer_db().clone();
     let mail_sender = state.mail_sender.clone();
     let app = create_test_app!(state);
     let (token, _) = register_and_login!(app);

--- a/tests/test_webdav_file.rs
+++ b/tests/test_webdav_file.rs
@@ -87,7 +87,7 @@ async fn test_aster_dav_file_write_mode_persists_empty_and_written_content() {
     empty_file.flush().await.unwrap();
 
     let empty_stored =
-        file_repo::find_by_name_in_folder(&state.db, user.id, None, "empty-dav-file.txt")
+        file_repo::find_by_name_in_folder(state.writer_db(), user.id, None, "empty-dav-file.txt")
             .await
             .unwrap()
             .expect("empty WebDAV flush should create a zero-byte file record");
@@ -115,11 +115,15 @@ async fn test_aster_dav_file_write_mode_persists_empty_and_written_content() {
         .unwrap();
     written_file.flush().await.unwrap();
 
-    let stored =
-        file_repo::find_by_name_in_folder(&state.db, user.id, None, "buffered-dav-file.txt")
-            .await
-            .unwrap()
-            .expect("buffered WebDAV flush should create a file record");
+    let stored = file_repo::find_by_name_in_folder(
+        state.writer_db(),
+        user.id,
+        None,
+        "buffered-dav-file.txt",
+    )
+    .await
+    .unwrap()
+    .expect("buffered WebDAV flush should create a file record");
     assert_eq!(stored.size, 11);
 }
 
@@ -163,12 +167,12 @@ async fn test_aster_dav_fs_reports_quota_and_roundtrips_custom_props() {
     assert_eq!(total, None);
 
     let mut updated_user: aster_drive::entities::user::ActiveModel =
-        user_repo::find_by_id(&state.db, user.id)
+        user_repo::find_by_id(state.writer_db(), user.id)
             .await
             .unwrap()
             .into();
     updated_user.storage_quota = Set(128);
-    updated_user.update(&state.db).await.unwrap();
+    updated_user.update(state.writer_db()).await.unwrap();
 
     let (used, total) = dav_fs.get_quota().await.unwrap();
     assert_eq!(used, content.len() as u64);
@@ -194,7 +198,7 @@ async fn test_aster_dav_fs_reports_quota_and_roundtrips_custom_props() {
     assert!(dav_fs.have_props(&file_path).await);
 
     let stored_file = aster_drive::db::repository::file_repo::find_by_name_in_folder(
-        &state.db,
+        state.writer_db(),
         user.id,
         None,
         "quota-props.txt",
@@ -203,7 +207,7 @@ async fn test_aster_dav_fs_reports_quota_and_roundtrips_custom_props() {
     .unwrap()
     .expect("stored file should exist");
     property_repo::upsert(
-        &state.db,
+        state.writer_db(),
         EntityType::File,
         stored_file.id,
         "system.archive_preview",
@@ -213,7 +217,7 @@ async fn test_aster_dav_fs_reports_quota_and_roundtrips_custom_props() {
     .await
     .unwrap();
     property_repo::upsert(
-        &state.db,
+        state.writer_db(),
         EntityType::File,
         stored_file.id,
         "DAV:",

--- a/tests/test_webdav_lock_system.rs
+++ b/tests/test_webdav_lock_system.rs
@@ -47,7 +47,7 @@ async fn test_db_lock_system_deep_lock_supports_check_refresh_discover_and_delet
     .await
     .unwrap();
 
-    let lock_system = DbLockSystem::new(state.db.clone(), user.id, None);
+    let lock_system = DbLockSystem::new(state.writer_db().clone(), user.id, None);
     let folder_path = DavPath::new("/projects/").unwrap();
     let child_path = DavPath::new("/projects/docs/note.txt").unwrap();
     let owner = Element::parse(Cursor::new(
@@ -70,7 +70,7 @@ async fn test_db_lock_system_deep_lock_supports_check_refresh_discover_and_delet
     assert_eq!(lock.principal.as_deref(), Some("tester"));
     assert!(!lock.token.is_empty());
 
-    let locked_folder = folder_repo::find_by_id(&state.db, projects.id)
+    let locked_folder = folder_repo::find_by_id(state.writer_db(), projects.id)
         .await
         .unwrap();
     assert!(locked_folder.is_locked);
@@ -107,7 +107,7 @@ async fn test_db_lock_system_deep_lock_supports_check_refresh_discover_and_delet
     assert!(refreshed.owner.is_some());
     assert_eq!(refreshed.timeout, Some(Duration::from_secs(30)));
 
-    let persisted = lock_repo::find_by_token(&state.db, &lock.token)
+    let persisted = lock_repo::find_by_token(state.writer_db(), &lock.token)
         .await
         .unwrap()
         .expect("refreshed lock should still exist");
@@ -115,12 +115,12 @@ async fn test_db_lock_system_deep_lock_supports_check_refresh_discover_and_delet
 
     lock_system.delete(&folder_path).await.unwrap();
     assert!(
-        lock_repo::find_by_token(&state.db, &lock.token)
+        lock_repo::find_by_token(state.writer_db(), &lock.token)
             .await
             .unwrap()
             .is_none()
     );
-    let unlocked_folder = folder_repo::find_by_id(&state.db, projects.id)
+    let unlocked_folder = folder_repo::find_by_id(state.writer_db(), projects.id)
         .await
         .unwrap();
     assert!(!unlocked_folder.is_locked);
@@ -171,7 +171,7 @@ async fn test_db_lock_system_replaces_expired_locks_and_rejects_active_conflicts
     .await
     .unwrap();
 
-    let lock_system = DbLockSystem::new(state.db.clone(), user.id, None);
+    let lock_system = DbLockSystem::new(state.writer_db().clone(), user.id, None);
     let file_path = DavPath::new("/expired.txt").unwrap();
 
     let replacement = lock_system
@@ -187,13 +187,15 @@ async fn test_db_lock_system_replaces_expired_locks_and_rejects_active_conflicts
         .unwrap();
     assert_ne!(replacement.token, expired_lock.token);
     assert!(
-        lock_repo::find_by_token(&state.db, &expired_lock.token)
+        lock_repo::find_by_token(state.writer_db(), &expired_lock.token)
             .await
             .unwrap()
             .is_none()
     );
 
-    let locked_file = file_repo::find_by_id(&state.db, file.id).await.unwrap();
+    let locked_file = file_repo::find_by_id(state.writer_db(), file.id)
+        .await
+        .unwrap();
     assert!(locked_file.is_locked);
 
     let conflict = lock_system
@@ -221,11 +223,13 @@ async fn test_db_lock_system_replaces_expired_locks_and_rejects_active_conflicts
         .await
         .unwrap();
     assert!(
-        lock_repo::find_by_token(&state.db, &replacement.token)
+        lock_repo::find_by_token(state.writer_db(), &replacement.token)
             .await
             .unwrap()
             .is_none()
     );
-    let unlocked_file = file_repo::find_by_id(&state.db, file.id).await.unwrap();
+    let unlocked_file = file_repo::find_by_id(state.writer_db(), file.id)
+        .await
+        .unwrap();
     assert!(!unlocked_file.is_locked);
 }

--- a/tests/test_webdav_path_resolver.rs
+++ b/tests/test_webdav_path_resolver.rs
@@ -102,7 +102,7 @@ async fn test_path_resolver_resolves_deep_folder_file_and_parent_paths() {
         seed_nested_file(&state, user.id, None).await;
 
     let folder_path = DavPath::new("/projects/docs/reports").unwrap();
-    match resolve_path(&state.db, user.id, &folder_path, None)
+    match resolve_path(state.writer_db(), user.id, &folder_path, None)
         .await
         .unwrap()
     {
@@ -111,7 +111,7 @@ async fn test_path_resolver_resolves_deep_folder_file_and_parent_paths() {
     }
 
     let file_path = DavPath::new("/projects/docs/reports/q1.txt").unwrap();
-    match resolve_path(&state.db, user.id, &file_path, None)
+    match resolve_path(state.writer_db(), user.id, &file_path, None)
         .await
         .unwrap()
     {
@@ -121,11 +121,11 @@ async fn test_path_resolver_resolves_deep_folder_file_and_parent_paths() {
 
     let missing_intermediate = DavPath::new("/projects/docs/q1.txt/final.txt").unwrap();
     assert!(matches!(
-        resolve_path(&state.db, user.id, &missing_intermediate, None).await,
+        resolve_path(state.writer_db(), user.id, &missing_intermediate, None).await,
         Err(FsError::NotFound)
     ));
 
-    let (parent_id, leaf_name) = resolve_parent(&state.db, user.id, &file_path, None)
+    let (parent_id, leaf_name) = resolve_parent(state.writer_db(), user.id, &file_path, None)
         .await
         .unwrap();
     assert_eq!(parent_id, Some(reports.id));
@@ -155,16 +155,21 @@ async fn test_path_resolver_honors_scoped_root_semantics() {
 
     let root_path = DavPath::new("/").unwrap();
     assert!(matches!(
-        resolve_path(&state.db, user.id, &root_path, Some(scoped_root.id))
+        resolve_path(state.writer_db(), user.id, &root_path, Some(scoped_root.id))
             .await
             .unwrap(),
         ResolvedNode::Root
     ));
 
     let scoped_file_path = DavPath::new("/projects/docs/reports/q1.txt").unwrap();
-    match resolve_path(&state.db, user.id, &scoped_file_path, Some(scoped_root.id))
-        .await
-        .unwrap()
+    match resolve_path(
+        state.writer_db(),
+        user.id,
+        &scoped_file_path,
+        Some(scoped_root.id),
+    )
+    .await
+    .unwrap()
     {
         ResolvedNode::File(found) => assert_eq!(found.id, file.id),
         other => panic!("expected scoped file, got {other:?}"),
@@ -172,12 +177,18 @@ async fn test_path_resolver_honors_scoped_root_semantics() {
 
     let escaped_scope = DavPath::new("/scoped-root/projects/docs/reports/q1.txt").unwrap();
     assert!(matches!(
-        resolve_path(&state.db, user.id, &escaped_scope, Some(scoped_root.id)).await,
+        resolve_path(
+            state.writer_db(),
+            user.id,
+            &escaped_scope,
+            Some(scoped_root.id)
+        )
+        .await,
         Err(FsError::NotFound)
     ));
 
     let (parent_id, leaf_name) = resolve_parent(
-        &state.db,
+        state.writer_db(),
         user.id,
         &DavPath::new("/draft.txt").unwrap(),
         Some(scoped_root.id),
@@ -219,18 +230,29 @@ async fn test_path_resolver_handles_root_level_and_missing_path_boundaries() {
     .unwrap();
 
     assert!(matches!(
-        resolve_path(&state.db, user.id, &DavPath::new("/").unwrap(), None)
-            .await
-            .unwrap(),
+        resolve_path(
+            state.writer_db(),
+            user.id,
+            &DavPath::new("/").unwrap(),
+            None
+        )
+        .await
+        .unwrap(),
         ResolvedNode::Root
     ));
     assert!(matches!(
-        resolve_parent(&state.db, user.id, &DavPath::new("/").unwrap(), None).await,
+        resolve_parent(
+            state.writer_db(),
+            user.id,
+            &DavPath::new("/").unwrap(),
+            None
+        )
+        .await,
         Err(FsError::Forbidden)
     ));
 
     match resolve_path(
-        &state.db,
+        state.writer_db(),
         user.id,
         &DavPath::new("/root.txt").unwrap(),
         None,
@@ -244,7 +266,7 @@ async fn test_path_resolver_handles_root_level_and_missing_path_boundaries() {
 
     assert!(matches!(
         resolve_path(
-            &state.db,
+            state.writer_db(),
             user.id,
             &DavPath::new("/missing.txt").unwrap(),
             None
@@ -254,7 +276,7 @@ async fn test_path_resolver_handles_root_level_and_missing_path_boundaries() {
     ));
     assert!(matches!(
         resolve_path(
-            &state.db,
+            state.writer_db(),
             user.id,
             &DavPath::new("/missing/final.txt").unwrap(),
             None,
@@ -264,7 +286,7 @@ async fn test_path_resolver_handles_root_level_and_missing_path_boundaries() {
     ));
     assert!(matches!(
         resolve_parent(
-            &state.db,
+            state.writer_db(),
             user.id,
             &DavPath::new("/missing/final.txt").unwrap(),
             None,
@@ -302,7 +324,7 @@ async fn test_path_resolver_prefers_folder_when_file_and_folder_share_name() {
     .unwrap();
 
     match resolve_path(
-        &state.db,
+        state.writer_db(),
         user.id,
         &DavPath::new("/shared-name").unwrap(),
         None,
@@ -315,7 +337,7 @@ async fn test_path_resolver_prefers_folder_when_file_and_folder_share_name() {
     }
 
     let (parent_id, leaf_name) = resolve_parent(
-        &state.db,
+        state.writer_db(),
         user.id,
         &DavPath::new("/shared-name/child.txt").unwrap(),
         None,
@@ -326,7 +348,7 @@ async fn test_path_resolver_prefers_folder_when_file_and_folder_share_name() {
     assert_eq!(leaf_name, "child.txt");
 
     let root_level_file = resolve_path(
-        &state.db,
+        state.writer_db(),
         user.id,
         &DavPath::new("/shared-name").unwrap(),
         None,
@@ -349,21 +371,22 @@ async fn test_path_resolver_hides_deleted_intermediate_folders() {
     let (_projects, docs, _reports, _file, _contents) =
         seed_nested_file(&state, user.id, None).await;
 
-    let docs_model = aster_drive::db::repository::folder_repo::find_by_id(&state.db, docs.id)
-        .await
-        .unwrap();
+    let docs_model =
+        aster_drive::db::repository::folder_repo::find_by_id(state.writer_db(), docs.id)
+            .await
+            .unwrap();
     let mut deleted_docs: aster_drive::entities::folder::ActiveModel = docs_model.into();
     deleted_docs.deleted_at = Set(Some(chrono::Utc::now()));
     deleted_docs.updated_at = Set(chrono::Utc::now());
-    deleted_docs.update(&state.db).await.unwrap();
+    deleted_docs.update(state.writer_db()).await.unwrap();
 
     let file_path = DavPath::new("/projects/docs/reports/q1.txt").unwrap();
     assert!(matches!(
-        resolve_path(&state.db, user.id, &file_path, None).await,
+        resolve_path(state.writer_db(), user.id, &file_path, None).await,
         Err(FsError::NotFound)
     ));
     assert!(matches!(
-        resolve_parent(&state.db, user.id, &file_path, None).await,
+        resolve_parent(state.writer_db(), user.id, &file_path, None).await,
         Err(FsError::NotFound)
     ));
 }
@@ -517,10 +540,11 @@ async fn test_aster_dav_fs_deep_write_create_new_and_overwrite_boundaries() {
         .unwrap();
     new_file.flush().await.unwrap();
 
-    let stored = file_repo::find_by_name_in_folder(&state.db, user.id, Some(reports.id), "new.txt")
-        .await
-        .unwrap()
-        .expect("deep WebDAV write should create a file");
+    let stored =
+        file_repo::find_by_name_in_folder(state.writer_db(), user.id, Some(reports.id), "new.txt")
+            .await
+            .unwrap()
+            .expect("deep WebDAV write should create a file");
     assert_eq!(stored.size, "first version".len() as i64);
 
     assert!(matches!(
@@ -539,7 +563,7 @@ async fn test_aster_dav_fs_deep_write_create_new_and_overwrite_boundaries() {
     overwrite.flush().await.unwrap();
 
     let overwritten =
-        file_repo::find_by_name_in_folder(&state.db, user.id, Some(reports.id), "new.txt")
+        file_repo::find_by_name_in_folder(state.writer_db(), user.id, Some(reports.id), "new.txt")
             .await
             .unwrap()
             .expect("overwritten file should still exist");
@@ -598,7 +622,7 @@ async fn test_aster_dav_fs_copy_file_publishes_storage_event() {
     assert_eq!(event.affected_parent_ids, vec![reports.id]);
     assert!(!event.root_affected);
 
-    match resolve_path(&state.db, user.id, &destination, None)
+    match resolve_path(state.writer_db(), user.id, &destination, None)
         .await
         .unwrap()
     {
@@ -645,7 +669,7 @@ async fn test_aster_dav_fs_remove_dir_publishes_storage_event() {
     assert_eq!(event.affected_parent_ids, vec![projects.id]);
     assert!(!event.root_affected);
     assert!(matches!(
-        resolve_path(&state.db, user.id, &target, None).await,
+        resolve_path(state.writer_db(), user.id, &target, None).await,
         Err(FsError::NotFound)
     ));
 }
@@ -690,7 +714,7 @@ async fn test_aster_dav_fs_copy_folder_publishes_storage_event() {
     assert!(!event.root_affected);
 
     match resolve_path(
-        &state.db,
+        state.writer_db(),
         user.id,
         &DavPath::new("/projects/docs-copy/reports/q1.txt").unwrap(),
         None,

--- a/tests/test_wopi.rs
+++ b/tests/test_wopi.rs
@@ -178,7 +178,7 @@ fn parse_wopi_result_url(url: &str) -> (i64, String) {
 async fn test_open_wopi_session_persists_token_and_check_file_info_succeeds() {
     let state = common::setup().await;
     configure_test_wopi_runtime(&state);
-    let db = state.db.clone();
+    let db = state.writer_db().clone();
     let app = create_test_app!(state);
 
     let (access_cookie, _) = register_and_login!(app);
@@ -1018,7 +1018,7 @@ async fn test_wopi_put_file_contents_rejects_non_put_override() {
 async fn test_wopi_put_relative_creates_copy_for_suggested_target() {
     let state = common::setup().await;
     configure_test_wopi_runtime(&state);
-    let db = state.db.clone();
+    let db = state.writer_db().clone();
     let app = create_test_app!(state);
 
     let (access_cookie, _) = register_and_login!(app);
@@ -1710,7 +1710,7 @@ async fn test_wopi_check_file_info_rejects_untrusted_referer() {
 async fn test_disabled_wopi_app_invalidates_existing_access_token() {
     let state = common::setup().await;
     configure_test_wopi_runtime(&state);
-    let db = state.db.clone();
+    let db = state.writer_db().clone();
     let runtime_config = state.runtime_config.clone();
     let app = create_test_app!(state);
 
@@ -1760,7 +1760,7 @@ async fn test_disabled_wopi_app_invalidates_existing_access_token() {
 async fn test_disabled_user_invalidates_wopi_access_token() {
     let state = common::setup().await;
     configure_test_wopi_runtime(&state);
-    let db = state.db.clone();
+    let db = state.writer_db().clone();
     let mail_sender = state.mail_sender.clone();
     let app = create_test_app!(state);
 
@@ -1815,7 +1815,7 @@ async fn test_disabled_user_invalidates_wopi_access_token() {
 async fn test_expired_wopi_access_token_is_rejected_and_removed() {
     let state = common::setup().await;
     configure_test_wopi_runtime(&state);
-    let db = state.db.clone();
+    let db = state.writer_db().clone();
     let app = create_test_app!(state);
 
     let (access_cookie, _) = register_and_login!(app);
@@ -1938,7 +1938,7 @@ async fn test_wopi_put_file_returns_conflict_when_file_is_locked_outside_wopi() 
 async fn test_revoked_user_sessions_invalidate_wopi_access_token() {
     let state = common::setup().await;
     configure_test_wopi_runtime(&state);
-    let db = state.db.clone();
+    let db = state.writer_db().clone();
     let app = create_test_app!(state);
 
     let (access_cookie, _) = register_and_login!(app);
@@ -1997,7 +1997,7 @@ async fn test_revoked_user_sessions_invalidate_wopi_access_token() {
 async fn test_team_file_wopi_open_persists_team_scope_and_allows_check_file_info() {
     let state = common::setup().await;
     configure_test_wopi_runtime(&state);
-    let db = state.db.clone();
+    let db = state.writer_db().clone();
     let mail_sender = state.mail_sender.clone();
     let app = create_test_app!(state);
 
@@ -2084,7 +2084,7 @@ async fn test_team_file_wopi_open_persists_team_scope_and_allows_check_file_info
 async fn test_team_wopi_access_token_is_rejected_after_member_removal() {
     let state = common::setup().await;
     configure_test_wopi_runtime(&state);
-    let db = state.db.clone();
+    let db = state.writer_db().clone();
     let mail_sender = state.mail_sender.clone();
     let app = create_test_app!(state);
 
@@ -2164,7 +2164,7 @@ async fn test_team_wopi_access_token_is_rejected_after_member_removal() {
 async fn test_team_wopi_put_relative_is_rejected_after_member_removal() {
     let state = common::setup().await;
     configure_test_wopi_runtime(&state);
-    let db = state.db.clone();
+    let db = state.writer_db().clone();
     let mail_sender = state.mail_sender.clone();
     let app = create_test_app!(state);
 
@@ -2247,7 +2247,7 @@ async fn test_team_wopi_put_relative_is_rejected_after_member_removal() {
 async fn test_team_wopi_put_relative_accepts_body_larger_than_global_payload_limit() {
     let state = common::setup().await;
     configure_test_wopi_runtime(&state);
-    let db = state.db.clone();
+    let db = state.writer_db().clone();
     let mail_sender = state.mail_sender.clone();
     let app = create_test_app!(state);
 
@@ -2352,7 +2352,7 @@ async fn test_team_wopi_put_relative_accepts_body_larger_than_global_payload_lim
 async fn test_team_file_wopi_open_rejects_non_member() {
     let state = common::setup().await;
     configure_test_wopi_runtime(&state);
-    let db = state.db.clone();
+    let db = state.writer_db().clone();
     let mail_sender = state.mail_sender.clone();
     let app = create_test_app!(state);
 


### PR DESCRIPTION
- 新增 `DbHandles` 结构体，持有 writer 和 reader 两个连接句柄，支持 `single()`（单连接模式）和 `connect_handles()`（读写分离模式）
- SQLite 文件数据库下自动开启独立 reader pool，使用 `mode=ro` 和 `PRAGMA query_only=ON`；内存 SQLite、PostgreSQL、MySQL 下 reader 与 writer 共用同一池
- `PrimaryAppState` 和 `FollowerAppState` 新增 `db_handles` 字段，`SharedRuntimeState` trait 新增 `writer_db()` / `reader_db()` 方法
- 列表、详情、搜索、上传进度、分享查询、统计等纯读路径切换至 `reader_db()`；事务、写入、配额判断等保持走 `writer_db()`
- 新增 `verify_file_access_for_read` / `verify_folder_access_for_read` / `load_upload_session_for_read` 等读专用入口，避免污染写路径语义
- 新增集成测试验证 reader pool 拒绝写入、reader 不阻塞于 busy writer pool、并发 refresh token 竞争锁行为
- 补充架构文档说明 `DbHandles` 读写分离使用规范

closed #190

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 支持 SQLite 读写分离：读操作在写操作繁忙时仍能继续响应，提升并发体验。
  * 强化刷新令牌旋转安全：更严格的复用/重放判定，减少会话攻击面。

* **改进**
  * 优化数据库连接管理，广泛将只读路径切换到读连接以降低写库争用。

* **文档**
  * 补充架构文档，说明读写句柄使用和 SQLite 只读 reader 行为。

* **测试**
  * 新增/更新测试，验证读连接在写锁占用下仍可工作。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->