### PR TITLE
refactor(db): 使用 SeaORM 查询构建器替代手动 SQL 拼接

### DIFF
--- a/src/cli/database_migration/apply/convert.rs
+++ b/src/cli/database_migration/apply/convert.rs
@@ -10,8 +10,8 @@ use sea_orm::{QueryResult, TryGetError, Value};
 
 use crate::errors::{AsterError, Result};
 
-use super::super::helpers::{parse_bool, parse_timestamp};
-use super::super::{BindingKind, CellValue, TablePlan};
+use crate::cli::database_migration::helpers::{parse_bool, parse_timestamp};
+use crate::cli::database_migration::{BindingKind, CellValue, TablePlan};
 
 /// Decodes a source row and converts each cell into the target backend value shape.
 pub(super) fn decode_row_values(

--- a/src/cli/database_migration/apply/copy.rs
+++ b/src/cli/database_migration/apply/copy.rs
@@ -11,14 +11,15 @@ use crate::cli::db_shared::{quote_ident, quote_literal, scalar_i64};
 use crate::errors::{AsterError, MapAsterErr, Result};
 use crate::utils::numbers::{i64_to_usize, usize_to_i64};
 
-use super::super::checkpoint::update_checkpoint;
-use super::super::helpers::now_ms;
-use super::super::schema::{binding_kind_from_raw_type, load_column_type_rows};
-use super::super::{
+use super::convert::decode_row_values;
+use crate::cli::database_migration::checkpoint::update_checkpoint;
+use crate::cli::database_migration::helpers::now_ms;
+use crate::cli::database_migration::schema::{binding_kind_from_raw_type, load_column_type_rows};
+use crate::cli::database_migration::ui::ProgressReporter;
+use crate::cli::database_migration::{
     BindingKind, COPY_BATCH_SIZE_ENV, DEFAULT_COPY_BATCH_SIZE, FAIL_AFTER_BATCHES_ENV,
     MigrationCheckpoint, TablePlan,
 };
-use super::convert::decode_row_values;
 
 /// Copies all planned tables in batches and persists checkpoint progress after each commit.
 pub(super) async fn copy_tables_with_resume(
@@ -27,7 +28,7 @@ pub(super) async fn copy_tables_with_resume(
     plans: &[TablePlan],
     target_type_hints: &BTreeMap<String, BTreeMap<String, BindingKind>>,
     checkpoint: &mut MigrationCheckpoint,
-    progress: &super::super::ui::ProgressReporter,
+    progress: &ProgressReporter,
 ) -> Result<()> {
     let batch_size = copy_batch_size()?;
     let fail_after_batches = fail_after_batches()?;

--- a/src/cli/database_migration/checkpoint.rs
+++ b/src/cli/database_migration/checkpoint.rs
@@ -3,15 +3,39 @@
 //! 这里负责创建、加载、更新和失败标记迁移检查点，让中断后的数据复制
 //! 可以从已提交的位置继续。
 
-use sea_orm::{ConnectionTrait, DatabaseConnection, Statement};
+use sea_orm::{
+    ConnectionTrait, DatabaseConnection, Statement,
+    entity::prelude::DeriveIden,
+    sea_query::{Alias, Expr, ExprTrait, Query, Value},
+};
 
-use crate::cli::db_shared::{quote_ident, quote_literal, redact_database_url};
+use crate::cli::db_shared::{quote_ident, redact_database_url};
 use crate::errors::{AsterError, MapAsterErr, Result};
 use crate::utils::hash::sha256_hex;
 
-use super::helpers::{now_ms, nullable_sql_string};
+use super::helpers::now_ms;
 use super::schema::{ensure_target_empty, total_source_rows};
 use super::{CHECKPOINT_TABLE, DatabaseMigrateArgs, MigrationCheckpoint, MigrationMode, TablePlan};
+
+#[derive(DeriveIden)]
+enum CheckpointColumn {
+    MigrationKey,
+    SourceDatabaseUrl,
+    TargetDatabaseUrl,
+    Mode,
+    Status,
+    Stage,
+    CurrentTable,
+    CurrentTableIndex,
+    CurrentTableOffset,
+    CopiedRows,
+    TotalRows,
+    PlanJson,
+    ResultJson,
+    LastError,
+    HeartbeatAtMs,
+    UpdatedAtMs,
+}
 
 #[derive(Debug)]
 pub(super) struct InitializedCheckpoint {
@@ -136,61 +160,51 @@ pub(super) async fn update_checkpoint<C>(db: &C, checkpoint: &MigrationCheckpoin
 where
     C: ConnectionTrait,
 {
-    let backend = db.get_database_backend();
-    let sql = format!(
-        "UPDATE {table_name} SET \
-            {source_col} = {source}, \
-            {target_col} = {target}, \
-            {mode_col} = {mode}, \
-            {status_col} = {status}, \
-            {stage_col} = {stage}, \
-            {current_table_col} = {current_table}, \
-            {current_table_index_col} = {current_table_index}, \
-            {current_table_offset_col} = {current_table_offset}, \
-            {copied_rows_col} = {copied_rows}, \
-            {total_rows_col} = {total_rows}, \
-            {plan_json_col} = {plan_json}, \
-            {result_json_col} = {result_json}, \
-            {last_error_col} = {last_error}, \
-            {heartbeat_col} = {heartbeat}, \
-            {updated_col} = {updated} \
-         WHERE {migration_key_col} = {migration_key}",
-        table_name = quote_ident(backend, CHECKPOINT_TABLE),
-        source_col = quote_ident(backend, "source_database_url"),
-        target_col = quote_ident(backend, "target_database_url"),
-        mode_col = quote_ident(backend, "mode"),
-        status_col = quote_ident(backend, "status"),
-        stage_col = quote_ident(backend, "stage"),
-        current_table_col = quote_ident(backend, "current_table"),
-        current_table_index_col = quote_ident(backend, "current_table_index"),
-        current_table_offset_col = quote_ident(backend, "current_table_offset"),
-        copied_rows_col = quote_ident(backend, "copied_rows"),
-        total_rows_col = quote_ident(backend, "total_rows"),
-        plan_json_col = quote_ident(backend, "plan_json"),
-        result_json_col = quote_ident(backend, "result_json"),
-        last_error_col = quote_ident(backend, "last_error"),
-        heartbeat_col = quote_ident(backend, "heartbeat_at_ms"),
-        updated_col = quote_ident(backend, "updated_at_ms"),
-        migration_key_col = quote_ident(backend, "migration_key"),
-        source = quote_literal(&checkpoint.source_database_url),
-        target = quote_literal(&checkpoint.target_database_url),
-        mode = quote_literal(&checkpoint.mode),
-        status = quote_literal(&checkpoint.status),
-        stage = quote_literal(&checkpoint.stage),
-        current_table = nullable_sql_string(checkpoint.current_table.as_deref()),
-        current_table_index = checkpoint.current_table_index,
-        current_table_offset = checkpoint.current_table_offset,
-        copied_rows = checkpoint.copied_rows,
-        total_rows = checkpoint.total_rows,
-        plan_json = quote_literal(&checkpoint.plan_json),
-        result_json = nullable_sql_string(checkpoint.result_json.as_deref()),
-        last_error = nullable_sql_string(checkpoint.last_error.as_deref()),
-        heartbeat = checkpoint.heartbeat_at_ms,
-        updated = checkpoint.updated_at_ms,
-        migration_key = quote_literal(&checkpoint.migration_key),
-    );
+    let statement = Query::update()
+        .table(Alias::new(CHECKPOINT_TABLE))
+        .value(
+            CheckpointColumn::SourceDatabaseUrl,
+            checkpoint.source_database_url.clone(),
+        )
+        .value(
+            CheckpointColumn::TargetDatabaseUrl,
+            checkpoint.target_database_url.clone(),
+        )
+        .value(CheckpointColumn::Mode, checkpoint.mode.clone())
+        .value(CheckpointColumn::Status, checkpoint.status.clone())
+        .value(CheckpointColumn::Stage, checkpoint.stage.clone())
+        .value(
+            CheckpointColumn::CurrentTable,
+            optional_string_expr(&checkpoint.current_table),
+        )
+        .value(
+            CheckpointColumn::CurrentTableIndex,
+            checkpoint.current_table_index,
+        )
+        .value(
+            CheckpointColumn::CurrentTableOffset,
+            checkpoint.current_table_offset,
+        )
+        .value(CheckpointColumn::CopiedRows, checkpoint.copied_rows)
+        .value(CheckpointColumn::TotalRows, checkpoint.total_rows)
+        .value(CheckpointColumn::PlanJson, checkpoint.plan_json.clone())
+        .value(
+            CheckpointColumn::ResultJson,
+            optional_string_expr(&checkpoint.result_json),
+        )
+        .value(
+            CheckpointColumn::LastError,
+            optional_string_expr(&checkpoint.last_error),
+        )
+        .value(CheckpointColumn::HeartbeatAtMs, checkpoint.heartbeat_at_ms)
+        .value(CheckpointColumn::UpdatedAtMs, checkpoint.updated_at_ms)
+        .and_where(
+            Expr::col(CheckpointColumn::MigrationKey)
+                .eq(Expr::val(checkpoint.migration_key.clone())),
+        )
+        .to_owned();
 
-    db.execute_raw(Statement::from_string(backend, sql))
+    db.execute(&statement)
         .await
         .map_aster_err(AsterError::database_operation)?;
     Ok(())
@@ -233,6 +247,7 @@ async fn load_checkpoint(
     migration_key: &str,
 ) -> Result<Option<MigrationCheckpoint>> {
     let backend = target.get_database_backend();
+    let migration_key_placeholder = migration_key_placeholder(backend);
     let sql = format!(
         "SELECT \
             {migration_key_col}, {source_col}, {target_col}, {mode_col}, {status_col}, {stage_col}, \
@@ -240,8 +255,7 @@ async fn load_checkpoint(
             {copied_rows_col}, {total_rows_col}, {plan_json_col}, {result_json_col}, \
             {last_error_col}, {heartbeat_col}, {updated_col} \
          FROM {table_name} \
-         WHERE {migration_key_col} = {}",
-        quote_literal(migration_key),
+         WHERE {migration_key_col} = {migration_key_placeholder}",
         migration_key_col = quote_ident(backend, "migration_key"),
         source_col = quote_ident(backend, "source_database_url"),
         target_col = quote_ident(backend, "target_database_url"),
@@ -262,7 +276,11 @@ async fn load_checkpoint(
     );
 
     let Some(row) = target
-        .query_one_raw(Statement::from_string(backend, sql))
+        .query_one_raw(Statement::from_sql_and_values(
+            backend,
+            sql,
+            [migration_key.into()],
+        ))
         .await
         .map_aster_err(AsterError::database_operation)?
     else {
@@ -327,58 +345,63 @@ async fn insert_checkpoint<C>(db: &C, checkpoint: &MigrationCheckpoint) -> Resul
 where
     C: ConnectionTrait,
 {
-    let backend = db.get_database_backend();
-    let sql = format!(
-        "INSERT INTO {table_name} (\
-            {migration_key_col}, {source_col}, {target_col}, {mode_col}, {status_col}, {stage_col}, \
-            {current_table_col}, {current_table_index_col}, {current_table_offset_col}, \
-            {copied_rows_col}, {total_rows_col}, {plan_json_col}, {result_json_col}, \
-            {last_error_col}, {heartbeat_col}, {updated_col}\
-        ) VALUES (\
-            {migration_key}, {source}, {target}, {mode}, {status}, {stage}, \
-            {current_table}, {current_table_index}, {current_table_offset}, \
-            {copied_rows}, {total_rows}, {plan_json}, {result_json}, \
-            {last_error}, {heartbeat}, {updated}\
-        )",
-        table_name = quote_ident(backend, CHECKPOINT_TABLE),
-        migration_key_col = quote_ident(backend, "migration_key"),
-        source_col = quote_ident(backend, "source_database_url"),
-        target_col = quote_ident(backend, "target_database_url"),
-        mode_col = quote_ident(backend, "mode"),
-        status_col = quote_ident(backend, "status"),
-        stage_col = quote_ident(backend, "stage"),
-        current_table_col = quote_ident(backend, "current_table"),
-        current_table_index_col = quote_ident(backend, "current_table_index"),
-        current_table_offset_col = quote_ident(backend, "current_table_offset"),
-        copied_rows_col = quote_ident(backend, "copied_rows"),
-        total_rows_col = quote_ident(backend, "total_rows"),
-        plan_json_col = quote_ident(backend, "plan_json"),
-        result_json_col = quote_ident(backend, "result_json"),
-        last_error_col = quote_ident(backend, "last_error"),
-        heartbeat_col = quote_ident(backend, "heartbeat_at_ms"),
-        updated_col = quote_ident(backend, "updated_at_ms"),
-        migration_key = quote_literal(&checkpoint.migration_key),
-        source = quote_literal(&checkpoint.source_database_url),
-        target = quote_literal(&checkpoint.target_database_url),
-        mode = quote_literal(&checkpoint.mode),
-        status = quote_literal(&checkpoint.status),
-        stage = quote_literal(&checkpoint.stage),
-        current_table = nullable_sql_string(checkpoint.current_table.as_deref()),
-        current_table_index = checkpoint.current_table_index,
-        current_table_offset = checkpoint.current_table_offset,
-        copied_rows = checkpoint.copied_rows,
-        total_rows = checkpoint.total_rows,
-        plan_json = quote_literal(&checkpoint.plan_json),
-        result_json = nullable_sql_string(checkpoint.result_json.as_deref()),
-        last_error = nullable_sql_string(checkpoint.last_error.as_deref()),
-        heartbeat = checkpoint.heartbeat_at_ms,
-        updated = checkpoint.updated_at_ms,
-    );
+    let statement = Query::insert()
+        .into_table(Alias::new(CHECKPOINT_TABLE))
+        .columns([
+            CheckpointColumn::MigrationKey,
+            CheckpointColumn::SourceDatabaseUrl,
+            CheckpointColumn::TargetDatabaseUrl,
+            CheckpointColumn::Mode,
+            CheckpointColumn::Status,
+            CheckpointColumn::Stage,
+            CheckpointColumn::CurrentTable,
+            CheckpointColumn::CurrentTableIndex,
+            CheckpointColumn::CurrentTableOffset,
+            CheckpointColumn::CopiedRows,
+            CheckpointColumn::TotalRows,
+            CheckpointColumn::PlanJson,
+            CheckpointColumn::ResultJson,
+            CheckpointColumn::LastError,
+            CheckpointColumn::HeartbeatAtMs,
+            CheckpointColumn::UpdatedAtMs,
+        ])
+        .values([
+            checkpoint.migration_key.clone().into(),
+            checkpoint.source_database_url.clone().into(),
+            checkpoint.target_database_url.clone().into(),
+            checkpoint.mode.clone().into(),
+            checkpoint.status.clone().into(),
+            checkpoint.stage.clone().into(),
+            optional_string_expr(&checkpoint.current_table),
+            checkpoint.current_table_index.into(),
+            checkpoint.current_table_offset.into(),
+            checkpoint.copied_rows.into(),
+            checkpoint.total_rows.into(),
+            checkpoint.plan_json.clone().into(),
+            optional_string_expr(&checkpoint.result_json),
+            optional_string_expr(&checkpoint.last_error),
+            checkpoint.heartbeat_at_ms.into(),
+            checkpoint.updated_at_ms.into(),
+        ])
+        .map_aster_err(AsterError::database_operation)?
+        .to_owned();
 
-    db.execute_raw(Statement::from_string(backend, sql))
+    db.execute(&statement)
         .await
         .map_aster_err(AsterError::database_operation)?;
     Ok(())
+}
+
+fn optional_string_expr(value: &Option<String>) -> Expr {
+    Expr::value(Value::String(value.clone()))
+}
+
+fn migration_key_placeholder(backend: sea_orm::DbBackend) -> &'static str {
+    match backend {
+        sea_orm::DbBackend::Postgres => "$1",
+        sea_orm::DbBackend::MySql | sea_orm::DbBackend::Sqlite => "?",
+        _ => "?",
+    }
 }
 
 fn build_migration_key(
@@ -393,4 +416,78 @@ fn build_migration_key(
         mode.as_str()
     );
     sha256_hex(key.as_bytes())
+}
+
+#[cfg(test)]
+mod tests {
+    use sea_orm::{Database, DbBackend};
+
+    use super::*;
+
+    #[tokio::test]
+    async fn checkpoint_insert_update_bind_values_without_sql_literal_concatenation() {
+        let db = Database::connect("sqlite::memory:").await.unwrap();
+        ensure_checkpoint_table(&db).await.unwrap();
+
+        let mut checkpoint = MigrationCheckpoint {
+            migration_key: "checkpoint-key".to_string(),
+            source_database_url: "sqlite:///.../source's.db?mode=rwc".to_string(),
+            target_database_url: "sqlite:///.../target\\path.db?mode=rwc".to_string(),
+            mode: "apply".to_string(),
+            status: "running".to_string(),
+            stage: "data_copy".to_string(),
+            current_table: Some("folders'quoted".to_string()),
+            current_table_index: 1,
+            current_table_offset: 2,
+            copied_rows: 3,
+            total_rows: 4,
+            plan_json: r#"[{"name":"files'quoted"}]"#.to_string(),
+            result_json: None,
+            last_error: Some("first line\nsecond line's detail".to_string()),
+            heartbeat_at_ms: 5,
+            updated_at_ms: 6,
+        };
+
+        insert_checkpoint(&db, &checkpoint).await.unwrap();
+        let loaded = load_checkpoint(&db, &checkpoint.migration_key)
+            .await
+            .unwrap()
+            .expect("checkpoint should be inserted");
+        assert_eq!(loaded.source_database_url, checkpoint.source_database_url);
+        assert_eq!(loaded.target_database_url, checkpoint.target_database_url);
+        assert_eq!(loaded.current_table, checkpoint.current_table);
+        assert_eq!(loaded.plan_json, checkpoint.plan_json);
+        assert_eq!(loaded.result_json, None);
+        assert_eq!(loaded.last_error, checkpoint.last_error);
+
+        checkpoint.status = "failed".to_string();
+        checkpoint.current_table = None;
+        checkpoint.result_json = Some(r#"{"ready":false,"note":"quoted'value"}"#.to_string());
+        checkpoint.last_error = None;
+        checkpoint.copied_rows = 9;
+        checkpoint.heartbeat_at_ms = 10;
+        checkpoint.updated_at_ms = 11;
+        update_checkpoint(&db, &checkpoint).await.unwrap();
+
+        let updated = load_checkpoint(&db, &checkpoint.migration_key)
+            .await
+            .unwrap()
+            .expect("checkpoint should still exist");
+        assert_eq!(updated.status, "failed");
+        assert_eq!(updated.current_table, None);
+        assert_eq!(updated.result_json, checkpoint.result_json);
+        assert_eq!(updated.last_error, None);
+        assert_eq!(updated.copied_rows, 9);
+        assert_eq!(updated.heartbeat_at_ms, 10);
+        assert_eq!(updated.updated_at_ms, 11);
+
+        assert_eq!(db.get_database_backend(), DbBackend::Sqlite);
+    }
+
+    #[test]
+    fn checkpoint_migration_key_placeholder_matches_backend() {
+        assert_eq!(migration_key_placeholder(DbBackend::Postgres), "$1");
+        assert_eq!(migration_key_placeholder(DbBackend::MySql), "?");
+        assert_eq!(migration_key_placeholder(DbBackend::Sqlite), "?");
+    }
 }

--- a/src/cli/database_migration/helpers.rs
+++ b/src/cli/database_migration/helpers.rs
@@ -43,9 +43,3 @@ pub(super) fn parse_bool(value: &str) -> Option<bool> {
 pub(super) fn parse_timestamp(value: &str) -> Option<DateTime<FixedOffset>> {
     DateTime::parse_from_rfc3339(value).ok()
 }
-
-pub(super) fn nullable_sql_string(value: Option<&str>) -> String {
-    value
-        .map(crate::cli::db_shared::quote_literal)
-        .unwrap_or_else(|| "NULL".to_string())
-}

--- a/src/db/repository/file_repo/blob/lookup.rs
+++ b/src/db/repository/file_repo/blob/lookup.rs
@@ -555,7 +555,7 @@ fn apply_admin_blob_order(
     }
 }
 
-fn sum_blob_size_as_i64_expr(backend: DbBackend) -> sea_orm::sea_query::SimpleExpr {
+pub(super) fn sum_blob_size_as_i64_expr(backend: DbBackend) -> sea_orm::sea_query::SimpleExpr {
     let type_name = match backend {
         DbBackend::Postgres => "bigint",
         DbBackend::MySql => "signed",

--- a/src/db/repository/file_repo/blob/lookup.rs
+++ b/src/db/repository/file_repo/blob/lookup.rs
@@ -1,7 +1,8 @@
 use chrono::Utc;
 use sea_orm::{
-    ActiveModelTrait, ColumnTrait, ConnectionTrait, DbBackend, EntityTrait, FromQueryResult,
-    PaginatorTrait, QueryFilter, QueryOrder, QuerySelect, Set, TryInsertResult,
+    ActiveModelTrait, ColumnTrait, ConnectionTrait, DbBackend, EntityTrait, ExprTrait,
+    FromQueryResult, PaginatorTrait, QueryFilter, QueryOrder, QuerySelect, Set, TryInsertResult,
+    sea_query::Expr,
 };
 
 use crate::api::pagination::{AdminFileBlobSortBy, SortOrder};
@@ -107,27 +108,24 @@ pub async fn summarize_blobs_by_policy<C: ConnectionTrait>(
     db: &C,
     policy_id: i64,
 ) -> Result<StoragePolicyBlobSummary> {
-    let backend = db.get_database_backend();
-    let sql = match backend {
-        DbBackend::Postgres => {
-            r#"SELECT COUNT(*) AS count, COALESCE(SUM(size), 0) AS total_size FROM file_blobs WHERE policy_id = $1"#
-        }
-        DbBackend::MySql => {
-            "SELECT COUNT(*) AS count, COALESCE(SUM(size), 0) AS total_size FROM file_blobs WHERE policy_id = ?"
-        }
-        DbBackend::Sqlite | _ => {
-            "SELECT COUNT(*) AS count, COALESCE(SUM(size), 0) AS total_size FROM file_blobs WHERE policy_id = ?"
-        }
-    };
-    StoragePolicyBlobSummary::find_by_statement(sea_orm::Statement::from_sql_and_values(
-        backend,
-        sql,
-        [policy_id.into()],
-    ))
-    .one(db)
-    .await
-    .map_err(AsterError::from)?
-    .ok_or_else(|| AsterError::internal_error("storage policy blob summary query returned no row"))
+    let (count, total_size) = FileBlob::find()
+        .select_only()
+        .column_as(Expr::col(file_blob::Column::Id).count(), "count")
+        .column_as(
+            sum_blob_size_as_i64_expr(db.get_database_backend()),
+            "total_size",
+        )
+        .filter(file_blob::Column::PolicyId.eq(policy_id))
+        .into_tuple::<(i64, Option<i64>)>()
+        .one(db)
+        .await
+        .map_err(AsterError::from)?
+        .unwrap_or((0, None));
+
+    Ok(StoragePolicyBlobSummary {
+        count,
+        total_size: total_size.unwrap_or(0),
+    })
 }
 
 pub async fn summarize_blob_hash_kinds_by_policy<C: ConnectionTrait>(
@@ -555,4 +553,13 @@ fn apply_admin_blob_order(
             file_blob::Column::Id,
         ),
     }
+}
+
+fn sum_blob_size_as_i64_expr(backend: DbBackend) -> sea_orm::sea_query::SimpleExpr {
+    let type_name = match backend {
+        DbBackend::Postgres => "bigint",
+        DbBackend::MySql => "signed",
+        _ => "integer",
+    };
+    Expr::col(file_blob::Column::Size).sum().cast_as(type_name)
 }

--- a/src/db/repository/file_repo/blob/tests.rs
+++ b/src/db/repository/file_repo/blob/tests.rs
@@ -4,7 +4,10 @@ use super::ref_count::{
 };
 use crate::entities::file_blob;
 use chrono::Utc;
-use sea_orm::{ColumnTrait, DbBackend, EntityTrait, ExprTrait, QueryFilter, QueryTrait, Set};
+use sea_orm::{
+    ColumnTrait, DbBackend, EntityTrait, ExprTrait, QueryFilter, QuerySelect, QueryTrait, Set,
+    sea_query::Expr,
+};
 use std::time::Duration;
 
 #[test]
@@ -61,6 +64,38 @@ fn postgres_find_or_create_blob_insert_sql_uses_valid_on_conflict() {
         "{sql}"
     );
     assert!(!sql.contains(" WHERE "), "{sql}");
+}
+
+#[test]
+fn summarize_blobs_by_policy_sql_uses_seaorm_aggregate_query() {
+    let statement = crate::entities::file_blob::Entity::find()
+        .select_only()
+        .column_as(Expr::col(file_blob::Column::Id).count(), "count")
+        .column_as(
+            Expr::col(file_blob::Column::Size).sum().cast_as("bigint"),
+            "total_size",
+        )
+        .filter(file_blob::Column::PolicyId.eq(42))
+        .build(DbBackend::Postgres);
+
+    assert!(
+        statement.sql.contains(r#"COUNT("id") AS "count""#),
+        "{}",
+        statement.sql
+    );
+    assert!(
+        statement
+            .sql
+            .contains(r#"CAST(SUM("size") AS bigint) AS "total_size""#),
+        "{}",
+        statement.sql
+    );
+    assert!(
+        statement.sql.contains(r#""policy_id" = $1"#),
+        "{}",
+        statement.sql
+    );
+    assert!(statement.values.is_some(), "{statement:?}");
 }
 
 // 第二轮审查有 agent 怀疑 `RefCount.gte(0)` 是无效过滤（误以为 ref_count 不能为负）。

--- a/src/db/repository/file_repo/blob/tests.rs
+++ b/src/db/repository/file_repo/blob/tests.rs
@@ -1,4 +1,4 @@
-use super::lookup::find_or_create_blob_retry_delay;
+use super::lookup::{find_or_create_blob_retry_delay, sum_blob_size_as_i64_expr};
 use super::ref_count::{
     blob_ref_count_decrement_expr, blob_ref_count_increment_expr, normalize_blob_ref_count_deltas,
 };
@@ -71,10 +71,7 @@ fn summarize_blobs_by_policy_sql_uses_seaorm_aggregate_query() {
     let statement = crate::entities::file_blob::Entity::find()
         .select_only()
         .column_as(Expr::col(file_blob::Column::Id).count(), "count")
-        .column_as(
-            Expr::col(file_blob::Column::Size).sum().cast_as("bigint"),
-            "total_size",
-        )
+        .column_as(sum_blob_size_as_i64_expr(DbBackend::Postgres), "total_size")
         .filter(file_blob::Column::PolicyId.eq(42))
         .build(DbBackend::Postgres);
 

--- a/src/external_auth/providers/oidc.rs
+++ b/src/external_auth/providers/oidc.rs
@@ -16,7 +16,7 @@ use crate::services::auth_service;
 use crate::types::{ExternalAuthProtocol, ExternalAuthProviderKind};
 use crate::utils::OUTBOUND_HTTP_USER_AGENT;
 
-use super::super::driver::{
+use crate::external_auth::driver::{
     ExternalAuthAuthorizationStart, ExternalAuthCallback, ExternalAuthProfile,
     ExternalAuthProviderConfig, ExternalAuthProviderDescriptor, ExternalAuthProviderDriver,
     ExternalAuthProviderTestCheck, ExternalAuthProviderTestResult,

--- a/src/services/archive_service/seven_zip_scan/tests.rs
+++ b/src/services/archive_service/seven_zip_scan/tests.rs
@@ -3,6 +3,9 @@ use std::io::Cursor;
 use super::*;
 use crate::services::archive_service::test_utils::crc32;
 
+const ENCRYPTED_7Z_ENTRY_FIXTURE: &[u8] =
+    include_bytes!("../../../../tests/fixtures/archives/encrypted-entry.7z");
+
 fn scan_limits() -> ArchiveScanLimits {
     ArchiveScanLimits {
         max_uncompressed_bytes: 1024 * 1024,
@@ -58,6 +61,268 @@ fn create_7z_bytes_with_anti_item(path: &str) -> Vec<u8> {
 
     let (_, cursor) = writer.finish_into_inner().expect("7z writer should finish");
     cursor.into_inner()
+}
+
+fn create_7z_bytes_with_attrs(path: &str, content: &[u8], attrs: u32) -> Vec<u8> {
+    let mut bytes = create_7z_bytes(&[(path, Some(content))], false);
+    patch_7z_single_entry_attrs(&mut bytes, attrs);
+    bytes
+}
+
+fn seven_zip_unix_attrs(mode: u32) -> u32 {
+    0x8000_0000 | ((mode & 0x7fff) << 16)
+}
+
+fn patch_7z_single_entry_attrs(bytes: &mut Vec<u8>, attrs: u32) {
+    let next_header_offset = read_u64_le(bytes, 12);
+    let next_header_size = read_u64_le(bytes, 20);
+    let next_header_start: usize = (32 + next_header_offset)
+        .try_into()
+        .expect("test 7z next header offset should fit usize");
+    let next_header_size: usize = next_header_size
+        .try_into()
+        .expect("test 7z next header size should fit usize");
+    let next_header_end = next_header_start + next_header_size;
+    let mut header = bytes[next_header_start..next_header_end].to_vec();
+    let insert_at = find_single_entry_files_info_end(&header);
+    let attrs_property = single_entry_attrs_property(attrs);
+
+    header.splice(insert_at..insert_at, attrs_property);
+    bytes.splice(next_header_start..next_header_end, header.iter().copied());
+
+    let next_header_size_u64 =
+        crate::utils::numbers::usize_to_u64(header.len(), "test 7z next header size")
+            .expect("test 7z next header size should fit u64");
+    bytes[20..28].copy_from_slice(&next_header_size_u64.to_le_bytes());
+    refresh_7z_header_checksums(bytes);
+}
+
+fn find_single_entry_files_info_end(header: &[u8]) -> usize {
+    let mut cursor = HeaderCursor::new(header);
+    assert_eq!(
+        cursor.read_u8(),
+        0x01,
+        "7z next header should start with Header"
+    );
+
+    loop {
+        let property = cursor.read_u8();
+        match property {
+            0x00 => panic!("FilesInfo should exist in test 7z header"),
+            0x04 => skip_main_streams_info(&mut cursor),
+            0x05 => return find_files_info_end(&mut cursor),
+            property => panic!("unexpected 7z top-level header property: {property:#x}"),
+        }
+    }
+}
+
+fn skip_main_streams_info(cursor: &mut HeaderCursor<'_>) {
+    loop {
+        let property = cursor.read_u8();
+        match property {
+            0x00 => return,
+            0x06 => skip_pack_info(cursor),
+            0x07 => skip_unpack_info(cursor),
+            0x08 => skip_substreams_info(cursor),
+            property => panic!("unexpected 7z streams property: {property:#x}"),
+        }
+    }
+}
+
+fn skip_pack_info(cursor: &mut HeaderCursor<'_>) {
+    let _pack_pos = cursor.read_var_u64();
+    let pack_streams = cursor.read_var_usize();
+    loop {
+        match cursor.read_u8() {
+            0x00 => return,
+            0x09 => {
+                for _ in 0..pack_streams {
+                    let _size = cursor.read_var_u64();
+                }
+            }
+            0x0a => skip_defined_crc(cursor, pack_streams),
+            property => panic!("unexpected 7z PackInfo property: {property:#x}"),
+        }
+    }
+}
+
+fn skip_unpack_info(cursor: &mut HeaderCursor<'_>) {
+    assert_eq!(
+        cursor.read_u8(),
+        0x0b,
+        "7z UnpackInfo should start with Folder"
+    );
+    let folders = cursor.read_var_usize();
+    assert_eq!(
+        cursor.read_u8(),
+        0,
+        "external 7z folders are not expected in test archive"
+    );
+    let mut total_out_streams = 0_usize;
+    for _ in 0..folders {
+        total_out_streams += skip_folder(cursor);
+    }
+
+    loop {
+        match cursor.read_u8() {
+            0x00 => return,
+            0x0c => {
+                for _ in 0..total_out_streams {
+                    let _size = cursor.read_var_u64();
+                }
+            }
+            0x0a => skip_defined_crc(cursor, folders),
+            property => panic!("unexpected 7z UnpackInfo property: {property:#x}"),
+        }
+    }
+}
+
+fn skip_folder(cursor: &mut HeaderCursor<'_>) -> usize {
+    let coders = cursor.read_var_usize();
+    let mut total_in_streams = 0_usize;
+    let mut total_out_streams = 0_usize;
+    for _ in 0..coders {
+        let flags = cursor.read_u8();
+        let method_id_size = usize::from(flags & 0x0f);
+        let is_complex = flags & 0x10 != 0;
+        let has_properties = flags & 0x20 != 0;
+        cursor.skip(method_id_size);
+
+        let (in_streams, out_streams) = if is_complex {
+            (cursor.read_var_usize(), cursor.read_var_usize())
+        } else {
+            (1, 1)
+        };
+        total_in_streams += in_streams;
+        total_out_streams += out_streams;
+
+        if has_properties {
+            let properties_size = cursor.read_var_usize();
+            cursor.skip(properties_size);
+        }
+    }
+    let bind_pairs = total_out_streams.saturating_sub(1);
+    for _ in 0..bind_pairs {
+        let _in_index = cursor.read_var_u64();
+        let _out_index = cursor.read_var_u64();
+    }
+    let packed_indices = total_in_streams.saturating_sub(bind_pairs);
+    if packed_indices > 1 {
+        for _ in 0..packed_indices {
+            let _index = cursor.read_var_u64();
+        }
+    }
+    total_out_streams
+}
+
+fn skip_substreams_info(cursor: &mut HeaderCursor<'_>) {
+    match cursor.read_u8() {
+        0x00 => {}
+        0x0d | 0x09 | 0x0a => {
+            panic!("test helper only supports simple single-stream 7z substreams")
+        }
+        property => panic!("unexpected 7z SubStreamsInfo property: {property:#x}"),
+    }
+}
+
+fn find_files_info_end(cursor: &mut HeaderCursor<'_>) -> usize {
+    let files = cursor.read_var_usize();
+    assert_eq!(files, 1, "test helper only supports one 7z file entry");
+    loop {
+        let property_start = cursor.position;
+        let property = cursor.read_u8();
+        match property {
+            0x00 => return property_start,
+            0x11 => {
+                let size = cursor.read_var_usize();
+                cursor.skip(size);
+            }
+            0x0e..=0x10 => {
+                let size = cursor.read_var_usize();
+                cursor.skip(size);
+            }
+            0x12..=0x16 => {
+                let size = cursor.read_var_usize();
+                cursor.skip(size);
+            }
+            property => panic!("unexpected 7z FilesInfo property: {property:#x}"),
+        }
+    }
+}
+
+fn skip_defined_crc(cursor: &mut HeaderCursor<'_>, count: usize) {
+    let all_defined = cursor.read_u8();
+    if all_defined == 0 {
+        cursor.skip(count.div_ceil(8));
+    }
+    cursor.skip(4 * count);
+}
+
+fn single_entry_attrs_property(attrs: u32) -> Vec<u8> {
+    let mut bytes = Vec::new();
+    bytes.push(0x15);
+    write_7z_var_u64(&mut bytes, 6);
+    bytes.push(1);
+    bytes.push(0);
+    bytes.extend_from_slice(&attrs.to_le_bytes());
+    bytes
+}
+
+fn write_7z_var_u64(bytes: &mut Vec<u8>, value: u64) {
+    if value < 0x80 {
+        bytes.push(u64_to_7z_single_byte(value));
+    } else {
+        panic!("test helper only writes single-byte 7z integers");
+    }
+}
+
+fn u64_to_7z_single_byte(value: u64) -> u8 {
+    u8::try_from(value).expect("test 7z integer should fit one byte")
+}
+
+struct HeaderCursor<'a> {
+    bytes: &'a [u8],
+    position: usize,
+}
+
+impl<'a> HeaderCursor<'a> {
+    fn new(bytes: &'a [u8]) -> Self {
+        Self { bytes, position: 0 }
+    }
+
+    fn read_u8(&mut self) -> u8 {
+        let value = self.bytes[self.position];
+        self.position += 1;
+        value
+    }
+
+    fn read_var_usize(&mut self) -> usize {
+        self.read_var_u64()
+            .try_into()
+            .expect("test 7z integer should fit usize")
+    }
+
+    fn read_var_u64(&mut self) -> u64 {
+        let first = u64::from(self.read_u8());
+        let mut mask = 0x80_u64;
+        let mut value = 0_u64;
+        for i in 0..8 {
+            if first & mask == 0 {
+                return value | ((first & (mask - 1)) << (8 * i));
+            }
+            value |= u64::from(self.read_u8()) << (8 * i);
+            mask >>= 1;
+        }
+        value
+    }
+
+    fn skip(&mut self, count: usize) {
+        self.position += count;
+        assert!(
+            self.position <= self.bytes.len(),
+            "test 7z header cursor should stay in bounds"
+        );
+    }
 }
 
 fn create_7z_bytes_with_patched_name(original_name: &str, patched_name: &str) -> Vec<u8> {
@@ -123,6 +388,13 @@ fn scan_7z(bytes: Vec<u8>, limits: ArchiveScanLimits) -> Result<ArchiveScanResul
         ArchiveScanNamePolicy::StrictAsterName,
         |_| Ok(()),
     )
+}
+
+fn scan_7z_raw(bytes: Vec<u8>, limits: ArchiveScanLimits) -> Result<ArchiveRawScanResult> {
+    let source_archive_size =
+        crate::utils::numbers::usize_to_u64(bytes.len(), "test 7z archive size")?;
+    let archive = open_seven_zip_streaming_archive(Cursor::new(bytes), limits)?;
+    scan_seven_zip_archive_raw(&archive, limits, source_archive_size, None)
 }
 
 fn scan_7z_with_source_size(
@@ -296,10 +568,85 @@ fn scan_seven_zip_rejects_anti_items() {
 }
 
 #[test]
+fn scan_seven_zip_raw_rejects_anti_items() {
+    let bytes = create_7z_bytes_with_anti_item("deleted.txt");
+    let error = scan_7z_raw(bytes, scan_limits())
+        .expect_err("7z raw scan should reject anti item")
+        .message()
+        .to_string();
+
+    assert!(error.contains("anti-item"));
+}
+
+#[test]
+fn scan_seven_zip_rejects_symlink_entries() {
+    let bytes = create_7z_bytes_with_attrs("link.txt", b"target.txt", 0o120777_u32 << 16);
+    let error = scan_7z(bytes, scan_limits())
+        .expect_err("7z scan should reject symlink entries")
+        .message()
+        .to_string();
+
+    assert!(
+        error.contains("symbolic link"),
+        "unexpected 7z symlink error: {error}"
+    );
+}
+
+#[test]
+fn scan_seven_zip_rejects_special_file_entries() {
+    let bytes = create_7z_bytes_with_attrs("device", b"", seven_zip_unix_attrs(0o060666));
+    let error = scan_7z(bytes, scan_limits())
+        .expect_err("7z scan should reject special file entries")
+        .message()
+        .to_string();
+
+    assert!(
+        error.contains("special file"),
+        "unexpected 7z special file error: {error}"
+    );
+}
+
+#[test]
+fn scan_seven_zip_rejects_encrypted_entries() {
+    let error = scan_7z(ENCRYPTED_7Z_ENTRY_FIXTURE.to_vec(), scan_limits())
+        .expect_err("7z scan should reject encrypted entries")
+        .message()
+        .to_string();
+
+    assert!(error.contains("encrypted"));
+}
+
+#[test]
 fn seven_zip_open_error_maps_password_failures_to_validation_error() {
     let error = map_seven_zip_open_error(zesven::Error::PasswordRequired);
 
     assert_eq!(error.message(), "encrypted 7z archives are not supported");
+}
+
+#[test]
+fn seven_zip_streaming_config_maps_resource_limits() {
+    let mut limits = scan_limits();
+    limits.max_entries = 17;
+    limits.max_entry_compression_ratio = 23;
+    limits.max_compression_ratio = 31;
+
+    let config = seven_zip_streaming_config(limits).expect("7z streaming config should be created");
+
+    assert_eq!(config.max_entries, 17);
+    assert_eq!(config.max_compression_ratio, 23);
+    assert_eq!(config.decoder_pool_capacity, None);
+}
+
+#[test]
+fn seven_zip_streaming_config_rejects_out_of_range_ratio() {
+    let mut limits = scan_limits();
+    limits.max_entry_compression_ratio = u64::from(u32::MAX) + 1;
+    limits.max_compression_ratio = u64::from(u32::MAX) + 1;
+
+    let error = seven_zip_streaming_config(limits)
+        .expect_err("7z streaming config should reject ratios beyond parser range");
+
+    assert!(error.message().contains("parser range"));
 }
 
 #[test]
@@ -386,6 +733,101 @@ fn build_seven_zip_scan_result_uses_single_source_size_for_total_ratio() {
     .expect_err("7z raw replay should reject against the source archive size once");
 
     assert!(error.message().contains("total compression ratio"));
+}
+
+#[test]
+fn scan_seven_zip_raw_returns_manifest_and_rejects_replay_path_traversal() {
+    let bytes = create_7z_bytes(&[("safe/file.txt", Some(b"payload".as_slice()))], false);
+    let raw = scan_7z_raw(bytes, scan_limits()).expect("7z raw scan should succeed");
+
+    assert_eq!(raw.entry_count, 1);
+    assert_eq!(raw.file_count, 1);
+    assert_eq!(raw.total_uncompressed_bytes, 7);
+    assert_eq!(raw.entries[0].display_name, "safe/file.txt");
+    assert_eq!(raw.entries[0].raw_name, b"safe/file.txt");
+
+    let mut tampered_entries = raw.entries;
+    tampered_entries[0].raw_name = b"../escape.txt".to_vec();
+    tampered_entries[0].display_name = "../escape.txt".to_string();
+    let error = build_seven_zip_scan_result_from_raw_entries(
+        &tampered_entries,
+        raw.total_compressed_base,
+        scan_limits(),
+        None,
+        ArchiveScanNamePolicy::StrictAsterName,
+        |_| Ok(()),
+    )
+    .expect_err("7z raw replay should reject unsafe paths");
+
+    assert!(error.message().contains("unsafe path"));
+}
+
+#[test]
+fn build_seven_zip_scan_result_rejects_raw_replay_entry_limit() {
+    let raw_entries = vec![
+        ArchiveRawScanEntry {
+            index: 0,
+            raw_name: b"first.txt".to_vec(),
+            display_name: "first.txt".to_string(),
+            raw_name_utf8: true,
+            kind: ArchiveScanEntryKind::File,
+            size: 1,
+            compressed_size: 1,
+            modified_at: None,
+        },
+        ArchiveRawScanEntry {
+            index: 1,
+            raw_name: b"second.txt".to_vec(),
+            display_name: "second.txt".to_string(),
+            raw_name_utf8: true,
+            kind: ArchiveScanEntryKind::File,
+            size: 1,
+            compressed_size: 1,
+            modified_at: None,
+        },
+    ];
+    let mut limits = scan_limits();
+    limits.max_entries = 1;
+
+    let error = build_seven_zip_scan_result_from_raw_entries(
+        &raw_entries,
+        2,
+        limits,
+        None,
+        ArchiveScanNamePolicy::StrictAsterName,
+        |_| Ok(()),
+    )
+    .expect_err("7z raw replay should reject entry limit");
+
+    assert!(error.message().contains("entries"));
+}
+
+#[test]
+fn build_seven_zip_scan_result_rejects_raw_replay_extracted_size_overflow() {
+    let raw_entries = vec![ArchiveRawScanEntry {
+        index: 0,
+        raw_name: b"payload.txt".to_vec(),
+        display_name: "payload.txt".to_string(),
+        raw_name_utf8: true,
+        kind: ArchiveScanEntryKind::File,
+        size: 11,
+        compressed_size: 11,
+        modified_at: None,
+    }];
+    let mut limits = scan_limits();
+    limits.max_uncompressed_bytes = 10;
+
+    let error = build_seven_zip_scan_result_from_raw_entries(
+        &raw_entries,
+        11,
+        limits,
+        None,
+        ArchiveScanNamePolicy::StrictAsterName,
+        |_| Ok(()),
+    )
+    .expect_err("7z raw replay should reject extracted size above preflight limit");
+
+    assert!(error.message().contains("uncompressed size"));
 }
 
 #[test]

--- a/src/services/archive_service/zip_scan/entry.rs
+++ b/src/services/archive_service/zip_scan/entry.rs
@@ -2,8 +2,7 @@ use std::io::Read;
 use std::path::PathBuf;
 
 use crate::errors::{AsterError, Result};
-
-use super::super::scan::{ArchiveScanEntry, ArchiveScanEntryKind};
+use crate::services::archive_service::scan::{ArchiveScanEntry, ArchiveScanEntryKind};
 
 const UNIX_FILE_TYPE_MASK: u32 = 0o170000;
 const UNIX_REGULAR_FILE_MODE: u32 = 0o100000;

--- a/src/services/archive_service/zip_scan/tests.rs
+++ b/src/services/archive_service/zip_scan/tests.rs
@@ -4,17 +4,18 @@ use std::path::PathBuf;
 use encoding_rs::{BIG5, EUC_KR, SHIFT_JIS, WINDOWS_1252};
 use oem_cp::{code_table::ENCODING_TABLE_CP850, encode_string_checked};
 
+use crate::services::archive_service::path::normalize_archive_entry_path;
 use crate::services::archive_service::scan::ArchiveScanEntry;
 use crate::services::archive_service::test_utils::{
     crc32, create_single_file_zip_with_raw_name, push_u16, push_u32,
 };
 
-use super::super::path::normalize_archive_entry_path;
 use super::*;
 use zip::HasZipMetadata;
 
 const ZIP_UTF8_NAME_FLAG: u16 = 0x0800;
 const ZIP_UNICODE_PATH_EXTRA_FIELD: u16 = 0x7075;
+const ZIP_ENCRYPTED_FLAG: u16 = 0x0001;
 
 fn scan_limits() -> ArchiveScanLimits {
     ArchiveScanLimits {
@@ -260,6 +261,106 @@ fn patch_zip_entry_raw_name_in_header(
     }
 
     assert!(patched, "zip entry header should be patched");
+}
+
+fn patch_zip_central_external_attrs(bytes: &mut [u8], path: &str, external_attrs: u32) {
+    let path = path.as_bytes();
+    let central_signature = [0x50, 0x4B, 0x01, 0x02];
+    let mut patched = false;
+
+    for index in 0..bytes.len().saturating_sub(central_signature.len()) {
+        if !bytes[index..].starts_with(&central_signature) {
+            continue;
+        }
+        let name_len = u16::from_le_bytes([bytes[index + 28], bytes[index + 29]]) as usize;
+        let name_start = index + 46;
+        let name_end = name_start + name_len;
+        if name_end <= bytes.len() && &bytes[name_start..name_end] == path {
+            bytes[index + 38..index + 42].copy_from_slice(&external_attrs.to_le_bytes());
+            bytes[index + 5] = 3;
+            patched = true;
+            break;
+        }
+    }
+
+    assert!(patched, "central directory entry should exist");
+}
+
+fn find_zip_header(
+    bytes: &[u8],
+    path: &str,
+    signature: &[u8; 4],
+    name_len_offset: usize,
+    name_offset: usize,
+) -> usize {
+    let path = path.as_bytes();
+    for index in 0..bytes.len().saturating_sub(signature.len()) {
+        if !bytes[index..].starts_with(signature) || index + name_offset > bytes.len() {
+            continue;
+        }
+        let name_len = u16::from_le_bytes([
+            bytes[index + name_len_offset],
+            bytes[index + name_len_offset + 1],
+        ]) as usize;
+        let name_start = index + name_offset;
+        let name_end = name_start + name_len;
+        if name_end <= bytes.len() && &bytes[name_start..name_end] == path {
+            return index;
+        }
+    }
+
+    panic!("zip entry header should exist");
+}
+
+fn patch_zip_entry_general_purpose_flag(bytes: &mut [u8], path: &str, flag_mask: u16) {
+    let local_header = find_zip_header(bytes, path, &[0x50, 0x4B, 0x03, 0x04], 26, 30);
+    let local_flags = u16::from_le_bytes([bytes[local_header + 6], bytes[local_header + 7]]);
+    bytes[local_header + 6..local_header + 8]
+        .copy_from_slice(&(local_flags | flag_mask).to_le_bytes());
+
+    let central_header = find_zip_header(bytes, path, &[0x50, 0x4B, 0x01, 0x02], 28, 46);
+    let central_flags = u16::from_le_bytes([bytes[central_header + 8], bytes[central_header + 9]]);
+    bytes[central_header + 8..central_header + 10]
+        .copy_from_slice(&(central_flags | flag_mask).to_le_bytes());
+}
+
+fn create_symlink_zip_bytes(path: &str, target: &str) -> Vec<u8> {
+    let mut bytes = create_stored_zip_bytes(&[(path, Some(target.as_bytes()))]);
+    patch_zip_central_external_attrs(&mut bytes, path, 0o120777_u32 << 16);
+    bytes
+}
+
+fn create_special_file_zip_bytes(path: &str) -> Vec<u8> {
+    let mut bytes = create_stored_zip_bytes(&[(path, Some(b""))]);
+    patch_zip_central_external_attrs(&mut bytes, path, 0o060666_u32 << 16);
+    bytes
+}
+
+fn create_encrypted_flag_zip_bytes(path: &str, content: &[u8]) -> Vec<u8> {
+    let mut bytes = create_stored_zip_bytes(&[(path, Some(content))]);
+    patch_zip_entry_general_purpose_flag(&mut bytes, path, ZIP_ENCRYPTED_FLAG);
+    bytes
+}
+
+fn scan_zip(bytes: Vec<u8>, limits: ArchiveScanLimits) -> Result<ArchiveScanResult> {
+    let cursor = Cursor::new(bytes);
+    let mut archive = zip::ZipArchive::new(cursor).expect("zip should open");
+
+    scan_zip_archive(
+        &mut archive,
+        limits,
+        None,
+        ArchiveFilenameEncoding::Auto,
+        ArchiveScanNamePolicy::StrictAsterName,
+        |_| Ok(()),
+    )
+}
+
+fn scan_zip_raw(bytes: Vec<u8>, limits: ArchiveScanLimits) -> Result<ArchiveRawScanResult> {
+    let cursor = Cursor::new(bytes);
+    let mut archive = zip::ZipArchive::new(cursor).expect("zip should open");
+
+    scan_zip_archive_raw(&mut archive, limits, None)
 }
 
 fn scan_error_with_encoding(bytes: Vec<u8>, filename_encoding: ArchiveFilenameEncoding) -> String {
@@ -560,6 +661,175 @@ fn preview_name_policy_allows_display_names_for_preview_only() {
     assert_eq!(entries[0].path, "folder/name:with-colon.txt");
     assert_eq!(entries[0].name, "name:with-colon.txt");
     assert_eq!(entries[0].parent.as_deref(), Some("folder"));
+}
+
+#[test]
+fn scan_rejects_encrypted_entries() {
+    let bytes = create_encrypted_flag_zip_bytes("secret.txt", b"secret");
+    let error = scan_zip(bytes, scan_limits())
+        .expect_err("encrypted ZIP entry should be rejected")
+        .message()
+        .to_string();
+
+    assert!(error.contains("encrypted"));
+}
+
+#[test]
+fn scan_rejects_symlink_entries() {
+    let bytes = create_symlink_zip_bytes("link.txt", "../target");
+    let error = scan_zip(bytes, scan_limits())
+        .expect_err("ZIP symlink entry should be rejected")
+        .message()
+        .to_string();
+
+    assert!(error.contains("symbolic link"));
+}
+
+#[test]
+fn scan_rejects_special_file_entries() {
+    let bytes = create_special_file_zip_bytes("device");
+    let error = scan_zip(bytes, scan_limits())
+        .expect_err("ZIP special file entry should be rejected")
+        .message()
+        .to_string();
+
+    assert!(error.contains("special file"));
+}
+
+#[test]
+fn scan_zip_raw_rejects_encrypted_entries() {
+    let bytes = create_encrypted_flag_zip_bytes("secret.txt", b"secret");
+    let error = scan_zip_raw(bytes, scan_limits())
+        .expect_err("raw ZIP scan should reject encrypted entries")
+        .message()
+        .to_string();
+
+    assert!(error.contains("encrypted"));
+}
+
+#[test]
+fn scan_zip_raw_returns_manifest_and_replay_rejects_path_traversal() {
+    let bytes = create_stored_zip_bytes(&[("safe/file.txt", Some(b"payload".as_slice()))]);
+    let raw = scan_zip_raw(bytes, scan_limits()).expect("raw ZIP scan should succeed");
+
+    assert_eq!(raw.entry_count, 1);
+    assert_eq!(raw.file_count, 1);
+    assert_eq!(raw.total_uncompressed_bytes, 7);
+    assert_eq!(raw.total_compressed_base, 7);
+    assert_eq!(raw.entries[0].display_name, "safe/file.txt");
+    assert_eq!(raw.entries[0].raw_name, b"safe/file.txt");
+
+    let mut tampered_entries = raw.entries;
+    tampered_entries[0].raw_name = b"../escape.txt".to_vec();
+    tampered_entries[0].display_name = "../escape.txt".to_string();
+    let error = build_zip_scan_result_from_raw_entries(
+        &tampered_entries,
+        scan_limits(),
+        None,
+        ArchiveFilenameEncoding::Auto,
+        ArchiveScanNamePolicy::StrictAsterName,
+        |_| Ok(()),
+    )
+    .expect_err("raw ZIP replay should reject unsafe paths");
+
+    assert!(error.message().contains("unsafe path"));
+}
+
+#[test]
+fn build_zip_scan_result_rejects_raw_replay_entry_limit() {
+    let raw_entries = vec![
+        ArchiveRawScanEntry {
+            index: 0,
+            raw_name: b"first.txt".to_vec(),
+            display_name: "first.txt".to_string(),
+            raw_name_utf8: true,
+            kind: ArchiveScanEntryKind::File,
+            size: 1,
+            compressed_size: 1,
+            modified_at: None,
+        },
+        ArchiveRawScanEntry {
+            index: 1,
+            raw_name: b"second.txt".to_vec(),
+            display_name: "second.txt".to_string(),
+            raw_name_utf8: true,
+            kind: ArchiveScanEntryKind::File,
+            size: 1,
+            compressed_size: 1,
+            modified_at: None,
+        },
+    ];
+    let mut limits = scan_limits();
+    limits.max_entries = 1;
+
+    let error = build_zip_scan_result_from_raw_entries(
+        &raw_entries,
+        limits,
+        None,
+        ArchiveFilenameEncoding::Auto,
+        ArchiveScanNamePolicy::StrictAsterName,
+        |_| Ok(()),
+    )
+    .expect_err("raw ZIP replay should reject entry limit");
+
+    assert!(error.message().contains("entries"));
+}
+
+#[test]
+fn build_zip_scan_result_rejects_raw_replay_extracted_size_overflow() {
+    let raw_entries = vec![ArchiveRawScanEntry {
+        index: 0,
+        raw_name: b"payload.txt".to_vec(),
+        display_name: "payload.txt".to_string(),
+        raw_name_utf8: true,
+        kind: ArchiveScanEntryKind::File,
+        size: 11,
+        compressed_size: 11,
+        modified_at: None,
+    }];
+    let mut limits = scan_limits();
+    limits.max_uncompressed_bytes = 10;
+
+    let error = build_zip_scan_result_from_raw_entries(
+        &raw_entries,
+        limits,
+        None,
+        ArchiveFilenameEncoding::Auto,
+        ArchiveScanNamePolicy::StrictAsterName,
+        |_| Ok(()),
+    )
+    .expect_err("raw ZIP replay should reject extracted size above preflight limit");
+
+    assert!(error.message().contains("uncompressed size"));
+}
+
+#[test]
+fn build_zip_scan_result_rejects_raw_replay_total_compression_ratio() {
+    let raw_entries = vec![ArchiveRawScanEntry {
+        index: 0,
+        raw_name: b"payload.txt".to_vec(),
+        display_name: "payload.txt".to_string(),
+        raw_name_utf8: true,
+        kind: ArchiveScanEntryKind::File,
+        size: 20,
+        compressed_size: 10,
+        modified_at: None,
+    }];
+    let mut limits = scan_limits();
+    limits.max_entry_compression_ratio = u64::MAX;
+    limits.max_compression_ratio = 1;
+
+    let error = build_zip_scan_result_from_raw_entries(
+        &raw_entries,
+        limits,
+        None,
+        ArchiveFilenameEncoding::Auto,
+        ArchiveScanNamePolicy::StrictAsterName,
+        |_| Ok(()),
+    )
+    .expect_err("raw ZIP replay should reject total compression ratio");
+
+    assert!(error.message().contains("total compression ratio"));
 }
 
 #[test]

--- a/src/services/auth_service/tokens/refresh.rs
+++ b/src/services/auth_service/tokens/refresh.rs
@@ -40,19 +40,18 @@ use std::sync::Mutex as StdMutex;
 use std::sync::{Arc, LazyLock, Weak};
 use tokio::sync::{Mutex, OwnedMutexGuard};
 
+use super::{ensure_token_type, issue_tokens_for_session_id, verify_token};
 use crate::api::subcode::ApiSubcode;
 use crate::db::repository::{auth_session_repo, user_repo};
 use crate::entities::auth_session;
 use crate::errors::{AsterError, Result, auth_forbidden_with_subcode};
 use crate::runtime::PrimaryAppState;
 use crate::services::audit_service::{self, AuditContext};
-use crate::types::TokenType;
-
-use super::super::Claims;
-use super::super::session::{
+use crate::services::auth_service::Claims;
+use crate::services::auth_service::session::{
     invalidate_auth_snapshot_cache, purge_all_auth_sessions_in_connection,
 };
-use super::{ensure_token_type, issue_tokens_for_session_id, verify_token};
+use crate::types::TokenType;
 
 // This window is only for classifying an already-rotated previous JTI. It does
 // not allow a second successful refresh; stale callers still receive E019.

--- a/src/services/media_processing_service/thumbnail/preview.rs
+++ b/src/services/media_processing_service/thumbnail/preview.rs
@@ -2,6 +2,7 @@ use crate::entities::file_blob;
 use crate::errors::Result;
 use crate::runtime::PrimaryAppState;
 
+use crate::services::media_processing_service::resolve::build_thumbnail_context;
 use crate::services::media_processing_service::shared::ImagePreviewData;
 
 use super::cache::load_thumbnail_from_path;
@@ -13,8 +14,7 @@ pub async fn generate_and_store_image_preview(
     file_name: &str,
     source_mime_type: &str,
 ) -> Result<ImagePreviewData> {
-    let ctx =
-        super::super::resolve::build_thumbnail_context(state, blob, file_name, source_mime_type)?;
+    let ctx = build_thumbnail_context(state, blob, file_name, source_mime_type)?;
     let preview_path = ctx.processor.image_preview_cache_path(&blob.hash);
     let preview_processor = ctx.processor.image_preview_processor().to_string();
     let preview_version = ctx.processor.image_preview_version().to_string();

--- a/src/services/task_service/archive/compress.rs
+++ b/src/services/task_service/archive/compress.rs
@@ -2,33 +2,36 @@
 
 use std::path::Path;
 
-use crate::entities::background_task;
-use crate::errors::{AsterError, MapAsterErr, Result};
-use crate::runtime::PrimaryAppState;
-use crate::services::{
-    batch_service,
-    workspace_storage_service::{self, WorkspaceStorageScope},
-};
-use crate::types::BackgroundTaskKind;
-
-use super::super::steps::{
-    TASK_STEP_BUILD_ARCHIVE, TASK_STEP_PREPARE_SOURCES, TASK_STEP_STORE_RESULT, TASK_STEP_WAITING,
-    parse_task_steps_json, set_task_step_active, set_task_step_succeeded,
-};
-use super::super::types::{
-    ArchiveCompressTaskPayload, ArchiveCompressTaskResult, CreateArchiveCompressTaskParams,
-    CreateArchiveTaskParams, TaskStepInfo, parse_task_payload, serialize_task_result,
-};
-use super::super::{
-    TaskLeaseGuard, cleanup_task_temp_dir_for_task, create_task_record, mark_task_progress,
-    mark_task_succeeded, prepare_task_temp_dir, task_scope,
-};
 use super::common::{ArchiveSinkContext, build_file_display_path, write_archive_to_sink};
 use super::selection::{
     ArchiveBuildLimits, collect_archive_entries_from_selection_in_scope,
     ensure_archive_selection_active, resolve_archive_compress_target_folder_id,
     resolve_archive_download_in_scope,
 };
+use crate::entities::background_task;
+use crate::errors::{AsterError, MapAsterErr, Result};
+use crate::runtime::PrimaryAppState;
+use crate::services::{
+    batch_service,
+    task_service::{
+        TaskLeaseGuard, cleanup_task_temp_dir_for_task, create_task_record, get_task_in_scope,
+        mark_task_progress, mark_task_succeeded, prepare_task_temp_dir,
+        steps::{
+            TASK_STEP_BUILD_ARCHIVE, TASK_STEP_PREPARE_SOURCES, TASK_STEP_STORE_RESULT,
+            TASK_STEP_WAITING, parse_task_steps_json, set_task_step_active,
+            set_task_step_succeeded,
+        },
+        task_scope,
+        types::{
+            ArchiveCompressTaskPayload, ArchiveCompressTaskResult, CreateArchiveCompressTaskParams,
+            CreateArchiveTaskParams, TaskInfo, TaskStepInfo, parse_task_payload,
+            serialize_task_result,
+        },
+        update_task_progress_db,
+    },
+    workspace_storage_service::{self, WorkspaceStorageScope},
+};
+use crate::types::BackgroundTaskKind;
 
 const EMIT_ARCHIVE_STORAGE_EVENT: bool = true;
 
@@ -36,7 +39,7 @@ pub(crate) async fn create_archive_compress_task_in_scope(
     state: &PrimaryAppState,
     scope: WorkspaceStorageScope,
     params: CreateArchiveCompressTaskParams,
-) -> Result<super::super::TaskInfo> {
+) -> Result<TaskInfo> {
     let resolved = resolve_archive_download_in_scope(
         state,
         scope,
@@ -74,7 +77,7 @@ pub(crate) async fn create_archive_compress_task_in_scope(
         &payload,
     )
     .await?;
-    super::super::get_task_in_scope(state, scope, task.id).await
+    get_task_in_scope(state, scope, task.id).await
 }
 
 pub(super) async fn process_archive_compress_task(
@@ -190,7 +193,7 @@ pub(super) async fn process_archive_compress_task(
                         Some((current, progress_total)),
                     )?;
                     handle.block_on(async {
-                        super::super::update_task_progress_db(
+                        update_task_progress_db(
                             &db,
                             &lease_guard_for_worker,
                             current,

--- a/src/services/task_service/archive/extract/import.rs
+++ b/src/services/task_service/archive/extract/import.rs
@@ -6,14 +6,16 @@ use std::path::{Path, PathBuf};
 use crate::entities::folder;
 use crate::errors::{AsterError, MapAsterErr, Result};
 use crate::runtime::PrimaryAppState;
-use crate::services::task_service::TaskStepInfo;
 use crate::services::{
-    workspace_storage_service, workspace_storage_service::WorkspaceStorageScope,
+    task_service::{
+        TaskLeaseGuard, TaskStepInfo,
+        archive::common::create_folder_exact_in_scope,
+        mark_task_progress,
+        steps::{TASK_STEP_IMPORT_RESULT, set_task_step_active},
+    },
+    workspace_storage_service,
+    workspace_storage_service::WorkspaceStorageScope,
 };
-
-use super::super::super::steps::{TASK_STEP_IMPORT_RESULT, set_task_step_active};
-use super::super::super::{TaskLeaseGuard, mark_task_progress};
-use super::super::common::create_folder_exact_in_scope;
 
 #[derive(Debug, Default)]
 struct StagedArchiveTree {

--- a/src/services/task_service/archive/extract/mod.rs
+++ b/src/services/task_service/archive/extract/mod.rs
@@ -7,32 +7,32 @@ use std::path::Path;
 
 use chrono::Utc;
 
+use super::common::{build_folder_display_path, create_unique_folder_in_scope};
 use crate::config::operations;
 use crate::db::repository::background_task_repo;
 use crate::entities::{background_task, file};
 use crate::errors::{AsterError, MapAsterErr, Result};
 use crate::runtime::PrimaryAppState;
+use crate::services::archive_service::format::{ArchiveFormat, detect_archive_extract_format};
 use crate::services::{
     storage_change_service,
+    task_service::{
+        TaskInfo, TaskLease, TaskLeaseGuard, cleanup_task_temp_dir_for_task, create_task_record,
+        get_task_in_scope, is_task_lease_lost, is_task_lease_renewal_timed_out, mark_task_progress,
+        mark_task_succeeded, prepare_task_temp_dir,
+        steps::{
+            TASK_STEP_DOWNLOAD_SOURCE, TASK_STEP_IMPORT_RESULT, TASK_STEP_WAITING,
+            parse_task_steps_json, set_task_step_active, set_task_step_succeeded,
+        },
+        task_scope,
+        types::{
+            ArchiveExtractTaskPayload, ArchiveExtractTaskResult, CreateArchiveExtractTaskParams,
+            parse_task_payload, serialize_task_result,
+        },
+    },
     workspace_storage_service::{self, WorkspaceStorageScope},
 };
 use crate::types::{BackgroundTaskKind, BackgroundTaskStatus};
-
-use super::super::steps::{
-    TASK_STEP_DOWNLOAD_SOURCE, TASK_STEP_IMPORT_RESULT, TASK_STEP_WAITING, parse_task_steps_json,
-    set_task_step_active, set_task_step_succeeded,
-};
-use super::super::types::{
-    ArchiveExtractTaskPayload, ArchiveExtractTaskResult, CreateArchiveExtractTaskParams,
-    parse_task_payload, serialize_task_result,
-};
-use super::super::{
-    TaskLease, TaskLeaseGuard, cleanup_task_temp_dir_for_task, create_task_record,
-    is_task_lease_lost, is_task_lease_renewal_timed_out, mark_task_progress, mark_task_succeeded,
-    prepare_task_temp_dir, task_scope,
-};
-use super::common::{build_folder_display_path, create_unique_folder_in_scope};
-use crate::services::archive_service::format::{ArchiveFormat, detect_archive_extract_format};
 use import::materialize_archive_extract_stage;
 use staging::{
     ArchiveExtractLimits, ArchiveExtractPolicyResolver, ArchiveExtractStageOptions,
@@ -45,7 +45,7 @@ pub(crate) async fn create_archive_extract_task_in_scope(
     scope: WorkspaceStorageScope,
     file_id: i64,
     params: CreateArchiveExtractTaskParams,
-) -> Result<super::super::TaskInfo> {
+) -> Result<TaskInfo> {
     workspace_storage_service::require_scope_access_with_db(state, state.writer_db(), scope)
         .await?;
     let source_file = workspace_storage_service::verify_file_access(state, scope, file_id).await?;
@@ -75,7 +75,7 @@ pub(crate) async fn create_archive_extract_task_in_scope(
         &payload,
     )
     .await?;
-    super::super::get_task_in_scope(state, scope, task.id).await
+    get_task_in_scope(state, scope, task.id).await
 }
 
 pub(super) async fn process_archive_extract_task(

--- a/src/services/task_service/archive/extract/staging.rs
+++ b/src/services/task_service/archive/extract/staging.rs
@@ -14,25 +14,29 @@ use crate::db::repository::file_repo;
 use crate::entities::file;
 use crate::errors::{AsterError, MapAsterErr, Result};
 use crate::runtime::PrimaryAppState;
-use crate::services::archive_service::io::copy_async_reader_to_writer_with_expected_size;
-use crate::services::archive_service::scan::{
-    ArchiveScanEntry, ArchiveScanLimits, ArchiveScanNamePolicy, ensure_archive_scan_deadline,
+use crate::services::{
+    archive_service::{
+        io::copy_async_reader_to_writer_with_expected_size,
+        scan::{
+            ArchiveScanEntry, ArchiveScanLimits, ArchiveScanNamePolicy,
+            ensure_archive_scan_deadline,
+        },
+        seven_zip_scan::{
+            map_seven_zip_entry_error, open_seven_zip_streaming_archive, scan_seven_zip_archive,
+            seven_zip_streaming_config,
+        },
+        zip_scan::scan_zip_archive,
+    },
+    task_service::{
+        TaskLeaseGuard, TaskStepInfo,
+        archive::common::copy_reader_to_writer_with_lease_and_expected_size,
+        steps::{TASK_STEP_EXTRACT_ARCHIVE, set_task_step_active, set_task_step_succeeded},
+        update_task_progress_db,
+    },
+    workspace_storage_service::{self, WorkspaceStorageScope},
 };
-use crate::services::archive_service::seven_zip_scan::{
-    map_seven_zip_entry_error, open_seven_zip_streaming_archive, scan_seven_zip_archive,
-    seven_zip_streaming_config,
-};
-use crate::services::archive_service::zip_scan::scan_zip_archive;
-use crate::services::task_service::TaskStepInfo;
-use crate::services::workspace_storage_service::{self, WorkspaceStorageScope};
 use crate::storage::PolicySnapshot;
 use crate::types::ArchiveFilenameEncoding;
-
-use super::super::super::TaskLeaseGuard;
-use super::super::super::steps::{
-    TASK_STEP_EXTRACT_ARCHIVE, set_task_step_active, set_task_step_succeeded,
-};
-use super::super::common::copy_reader_to_writer_with_lease_and_expected_size;
 
 #[derive(Debug)]
 pub(super) struct StagedArchiveStats {
@@ -98,7 +102,7 @@ impl ArchiveStagingProgressSink<'_, '_> {
             Some((self.progress.processed_bytes, self.progress.total_bytes)),
         )?;
         self.runtime.handle.block_on(async {
-            super::super::super::update_task_progress_db(
+            update_task_progress_db(
                 self.runtime.db,
                 self.runtime.lease_guard,
                 self.progress.processed_bytes,
@@ -491,7 +495,7 @@ fn set_archive_staging_reading_step(
         step_progress,
     )?;
     handle.block_on(async {
-        super::super::super::update_task_progress_db(
+        update_task_progress_db(
             db,
             lease_guard,
             0,
@@ -940,4 +944,27 @@ fn ensure_seven_zip_entry_matches_preflight(
         }
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ensure_seven_zip_entry_count_matches_preflight;
+
+    #[test]
+    fn seven_zip_preflight_entry_count_match_accepts_equal_counts() {
+        ensure_seven_zip_entry_count_matches_preflight(2, 2)
+            .expect("matching preflight and archive entry counts should pass");
+    }
+
+    #[test]
+    fn seven_zip_preflight_entry_count_match_rejects_mismatch() {
+        let error = ensure_seven_zip_entry_count_matches_preflight(1, 2)
+            .expect_err("mismatched preflight and archive entry counts should fail");
+
+        assert!(
+            error
+                .message()
+                .contains("preflight entry count 1 differs from archive entry count 2")
+        );
+    }
 }

--- a/src/services/task_service/archive/preview.rs
+++ b/src/services/task_service/archive/preview.rs
@@ -5,20 +5,24 @@ use crate::db::repository::file_repo;
 use crate::entities::{background_task, file, file_blob};
 use crate::errors::{AsterError, Result};
 use crate::runtime::PrimaryAppState;
-use crate::services::{archive_preview_service, workspace_storage_service::WorkspaceStorageScope};
+use crate::services::{
+    archive_preview_service,
+    task_service::{
+        TaskLeaseGuard, cleanup_task_temp_dir_for_task, create_task_record, mark_task_progress,
+        mark_task_succeeded, prepare_task_temp_dir,
+        steps::{
+            TASK_STEP_DOWNLOAD_SOURCE, TASK_STEP_PERSIST_MANIFEST, TASK_STEP_SCAN_ARCHIVE,
+            TASK_STEP_WAITING, parse_task_steps_json, set_task_step_active,
+            set_task_step_succeeded,
+        },
+        types::{
+            ArchivePreviewTaskPayload, ArchivePreviewTaskResult, parse_task_payload,
+            serialize_task_result,
+        },
+    },
+    workspace_storage_service::WorkspaceStorageScope,
+};
 use crate::types::{BackgroundTaskKind, BackgroundTaskStatus};
-
-use super::super::steps::{
-    TASK_STEP_DOWNLOAD_SOURCE, TASK_STEP_PERSIST_MANIFEST, TASK_STEP_SCAN_ARCHIVE,
-    TASK_STEP_WAITING, parse_task_steps_json, set_task_step_active, set_task_step_succeeded,
-};
-use super::super::types::{
-    ArchivePreviewTaskPayload, ArchivePreviewTaskResult, parse_task_payload, serialize_task_result,
-};
-use super::super::{
-    TaskLeaseGuard, cleanup_task_temp_dir_for_task, create_task_record, mark_task_progress,
-    mark_task_succeeded, prepare_task_temp_dir,
-};
 
 pub(crate) async fn ensure_archive_preview_task(
     state: &PrimaryAppState,

--- a/src/services/task_service/archive/selection.rs
+++ b/src/services/task_service/archive/selection.rs
@@ -8,6 +8,10 @@ use std::{
 use actix_web::HttpResponse;
 use chrono::Utc;
 
+use super::common::{
+    ArchiveEntry, ArchiveFileEntry, ArchiveSinkContext, ends_with_ignore_ascii_case,
+    is_client_disconnect_error_text, write_archive_to_sink,
+};
 use crate::config::operations;
 use crate::db::repository::{file_repo, folder_repo};
 use crate::entities::{file, folder};
@@ -15,13 +19,8 @@ use crate::errors::{AsterError, Result};
 use crate::runtime::PrimaryAppState;
 use crate::services::{
     batch_service, folder_service,
+    task_service::types::CreateArchiveTaskParams,
     workspace_storage_service::{self, WorkspaceStorageScope},
-};
-
-use super::super::types::CreateArchiveTaskParams;
-use super::common::{
-    ArchiveEntry, ArchiveFileEntry, ArchiveSinkContext, ends_with_ignore_ascii_case,
-    is_client_disconnect_error_text, write_archive_to_sink,
 };
 
 pub(crate) struct PreparedArchiveDownload {

--- a/src/services/task_service/dispatch/execute.rs
+++ b/src/services/task_service/dispatch/execute.rs
@@ -5,27 +5,23 @@ use futures::stream::{self, StreamExt};
 use sea_orm::ActiveEnum;
 use tokio::time::MissedTickBehavior;
 
-use crate::db::repository::background_task_repo;
-use crate::entities::background_task;
-use crate::errors::{AsterError, Result};
-use crate::runtime::PrimaryAppState;
-use crate::types::BackgroundTaskKind;
-
-use super::super::archive;
-use super::super::blob_maintenance;
-use super::super::media_metadata;
-use super::super::retry::{TaskRetryClass, TaskRetryPolicy};
-use super::super::runtime;
-use super::super::steps::{mark_active_step_failed, parse_task_steps_json, serialize_task_steps};
-use super::super::storage_migration;
-use super::super::storage_policy_cleanup;
-use super::super::thumbnail;
-use super::super::trash;
 use super::{
     DispatchStats, TASK_HEARTBEAT_INTERVAL_SECS, TaskDispatchOutcome, TaskLease, TaskLeaseGuard,
     is_task_lease_lost, is_task_lease_renewal_timed_out, task_expiration_from,
     task_lease_expires_at, truncate_error,
 };
+use crate::db::repository::background_task_repo;
+use crate::entities::background_task;
+use crate::errors::{AsterError, Result};
+use crate::runtime::PrimaryAppState;
+use crate::services::task_service::{
+    archive, blob_maintenance, media_metadata, retry,
+    retry::{TaskRetryClass, TaskRetryPolicy},
+    runtime,
+    steps::{mark_active_step_failed, parse_task_steps_json, serialize_task_steps},
+    storage_migration, storage_policy_cleanup, thumbnail, trash,
+};
+use crate::types::BackgroundTaskKind;
 
 pub(super) async fn run_claimed_tasks(
     state: &PrimaryAppState,
@@ -347,14 +343,10 @@ pub(super) fn task_retry_class(kind: BackgroundTaskKind, error: &AsterError) -> 
         BackgroundTaskKind::MediaMetadataExtract => {
             media_metadata::MediaMetadataRetryPolicy::retry_class(error)
         }
-        BackgroundTaskKind::TrashPurgeAll => super::super::retry::default_retry_class(error),
-        BackgroundTaskKind::StoragePolicyTempCleanup => {
-            super::super::retry::default_retry_class(error)
-        }
-        BackgroundTaskKind::StoragePolicyMigration => {
-            super::super::retry::default_retry_class(error)
-        }
-        BackgroundTaskKind::BlobMaintenance => super::super::retry::default_retry_class(error),
+        BackgroundTaskKind::TrashPurgeAll => retry::default_retry_class(error),
+        BackgroundTaskKind::StoragePolicyTempCleanup => retry::default_retry_class(error),
+        BackgroundTaskKind::StoragePolicyMigration => retry::default_retry_class(error),
+        BackgroundTaskKind::BlobMaintenance => retry::default_retry_class(error),
         BackgroundTaskKind::SystemRuntime => runtime::RuntimeRetryPolicy::retry_class(error),
     }
 }

--- a/src/storage/extensions.rs
+++ b/src/storage/extensions.rs
@@ -158,7 +158,7 @@ pub mod fallback {
         _size: i64,
     ) -> Result<String>
     where
-        D: super::super::driver::StorageDriver + ?Sized,
+        D: crate::storage::driver::StorageDriver + ?Sized,
     {
         // 创建临时文件
         let temp_dir = std::env::temp_dir();

--- a/src/storage/remote_protocol/runtime.rs
+++ b/src/storage/remote_protocol/runtime.rs
@@ -173,7 +173,7 @@ mod tests {
             "/root/api/v1/internal/storage/objects/object.bin"
         );
         assert!(parsed.query_pairs().any(|(key, value)| key
-            == super::super::PRESIGNED_AUTH_ACCESS_KEY_QUERY
+            == crate::storage::remote_protocol::PRESIGNED_AUTH_ACCESS_KEY_QUERY
             && value == "runtime-access"));
     }
 }

--- a/src/storage/remote_protocol/tunnel/server/auth.rs
+++ b/src/storage/remote_protocol/tunnel/server/auth.rs
@@ -5,7 +5,7 @@ use crate::runtime::PrimaryRuntimeState;
 
 use hmac::Mac;
 
-use super::super::super::{
+use crate::storage::remote_protocol::{
     INTERNAL_AUTH_ACCESS_KEY_HEADER, INTERNAL_AUTH_NONCE_HEADER, INTERNAL_AUTH_NONCE_TTL_SECS,
     INTERNAL_AUTH_SIGNATURE_HEADER, INTERNAL_AUTH_SKEW_SECS, INTERNAL_AUTH_TIMESTAMP_HEADER,
     internal_request_mac, sign_internal_request,

--- a/src/storage/remote_protocol/tunnel/server/registry/polling.rs
+++ b/src/storage/remote_protocol/tunnel/server/registry/polling.rs
@@ -2,17 +2,18 @@ use bytes::Bytes;
 use http::Method;
 use tokio::sync::oneshot;
 
-use crate::entities::managed_follower;
-use crate::errors::{AsterError, Result};
-use crate::storage::error::{StorageErrorKind, storage_driver_error};
-
-use super::super::response::tunnel_http_response;
-use super::super::{REMOTE_TUNNEL_BODY_LIMIT, RemoteTunnelRequest, RemoteTunnelResponse};
 use super::broker::RemoteTunnelHttpResponse;
 use super::headers::request_headers;
 use super::{
     REMOTE_TUNNEL_CONNECT_WAIT_TIMEOUT, REMOTE_TUNNEL_REQUEST_TIMEOUT, RemoteTunnelRegistry,
     reverse_tunnel_offline_error,
+};
+use crate::entities::managed_follower;
+use crate::errors::{AsterError, Result};
+use crate::storage::error::{StorageErrorKind, storage_driver_error};
+use crate::storage::remote_protocol::tunnel::server::response::tunnel_http_response;
+use crate::storage::remote_protocol::tunnel::server::{
+    REMOTE_TUNNEL_BODY_LIMIT, RemoteTunnelRequest, RemoteTunnelResponse,
 };
 
 #[derive(Debug)]

--- a/src/storage/remote_protocol/tunnel/server/registry/streaming.rs
+++ b/src/storage/remote_protocol/tunnel/server/registry/streaming.rs
@@ -9,19 +9,18 @@ use tokio::io::{AsyncRead, AsyncReadExt};
 use tokio::sync::{mpsc, oneshot};
 use tokio_util::io::StreamReader;
 
-use crate::entities::managed_follower;
-use crate::errors::{AsterError, Result};
-use crate::storage::error::{StorageErrorKind, storage_driver_error};
-
-use super::super::response::header_pairs_to_map;
-use super::super::{
-    REMOTE_TUNNEL_STREAM_CHUNK_SIZE, RemoteTunnelStreamFrame, RemoteTunnelStreamFrameKind,
-};
 use super::broker::RemoteTunnelStreamHttpResponse;
 use super::headers::request_headers;
 use super::{
     REMOTE_TUNNEL_CONNECT_WAIT_TIMEOUT, REMOTE_TUNNEL_REQUEST_TIMEOUT,
     REMOTE_TUNNEL_STREAM_CHANNEL_CAPACITY, RemoteTunnelRegistry, reverse_tunnel_offline_error,
+};
+use crate::entities::managed_follower;
+use crate::errors::{AsterError, Result};
+use crate::storage::error::{StorageErrorKind, storage_driver_error};
+use crate::storage::remote_protocol::tunnel::server::response::header_pairs_to_map;
+use crate::storage::remote_protocol::tunnel::server::{
+    REMOTE_TUNNEL_STREAM_CHUNK_SIZE, RemoteTunnelStreamFrame, RemoteTunnelStreamFrameKind,
 };
 
 struct PinnedAsyncRead {


### PR DESCRIPTION
- 迁移 checkpoint 模块的 INSERT/UPDATE 语句到 SeaORM Query API，消除 SQL 注入风险
- 重构 blob 汇总查询使用类型安全的聚合表达式
- 统一 import 路径，移除冗余的 `super::super` 引用
- 新增测试覆盖参数化查询和边界条件验证
- 删除已废弃的 `nullable_sql_string` 辅助函数

closed #227, closed #222, closed #219

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **Bug 修复**
  * 改进数据库迁移检查点写入与查询，避免 SQL 字面量拼接问题，提升安全性与稳定性
  * 优化文件 Blob 汇总查询与空结果处理，改进后端兼容性与错误处理

* **测试**
  * 扩充归档扫描与解压/回放相关测试，覆盖加密、符号链接、特殊文件、路径穿越与大小限制等场景

* **代码重构**
  * 统一和整理模块引用路径与查询构建方式，提高可维护性和跨数据库一致性

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AptS-1547/AsterDrive/pull/228?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->