### PR TITLE
feat(workspace_storage_service): add cancellable storage operation context

### DIFF
--- a/src/services/file_service/content.rs
+++ b/src/services/file_service/content.rs
@@ -321,6 +321,7 @@ pub(crate) async fn update_content_in_scope(
                 resolved_policy: Some(resolved_policy),
                 precomputed_hash: precomputed_hash.as_deref(),
                 actor_username: None,
+                ..Default::default()
             },
         )
         .await;
@@ -437,6 +438,7 @@ pub(crate) async fn update_content_stream_in_scope(
             resolved_policy,
             precomputed_hash: precomputed_hash.as_deref(),
             actor_username: None,
+            ..Default::default()
         },
     )
     .await;

--- a/src/services/task_service/archive/compress.rs
+++ b/src/services/task_service/archive/compress.rs
@@ -258,7 +258,10 @@ pub(super) async fn process_archive_compress_task(
                 &archive_temp_path_string,
                 archive_size,
             ),
-            workspace_storage_service::StoreFromTempHints::default(),
+            workspace_storage_service::StoreFromTempHints {
+                operation_context: context.storage_operation_context(),
+                ..Default::default()
+            },
             workspace_storage_service::NewFileMode::ResolveUnique,
             EMIT_ARCHIVE_STORAGE_EVENT,
         )

--- a/src/services/task_service/archive/extract/import.rs
+++ b/src/services/task_service/archive/extract/import.rs
@@ -106,7 +106,10 @@ pub(super) async fn materialize_archive_extract_stage(
                 &temp_path.to_string_lossy(),
                 size,
             ),
-            workspace_storage_service::StoreFromTempHints::default(),
+            workspace_storage_service::StoreFromTempHints {
+                operation_context: context.storage_operation_context(),
+                ..Default::default()
+            },
         )
         .await?;
         summary.file_ids.push(created.id);

--- a/src/services/task_service/mod.rs
+++ b/src/services/task_service/mod.rs
@@ -289,6 +289,14 @@ impl TaskExecutionContext {
         self.lease_guard.ensure_active()
     }
 
+    pub(super) fn storage_operation_context(
+        &self,
+    ) -> workspace_storage_service::StorageOperationContext {
+        workspace_storage_service::StorageOperationContext::new(TaskStorageCancellationCheck {
+            context: self.clone(),
+        })
+    }
+
     pub(super) async fn sleep_or_shutdown(&self, duration: StdDuration) -> Result<()> {
         self.lease_guard.ensure_active()?;
 
@@ -302,6 +310,17 @@ impl TaskExecutionContext {
     pub(super) async fn shutdown_requested(&self) -> Result<()> {
         self.shutdown_token.cancelled().await;
         Err(self.lease_guard.mark_shutdown_requested())
+    }
+}
+
+#[derive(Clone)]
+struct TaskStorageCancellationCheck {
+    context: TaskExecutionContext,
+}
+
+impl workspace_storage_service::StorageCancellationCheck for TaskStorageCancellationCheck {
+    fn checkpoint(&self) -> Result<()> {
+        self.context.ensure_active()
     }
 }
 

--- a/src/services/task_service/offline_download.rs
+++ b/src/services/task_service/offline_download.rs
@@ -259,6 +259,7 @@ pub(super) async fn process_offline_download_task(
             ),
             workspace_storage_service::StoreFromTempHints {
                 precomputed_hash: Some(&downloaded.sha256),
+                operation_context: context.storage_operation_context(),
                 ..Default::default()
             },
             workspace_storage_service::NewFileMode::ResolveUnique,

--- a/src/services/wopi_service/targets.rs
+++ b/src/services/wopi_service/targets.rs
@@ -381,6 +381,7 @@ pub(crate) async fn store_relative_target_from_stream(
                 resolved_policy,
                 precomputed_hash: precomputed_hash.as_deref(),
                 actor_username: None,
+                ..Default::default()
             },
         )
         .await
@@ -400,6 +401,7 @@ pub(crate) async fn store_relative_target_from_stream(
                 resolved_policy,
                 precomputed_hash: precomputed_hash.as_deref(),
                 actor_username: None,
+                ..Default::default()
             },
         )
         .await

--- a/src/services/workspace_storage_service/blob_upload.rs
+++ b/src/services/workspace_storage_service/blob_upload.rs
@@ -5,10 +5,15 @@ use std::path::{Component, Path, PathBuf};
 use tokio::io::AsyncRead;
 
 use crate::entities::file_blob;
-use crate::errors::Result;
+use crate::errors::{AsterError, MapAsterErr, Result};
 use crate::types::DriverType;
 
-use super::{create_nondedup_blob_with_key, create_remote_nondedup_blob, create_s3_nondedup_blob};
+use super::{
+    StorageOperationContext, create_nondedup_blob_with_key, create_remote_nondedup_blob,
+    create_s3_nondedup_blob,
+};
+
+const LOCAL_COPY_BUF_SIZE: usize = 1024 * 1024;
 
 #[derive(Debug, Clone)]
 pub(crate) enum PreparedNonDedupBlobUpload {
@@ -214,6 +219,199 @@ pub(crate) async fn upload_temp_file_to_prepared_blob(
     Ok(())
 }
 
+pub(crate) async fn upload_temp_file_to_prepared_blob_cancellable(
+    driver: &dyn crate::storage::driver::StorageDriver,
+    prepared: &PreparedNonDedupBlobUpload,
+    temp_path: &str,
+    operation_context: &StorageOperationContext,
+) -> Result<()> {
+    if let PreparedNonDedupBlobUpload::Local {
+        base_path,
+        storage_path,
+        size,
+        ..
+    } = prepared
+    {
+        return upload_temp_file_to_local_prepared_blob_cancellable(
+            base_path,
+            storage_path,
+            *size,
+            temp_path,
+            operation_context,
+        )
+        .await;
+    }
+
+    operation_context.checkpoint()?;
+    let file = tokio::fs::File::open(temp_path).await.map_aster_err_ctx(
+        "open temp file for upload",
+        AsterError::storage_driver_error,
+    )?;
+    let reader = operation_context.wrap_reader(Box::new(file));
+    upload_reader_to_prepared_blob_with_context(
+        driver,
+        prepared,
+        reader,
+        prepared_size(prepared),
+        operation_context,
+    )
+    .await
+}
+
+async fn upload_temp_file_to_local_prepared_blob_cancellable(
+    base_path: &Path,
+    storage_path: &str,
+    size: i64,
+    temp_path: &str,
+    operation_context: &StorageOperationContext,
+) -> Result<()> {
+    operation_context.checkpoint()?;
+    let full_path = base_path.join(storage_path.trim_start_matches('/'));
+    if let Some(parent) = full_path.parent() {
+        tokio::fs::create_dir_all(parent)
+            .await
+            .map_aster_err(AsterError::storage_driver_error)?;
+    }
+    operation_context.checkpoint()?;
+
+    let result = match tokio::fs::hard_link(temp_path, &full_path).await {
+        Ok(()) => validate_local_prepared_blob(&full_path, size, operation_context).await,
+        Err(link_error) => {
+            copy_temp_file_to_local_prepared_blob(
+                temp_path,
+                &full_path,
+                size,
+                link_error,
+                operation_context,
+            )
+            .await
+        }
+    };
+
+    if let Err(error) = result {
+        cleanup_local_prepared_blob(
+            base_path,
+            &full_path,
+            storage_path,
+            "cancellable upload error",
+        )
+        .await;
+        return Err(error);
+    }
+
+    if let Err(error) = operation_context.checkpoint() {
+        cleanup_local_prepared_blob(
+            base_path,
+            &full_path,
+            storage_path,
+            "cancellation after local upload",
+        )
+        .await;
+        return Err(error);
+    }
+    Ok(())
+}
+
+async fn copy_temp_file_to_local_prepared_blob(
+    temp_path: &str,
+    full_path: &Path,
+    size: i64,
+    link_error: std::io::Error,
+    operation_context: &StorageOperationContext,
+) -> Result<()> {
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    operation_context.checkpoint()?;
+    let mut source = tokio::fs::File::open(temp_path).await.map_err(|error| {
+        AsterError::storage_driver_error(format!(
+            "open local upload source after hardlink failed ({link_error}): {error}"
+        ))
+    })?;
+    let mut target = tokio::fs::File::create(full_path).await.map_aster_err_ctx(
+        "create local upload target",
+        AsterError::storage_driver_error,
+    )?;
+    let mut buf = vec![0_u8; LOCAL_COPY_BUF_SIZE];
+    let mut copied = 0_i64;
+
+    loop {
+        operation_context.checkpoint()?;
+        let read = source
+            .read(&mut buf)
+            .await
+            .map_aster_err_ctx("read local upload source", AsterError::storage_driver_error)?;
+        if read == 0 {
+            break;
+        }
+        target.write_all(&buf[..read]).await.map_aster_err_ctx(
+            "write local upload target",
+            AsterError::storage_driver_error,
+        )?;
+        let read = i64::try_from(read).map_err(|_| {
+            AsterError::storage_driver_error("local upload read size exceeds i64 range")
+        })?;
+        copied = copied
+            .checked_add(read)
+            .ok_or_else(|| AsterError::storage_driver_error("local upload copy size overflow"))?;
+    }
+    target.flush().await.map_aster_err_ctx(
+        "flush local upload target",
+        AsterError::storage_driver_error,
+    )?;
+    operation_context.checkpoint()?;
+
+    if copied != size {
+        return Err(AsterError::storage_driver_error(format!(
+            "local upload copy size mismatch: expected {size}, copied {copied}"
+        )));
+    }
+
+    Ok(())
+}
+
+async fn validate_local_prepared_blob(
+    full_path: &Path,
+    size: i64,
+    operation_context: &StorageOperationContext,
+) -> Result<()> {
+    let expected_size = crate::utils::numbers::i64_to_u64(size, "local upload blob size")?;
+    let metadata = tokio::fs::metadata(full_path).await.map_aster_err_ctx(
+        "inspect local upload blob",
+        AsterError::storage_driver_error,
+    )?;
+    if metadata.len() != expected_size {
+        return Err(AsterError::storage_driver_error(format!(
+            "local upload size mismatch: expected {expected_size}, actual {}",
+            metadata.len()
+        )));
+    }
+    operation_context.checkpoint()
+}
+
+async fn cleanup_local_prepared_blob(
+    base_path: &Path,
+    full_path: &Path,
+    storage_path: &str,
+    reason: &str,
+) {
+    match tokio::fs::remove_file(full_path).await {
+        Ok(()) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(error) => {
+            tracing::warn!(
+                storage_path,
+                full_path = %full_path.display(),
+                "failed to cleanup local prepared blob after {reason}: {error}"
+            );
+            return;
+        }
+    }
+
+    if let Some(parent) = full_path.parent() {
+        cleanup_empty_local_blob_dirs(parent, base_path).await;
+    }
+}
+
 pub(crate) async fn upload_reader_to_prepared_blob(
     driver: &dyn crate::storage::driver::StorageDriver,
     prepared: &PreparedNonDedupBlobUpload,
@@ -233,6 +431,44 @@ pub(crate) async fn upload_reader_to_prepared_blob(
     }
 
     Ok(())
+}
+
+async fn upload_reader_to_prepared_blob_with_context(
+    driver: &dyn crate::storage::driver::StorageDriver,
+    prepared: &PreparedNonDedupBlobUpload,
+    reader: Box<dyn AsyncRead + Unpin + Send + Sync>,
+    size: i64,
+    operation_context: &StorageOperationContext,
+) -> Result<()> {
+    let stream_driver = driver.as_stream_upload().ok_or_else(|| {
+        crate::errors::AsterError::storage_driver_error("stream upload not supported")
+    })?;
+
+    operation_context.checkpoint()?;
+    if let Err(error) = stream_driver
+        .put_reader(prepared.storage_path(), reader, size)
+        .await
+    {
+        cleanup_preuploaded_blob_upload(driver, prepared, "stream upload error").await;
+        if let Err(cancellation_error) = operation_context.checkpoint() {
+            return Err(cancellation_error);
+        }
+        return Err(error);
+    }
+    if let Err(error) = operation_context.checkpoint() {
+        cleanup_preuploaded_blob_upload(driver, prepared, "cancellation after stream upload").await;
+        return Err(error);
+    }
+
+    Ok(())
+}
+
+fn prepared_size(prepared: &PreparedNonDedupBlobUpload) -> i64 {
+    match prepared {
+        PreparedNonDedupBlobUpload::Local { size, .. }
+        | PreparedNonDedupBlobUpload::S3 { size, .. }
+        | PreparedNonDedupBlobUpload::Remote { size, .. } => *size,
+    }
 }
 
 pub(crate) async fn persist_preuploaded_blob<C: ConnectionTrait>(

--- a/src/services/workspace_storage_service/blob_upload.rs
+++ b/src/services/workspace_storage_service/blob_upload.rs
@@ -13,8 +13,6 @@ use super::{
     create_s3_nondedup_blob,
 };
 
-const LOCAL_COPY_BUF_SIZE: usize = 1024 * 1024;
-
 #[derive(Debug, Clone)]
 pub(crate) enum PreparedNonDedupBlobUpload {
     Local {
@@ -319,46 +317,23 @@ async fn copy_temp_file_to_local_prepared_blob(
     link_error: std::io::Error,
     operation_context: &StorageOperationContext,
 ) -> Result<()> {
-    use tokio::io::{AsyncReadExt, AsyncWriteExt};
-
     operation_context.checkpoint()?;
-    let mut source = tokio::fs::File::open(temp_path).await.map_err(|error| {
+    let copied = crate::storage::drivers::local::copy_file_with_checkpoint(
+        Path::new(temp_path),
+        full_path,
+        || operation_context.checkpoint(),
+        "local upload",
+    )
+    .await
+    .map_err(|error| {
         AsterError::storage_driver_error(format!(
-            "open local upload source after hardlink failed ({link_error}): {error}"
+            "copy local upload after hardlink failed ({link_error}): {}",
+            error.message()
         ))
     })?;
-    let mut target = tokio::fs::File::create(full_path).await.map_aster_err_ctx(
-        "create local upload target",
-        AsterError::storage_driver_error,
-    )?;
-    let mut buf = vec![0_u8; LOCAL_COPY_BUF_SIZE];
-    let mut copied = 0_i64;
-
-    loop {
-        operation_context.checkpoint()?;
-        let read = source
-            .read(&mut buf)
-            .await
-            .map_aster_err_ctx("read local upload source", AsterError::storage_driver_error)?;
-        if read == 0 {
-            break;
-        }
-        target.write_all(&buf[..read]).await.map_aster_err_ctx(
-            "write local upload target",
-            AsterError::storage_driver_error,
-        )?;
-        let read = i64::try_from(read).map_err(|_| {
-            AsterError::storage_driver_error("local upload read size exceeds i64 range")
-        })?;
-        copied = copied
-            .checked_add(read)
-            .ok_or_else(|| AsterError::storage_driver_error("local upload copy size overflow"))?;
-    }
-    target.flush().await.map_aster_err_ctx(
-        "flush local upload target",
-        AsterError::storage_driver_error,
-    )?;
-    operation_context.checkpoint()?;
+    let copied = i64::try_from(copied).map_err(|_| {
+        AsterError::storage_driver_error("local upload copied size exceeds i64 range")
+    })?;
 
     if copied != size {
         return Err(AsterError::storage_driver_error(format!(

--- a/src/services/workspace_storage_service/mod.rs
+++ b/src/services/workspace_storage_service/mod.rs
@@ -6,6 +6,7 @@
 
 mod blob_upload;
 mod multipart;
+mod operation_context;
 mod store;
 #[cfg(test)]
 mod tests;
@@ -39,9 +40,10 @@ pub(crate) use crate::services::workspace_scope_service::load_scope_actor_userna
 pub(crate) use blob_upload::{
     PreparedNonDedupBlobUpload, cleanup_preuploaded_blob_upload, persist_preuploaded_blob,
     prepare_non_dedup_blob_upload, upload_reader_to_prepared_blob,
-    upload_temp_file_to_prepared_blob,
+    upload_temp_file_to_prepared_blob, upload_temp_file_to_prepared_blob_cancellable,
 };
 pub(crate) use multipart::{WorkspaceUploadHints, upload_with_hints};
+pub(crate) use operation_context::{StorageCancellationCheck, StorageOperationContext};
 pub(crate) use store::from_temp::store_from_temp_internal;
 pub(crate) use store::{
     StoreFromTempHints, StoreFromTempParams, StorePreuploadedNondedupParams, create_empty,

--- a/src/services/workspace_storage_service/multipart/local_direct.rs
+++ b/src/services/workspace_storage_service/multipart/local_direct.rs
@@ -124,6 +124,7 @@ pub(super) async fn upload_local_direct(
                     resolved_policy,
                     precomputed_hash: precomputed_hash.as_deref(),
                     actor_username,
+                    ..Default::default()
                 },
             )
             .await;

--- a/src/services/workspace_storage_service/operation_context.rs
+++ b/src/services/workspace_storage_service/operation_context.rs
@@ -6,6 +6,9 @@ use tokio::io::{AsyncRead, ReadBuf};
 
 use crate::errors::Result;
 
+const CANCELLATION_CHECK_EAGER_READS: u32 = 8;
+const CANCELLATION_CHECK_READ_INTERVAL: u32 = 64;
+
 pub(crate) trait StorageCancellationCheck: Send + Sync {
     fn checkpoint(&self) -> Result<()>;
 }
@@ -49,22 +52,24 @@ impl StorageOperationContext {
         &self,
         reader: Box<dyn AsyncRead + Unpin + Send>,
     ) -> Box<dyn AsyncRead + Unpin + Send + Sync> {
-        let reader: Box<dyn AsyncRead + Unpin + Send + Sync> = Box::new(SyncRead::new(reader));
+        let reader: Box<dyn AsyncRead + Unpin + Send + Sync> =
+            Box::new(SendToSyncReader::new(reader));
         match &self.cancellation {
             Some(cancellation) => Box::new(CancellationAwareReader {
                 inner: reader,
                 cancellation: cancellation.clone(),
+                read_count: 0,
             }),
             None => reader,
         }
     }
 }
 
-struct SyncRead {
+struct SendToSyncReader {
     inner: Mutex<Box<dyn AsyncRead + Unpin + Send>>,
 }
 
-impl SyncRead {
+impl SendToSyncReader {
     fn new(inner: Box<dyn AsyncRead + Unpin + Send>) -> Self {
         Self {
             inner: Mutex::new(inner),
@@ -72,7 +77,7 @@ impl SyncRead {
     }
 }
 
-impl AsyncRead for SyncRead {
+impl AsyncRead for SendToSyncReader {
     fn poll_read(
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,
@@ -80,32 +85,51 @@ impl AsyncRead for SyncRead {
     ) -> Poll<std::io::Result<()>> {
         match self.inner.lock() {
             Ok(mut inner) => Pin::new(&mut *inner).poll_read(cx, buf),
-            Err(_) => Poll::Ready(Err(std::io::Error::other("sync reader mutex poisoned"))),
+            Err(_) => Poll::Ready(Err(std::io::Error::other(
+                "send-to-sync reader mutex poisoned",
+            ))),
         }
     }
 }
 
-impl Unpin for SyncRead {}
+impl Unpin for SendToSyncReader {}
 
 struct CancellationAwareReader {
     inner: Box<dyn AsyncRead + Unpin + Send + Sync>,
     cancellation: Arc<dyn StorageCancellationCheck>,
+    read_count: u32,
 }
 
 impl AsyncRead for CancellationAwareReader {
     fn poll_read(
-        mut self: Pin<&mut Self>,
+        self: Pin<&mut Self>,
         cx: &mut Context<'_>,
         buf: &mut ReadBuf<'_>,
     ) -> Poll<std::io::Result<()>> {
-        if let Err(error) = self.cancellation.checkpoint() {
+        let this = self.get_mut();
+        if should_check_cancellation(this.read_count)
+            && let Err(error) = this.cancellation.checkpoint()
+        {
             return Poll::Ready(Err(std::io::Error::new(
                 std::io::ErrorKind::Interrupted,
                 error.to_string(),
             )));
         }
-        Pin::new(&mut self.inner).poll_read(cx, buf)
+
+        let before = buf.filled().len();
+        let poll = Pin::new(&mut this.inner).poll_read(cx, buf);
+        if let Poll::Ready(Ok(())) = &poll
+            && buf.filled().len() > before
+        {
+            this.read_count = this.read_count.wrapping_add(1);
+        }
+        poll
     }
 }
 
 impl Unpin for CancellationAwareReader {}
+
+fn should_check_cancellation(read_count: u32) -> bool {
+    read_count < CANCELLATION_CHECK_EAGER_READS
+        || read_count.is_multiple_of(CANCELLATION_CHECK_READ_INTERVAL)
+}

--- a/src/services/workspace_storage_service/operation_context.rs
+++ b/src/services/workspace_storage_service/operation_context.rs
@@ -1,0 +1,111 @@
+use std::pin::Pin;
+use std::sync::{Arc, Mutex};
+use std::task::{Context, Poll};
+
+use tokio::io::{AsyncRead, ReadBuf};
+
+use crate::errors::Result;
+
+pub(crate) trait StorageCancellationCheck: Send + Sync {
+    fn checkpoint(&self) -> Result<()>;
+}
+
+impl<F> StorageCancellationCheck for F
+where
+    F: Fn() -> Result<()> + Send + Sync,
+{
+    fn checkpoint(&self) -> Result<()> {
+        self()
+    }
+}
+
+#[derive(Clone, Default)]
+pub(crate) struct StorageOperationContext {
+    cancellation: Option<Arc<dyn StorageCancellationCheck>>,
+}
+
+impl StorageOperationContext {
+    pub(crate) fn new<C>(cancellation: C) -> Self
+    where
+        C: StorageCancellationCheck + 'static,
+    {
+        Self {
+            cancellation: Some(Arc::new(cancellation)),
+        }
+    }
+
+    pub(crate) fn checkpoint(&self) -> Result<()> {
+        if let Some(cancellation) = &self.cancellation {
+            cancellation.checkpoint()?;
+        }
+        Ok(())
+    }
+
+    pub(crate) fn is_cancellable(&self) -> bool {
+        self.cancellation.is_some()
+    }
+
+    pub(crate) fn wrap_reader(
+        &self,
+        reader: Box<dyn AsyncRead + Unpin + Send>,
+    ) -> Box<dyn AsyncRead + Unpin + Send + Sync> {
+        let reader: Box<dyn AsyncRead + Unpin + Send + Sync> = Box::new(SyncRead::new(reader));
+        match &self.cancellation {
+            Some(cancellation) => Box::new(CancellationAwareReader {
+                inner: reader,
+                cancellation: cancellation.clone(),
+            }),
+            None => reader,
+        }
+    }
+}
+
+struct SyncRead {
+    inner: Mutex<Box<dyn AsyncRead + Unpin + Send>>,
+}
+
+impl SyncRead {
+    fn new(inner: Box<dyn AsyncRead + Unpin + Send>) -> Self {
+        Self {
+            inner: Mutex::new(inner),
+        }
+    }
+}
+
+impl AsyncRead for SyncRead {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<std::io::Result<()>> {
+        match self.inner.lock() {
+            Ok(mut inner) => Pin::new(&mut *inner).poll_read(cx, buf),
+            Err(_) => Poll::Ready(Err(std::io::Error::other("sync reader mutex poisoned"))),
+        }
+    }
+}
+
+impl Unpin for SyncRead {}
+
+struct CancellationAwareReader {
+    inner: Box<dyn AsyncRead + Unpin + Send + Sync>,
+    cancellation: Arc<dyn StorageCancellationCheck>,
+}
+
+impl AsyncRead for CancellationAwareReader {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<std::io::Result<()>> {
+        if let Err(error) = self.cancellation.checkpoint() {
+            return Poll::Ready(Err(std::io::Error::new(
+                std::io::ErrorKind::Interrupted,
+                error.to_string(),
+            )));
+        }
+        Pin::new(&mut self.inner).poll_read(cx, buf)
+    }
+}
+
+impl Unpin for CancellationAwareReader {}

--- a/src/services/workspace_storage_service/store/from_temp.rs
+++ b/src/services/workspace_storage_service/store/from_temp.rs
@@ -28,11 +28,14 @@ pub(crate) async fn store_from_temp_internal(
     new_file_mode: NewFileMode,
     emit_storage_event: bool,
 ) -> Result<file::Model> {
+    hints.operation_context.checkpoint()?;
     let prepared = prepare::prepare_store_from_temp(state, params, hints).await?;
     let scope = prepared.scope;
     let existing_file_id = prepared.existing_file_id;
     let storage_delta = prepared.storage_delta;
+    let operation_context = prepared.operation_context.clone();
     let overwritten = existing_file_id.is_some();
+    operation_context.checkpoint()?;
     let result = persist::persist_temp_store(state, prepared, new_file_mode).await?;
 
     if emit_storage_event {

--- a/src/services/workspace_storage_service/store/mod.rs
+++ b/src/services/workspace_storage_service/store/mod.rs
@@ -67,6 +67,7 @@ pub(crate) struct StoreFromTempHints<'a> {
     pub resolved_policy: Option<crate::entities::storage_policy::Model>,
     pub precomputed_hash: Option<&'a str>,
     pub actor_username: Option<&'a str>,
+    pub operation_context: crate::services::workspace_storage_service::StorageOperationContext,
 }
 
 pub(crate) struct StorePreuploadedNondedupParams<'a> {

--- a/src/services/workspace_storage_service/store/persist.rs
+++ b/src/services/workspace_storage_service/store/persist.rs
@@ -3,7 +3,7 @@ use crate::entities::{file, file_blob};
 use crate::errors::{AsterError, Result};
 use crate::runtime::PrimaryAppState;
 use crate::services::workspace_storage_service::{
-    check_quota, cleanup_preuploaded_blob_upload, persist_preuploaded_blob,
+    StorageOperationContext, check_quota, cleanup_preuploaded_blob_upload, persist_preuploaded_blob,
 };
 use sea_orm::ConnectionTrait;
 
@@ -27,6 +27,7 @@ pub(super) async fn persist_temp_store(
         driver,
         blob_plan,
         overwrite_ctx,
+        operation_context,
         storage_delta,
         quota_prechecked,
         mime,
@@ -35,19 +36,44 @@ pub(super) async fn persist_temp_store(
     } = prepared;
     let cleanup_blob_plan = blob_plan.clone();
 
+    operation_context.checkpoint()?;
     if storage_delta > 0 && !quota_prechecked {
         check_quota(state.writer_db(), scope, storage_delta).await?;
     }
-    let staged_dedup_target =
-        stage_temp_blob_before_transaction(&blob_plan, driver.as_ref(), size, &temp_path).await?;
+    operation_context.checkpoint()?;
+    let staged_dedup_target = stage_temp_blob_before_transaction(
+        &blob_plan,
+        driver.as_ref(),
+        size,
+        &temp_path,
+        &operation_context,
+    )
+    .await?;
+    if let Err(error) = operation_context.checkpoint() {
+        if staged_dedup_target {
+            rollback_staged_dedup_blob(state, &blob_plan, driver.as_ref(), policy.id).await;
+        }
+        if let TempBlobPlan::Preuploaded(preuploaded_blob) = &cleanup_blob_plan {
+            cleanup_preuploaded_blob_upload(
+                driver.as_ref(),
+                preuploaded_blob,
+                "cancellation after temp file upload",
+            )
+            .await;
+        }
+        return Err(error);
+    }
 
     let create_result = async {
         let txn = crate::db::transaction::begin(state.writer_db()).await?;
+        operation_context.checkpoint()?;
         if storage_delta > 0 {
             check_quota(&txn, scope, storage_delta).await?;
         }
+        operation_context.checkpoint()?;
 
         let blob = persist_temp_blob(&txn, &blob_plan, size, policy.id).await?;
+        operation_context.checkpoint()?;
         let result = super::write_record::write_file_record_from_temp(
             &txn,
             WriteFileRecordFromTempParams {
@@ -64,6 +90,7 @@ pub(super) async fn persist_temp_store(
             },
         )
         .await?;
+        operation_context.checkpoint()?;
 
         crate::db::transaction::commit(txn).await?;
         Ok::<file::Model, AsterError>(result)
@@ -94,14 +121,16 @@ async fn stage_temp_blob_before_transaction(
     driver: &dyn crate::storage::driver::StorageDriver,
     size: i64,
     temp_path: &str,
+    operation_context: &StorageOperationContext,
 ) -> Result<bool> {
     match blob_plan {
         TempBlobPlan::Dedup(target) => Ok(
-            crate::storage::drivers::local::promote_local_file_if_absent(
+            crate::storage::drivers::local::promote_local_file_if_absent_with_check(
                 driver,
                 &target.storage_path,
                 temp_path,
                 size,
+                || operation_context.checkpoint(),
             )
             .await?
             .created(),

--- a/src/services/workspace_storage_service/store/prepare.rs
+++ b/src/services/workspace_storage_service/store/prepare.rs
@@ -11,9 +11,10 @@ use crate::errors::{AsterError, MapAsterErr, Result, file_upload_error_with_subc
 use crate::runtime::PrimaryAppState;
 use crate::services::workspace_storage_service::HASH_BUF_SIZE;
 use crate::services::workspace_storage_service::{
-    StoreFromTempHints, StoreFromTempParams, WorkspaceStorageScope, check_quota,
-    local_content_dedup_enabled, prepare_non_dedup_blob_upload, resolve_policy_for_size,
-    upload_temp_file_to_prepared_blob, verify_file_access,
+    StorageOperationContext, StoreFromTempHints, StoreFromTempParams, WorkspaceStorageScope,
+    check_quota, local_content_dedup_enabled, prepare_non_dedup_blob_upload,
+    resolve_policy_for_size, upload_temp_file_to_prepared_blob,
+    upload_temp_file_to_prepared_blob_cancellable, verify_file_access,
 };
 use crate::storage::driver::StorageDriver;
 
@@ -28,6 +29,7 @@ pub(super) struct PreparedStoreFromTemp {
     pub driver: Arc<dyn StorageDriver>,
     pub blob_plan: TempBlobPlan,
     pub overwrite_ctx: Option<OverwriteContext>,
+    pub operation_context: StorageOperationContext,
     pub storage_delta: i64,
     pub quota_prechecked: bool,
     pub mime: String,
@@ -67,7 +69,9 @@ pub(super) async fn prepare_store_from_temp(
         resolved_policy,
         precomputed_hash,
         actor_username,
+        operation_context,
     } = hints;
+    operation_context.checkpoint()?;
 
     tracing::debug!(
         scope = ?scope,
@@ -87,6 +91,7 @@ pub(super) async fn prepare_store_from_temp(
         Some(policy) => policy,
         None => resolve_policy_for_size(state, scope, folder_id, size).await?,
     };
+    operation_context.checkpoint()?;
     let should_dedup = local_content_dedup_enabled(&policy);
 
     tracing::debug!(
@@ -105,19 +110,50 @@ pub(super) async fn prepare_store_from_temp(
     }
 
     let driver = state.driver_registry.get_driver(&policy)?;
-    let blob_plan =
-        build_temp_blob_plan(temp_path, size, precomputed_hash, should_dedup, &policy).await?;
+    let blob_plan = build_temp_blob_plan(
+        temp_path,
+        size,
+        precomputed_hash,
+        should_dedup,
+        &policy,
+        &operation_context,
+    )
+    .await?;
+    operation_context.checkpoint()?;
     let overwrite_ctx =
         load_overwrite_context(state, scope, existing_file_id, skip_lock_check).await?;
+    operation_context.checkpoint()?;
     let storage_delta = overwrite_ctx.as_ref().map_or(size, |_| size);
 
     let quota_prechecked = storage_delta > 0 && matches!(blob_plan, TempBlobPlan::Preuploaded(_));
     if quota_prechecked {
         check_quota(state.writer_db(), scope, storage_delta).await?;
     }
+    operation_context.checkpoint()?;
 
     if let TempBlobPlan::Preuploaded(preuploaded_blob) = &blob_plan {
-        upload_temp_file_to_prepared_blob(driver.as_ref(), preuploaded_blob, temp_path).await?;
+        if operation_context.is_cancellable() {
+            upload_temp_file_to_prepared_blob_cancellable(
+                driver.as_ref(),
+                preuploaded_blob,
+                temp_path,
+                &operation_context,
+            )
+            .await?;
+        } else {
+            upload_temp_file_to_prepared_blob(driver.as_ref(), preuploaded_blob, temp_path).await?;
+        }
+        if let Err(error) = operation_context.checkpoint() {
+            crate::services::workspace_storage_service::cleanup_preuploaded_blob_upload(
+                driver.as_ref(),
+                preuploaded_blob,
+                "cancellation after temp preupload",
+            )
+            .await;
+            return Err(error);
+        }
+    } else {
+        operation_context.checkpoint()?;
     }
 
     Ok(PreparedStoreFromTemp {
@@ -131,6 +167,7 @@ pub(super) async fn prepare_store_from_temp(
         driver,
         blob_plan,
         overwrite_ctx,
+        operation_context,
         storage_delta,
         quota_prechecked,
         mime: mime_guess::from_path(&filename)
@@ -147,10 +184,11 @@ async fn build_temp_blob_plan(
     precomputed_hash: Option<&str>,
     should_dedup: bool,
     policy: &storage_policy::Model,
+    operation_context: &StorageOperationContext,
 ) -> Result<TempBlobPlan> {
     if should_dedup {
         return Ok(TempBlobPlan::Dedup(
-            compute_dedup_target(temp_path, precomputed_hash).await?,
+            compute_dedup_target(temp_path, precomputed_hash, operation_context).await?,
         ));
     }
 
@@ -162,9 +200,11 @@ async fn build_temp_blob_plan(
 async fn compute_dedup_target(
     temp_path: &str,
     precomputed_hash: Option<&str>,
+    operation_context: &StorageOperationContext,
 ) -> Result<DedupTarget> {
     use tokio::io::AsyncReadExt;
 
+    operation_context.checkpoint()?;
     let file_hash = match precomputed_hash {
         Some(file_hash) => file_hash.to_string(),
         None => {
@@ -174,6 +214,7 @@ async fn compute_dedup_target(
                 .map_aster_err_ctx("open temp", upload_hash_temp_open_failed)?;
             let mut buf = vec![0u8; HASH_BUF_SIZE];
             loop {
+                operation_context.checkpoint()?;
                 let n = reader
                     .read(&mut buf)
                     .await
@@ -183,6 +224,7 @@ async fn compute_dedup_target(
                 }
                 hasher.update(&buf[..n]);
             }
+            operation_context.checkpoint()?;
             crate::utils::hash::sha256_digest_to_hex(&hasher.finalize())
         }
     };

--- a/src/services/workspace_storage_service/tests.rs
+++ b/src/services/workspace_storage_service/tests.rs
@@ -1,8 +1,9 @@
 //! 工作空间存储服务测试。
 
+use crate::api::subcode::ApiSubcode;
 use crate::cache;
 use crate::config::{CacheConfig, Config, DatabaseConfig, RuntimeConfig};
-use crate::entities::{file_blob, storage_policy, user};
+use crate::entities::{file, file_blob, storage_policy, user};
 use crate::runtime::PrimaryAppState;
 use crate::services::mail_service;
 use crate::storage::driver::{BlobMetadata, StoragePathVisitor};
@@ -15,27 +16,85 @@ use async_trait::async_trait;
 use chrono::Utc;
 use migration::Migrator;
 use sea_orm::{ActiveModelTrait, EntityTrait, PaginatorTrait, Set};
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
 use std::sync::{
     Arc, Mutex,
-    atomic::{AtomicUsize, Ordering},
+    atomic::{AtomicBool, AtomicUsize, Ordering},
     mpsc,
 };
 use std::time::Duration;
-use tokio::io::AsyncRead;
+use tokio::io::{AsyncRead, AsyncReadExt};
 use tokio::sync::{Notify, oneshot};
 
 use super::{
-    StoreFromTempHints, StoreFromTempParams, StorePreuploadedNondedupParams, WorkspaceStorageScope,
-    prepare_non_dedup_blob_upload, store_from_temp_exact_name_silent_with_hints,
-    store_from_temp_exact_name_with_hints, store_from_temp_with_hints, store_preuploaded_nondedup,
-    upload_temp_file_to_prepared_blob,
+    StorageCancellationCheck, StorageOperationContext, StoreFromTempHints, StoreFromTempParams,
+    StorePreuploadedNondedupParams, WorkspaceStorageScope, prepare_non_dedup_blob_upload,
+    store_from_temp_exact_name_silent_with_hints, store_from_temp_exact_name_with_hints,
+    store_from_temp_with_hints, store_preuploaded_nondedup, upload_temp_file_to_prepared_blob,
 };
+
+#[derive(Clone)]
+struct CancelFlagCheck {
+    cancelled: Arc<AtomicBool>,
+}
+
+impl StorageCancellationCheck for CancelFlagCheck {
+    fn checkpoint(&self) -> crate::errors::Result<()> {
+        if self.cancelled.load(Ordering::SeqCst) {
+            return Err(crate::errors::precondition_failed_with_subcode(
+                ApiSubcode::TaskWorkerShutdownRequested,
+                "test storage operation cancelled",
+            ));
+        }
+        Ok(())
+    }
+}
+
+fn cancellation_context(cancelled: Arc<AtomicBool>) -> StorageOperationContext {
+    StorageOperationContext::new(CancelFlagCheck { cancelled })
+}
+
+struct CancelWhenStorageFileExistsCheck {
+    root: PathBuf,
+}
+
+impl StorageCancellationCheck for CancelWhenStorageFileExistsCheck {
+    fn checkpoint(&self) -> crate::errors::Result<()> {
+        if storage_root_has_file(&self.root) {
+            return Err(crate::errors::precondition_failed_with_subcode(
+                ApiSubcode::TaskWorkerShutdownRequested,
+                "test storage operation cancelled after staging",
+            ));
+        }
+        Ok(())
+    }
+}
+
+fn cancel_when_storage_file_exists_context(root: PathBuf) -> StorageOperationContext {
+    StorageOperationContext::new(CancelWhenStorageFileExistsCheck { root })
+}
+
+fn storage_root_has_file(root: &Path) -> bool {
+    let Ok(entries) = std::fs::read_dir(root) else {
+        return false;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_file() {
+            return true;
+        }
+        if path.is_dir() && storage_root_has_file(&path) {
+            return true;
+        }
+    }
+    false
+}
 
 struct CountingUploadDriver {
     inner: crate::storage::drivers::local::LocalDriver,
     put_file_count: AtomicUsize,
+    put_reader_count: AtomicUsize,
 }
 
 impl CountingUploadDriver {
@@ -44,11 +103,16 @@ impl CountingUploadDriver {
             inner: crate::storage::drivers::local::LocalDriver::new(policy)
                 .expect("counting test driver should initialize"),
             put_file_count: AtomicUsize::new(0),
+            put_reader_count: AtomicUsize::new(0),
         }
     }
 
     fn put_file_count(&self) -> usize {
         self.put_file_count.load(Ordering::SeqCst)
+    }
+
+    fn put_reader_count(&self) -> usize {
+        self.put_reader_count.load(Ordering::SeqCst)
     }
 }
 
@@ -126,6 +190,7 @@ impl StreamUploadDriver for CountingUploadDriver {
         reader: Box<dyn AsyncRead + Unpin + Send + Sync>,
         size: i64,
     ) -> crate::errors::Result<String> {
+        self.put_reader_count.fetch_add(1, Ordering::SeqCst);
         self.inner.put_reader(storage_path, reader, size).await
     }
 }
@@ -242,6 +307,15 @@ impl StreamUploadDriver for BlockingPutFileDriver {
         reader: Box<dyn AsyncRead + Unpin + Send + Sync>,
         size: i64,
     ) -> crate::errors::Result<String> {
+        if let Some(sender) = self
+            .put_file_entered
+            .lock()
+            .expect("blocking test driver lock should succeed")
+            .take()
+        {
+            let _ = sender.send(());
+        }
+        self.release_put_file.notified().await;
         self.inner.put_reader(storage_path, reader, size).await
     }
 }
@@ -368,6 +442,283 @@ impl LocalPathStorageDriver for BlockingLocalPathDriver {
             ))
         })?;
         self.inner.as_local_path().unwrap().resolve_local_path(path)
+    }
+}
+
+struct CancelAfterFirstReadDriver {
+    cancelled: Arc<AtomicBool>,
+    delete_count: AtomicUsize,
+}
+
+impl CancelAfterFirstReadDriver {
+    fn new(cancelled: Arc<AtomicBool>) -> Self {
+        Self {
+            cancelled,
+            delete_count: AtomicUsize::new(0),
+        }
+    }
+
+    fn delete_count(&self) -> usize {
+        self.delete_count.load(Ordering::SeqCst)
+    }
+}
+
+struct RecoverableStreamDriver {
+    cancel_next_upload: AtomicBool,
+    cancelled: Arc<AtomicBool>,
+    objects: Mutex<BTreeMap<String, Vec<u8>>>,
+    delete_count: AtomicUsize,
+}
+
+impl RecoverableStreamDriver {
+    fn new(cancelled: Arc<AtomicBool>) -> Self {
+        Self {
+            cancel_next_upload: AtomicBool::new(true),
+            cancelled,
+            objects: Mutex::new(BTreeMap::new()),
+            delete_count: AtomicUsize::new(0),
+        }
+    }
+
+    fn delete_count(&self) -> usize {
+        self.delete_count.load(Ordering::SeqCst)
+    }
+}
+
+#[async_trait]
+impl StorageDriver for RecoverableStreamDriver {
+    async fn put(&self, path: &str, data: &[u8]) -> crate::errors::Result<String> {
+        self.objects
+            .lock()
+            .expect("recoverable stream driver lock should succeed")
+            .insert(path.to_string(), data.to_vec());
+        Ok(path.to_string())
+    }
+
+    async fn get(&self, path: &str) -> crate::errors::Result<Vec<u8>> {
+        self.objects
+            .lock()
+            .expect("recoverable stream driver lock should succeed")
+            .get(path)
+            .cloned()
+            .ok_or_else(|| crate::errors::AsterError::storage_driver_error("object not found"))
+    }
+
+    async fn get_stream(
+        &self,
+        _path: &str,
+    ) -> crate::errors::Result<Box<dyn AsyncRead + Unpin + Send>> {
+        unreachable!()
+    }
+
+    async fn delete(&self, path: &str) -> crate::errors::Result<()> {
+        self.delete_count.fetch_add(1, Ordering::SeqCst);
+        self.objects
+            .lock()
+            .expect("recoverable stream driver lock should succeed")
+            .remove(path);
+        Ok(())
+    }
+
+    async fn exists(&self, path: &str) -> crate::errors::Result<bool> {
+        Ok(self
+            .objects
+            .lock()
+            .expect("recoverable stream driver lock should succeed")
+            .contains_key(path))
+    }
+
+    async fn metadata(&self, path: &str) -> crate::errors::Result<BlobMetadata> {
+        let size = self.get(path).await?.len();
+        Ok(BlobMetadata {
+            size: u64::try_from(size).expect("test object size should fit u64"),
+            content_type: None,
+        })
+    }
+
+    fn as_stream_upload(&self) -> Option<&dyn StreamUploadDriver> {
+        Some(self)
+    }
+}
+
+#[async_trait]
+impl StreamUploadDriver for RecoverableStreamDriver {
+    async fn put_file(
+        &self,
+        storage_path: &str,
+        local_path: &str,
+    ) -> crate::errors::Result<String> {
+        let data = tokio::fs::read(local_path).await.map_err(|error| {
+            crate::errors::AsterError::storage_driver_error(format!(
+                "read test local file: {error}"
+            ))
+        })?;
+        self.put(storage_path, &data).await
+    }
+
+    async fn put_reader(
+        &self,
+        storage_path: &str,
+        mut reader: Box<dyn AsyncRead + Unpin + Send + Sync>,
+        _size: i64,
+    ) -> crate::errors::Result<String> {
+        let mut data = Vec::new();
+        if self.cancel_next_upload.swap(false, Ordering::SeqCst) {
+            let mut buf = [0_u8; 4];
+            let read = reader.read(&mut buf).await.map_err(|error| {
+                crate::errors::AsterError::storage_driver_error(format!(
+                    "read first test upload chunk: {error}"
+                ))
+            })?;
+            data.extend_from_slice(&buf[..read]);
+            self.cancelled.store(true, Ordering::SeqCst);
+            let mut next = [0_u8; 4];
+            return match reader.read(&mut next).await {
+                Ok(_) => Err(crate::errors::AsterError::storage_driver_error(
+                    "reader continued after cancellation",
+                )),
+                Err(error) => Err(crate::errors::AsterError::storage_driver_error(format!(
+                    "reader stopped after cancellation: {error}"
+                ))),
+            };
+        }
+
+        reader.read_to_end(&mut data).await.map_err(|error| {
+            crate::errors::AsterError::storage_driver_error(format!(
+                "read retry test upload: {error}"
+            ))
+        })?;
+        self.put(storage_path, &data).await
+    }
+}
+
+#[async_trait]
+impl StorageDriver for CancelAfterFirstReadDriver {
+    async fn put(&self, _path: &str, _data: &[u8]) -> crate::errors::Result<String> {
+        unreachable!("temp import should use put_reader")
+    }
+
+    async fn get(&self, _path: &str) -> crate::errors::Result<Vec<u8>> {
+        unreachable!()
+    }
+
+    async fn get_stream(
+        &self,
+        _path: &str,
+    ) -> crate::errors::Result<Box<dyn AsyncRead + Unpin + Send>> {
+        unreachable!()
+    }
+
+    async fn delete(&self, _path: &str) -> crate::errors::Result<()> {
+        self.delete_count.fetch_add(1, Ordering::SeqCst);
+        Ok(())
+    }
+
+    async fn exists(&self, _path: &str) -> crate::errors::Result<bool> {
+        Ok(false)
+    }
+
+    async fn metadata(&self, _path: &str) -> crate::errors::Result<BlobMetadata> {
+        unreachable!()
+    }
+
+    fn as_stream_upload(&self) -> Option<&dyn StreamUploadDriver> {
+        Some(self)
+    }
+}
+
+#[async_trait]
+impl StreamUploadDriver for CancelAfterFirstReadDriver {
+    async fn put_file(
+        &self,
+        _storage_path: &str,
+        _local_path: &str,
+    ) -> crate::errors::Result<String> {
+        unreachable!("cancellable temp import should not use put_file")
+    }
+
+    async fn put_reader(
+        &self,
+        _storage_path: &str,
+        mut reader: Box<dyn AsyncRead + Unpin + Send + Sync>,
+        _size: i64,
+    ) -> crate::errors::Result<String> {
+        let mut buf = [0_u8; 4];
+        let first = reader
+            .read(&mut buf)
+            .await
+            .map_err(|error| crate::errors::AsterError::storage_driver_error(error.to_string()))?;
+        assert!(first > 0, "first reader chunk should contain payload bytes");
+        self.cancelled.store(true, Ordering::SeqCst);
+        match reader.read(&mut buf).await {
+            Ok(_) => Err(crate::errors::AsterError::storage_driver_error(
+                "reader continued after cancellation",
+            )),
+            Err(error) => Err(crate::errors::AsterError::storage_driver_error(format!(
+                "reader stopped after cancellation: {error}"
+            ))),
+        }
+    }
+}
+
+struct CancelAfterLocalPathDriver {
+    inner: crate::storage::drivers::local::LocalDriver,
+    cancelled: Arc<AtomicBool>,
+}
+
+impl CancelAfterLocalPathDriver {
+    fn new(policy: &storage_policy::Model, cancelled: Arc<AtomicBool>) -> Self {
+        Self {
+            inner: crate::storage::drivers::local::LocalDriver::new(policy)
+                .expect("cancel after local path test driver should initialize"),
+            cancelled,
+        }
+    }
+}
+
+#[async_trait]
+impl StorageDriver for CancelAfterLocalPathDriver {
+    async fn put(&self, path: &str, data: &[u8]) -> crate::errors::Result<String> {
+        self.inner.put(path, data).await
+    }
+
+    async fn get(&self, path: &str) -> crate::errors::Result<Vec<u8>> {
+        self.inner.get(path).await
+    }
+
+    async fn get_stream(
+        &self,
+        path: &str,
+    ) -> crate::errors::Result<Box<dyn AsyncRead + Unpin + Send>> {
+        self.inner.get_stream(path).await
+    }
+
+    async fn delete(&self, path: &str) -> crate::errors::Result<()> {
+        self.inner.delete(path).await
+    }
+
+    async fn exists(&self, path: &str) -> crate::errors::Result<bool> {
+        self.inner.exists(path).await
+    }
+
+    async fn metadata(&self, path: &str) -> crate::errors::Result<BlobMetadata> {
+        self.inner.metadata(path).await
+    }
+
+    fn as_local_path(&self) -> Option<&dyn LocalPathStorageDriver> {
+        Some(self)
+    }
+}
+
+impl LocalPathStorageDriver for CancelAfterLocalPathDriver {
+    fn resolve_local_path(&self, path: &str) -> crate::errors::Result<PathBuf> {
+        let resolved = self
+            .inner
+            .as_local_path()
+            .unwrap()
+            .resolve_local_path(path)?;
+        self.cancelled.store(true, Ordering::SeqCst);
+        Ok(resolved)
     }
 }
 
@@ -524,6 +875,7 @@ async fn exact_name_conflict_cleans_preuploaded_local_blob() {
             resolved_policy: Some(policy.clone()),
             precomputed_hash: None,
             actor_username: None,
+            ..Default::default()
         },
     )
     .await
@@ -551,6 +903,7 @@ async fn exact_name_conflict_cleans_preuploaded_local_blob() {
             resolved_policy: Some(policy),
             precomputed_hash: None,
             actor_username: None,
+            ..Default::default()
         },
     )
     .await
@@ -596,6 +949,7 @@ async fn temp_store_silent_exact_name_updates_storage_without_storage_event() {
             resolved_policy: Some(policy.clone()),
             precomputed_hash: None,
             actor_username: None,
+            ..Default::default()
         },
     )
     .await
@@ -624,6 +978,7 @@ async fn temp_store_silent_exact_name_updates_storage_without_storage_event() {
             resolved_policy: Some(policy),
             precomputed_hash: None,
             actor_username: None,
+            ..Default::default()
         },
     )
     .await
@@ -680,6 +1035,7 @@ async fn temp_preupload_quota_failure_does_not_write_blob() {
             resolved_policy: Some(policy),
             precomputed_hash: None,
             actor_username: None,
+            ..Default::default()
         },
     )
     .await
@@ -792,6 +1148,7 @@ async fn slow_nondedup_preupload_does_not_block_task_listing() {
                 resolved_policy: Some(policy_for_store),
                 precomputed_hash: None,
                 actor_username: None,
+                ..Default::default()
             },
         )
         .await
@@ -856,6 +1213,7 @@ async fn slow_dedup_blob_publish_does_not_block_task_listing() {
                 resolved_policy: Some(policy_for_store),
                 precomputed_hash: None,
                 actor_username: None,
+                ..Default::default()
             },
         ))
     });
@@ -883,6 +1241,563 @@ async fn slow_dedup_blob_publish_does_not_block_task_listing() {
         .expect("store task should join")
         .expect("store task should succeed");
     assert_eq!(stored.name, "slow-dedup-upload.bin");
+
+    drop(state);
+    let _ = std::fs::remove_dir_all(&temp_root);
+}
+
+#[tokio::test]
+async fn temp_store_cancellation_before_hash_does_not_touch_temp_file() {
+    let (state, temp_root, policy, user) = build_test_state().await;
+    let policy = enable_content_dedup(&policy);
+    let scope = WorkspaceStorageScope::Personal { user_id: user.id };
+    let cancelled = Arc::new(AtomicBool::new(true));
+
+    let err = store_from_temp_with_hints(
+        &state,
+        StoreFromTempParams::new(
+            scope,
+            None,
+            "missing.bin",
+            &temp_root.join("does-not-exist.bin").to_string_lossy(),
+            1,
+        ),
+        StoreFromTempHints {
+            resolved_policy: Some(policy),
+            operation_context: cancellation_context(cancelled),
+            ..Default::default()
+        },
+    )
+    .await
+    .expect_err("pre-cancelled temp import should stop before opening temp file");
+
+    assert_eq!(
+        err.api_error_subcode(),
+        Some(ApiSubcode::TaskWorkerShutdownRequested)
+    );
+    assert_eq!(
+        file_blob::Entity::find()
+            .count(state.writer_db())
+            .await
+            .unwrap(),
+        0
+    );
+
+    drop(state);
+    let _ = std::fs::remove_dir_all(&temp_root);
+}
+
+#[tokio::test]
+async fn cancelled_before_hash_can_resume_from_same_temp_file() {
+    let (state, temp_root, policy, user) = build_test_state().await;
+    let policy = enable_content_dedup(&policy);
+    let scope = WorkspaceStorageScope::Personal { user_id: user.id };
+    let cancelled = Arc::new(AtomicBool::new(true));
+
+    let payload = b"resume before hash payload";
+    let temp_file = temp_root.join("resume-before-hash.bin");
+    tokio::fs::write(&temp_file, payload).await.unwrap();
+    let temp_path = temp_file.to_string_lossy().into_owned();
+
+    let err = store_from_temp_with_hints(
+        &state,
+        StoreFromTempParams::new(
+            scope,
+            None,
+            "resume-before-hash.bin",
+            &temp_path,
+            payload.len() as i64,
+        ),
+        StoreFromTempHints {
+            resolved_policy: Some(policy.clone()),
+            operation_context: cancellation_context(cancelled.clone()),
+            ..Default::default()
+        },
+    )
+    .await
+    .expect_err("first import should be interrupted before hash");
+
+    assert_eq!(
+        err.api_error_subcode(),
+        Some(ApiSubcode::TaskWorkerShutdownRequested)
+    );
+    assert!(temp_file.exists());
+    assert_eq!(
+        file::Entity::find().count(state.writer_db()).await.unwrap(),
+        0
+    );
+    assert_eq!(
+        file_blob::Entity::find()
+            .count(state.writer_db())
+            .await
+            .unwrap(),
+        0
+    );
+
+    cancelled.store(false, Ordering::SeqCst);
+    let stored = store_from_temp_with_hints(
+        &state,
+        StoreFromTempParams::new(
+            scope,
+            None,
+            "resume-before-hash.bin",
+            &temp_path,
+            payload.len() as i64,
+        ),
+        StoreFromTempHints {
+            resolved_policy: Some(policy),
+            operation_context: cancellation_context(cancelled),
+            ..Default::default()
+        },
+    )
+    .await
+    .expect("retry should import the same temp file");
+
+    assert_eq!(stored.name, "resume-before-hash.bin");
+    assert_eq!(
+        file::Entity::find().count(state.writer_db()).await.unwrap(),
+        1
+    );
+    assert_eq!(
+        file_blob::Entity::find()
+            .count(state.writer_db())
+            .await
+            .unwrap(),
+        1
+    );
+
+    drop(state);
+    let _ = std::fs::remove_dir_all(&temp_root);
+}
+
+#[tokio::test]
+async fn temp_store_cancellation_during_stream_upload_cleans_preuploaded_blob() {
+    let (state, temp_root, mut policy, user) = build_test_state().await;
+    policy.driver_type = DriverType::S3;
+    let scope = WorkspaceStorageScope::Personal { user_id: user.id };
+    let cancelled = Arc::new(AtomicBool::new(false));
+    let driver = Arc::new(CancelAfterFirstReadDriver::new(cancelled.clone()));
+    state
+        .driver_registry
+        .insert_for_test(policy.id, driver.clone());
+
+    let payload = b"streaming cancellation payload";
+    let temp_file = temp_root.join("cancel-stream.bin");
+    tokio::fs::write(&temp_file, payload).await.unwrap();
+
+    let err = store_from_temp_with_hints(
+        &state,
+        StoreFromTempParams::new(
+            scope,
+            None,
+            "cancel-stream.bin",
+            &temp_file.to_string_lossy(),
+            payload.len() as i64,
+        ),
+        StoreFromTempHints {
+            resolved_policy: Some(policy),
+            operation_context: cancellation_context(cancelled),
+            ..Default::default()
+        },
+    )
+    .await
+    .expect_err("streaming temp import should surface cancellation");
+
+    assert_eq!(
+        err.api_error_subcode(),
+        Some(ApiSubcode::TaskWorkerShutdownRequested)
+    );
+    assert_eq!(driver.delete_count(), 1);
+    assert_eq!(
+        file_blob::Entity::find()
+            .count(state.writer_db())
+            .await
+            .unwrap(),
+        0
+    );
+
+    drop(state);
+    let _ = std::fs::remove_dir_all(&temp_root);
+}
+
+#[tokio::test]
+async fn cancelled_during_stream_upload_can_resume_from_same_temp_file() {
+    let (state, temp_root, mut policy, user) = build_test_state().await;
+    policy.driver_type = DriverType::S3;
+    let scope = WorkspaceStorageScope::Personal { user_id: user.id };
+    let cancelled = Arc::new(AtomicBool::new(false));
+    let driver = Arc::new(RecoverableStreamDriver::new(cancelled.clone()));
+    state
+        .driver_registry
+        .insert_for_test(policy.id, driver.clone());
+
+    let payload = b"resume stream upload payload";
+    let temp_file = temp_root.join("resume-stream.bin");
+    tokio::fs::write(&temp_file, payload).await.unwrap();
+    let temp_path = temp_file.to_string_lossy().into_owned();
+
+    let err = store_from_temp_with_hints(
+        &state,
+        StoreFromTempParams::new(
+            scope,
+            None,
+            "resume-stream.bin",
+            &temp_path,
+            payload.len() as i64,
+        ),
+        StoreFromTempHints {
+            resolved_policy: Some(policy.clone()),
+            operation_context: cancellation_context(cancelled.clone()),
+            ..Default::default()
+        },
+    )
+    .await
+    .expect_err("first stream upload should be interrupted");
+
+    assert_eq!(
+        err.api_error_subcode(),
+        Some(ApiSubcode::TaskWorkerShutdownRequested)
+    );
+    assert_eq!(driver.delete_count(), 1);
+    assert!(temp_file.exists());
+    assert_eq!(
+        file::Entity::find().count(state.writer_db()).await.unwrap(),
+        0
+    );
+    assert_eq!(
+        file_blob::Entity::find()
+            .count(state.writer_db())
+            .await
+            .unwrap(),
+        0
+    );
+
+    cancelled.store(false, Ordering::SeqCst);
+    let stored = store_from_temp_with_hints(
+        &state,
+        StoreFromTempParams::new(
+            scope,
+            None,
+            "resume-stream.bin",
+            &temp_path,
+            payload.len() as i64,
+        ),
+        StoreFromTempHints {
+            resolved_policy: Some(policy),
+            operation_context: cancellation_context(cancelled),
+            ..Default::default()
+        },
+    )
+    .await
+    .expect("retry should stream the same temp file");
+
+    let blob = crate::db::repository::file_repo::find_blob_by_id(state.writer_db(), stored.blob_id)
+        .await
+        .unwrap();
+    assert_eq!(driver.get(&blob.storage_path).await.unwrap(), payload);
+    assert_eq!(
+        file::Entity::find().count(state.writer_db()).await.unwrap(),
+        1
+    );
+    assert_eq!(
+        file_blob::Entity::find()
+            .count(state.writer_db())
+            .await
+            .unwrap(),
+        1
+    );
+
+    drop(state);
+    let _ = std::fs::remove_dir_all(&temp_root);
+}
+
+#[tokio::test]
+async fn cancellable_local_temp_store_uses_local_fast_path_without_driver_stream_upload() {
+    let (state, temp_root, policy, user) = build_test_state().await;
+    let scope = WorkspaceStorageScope::Personal { user_id: user.id };
+    let cancelled = Arc::new(AtomicBool::new(false));
+    let driver = Arc::new(CountingUploadDriver::new(&policy));
+    state
+        .driver_registry
+        .insert_for_test(policy.id, driver.clone());
+
+    let payload = b"local fast path payload";
+    let temp_file = temp_root.join("local-fast-path.bin");
+    tokio::fs::write(&temp_file, payload).await.unwrap();
+    let temp_path = temp_file.to_string_lossy().into_owned();
+
+    let stored = store_from_temp_with_hints(
+        &state,
+        StoreFromTempParams::new(
+            scope,
+            None,
+            "local-fast-path.bin",
+            &temp_path,
+            payload.len() as i64,
+        ),
+        StoreFromTempHints {
+            resolved_policy: Some(policy),
+            operation_context: cancellation_context(cancelled),
+            ..Default::default()
+        },
+    )
+    .await
+    .expect("cancellable local temp store should succeed");
+
+    assert_eq!(driver.put_file_count(), 0);
+    assert_eq!(driver.put_reader_count(), 0);
+    assert!(
+        temp_file.exists(),
+        "cancellable local fast path should preserve the source temp file for retry safety"
+    );
+    let blob = crate::db::repository::file_repo::find_blob_by_id(state.writer_db(), stored.blob_id)
+        .await
+        .unwrap();
+    assert_eq!(
+        driver.get(&blob.storage_path).await.unwrap(),
+        payload,
+        "stored local blob should contain original payload"
+    );
+
+    drop(state);
+    let _ = std::fs::remove_dir_all(&temp_root);
+}
+
+#[tokio::test]
+async fn cancelled_after_local_preupload_staging_can_resume_from_same_temp_file() {
+    let (state, temp_root, policy, user) = build_test_state().await;
+    let scope = WorkspaceStorageScope::Personal { user_id: user.id };
+    let uploads_root = temp_root.join("uploads");
+
+    let payload = b"resume local staging payload";
+    let temp_file = temp_root.join("resume-local-stage.bin");
+    tokio::fs::write(&temp_file, payload).await.unwrap();
+    let temp_path = temp_file.to_string_lossy().into_owned();
+
+    let err = store_from_temp_with_hints(
+        &state,
+        StoreFromTempParams::new(
+            scope,
+            None,
+            "resume-local-stage.bin",
+            &temp_path,
+            payload.len() as i64,
+        ),
+        StoreFromTempHints {
+            resolved_policy: Some(policy.clone()),
+            operation_context: cancel_when_storage_file_exists_context(uploads_root.clone()),
+            ..Default::default()
+        },
+    )
+    .await
+    .expect_err("first local preupload should be interrupted after staging");
+
+    assert_eq!(
+        err.api_error_subcode(),
+        Some(ApiSubcode::TaskWorkerShutdownRequested)
+    );
+    assert!(temp_file.exists());
+    assert_eq!(
+        file::Entity::find().count(state.writer_db()).await.unwrap(),
+        0
+    );
+    assert_eq!(
+        file_blob::Entity::find()
+            .count(state.writer_db())
+            .await
+            .unwrap(),
+        0
+    );
+    let remaining_upload_entries = snapshot_dir_tree(&uploads_root).unwrap();
+    assert!(
+        remaining_upload_entries
+            .iter()
+            .all(|entry| entry.ends_with('/')),
+        "cancelled local preupload should cleanup staged files: {remaining_upload_entries:?}"
+    );
+
+    let stored = store_from_temp_with_hints(
+        &state,
+        StoreFromTempParams::new(
+            scope,
+            None,
+            "resume-local-stage.bin",
+            &temp_path,
+            payload.len() as i64,
+        ),
+        StoreFromTempHints {
+            resolved_policy: Some(policy.clone()),
+            ..Default::default()
+        },
+    )
+    .await
+    .expect("retry should import the same local temp file");
+
+    let driver = state.driver_registry.get_driver(&policy).unwrap();
+    let blob = crate::db::repository::file_repo::find_blob_by_id(state.writer_db(), stored.blob_id)
+        .await
+        .unwrap();
+    assert_eq!(driver.get(&blob.storage_path).await.unwrap(), payload);
+    assert_eq!(
+        file::Entity::find().count(state.writer_db()).await.unwrap(),
+        1
+    );
+    assert_eq!(
+        file_blob::Entity::find()
+            .count(state.writer_db())
+            .await
+            .unwrap(),
+        1
+    );
+
+    drop(state);
+    let _ = std::fs::remove_dir_all(&temp_root);
+}
+
+#[tokio::test]
+async fn temp_store_cancellation_after_dedup_staging_rolls_back_object() {
+    let (state, temp_root, policy, user) = build_test_state().await;
+    let policy = enable_content_dedup(&policy);
+    let scope = WorkspaceStorageScope::Personal { user_id: user.id };
+    let uploads_root = temp_root.join("uploads");
+    let cancelled = Arc::new(AtomicBool::new(false));
+    let driver = Arc::new(CancelAfterLocalPathDriver::new(&policy, cancelled.clone()));
+    state
+        .driver_registry
+        .insert_for_test(policy.id, driver.clone());
+
+    let payload = b"dedup staging cancellation payload";
+    let temp_file = temp_root.join("cancel-dedup-stage.bin");
+    tokio::fs::write(&temp_file, payload).await.unwrap();
+
+    let err = store_from_temp_with_hints(
+        &state,
+        StoreFromTempParams::new(
+            scope,
+            None,
+            "cancel-dedup-stage.bin",
+            &temp_file.to_string_lossy(),
+            payload.len() as i64,
+        ),
+        StoreFromTempHints {
+            resolved_policy: Some(policy),
+            operation_context: cancellation_context(cancelled),
+            ..Default::default()
+        },
+    )
+    .await
+    .expect_err("dedup staging cancellation should stop before DB persist");
+
+    assert_eq!(
+        err.api_error_subcode(),
+        Some(ApiSubcode::TaskWorkerShutdownRequested)
+    );
+    assert_eq!(
+        file_blob::Entity::find()
+            .count(state.writer_db())
+            .await
+            .unwrap(),
+        0
+    );
+    let remaining_upload_entries = snapshot_dir_tree(&uploads_root).unwrap();
+    assert!(
+        remaining_upload_entries
+            .iter()
+            .all(|entry| entry.ends_with('/')),
+        "dedup rollback should not leave staged files: {remaining_upload_entries:?}"
+    );
+
+    drop(state);
+    let _ = std::fs::remove_dir_all(&temp_root);
+}
+
+#[tokio::test]
+async fn cancelled_after_dedup_staging_can_resume_from_same_temp_file() {
+    let (state, temp_root, policy, user) = build_test_state().await;
+    let policy = enable_content_dedup(&policy);
+    let scope = WorkspaceStorageScope::Personal { user_id: user.id };
+    let uploads_root = temp_root.join("uploads");
+
+    let payload = b"resume dedup staging payload";
+    let temp_file = temp_root.join("resume-dedup-stage.bin");
+    tokio::fs::write(&temp_file, payload).await.unwrap();
+    let temp_path = temp_file.to_string_lossy().into_owned();
+
+    let err = store_from_temp_with_hints(
+        &state,
+        StoreFromTempParams::new(
+            scope,
+            None,
+            "resume-dedup-stage.bin",
+            &temp_path,
+            payload.len() as i64,
+        ),
+        StoreFromTempHints {
+            resolved_policy: Some(policy.clone()),
+            operation_context: cancel_when_storage_file_exists_context(uploads_root.clone()),
+            ..Default::default()
+        },
+    )
+    .await
+    .expect_err("first dedup import should be interrupted after staging");
+
+    assert_eq!(
+        err.api_error_subcode(),
+        Some(ApiSubcode::TaskWorkerShutdownRequested)
+    );
+    assert!(temp_file.exists());
+    assert_eq!(
+        file::Entity::find().count(state.writer_db()).await.unwrap(),
+        0
+    );
+    assert_eq!(
+        file_blob::Entity::find()
+            .count(state.writer_db())
+            .await
+            .unwrap(),
+        0
+    );
+    let remaining_upload_entries = snapshot_dir_tree(&uploads_root).unwrap();
+    assert!(
+        remaining_upload_entries
+            .iter()
+            .all(|entry| entry.ends_with('/')),
+        "cancelled dedup staging should rollback staged files: {remaining_upload_entries:?}"
+    );
+
+    let stored = store_from_temp_with_hints(
+        &state,
+        StoreFromTempParams::new(
+            scope,
+            None,
+            "resume-dedup-stage.bin",
+            &temp_path,
+            payload.len() as i64,
+        ),
+        StoreFromTempHints {
+            resolved_policy: Some(policy.clone()),
+            ..Default::default()
+        },
+    )
+    .await
+    .expect("retry should import the same dedup temp file");
+
+    let driver = state.driver_registry.get_driver(&policy).unwrap();
+    let blob = crate::db::repository::file_repo::find_blob_by_id(state.writer_db(), stored.blob_id)
+        .await
+        .unwrap();
+    assert_eq!(driver.get(&blob.storage_path).await.unwrap(), payload);
+    assert_eq!(
+        file::Entity::find().count(state.writer_db()).await.unwrap(),
+        1
+    );
+    assert_eq!(
+        file_blob::Entity::find()
+            .count(state.writer_db())
+            .await
+            .unwrap(),
+        1
+    );
 
     drop(state);
     let _ = std::fs::remove_dir_all(&temp_root);

--- a/src/storage/drivers/local/copy.rs
+++ b/src/storage/drivers/local/copy.rs
@@ -1,0 +1,60 @@
+use std::path::Path;
+
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+use crate::errors::{AsterError, MapAsterErr, Result};
+
+const LOCAL_COPY_BUF_SIZE: usize = 1024 * 1024;
+
+pub async fn copy_file_with_checkpoint(
+    source_path: &Path,
+    target_path: &Path,
+    checkpoint: impl Fn() -> Result<()>,
+    operation_name: &str,
+) -> Result<u64> {
+    checkpoint()?;
+    let mut source = tokio::fs::File::open(source_path).await.map_err(|error| {
+        AsterError::storage_driver_error(format!(
+            "open {operation_name} source {}: {error}",
+            source_path.display()
+        ))
+    })?;
+    let mut target = tokio::fs::File::create(target_path)
+        .await
+        .map_err(|error| {
+            AsterError::storage_driver_error(format!(
+                "create {operation_name} target {}: {error}",
+                target_path.display()
+            ))
+        })?;
+    let mut buf = vec![0_u8; LOCAL_COPY_BUF_SIZE];
+    let mut copied = 0_u64;
+
+    loop {
+        checkpoint()?;
+        let read = source.read(&mut buf).await.map_err(|error| {
+            AsterError::storage_driver_error(format!("read {operation_name} source: {error}"))
+        })?;
+        if read == 0 {
+            break;
+        }
+        target.write_all(&buf[..read]).await.map_err(|error| {
+            AsterError::storage_driver_error(format!("write {operation_name} target: {error}"))
+        })?;
+        let read = u64::try_from(read).map_err(|_| {
+            AsterError::storage_driver_error(format!(
+                "{operation_name} read size exceeds u64 range"
+            ))
+        })?;
+        copied = copied.checked_add(read).ok_or_else(|| {
+            AsterError::storage_driver_error(format!("{operation_name} copy size overflow"))
+        })?;
+    }
+    target
+        .sync_all()
+        .await
+        .map_aster_err_ctx("sync local copy target", AsterError::storage_driver_error)?;
+    checkpoint()?;
+
+    Ok(copied)
+}

--- a/src/storage/drivers/local/mod.rs
+++ b/src/storage/drivers/local/mod.rs
@@ -14,7 +14,7 @@ use crate::entities::storage_policy;
 use crate::errors::Result;
 
 pub use paths::{effective_base_path, resolved_base_path, upload_staging_path};
-pub use promote::promote_local_file_if_absent;
+pub use promote::{promote_local_file_if_absent, promote_local_file_if_absent_with_check};
 
 pub struct LocalDriver {
     pub(super) base_path: PathBuf,

--- a/src/storage/drivers/local/mod.rs
+++ b/src/storage/drivers/local/mod.rs
@@ -1,5 +1,6 @@
 //! 存储驱动实现：`local`。
 
+mod copy;
 mod driver_impl;
 mod listing;
 mod paths;
@@ -13,6 +14,7 @@ use std::path::PathBuf;
 use crate::entities::storage_policy;
 use crate::errors::Result;
 
+pub(crate) use copy::copy_file_with_checkpoint;
 pub use paths::{effective_base_path, resolved_base_path, upload_staging_path};
 pub use promote::{promote_local_file_if_absent, promote_local_file_if_absent_with_check};
 

--- a/src/storage/drivers/local/promote.rs
+++ b/src/storage/drivers/local/promote.rs
@@ -4,6 +4,8 @@ use crate::errors::{AsterError, MapAsterErr, Result};
 use crate::storage::driver::StorageDriver;
 use crate::utils::numbers;
 
+const LOCAL_COPY_BUF_SIZE: usize = 1024 * 1024;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PromoteLocalFileOutcome {
     Created,
@@ -22,21 +24,61 @@ pub async fn promote_local_file_if_absent(
     local_path: &str,
     expected_size: i64,
 ) -> Result<PromoteLocalFileOutcome> {
+    promote_local_file_if_absent_inner(
+        driver,
+        storage_path,
+        local_path,
+        expected_size,
+        false,
+        || Ok(()),
+    )
+    .await
+}
+
+pub async fn promote_local_file_if_absent_with_check(
+    driver: &dyn StorageDriver,
+    storage_path: &str,
+    local_path: &str,
+    expected_size: i64,
+    checkpoint: impl Fn() -> Result<()>,
+) -> Result<PromoteLocalFileOutcome> {
+    promote_local_file_if_absent_inner(
+        driver,
+        storage_path,
+        local_path,
+        expected_size,
+        true,
+        checkpoint,
+    )
+    .await
+}
+
+async fn promote_local_file_if_absent_inner(
+    driver: &dyn StorageDriver,
+    storage_path: &str,
+    local_path: &str,
+    expected_size: i64,
+    preserve_source: bool,
+    checkpoint: impl Fn() -> Result<()>,
+) -> Result<PromoteLocalFileOutcome> {
+    checkpoint()?;
     let local_driver = driver.as_local_path().ok_or_else(|| {
         AsterError::storage_driver_error("local path storage driver not supported")
     })?;
     let target = local_driver.resolve_local_path(storage_path)?;
+    checkpoint()?;
     if let Some(parent) = target.parent() {
         tokio::fs::create_dir_all(parent)
             .await
             .map_aster_err(AsterError::storage_driver_error)?;
     }
+    checkpoint()?;
 
     let expected_size = numbers::i64_to_u64(expected_size, "local dedup blob size")?;
     match tokio::fs::hard_link(local_path, &target).await {
         Ok(()) => match validate_existing_local_blob_size(&target, expected_size).await {
             Ok(()) => {
-                crate::utils::cleanup_temp_file(local_path).await;
+                cleanup_promoted_source(local_path, preserve_source).await;
                 Ok(PromoteLocalFileOutcome::Created)
             }
             Err(error) => {
@@ -53,11 +95,19 @@ pub async fn promote_local_file_if_absent(
         },
         Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
             validate_existing_local_blob_size(&target, expected_size).await?;
-            crate::utils::cleanup_temp_file(local_path).await;
+            cleanup_promoted_source(local_path, preserve_source).await;
             Ok(PromoteLocalFileOutcome::AlreadyExists)
         }
         Err(link_error) => {
-            promote_local_file_via_temp_copy(local_path, &target, expected_size, link_error).await
+            promote_local_file_via_temp_copy(
+                local_path,
+                &target,
+                expected_size,
+                link_error,
+                preserve_source,
+                checkpoint,
+            )
+            .await
         }
     }
 }
@@ -67,6 +117,8 @@ async fn promote_local_file_via_temp_copy(
     target: &Path,
     expected_size: u64,
     link_error: std::io::Error,
+    preserve_source: bool,
+    checkpoint: impl Fn() -> Result<()>,
 ) -> Result<PromoteLocalFileOutcome> {
     let Some(parent) = target.parent() else {
         return Err(AsterError::storage_driver_error(format!(
@@ -77,7 +129,7 @@ async fn promote_local_file_via_temp_copy(
     let temp_name = format!(".aster-promote-{}.tmp", crate::utils::id::new_uuid());
     let temp_path = parent.join(temp_name);
 
-    match copy_file_to_temp(local_path, &temp_path, expected_size).await {
+    match copy_file_to_temp(local_path, &temp_path, expected_size, &checkpoint).await {
         Ok(()) => {}
         Err(error) => {
             if let Err(cleanup_error) = tokio::fs::remove_file(&temp_path).await
@@ -91,15 +143,17 @@ async fn promote_local_file_via_temp_copy(
             return Err(error);
         }
     }
+    checkpoint()?;
 
     let result = match tokio::fs::hard_link(&temp_path, target).await {
         Ok(()) => {
-            crate::utils::cleanup_temp_file(local_path).await;
+            cleanup_promoted_source(local_path, preserve_source).await;
             Ok(PromoteLocalFileOutcome::Created)
         }
         Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
             validate_existing_local_blob_size(target, expected_size).await?;
-            crate::utils::cleanup_temp_file(local_path).await;
+            checkpoint()?;
+            cleanup_promoted_source(local_path, preserve_source).await;
             Ok(PromoteLocalFileOutcome::AlreadyExists)
         }
         Err(error) => Err(AsterError::storage_driver_error(format!(
@@ -118,13 +172,56 @@ async fn promote_local_file_via_temp_copy(
     result
 }
 
-async fn copy_file_to_temp(local_path: &str, temp_path: &Path, expected_size: u64) -> Result<()> {
-    let copied = tokio::fs::copy(local_path, temp_path)
+async fn cleanup_promoted_source(local_path: &str, preserve_source: bool) {
+    if !preserve_source {
+        crate::utils::cleanup_temp_file(local_path).await;
+    }
+}
+
+async fn copy_file_to_temp(
+    local_path: &str,
+    temp_path: &Path,
+    expected_size: u64,
+    checkpoint: impl Fn() -> Result<()>,
+) -> Result<()> {
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    checkpoint()?;
+    let mut source = tokio::fs::File::open(local_path)
         .await
-        .map_aster_err_ctx(
-            "copy local dedup blob to temp",
-            AsterError::storage_driver_error,
-        )?;
+        .map_aster_err_ctx("open local dedup source", AsterError::storage_driver_error)?;
+    let mut target = tokio::fs::File::create(temp_path)
+        .await
+        .map_aster_err_ctx("create local dedup temp", AsterError::storage_driver_error)?;
+    let mut buf = vec![0_u8; LOCAL_COPY_BUF_SIZE];
+    let mut copied = 0_u64;
+
+    loop {
+        checkpoint()?;
+        let read = source
+            .read(&mut buf)
+            .await
+            .map_aster_err_ctx("read local dedup source", AsterError::storage_driver_error)?;
+        if read == 0 {
+            break;
+        }
+        target
+            .write_all(&buf[..read])
+            .await
+            .map_aster_err_ctx("write local dedup temp", AsterError::storage_driver_error)?;
+        let read = u64::try_from(read).map_err(|_| {
+            AsterError::storage_driver_error("local dedup read size exceeds u64 range")
+        })?;
+        copied = copied
+            .checked_add(read)
+            .ok_or_else(|| AsterError::storage_driver_error("local dedup copy size overflow"))?;
+    }
+    target
+        .flush()
+        .await
+        .map_aster_err_ctx("flush local dedup temp", AsterError::storage_driver_error)?;
+    checkpoint()?;
+
     if copied != expected_size {
         return Err(AsterError::storage_driver_error(format!(
             "local dedup temp copy size mismatch: expected {expected_size}, copied {copied}"

--- a/src/storage/drivers/local/promote.rs
+++ b/src/storage/drivers/local/promote.rs
@@ -4,8 +4,6 @@ use crate::errors::{AsterError, MapAsterErr, Result};
 use crate::storage::driver::StorageDriver;
 use crate::utils::numbers;
 
-const LOCAL_COPY_BUF_SIZE: usize = 1024 * 1024;
-
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PromoteLocalFileOutcome {
     Created,
@@ -184,43 +182,14 @@ async fn copy_file_to_temp(
     expected_size: u64,
     checkpoint: impl Fn() -> Result<()>,
 ) -> Result<()> {
-    use tokio::io::{AsyncReadExt, AsyncWriteExt};
-
     checkpoint()?;
-    let mut source = tokio::fs::File::open(local_path)
-        .await
-        .map_aster_err_ctx("open local dedup source", AsterError::storage_driver_error)?;
-    let mut target = tokio::fs::File::create(temp_path)
-        .await
-        .map_aster_err_ctx("create local dedup temp", AsterError::storage_driver_error)?;
-    let mut buf = vec![0_u8; LOCAL_COPY_BUF_SIZE];
-    let mut copied = 0_u64;
-
-    loop {
-        checkpoint()?;
-        let read = source
-            .read(&mut buf)
-            .await
-            .map_aster_err_ctx("read local dedup source", AsterError::storage_driver_error)?;
-        if read == 0 {
-            break;
-        }
-        target
-            .write_all(&buf[..read])
-            .await
-            .map_aster_err_ctx("write local dedup temp", AsterError::storage_driver_error)?;
-        let read = u64::try_from(read).map_err(|_| {
-            AsterError::storage_driver_error("local dedup read size exceeds u64 range")
-        })?;
-        copied = copied
-            .checked_add(read)
-            .ok_or_else(|| AsterError::storage_driver_error("local dedup copy size overflow"))?;
-    }
-    target
-        .flush()
-        .await
-        .map_aster_err_ctx("flush local dedup temp", AsterError::storage_driver_error)?;
-    checkpoint()?;
+    let copied = super::copy_file_with_checkpoint(
+        Path::new(local_path),
+        temp_path,
+        checkpoint,
+        "local dedup",
+    )
+    .await?;
 
     if copied != expected_size {
         return Err(AsterError::storage_driver_error(format!(

--- a/src/webdav/file/mod.rs
+++ b/src/webdav/file/mod.rs
@@ -507,6 +507,7 @@ impl DavFile for AsterDavFile {
                             resolved_policy: resolved_policy_hint,
                             precomputed_hash: precomputed_hash.as_deref(),
                             actor_username: None,
+                            ..Default::default()
                         },
                     )
                     .await


### PR DESCRIPTION
- Introduce `StorageOperationContext` with cancellation checkpoint support
- Implement cancellable async file upload helpers (`upload_temp_file_to_prepared_blob_cancellable`)
- Add cancellation-aware wrappers around async file readers
- Enhance deduplication promotion and blob staging operations to support cancellation checkpoints
- Integrate cancellation context through preparation, persist, and store methods in workspace storage service
- Add cancellation checkpoints during compute hash, staging, quota checks, and upload
- Extend storage drivers and local promotion logic for cancellable checkpoints
- Add extensive integration tests for cancellation and resume of temp file store operations
- Refactor usages in file_service, task_service, wopi_service to pass default or proper operation context
- Ensure cancellation-aware cleanup of staged blobs and rollback on cancellation or errors
- Add new module `operation_context.rs` for cancellation context and reader wrapping
- Track progress and allow interruption in local file copy, dedup promotion, and stream upload flows
- Improve safety allowing long-running storage tasks to be cancelled cooperatively with side-effect cleanup

This enables graceful handling of cancellation in long-running workspace storage operations like file uploads, deduplication, staging, and blob persistence, improving task responsiveness and resource cleanup.

closed #253

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Refactor**
  * 增强了存储操作的可取消能力，文件上传、内容更新及归档操作现在可在执行过程中响应取消请求。
  * 引入操作上下文机制，改进了任务执行期间对中止信号的响应速度与粒度。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->