### PR TITLE
fix(webdav): declare requested DAV namespace prefix in PROPFIND responses

### DIFF
--- a/src/services/task_service/storage_migration.rs
+++ b/src/services/task_service/storage_migration.rs
@@ -56,6 +56,16 @@ struct BlobMigrationOutcome {
     renamed_opaque_blobs: i64,
 }
 
+struct BlobMigrationContext<'a> {
+    state: &'a PrimaryAppState,
+    execution: &'a TaskExecutionContext,
+    task_id: i64,
+    source_policy_id: i64,
+    target_policy_id: i64,
+    source_driver: &'a dyn StorageDriver,
+    target_driver: &'a dyn StorageDriver,
+}
+
 struct StoragePolicyMigrationPreflight {
     source_policy: storage_policy::Model,
     target_policy: storage_policy::Model,
@@ -409,6 +419,16 @@ pub(super) async fn process_storage_policy_migration_task(
     )
     .await?;
 
+    let migration_context = BlobMigrationContext {
+        state,
+        execution: &context,
+        task_id: task.id,
+        source_policy_id: payload.source_policy_id,
+        target_policy_id: payload.target_policy_id,
+        source_driver: source_driver.as_ref(),
+        target_driver: target_driver.as_ref(),
+    };
+
     loop {
         context.ensure_active()?;
         let blobs = file_repo::find_blobs_by_policy_paginated(
@@ -437,17 +457,7 @@ pub(super) async fn process_storage_policy_migration_task(
 
         for blob in blobs {
             context.ensure_active()?;
-            let outcome = migrate_one_blob(
-                state,
-                &context,
-                task.id,
-                payload.source_policy_id,
-                payload.target_policy_id,
-                source_driver.as_ref(),
-                target_driver.as_ref(),
-                blob,
-            )
-            .await?;
+            let outcome = migrate_one_blob(&migration_context, blob).await?;
 
             checkpoint =
                 storage_migration_checkpoint_repo::get_by_task_id(state.writer_db(), task.id)
@@ -533,15 +543,18 @@ pub(super) async fn process_storage_policy_migration_task(
 }
 
 async fn migrate_one_blob(
-    state: &PrimaryAppState,
-    context: &TaskExecutionContext,
-    task_id: i64,
-    source_policy_id: i64,
-    target_policy_id: i64,
-    source_driver: &dyn StorageDriver,
-    target_driver: &dyn StorageDriver,
+    migration: &BlobMigrationContext<'_>,
     blob: file_blob::Model,
 ) -> Result<BlobMigrationOutcome> {
+    let BlobMigrationContext {
+        state,
+        execution: context,
+        task_id,
+        source_policy_id,
+        target_policy_id,
+        source_driver,
+        target_driver,
+    } = *migration;
     let latest = match file_repo::find_blob_by_id(state.writer_db(), blob.id).await {
         Ok(blob) => blob,
         Err(error) if error.code() == "E006" => {

--- a/src/services/workspace_storage_service/blob_upload.rs
+++ b/src/services/workspace_storage_service/blob_upload.rs
@@ -425,9 +425,7 @@ async fn upload_reader_to_prepared_blob_with_context(
         .await
     {
         cleanup_preuploaded_blob_upload(driver, prepared, "stream upload error").await;
-        if let Err(cancellation_error) = operation_context.checkpoint() {
-            return Err(cancellation_error);
-        }
+        operation_context.checkpoint()?;
         return Err(error);
     }
     if let Err(error) = operation_context.checkpoint() {

--- a/src/webdav/handler_tests/mod.rs
+++ b/src/webdav/handler_tests/mod.rs
@@ -533,6 +533,120 @@ async fn propfind_href_is_percent_encoded_and_xml_parseable() {
     let _ = std::fs::remove_dir_all(temp_root);
 }
 
+#[actix_web::test]
+async fn propfind_declares_requested_dav_prefix_for_rclone_size_check() {
+    let driver = CountingDirectUploadDriver::default();
+    let (state, user, policy, temp_root) = build_webdav_test_state(
+        DriverType::Local,
+        crate::types::StoredStoragePolicyOptions::empty(),
+        std::sync::Arc::new(driver),
+    )
+    .await;
+    create_root_file(
+        &state,
+        user.id,
+        policy.id,
+        "rclone-size.txt",
+        129106,
+        "files/rclone.txt",
+    )
+    .await;
+
+    let dav_fs = AsterDavFs::new(state.clone(), user.id, None);
+    let lock_system = NoopLockSystem;
+    let req = actix_web::test::TestRequest::default()
+        .method(actix_web::http::Method::from_bytes(b"PROPFIND").expect("valid method"))
+        .uri("/webdav/rclone-size.txt")
+        .insert_header((header::HeaderName::from_static("depth"), "0"))
+        .to_http_request();
+    let body = br#"<?xml version="1.0"?>
+<d:propfind xmlns:d="DAV:">
+  <d:prop>
+    <d:displayname/>
+    <d:getlastmodified/>
+    <d:getcontentlength/>
+    <d:quota-used-bytes/>
+    <d:resourcetype/>
+  </d:prop>
+</d:propfind>"#;
+
+    let response = handle_propfind(&req, &dav_fs, &lock_system, "/webdav", body).await;
+
+    assert_eq!(response.status(), StatusCode::from_u16(207).unwrap());
+    let body = to_bytes(response.into_body())
+        .await
+        .expect("PROPFIND response body should be readable");
+    let body_text = String::from_utf8(body.to_vec()).expect("PROPFIND XML should be utf-8");
+    assert!(
+        body_text.contains("xmlns:d=\"DAV:\""),
+        "PROPFIND response must declare echoed lowercase DAV prefix: {body_text}"
+    );
+    assert!(
+        body_text.contains("<d:getcontentlength xmlns:d=\"DAV:\">129106</d:getcontentlength>"),
+        "PROPFIND response should expose file size under the requested DAV prefix: {body_text}"
+    );
+    assert!(
+        body_text.contains("<d:quota-used-bytes xmlns:d=\"DAV:\" />"),
+        "missing DAV props should also declare the echoed lowercase DAV prefix: {body_text}"
+    );
+    Element::parse(Cursor::new(body_text.as_bytes())).expect("PROPFIND XML should parse cleanly");
+
+    drop(state);
+    let _ = std::fs::remove_dir_all(temp_root);
+}
+
+#[actix_web::test]
+async fn propfind_allprop_keeps_default_dav_prefix_xml_parseable() {
+    let driver = CountingDirectUploadDriver::default();
+    let (state, user, policy, temp_root) = build_webdav_test_state(
+        DriverType::Local,
+        crate::types::StoredStoragePolicyOptions::empty(),
+        std::sync::Arc::new(driver),
+    )
+    .await;
+    create_root_file(
+        &state,
+        user.id,
+        policy.id,
+        "allprop.txt",
+        42,
+        "files/allprop.txt",
+    )
+    .await;
+
+    let dav_fs = AsterDavFs::new(state.clone(), user.id, None);
+    let lock_system = NoopLockSystem;
+    let req = actix_web::test::TestRequest::default()
+        .method(actix_web::http::Method::from_bytes(b"PROPFIND").expect("valid method"))
+        .uri("/webdav/allprop.txt")
+        .insert_header((header::HeaderName::from_static("depth"), "0"))
+        .to_http_request();
+
+    let response = handle_propfind(&req, &dav_fs, &lock_system, "/webdav", &[]).await;
+
+    assert_eq!(response.status(), StatusCode::from_u16(207).unwrap());
+    let body = to_bytes(response.into_body())
+        .await
+        .expect("PROPFIND response body should be readable");
+    let body_text = String::from_utf8(body.to_vec()).expect("PROPFIND XML should be utf-8");
+    assert!(
+        body_text.contains("<D:multistatus xmlns:D=\"DAV:\">"),
+        "allprop response should declare the canonical DAV prefix at the root: {body_text}"
+    );
+    assert!(
+        body_text.contains("<D:getcontentlength>42</D:getcontentlength>"),
+        "allprop response should expose file size under the canonical DAV prefix: {body_text}"
+    );
+    assert!(
+        !body_text.contains("xmlns:D=\"DAV:\" xmlns:D=\"DAV:\""),
+        "allprop response should not duplicate the canonical DAV namespace declaration: {body_text}"
+    );
+    Element::parse(Cursor::new(body_text.as_bytes())).expect("PROPFIND XML should parse cleanly");
+
+    drop(state);
+    let _ = std::fs::remove_dir_all(temp_root);
+}
+
 fn collect_href_text(element: &Element, hrefs: &mut Vec<String>) {
     if (element.name == "href" || element.name == "D:href")
         && let Some(text) = element.get_text()

--- a/src/webdav/props/mod.rs
+++ b/src/webdav/props/mod.rs
@@ -59,7 +59,7 @@ impl RequestedProp {
         };
         let mut element = Element::new(&tag);
         if let Some(namespace) = &self.namespace
-            && namespace != "DAV:"
+            && should_declare_namespace(prefix, namespace)
         {
             element
                 .attributes
@@ -515,7 +515,7 @@ fn prop_element(prop: &DavProp, requested: Option<&RequestedProp>) -> Element {
     };
     let mut element = Element::new(&tag);
     if let Some(namespace) = namespace
-        && namespace != "DAV:"
+        && should_declare_namespace(prefix, namespace)
     {
         element
             .attributes
@@ -554,4 +554,8 @@ fn default_prefix(namespace: Option<&str>) -> &str {
         Some(_) => "A",
         None => "",
     }
+}
+
+fn should_declare_namespace(prefix: &str, namespace: &str) -> bool {
+    namespace != "DAV:" || prefix != "D"
 }

--- a/tests/test_webdav.rs
+++ b/tests/test_webdav.rs
@@ -13,7 +13,9 @@ use aster_drive::types::{EntityType, TeamMemberRole, UserRole, UserStatus};
 use base64::Engine;
 use chrono::Utc;
 use sea_orm::{ActiveModelTrait, IntoActiveModel, Set};
+use std::io::Cursor;
 use tokio::task::JoinHandle;
+use xmltree::Element;
 
 fn basic_auth_header(username: &str, password: &str) -> String {
     format!(
@@ -628,6 +630,67 @@ async fn test_webdav_real_http_put_with_content_length_persists_bytes() {
     assert_eq!(get.status(), reqwest::StatusCode::OK);
     let bytes = get.bytes().await.expect("real WebDAV GET body should read");
     assert_eq!(bytes.as_ref(), data.as_slice());
+
+    server.stop().await;
+}
+
+#[actix_web::test]
+async fn test_webdav_real_http_rclone_propfind_reports_uploaded_size_with_declared_prefix() {
+    let state = common::setup().await;
+    let (username, password) = seed_real_webdav_account(&state).await;
+    let server = start_real_webdav_server(state).await;
+    let client = reqwest::Client::new();
+    let data: Vec<u8> = (0..=255).cycle().take(129106).collect();
+    let url = format!("{}/webdav/rclone-size-check.bin", server.base_url);
+
+    let put = client
+        .put(&url)
+        .basic_auth(&username, Some(&password))
+        .header(reqwest::header::CONTENT_TYPE, "application/octet-stream")
+        .header(reqwest::header::CONTENT_LENGTH, data.len().to_string())
+        .body(data)
+        .send()
+        .await
+        .expect("real WebDAV PUT for rclone PROPFIND check should receive a response");
+    assert!(
+        put.status() == reqwest::StatusCode::CREATED
+            || put.status() == reqwest::StatusCode::NO_CONTENT,
+        "real WebDAV PUT should create or overwrite the file, got {}",
+        put.status()
+    );
+
+    let propfind_body = r#"<?xml version="1.0"?>
+<d:propfind xmlns:d="DAV:">
+ <d:prop>
+  <d:displayname/>
+  <d:getlastmodified/>
+  <d:getcontentlength/>
+  <d:resourcetype/>
+ </d:prop>
+</d:propfind>"#;
+    let propfind = client
+        .request(reqwest::Method::from_bytes(b"PROPFIND").unwrap(), &url)
+        .basic_auth(&username, Some(&password))
+        .header("Depth", "0")
+        .header(reqwest::header::CONTENT_TYPE, "application/xml")
+        .body(propfind_body)
+        .send()
+        .await
+        .expect("rclone-style PROPFIND should receive a response");
+    assert_eq!(propfind.status(), reqwest::StatusCode::MULTI_STATUS);
+    let body = propfind
+        .text()
+        .await
+        .expect("rclone-style PROPFIND response body should be readable");
+    assert!(
+        body.contains("xmlns:d=\"DAV:\""),
+        "PROPFIND response must declare the lowercase DAV prefix used in echoed props: {body}"
+    );
+    assert!(
+        body.contains("<d:getcontentlength xmlns:d=\"DAV:\">129106</d:getcontentlength>"),
+        "PROPFIND response should report uploaded size under the requested DAV prefix: {body}"
+    );
+    Element::parse(Cursor::new(body.as_bytes())).expect("PROPFIND response XML should parse");
 
     server.stop().await;
 }


### PR DESCRIPTION
Fix namespace declaration handling in PROPFIND responses to ensure XML parsability for clients like rclone that request lowercase DAV prefixes.

Changes:
- Add namespace declaration for requested DAV prefix when different from canonical "D"
- Introduce `should_declare_namespace()` to control when xmlns attributes are emitted
- Preserve canonical "D:DAV:" prefix for allprop requests without duplication
- Add unit tests verifying prefix declaration for rclone size check scenario
- Add unit tests confirming canonical prefix behavior for allprop requests
- Add integration test validating real HTTP PROPFIND with lowercase prefix