### PR TITLE
Refactor storage tasks and enhance blob migration with multipart support

### DIFF
--- a/src/api/routes/files/access.rs
+++ b/src/api/routes/files/access.rs
@@ -1135,7 +1135,7 @@ mod tests {
     #[actix_web::test]
     async fn image_preview_response_returns_ok_with_etag_and_cache_headers() {
         let result = ImagePreviewResult {
-            data: vec![1, 2, 3],
+            data: bytes::Bytes::from_static(&[1, 2, 3]),
             blob_hash: "abc".repeat(21) + "a",
             image_preview_processor: "images".to_string(),
             image_preview_version: "1".to_string(),
@@ -1169,7 +1169,7 @@ mod tests {
     #[actix_web::test]
     async fn image_preview_response_respects_if_none_match() {
         let result = ImagePreviewResult {
-            data: vec![1, 2, 3],
+            data: bytes::Bytes::from_static(&[1, 2, 3]),
             blob_hash: "abc".repeat(21) + "a",
             image_preview_processor: "images".to_string(),
             image_preview_version: "1".to_string(),

--- a/src/api/routes/files/access.rs
+++ b/src/api/routes/files/access.rs
@@ -1193,7 +1193,7 @@ mod tests {
     #[actix_web::test]
     async fn thumbnail_response_respects_if_none_match() {
         let result = ThumbnailResult {
-            data: vec![1, 2, 3],
+            data: web::Bytes::from_static(&[1, 2, 3]),
             blob_hash: "abc".repeat(21) + "a",
             thumbnail_processor: Some("images".to_string()),
             thumbnail_version: Some("1".to_string()),

--- a/src/config/operations.rs
+++ b/src/config/operations.rs
@@ -44,6 +44,7 @@ pub const DEFAULT_BACKGROUND_TASK_MAX_CONCURRENCY: usize = 1;
 pub const DEFAULT_BACKGROUND_TASK_ARCHIVE_MAX_CONCURRENCY: usize = 2;
 pub const DEFAULT_BACKGROUND_TASK_THUMBNAIL_MAX_CONCURRENCY: usize = 1;
 pub const DEFAULT_BACKGROUND_TASK_STORAGE_MIGRATION_MAX_CONCURRENCY: usize = 1;
+const MAX_BACKGROUND_TASK_CONCURRENCY: usize = 16;
 pub const DEFAULT_BACKGROUND_TASK_MAX_ATTEMPTS: i32 = 3;
 pub const DEFAULT_SHARE_DOWNLOAD_ROLLBACK_QUEUE_CAPACITY: usize = 1024;
 pub const DEFAULT_SHARE_STREAM_SESSION_TTL_SECS: u64 = 3 * 60 * 60;
@@ -142,7 +143,14 @@ pub fn normalize_interval_config_value(key: &str, value: &str) -> Result<String>
 }
 
 pub fn normalize_concurrency_config_value(key: &str, value: &str) -> Result<String> {
-    normalize_positive_u64_config_value(key, value)
+    let parsed = parse_positive_u64(value)
+        .ok_or_else(|| AsterError::validation_error(format!("{key} must be a positive integer")))?;
+    if parsed > usize_to_u64(MAX_BACKGROUND_TASK_CONCURRENCY, key).unwrap_or(u64::MAX) {
+        return Err(AsterError::validation_error(format!(
+            "{key} cannot exceed {MAX_BACKGROUND_TASK_CONCURRENCY}"
+        )));
+    }
+    Ok(parsed.to_string())
 }
 
 pub fn normalize_attempts_config_value(key: &str, value: &str) -> Result<String> {
@@ -851,10 +859,20 @@ fn read_bool(runtime_config: &RuntimeConfig, key: &str, default: bool) -> bool {
 
 fn read_concurrency(runtime_config: &RuntimeConfig, key: &str, default: usize) -> usize {
     let default_value = usize_to_u64(default, key).unwrap_or(u64::MAX);
-    usize::try_from(read_positive_u64(runtime_config, key, default_value)).unwrap_or_else(|_| {
-        tracing::warn!(key, "{key} exceeds usize; using default");
-        default
-    })
+    let value = usize::try_from(read_positive_u64(runtime_config, key, default_value))
+        .unwrap_or_else(|_| {
+            tracing::warn!(key, "{key} exceeds usize; using default");
+            default
+        });
+    if value > MAX_BACKGROUND_TASK_CONCURRENCY {
+        tracing::warn!(
+            key,
+            value,
+            max = MAX_BACKGROUND_TASK_CONCURRENCY,
+            "runtime concurrency config exceeds maximum; clamping"
+        );
+    }
+    value.min(MAX_BACKGROUND_TASK_CONCURRENCY)
 }
 
 fn read_bounded_u64(
@@ -900,15 +918,16 @@ mod tests {
         DEFAULT_REMOTE_NODE_HEALTH_TEST_INTERVAL_SECS,
         DEFAULT_SHARE_DOWNLOAD_ROLLBACK_QUEUE_CAPACITY, DEFAULT_SHARE_STREAM_SESSION_TTL_SECS,
         DEFAULT_TASK_LIST_MAX_LIMIT, DEFAULT_TEAM_MEMBER_LIST_MAX_LIMIT,
-        MAX_SHARE_STREAM_SESSION_TTL_SECS, MIN_SHARE_STREAM_SESSION_TTL_SECS,
-        OFFLINE_DOWNLOAD_ENGINE_KEY, OFFLINE_DOWNLOAD_ENGINE_REGISTRY_JSON_KEY,
-        OFFLINE_DOWNLOAD_MAX_CONCURRENCY_KEY, OFFLINE_DOWNLOAD_MAX_MB_PER_SEC_KEY,
-        OFFLINE_DOWNLOAD_TEMP_DIR_KEY, REMOTE_NODE_HEALTH_TEST_INTERVAL_SECS_KEY,
-        SHARE_DOWNLOAD_ROLLBACK_QUEUE_CAPACITY_KEY, SHARE_STREAM_SESSION_TTL_SECS_KEY,
-        TASK_LIST_MAX_LIMIT_KEY, TEAM_MEMBER_LIST_MAX_LIMIT_KEY, archive_extract_max_staging_bytes,
-        avatar_max_upload_size_bytes, background_task_archive_max_concurrency,
-        background_task_dispatch_idle_max_interval_secs, background_task_max_attempts,
-        background_task_max_concurrency, background_task_storage_migration_max_concurrency,
+        MAX_BACKGROUND_TASK_CONCURRENCY, MAX_SHARE_STREAM_SESSION_TTL_SECS,
+        MIN_SHARE_STREAM_SESSION_TTL_SECS, OFFLINE_DOWNLOAD_ENGINE_KEY,
+        OFFLINE_DOWNLOAD_ENGINE_REGISTRY_JSON_KEY, OFFLINE_DOWNLOAD_MAX_CONCURRENCY_KEY,
+        OFFLINE_DOWNLOAD_MAX_MB_PER_SEC_KEY, OFFLINE_DOWNLOAD_TEMP_DIR_KEY,
+        REMOTE_NODE_HEALTH_TEST_INTERVAL_SECS_KEY, SHARE_DOWNLOAD_ROLLBACK_QUEUE_CAPACITY_KEY,
+        SHARE_STREAM_SESSION_TTL_SECS_KEY, TASK_LIST_MAX_LIMIT_KEY, TEAM_MEMBER_LIST_MAX_LIMIT_KEY,
+        archive_extract_max_staging_bytes, avatar_max_upload_size_bytes,
+        background_task_archive_max_concurrency, background_task_dispatch_idle_max_interval_secs,
+        background_task_max_attempts, background_task_max_concurrency,
+        background_task_storage_migration_max_concurrency,
         background_task_thumbnail_max_concurrency, blob_reconcile_interval_secs,
         normalize_attempts_config_value, normalize_bool_config_value, normalize_bytes_config_value,
         normalize_concurrency_config_value, normalize_interval_config_value,
@@ -916,7 +935,7 @@ mod tests {
         normalize_offline_download_temp_dir_config_value,
         normalize_share_stream_session_ttl_config_value, offline_download_enabled_engines,
         offline_download_max_bytes_per_sec, offline_download_max_concurrency,
-        offline_download_temp_dir, remote_node_health_test_interval_secs,
+        offline_download_temp_dir, read_concurrency, remote_node_health_test_interval_secs,
         share_download_rollback_queue_capacity, share_stream_session_ttl_secs, task_list_max_limit,
         team_member_list_max_limit,
     };
@@ -1118,6 +1137,95 @@ mod tests {
         assert_eq!(
             offline_download_max_concurrency(&runtime_config),
             DEFAULT_OFFLINE_DOWNLOAD_MAX_CONCURRENCY
+        );
+
+        runtime_config.apply(config_model(
+            BACKGROUND_TASK_MAX_CONCURRENCY_KEY,
+            &(MAX_BACKGROUND_TASK_CONCURRENCY + 1).to_string(),
+        ));
+        runtime_config.apply(config_model(
+            BACKGROUND_TASK_ARCHIVE_MAX_CONCURRENCY_KEY,
+            "999",
+        ));
+        runtime_config.apply(config_model(
+            BACKGROUND_TASK_THUMBNAIL_MAX_CONCURRENCY_KEY,
+            "18446744073709551615",
+        ));
+        runtime_config.apply(config_model(OFFLINE_DOWNLOAD_MAX_CONCURRENCY_KEY, "100"));
+        assert_eq!(
+            background_task_max_concurrency(&runtime_config),
+            MAX_BACKGROUND_TASK_CONCURRENCY
+        );
+        assert_eq!(
+            background_task_archive_max_concurrency(&runtime_config),
+            MAX_BACKGROUND_TASK_CONCURRENCY
+        );
+        assert_eq!(
+            background_task_thumbnail_max_concurrency(&runtime_config),
+            MAX_BACKGROUND_TASK_CONCURRENCY
+        );
+        assert_eq!(
+            offline_download_max_concurrency(&runtime_config),
+            MAX_BACKGROUND_TASK_CONCURRENCY
+        );
+    }
+
+    #[test]
+    fn read_concurrency_applies_min_max_and_fallback_boundaries() {
+        let runtime_config = RuntimeConfig::new();
+        assert_eq!(
+            read_concurrency(&runtime_config, BACKGROUND_TASK_MAX_CONCURRENCY_KEY, 3),
+            3
+        );
+
+        runtime_config.apply(config_model(BACKGROUND_TASK_MAX_CONCURRENCY_KEY, "1"));
+        assert_eq!(
+            read_concurrency(&runtime_config, BACKGROUND_TASK_MAX_CONCURRENCY_KEY, 3),
+            1
+        );
+
+        runtime_config.apply(config_model(
+            BACKGROUND_TASK_MAX_CONCURRENCY_KEY,
+            &MAX_BACKGROUND_TASK_CONCURRENCY.to_string(),
+        ));
+        assert_eq!(
+            read_concurrency(&runtime_config, BACKGROUND_TASK_MAX_CONCURRENCY_KEY, 3),
+            MAX_BACKGROUND_TASK_CONCURRENCY
+        );
+
+        runtime_config.apply(config_model(
+            BACKGROUND_TASK_MAX_CONCURRENCY_KEY,
+            &(MAX_BACKGROUND_TASK_CONCURRENCY + 1).to_string(),
+        ));
+        assert_eq!(
+            read_concurrency(&runtime_config, BACKGROUND_TASK_MAX_CONCURRENCY_KEY, 3),
+            MAX_BACKGROUND_TASK_CONCURRENCY
+        );
+
+        runtime_config.apply(config_model(BACKGROUND_TASK_MAX_CONCURRENCY_KEY, "0"));
+        assert_eq!(
+            read_concurrency(&runtime_config, BACKGROUND_TASK_MAX_CONCURRENCY_KEY, 3),
+            3
+        );
+
+        runtime_config.apply(config_model(BACKGROUND_TASK_MAX_CONCURRENCY_KEY, "abc"));
+        assert_eq!(
+            read_concurrency(&runtime_config, BACKGROUND_TASK_MAX_CONCURRENCY_KEY, 3),
+            3
+        );
+
+        runtime_config.apply(config_model(
+            BACKGROUND_TASK_MAX_CONCURRENCY_KEY,
+            "18446744073709551615",
+        ));
+        let expected = if usize::try_from(u64::MAX).is_ok() {
+            MAX_BACKGROUND_TASK_CONCURRENCY
+        } else {
+            3
+        };
+        assert_eq!(
+            read_concurrency(&runtime_config, BACKGROUND_TASK_MAX_CONCURRENCY_KEY, 3),
+            expected
         );
     }
 
@@ -1331,6 +1439,21 @@ mod tests {
         assert_eq!(
             normalize_concurrency_config_value("test_concurrency", "4").unwrap(),
             "4"
+        );
+        assert_eq!(
+            normalize_concurrency_config_value(
+                "test_concurrency",
+                &MAX_BACKGROUND_TASK_CONCURRENCY.to_string()
+            )
+            .unwrap(),
+            MAX_BACKGROUND_TASK_CONCURRENCY.to_string()
+        );
+        assert!(
+            normalize_concurrency_config_value(
+                "test_concurrency",
+                &(MAX_BACKGROUND_TASK_CONCURRENCY + 1).to_string()
+            )
+            .is_err()
         );
         assert_eq!(
             normalize_attempts_config_value("test_attempts", "3").unwrap(),

--- a/src/config/operations.rs
+++ b/src/config/operations.rs
@@ -153,6 +153,10 @@ pub fn normalize_concurrency_config_value(key: &str, value: &str) -> Result<Stri
     Ok(parsed.to_string())
 }
 
+pub fn normalize_queue_capacity_config_value(key: &str, value: &str) -> Result<String> {
+    normalize_positive_u64_config_value(key, value)
+}
+
 pub fn normalize_attempts_config_value(key: &str, value: &str) -> Result<String> {
     normalize_positive_i32_config_value(key, value)
 }
@@ -932,7 +936,7 @@ mod tests {
         normalize_attempts_config_value, normalize_bool_config_value, normalize_bytes_config_value,
         normalize_concurrency_config_value, normalize_interval_config_value,
         normalize_list_max_limit_config_value, normalize_non_negative_u64_config_value,
-        normalize_offline_download_temp_dir_config_value,
+        normalize_offline_download_temp_dir_config_value, normalize_queue_capacity_config_value,
         normalize_share_stream_session_ttl_config_value, offline_download_enabled_engines,
         offline_download_max_bytes_per_sec, offline_download_max_concurrency,
         offline_download_temp_dir, read_concurrency, remote_node_health_test_interval_secs,
@@ -1456,6 +1460,14 @@ mod tests {
             .is_err()
         );
         assert_eq!(
+            normalize_queue_capacity_config_value(
+                SHARE_DOWNLOAD_ROLLBACK_QUEUE_CAPACITY_KEY,
+                &DEFAULT_SHARE_DOWNLOAD_ROLLBACK_QUEUE_CAPACITY.to_string()
+            )
+            .unwrap(),
+            DEFAULT_SHARE_DOWNLOAD_ROLLBACK_QUEUE_CAPACITY.to_string()
+        );
+        assert_eq!(
             normalize_attempts_config_value("test_attempts", "3").unwrap(),
             "3"
         );
@@ -1485,6 +1497,10 @@ mod tests {
         );
         assert!(normalize_interval_config_value("test_interval", "0").is_err());
         assert!(normalize_concurrency_config_value("test_concurrency", "0").is_err());
+        assert!(
+            normalize_queue_capacity_config_value(SHARE_DOWNLOAD_ROLLBACK_QUEUE_CAPACITY_KEY, "0")
+                .is_err()
+        );
         assert!(normalize_attempts_config_value("test_attempts", "0").is_err());
         assert!(normalize_bytes_config_value("test_bytes", "-1").is_err());
         assert!(normalize_list_max_limit_config_value("test_limit", "1001").is_err());

--- a/src/config/system_config.rs
+++ b/src/config/system_config.rs
@@ -174,7 +174,7 @@ where
             operations::normalize_concurrency_config_value(key, value)
         }
         operations::SHARE_DOWNLOAD_ROLLBACK_QUEUE_CAPACITY_KEY => {
-            operations::normalize_concurrency_config_value(key, value)
+            operations::normalize_queue_capacity_config_value(key, value)
         }
         operations::BACKGROUND_TASK_MAX_ATTEMPTS_KEY => {
             operations::normalize_attempts_config_value(key, value)
@@ -280,8 +280,9 @@ pub fn apply_definition(mut config: system_config::Model) -> system_config::Mode
 mod tests {
     use super::{apply_definition, normalize_system_value, validate_value_type};
     use crate::config::operations::{
+        BACKGROUND_TASK_MAX_CONCURRENCY_KEY, DEFAULT_SHARE_DOWNLOAD_ROLLBACK_QUEUE_CAPACITY,
         MAX_SHARE_STREAM_SESSION_TTL_SECS, MIN_SHARE_STREAM_SESSION_TTL_SECS,
-        SHARE_STREAM_SESSION_TTL_SECS_KEY,
+        SHARE_DOWNLOAD_ROLLBACK_QUEUE_CAPACITY_KEY, SHARE_STREAM_SESSION_TTL_SECS_KEY,
     };
     use crate::entities::system_config;
     use crate::types::{SystemConfigSource, SystemConfigValueType};
@@ -354,6 +355,23 @@ mod tests {
             )
             .unwrap(),
             "[]"
+        );
+    }
+
+    #[test]
+    fn normalize_system_value_uses_capacity_limit_for_share_download_rollback_queue() {
+        let lookup = HashMap::new();
+        assert_eq!(
+            normalize_system_value(
+                &lookup,
+                SHARE_DOWNLOAD_ROLLBACK_QUEUE_CAPACITY_KEY,
+                &DEFAULT_SHARE_DOWNLOAD_ROLLBACK_QUEUE_CAPACITY.to_string(),
+            )
+            .unwrap(),
+            DEFAULT_SHARE_DOWNLOAD_ROLLBACK_QUEUE_CAPACITY.to_string()
+        );
+        assert!(
+            normalize_system_value(&lookup, BACKGROUND_TASK_MAX_CONCURRENCY_KEY, "1024").is_err()
         );
     }
 

--- a/src/db/repository/audit_log_repo.rs
+++ b/src/db/repository/audit_log_repo.rs
@@ -2,8 +2,8 @@
 
 use chrono::{DateTime, Utc};
 use sea_orm::{
-    ActiveModelTrait, ColumnTrait, ConnectionTrait, EntityTrait, PaginatorTrait, QueryFilter,
-    QuerySelect, Select,
+    ActiveModelTrait, ColumnTrait, Condition, ConnectionTrait, EntityTrait, PaginatorTrait,
+    QueryFilter, QueryOrder, QuerySelect, Select,
 };
 
 use crate::api::pagination::{AdminAuditLogSortBy, SortOrder};
@@ -151,6 +151,49 @@ pub async fn find_actions_in_range<C: ConnectionTrait>(
         .filter(audit_log::Column::CreatedAt.gte(start))
         .filter(audit_log::Column::CreatedAt.lt(end))
         .into_tuple::<(String, DateTime<Utc>)>()
+        .all(db)
+        .await
+        .map_err(AsterError::from)
+}
+
+/// Cursor page for admin overview daily aggregation.
+///
+/// Overview only needs `action` and `created_at`, but the cursor also carries
+/// `id` so rows sharing the same timestamp are scanned exactly once without
+/// offset pagination. This keeps memory bounded even when the audit retention
+/// window contains a large number of events.
+pub async fn find_action_page_in_range<C: ConnectionTrait>(
+    db: &C,
+    start: DateTime<Utc>,
+    end: DateTime<Utc>,
+    after: Option<(DateTime<Utc>, i64)>,
+    limit: u64,
+) -> Result<Vec<(i64, String, DateTime<Utc>)>> {
+    let mut query = AuditLog::find()
+        .select_only()
+        .column(audit_log::Column::Id)
+        .column(audit_log::Column::Action)
+        .column(audit_log::Column::CreatedAt)
+        .filter(audit_log::Column::CreatedAt.gte(start))
+        .filter(audit_log::Column::CreatedAt.lt(end))
+        .order_by_asc(audit_log::Column::CreatedAt)
+        .order_by_asc(audit_log::Column::Id)
+        .limit(limit);
+
+    if let Some((created_at, id)) = after {
+        query = query.filter(
+            Condition::any()
+                .add(audit_log::Column::CreatedAt.gt(created_at))
+                .add(
+                    Condition::all()
+                        .add(audit_log::Column::CreatedAt.eq(created_at))
+                        .add(audit_log::Column::Id.gt(id)),
+                ),
+        );
+    }
+
+    query
+        .into_tuple::<(i64, String, DateTime<Utc>)>()
         .all(db)
         .await
         .map_err(AsterError::from)

--- a/src/services/admin_service.rs
+++ b/src/services/admin_service.rs
@@ -29,6 +29,7 @@ const DEFAULT_EVENT_LIMIT: u64 = 8;
 const MAX_EVENT_LIMIT: u64 = 50;
 const DEFAULT_TIMEZONE: &str = "UTC";
 const ADMIN_OVERVIEW_CACHE_TTL: u64 = 15;
+const ADMIN_OVERVIEW_AUDIT_ACTION_BATCH_SIZE: u64 = 1_000;
 
 #[derive(Clone, Debug, Deserialize)]
 #[cfg_attr(
@@ -491,16 +492,30 @@ async fn build_daily_reports(
     let end = start_of_local_day(today + Duration::days(1), timezone)?;
 
     audit_service::flush_global_audit_log_manager().await;
-    let events = audit_log_repo::find_actions_in_range(state.reader_db(), start, end).await?;
+    let mut cursor = None;
+    loop {
+        let events = audit_log_repo::find_action_page_in_range(
+            state.reader_db(),
+            start,
+            end,
+            cursor,
+            ADMIN_OVERVIEW_AUDIT_ACTION_BATCH_SIZE,
+        )
+        .await?;
+        if events.is_empty() {
+            break;
+        }
 
-    for (action, created_at) in events {
-        let date = created_at.with_timezone(&timezone).date_naive();
-        let Some(report_index) = report_indexes.get(&date).copied() else {
-            continue;
-        };
-        let report = &mut reports[report_index];
-        let action = audit_service::AuditAction::from_str_name(&action);
-        record_audit_action(report, action);
+        for (_id, action, created_at) in &events {
+            let date = created_at.with_timezone(&timezone).date_naive();
+            let Some(report_index) = report_indexes.get(&date).copied() else {
+                continue;
+            };
+            let report = &mut reports[report_index];
+            let action = audit_service::AuditAction::from_str_name(action);
+            record_audit_action(report, action);
+        }
+        cursor = events.last().map(|(id, _, created_at)| (*created_at, *id));
     }
 
     Ok(reports)

--- a/src/services/config_service/public.rs
+++ b/src/services/config_service/public.rs
@@ -5,6 +5,9 @@ use crate::db::repository::config_repo;
 use crate::errors::Result;
 use crate::runtime::PrimaryAppState;
 use crate::services::preview_app_service;
+use crate::storage::{
+    driver_type_supports_native_media_metadata, driver_type_supports_native_thumbnail,
+};
 use crate::types::parse_storage_policy_options;
 use moka::future::Cache;
 use serde::Serialize;
@@ -139,17 +142,10 @@ fn build_public_thumbnail_support(
             continue;
         }
 
-        match state.driver_registry.get_driver(&policy) {
-            Ok(driver) if driver.as_native_thumbnail().is_some() => {
-                extensions.extend(options.thumbnail_extensions);
-            }
-            Ok(_) => {}
-            Err(error) => {
-                tracing::debug!(
-                    policy_id = policy.id,
-                    "skip storage-native thumbnail public support for policy: {error}"
-                );
-            }
+        // 这里是 public capability 聚合，不能实例化 driver：前端正常加载该接口时
+        // 可能遍历所有策略，若调用 get_driver() 会把冷 COS/S3 client 常驻进全局缓存。
+        if driver_type_supports_native_thumbnail(policy.driver_type) {
+            extensions.extend(options.thumbnail_extensions);
         }
     }
 
@@ -174,17 +170,9 @@ fn build_public_media_data_support(
             continue;
         }
 
-        match state.driver_registry.get_driver(&policy) {
-            Ok(driver) if driver.as_native_media_metadata().is_some() => {
-                storage_native_extensions.extend(options.media_metadata_extensions);
-            }
-            Ok(_) => {}
-            Err(error) => {
-                tracing::warn!(
-                    policy_id = policy.id,
-                    "skip storage-native media metadata public support for policy: {error}"
-                );
-            }
+        // 同上，public support 只需要静态能力并集；不要为了能力判断创建远端 driver。
+        if driver_type_supports_native_media_metadata(policy.driver_type) {
+            storage_native_extensions.extend(options.media_metadata_extensions);
         }
     }
 

--- a/src/services/file_service/deletion/blob_cleanup.rs
+++ b/src/services/file_service/deletion/blob_cleanup.rs
@@ -123,6 +123,12 @@ async fn cleanup_claimed_blob(state: &PrimaryAppState, current_blob: &file_blob:
             blob_id = current_blob.id,
             "failed to delete thumbnail during blob cleanup: {error}"
         );
+        // Keep the blob row until every derived object is gone. If we deleted
+        // the primary object and row after a thumbnail delete failure, that
+        // thumbnail would become an untracked storage object with no normal
+        // maintenance path left to retry it.
+        restore_cleanup_claim(state, current_blob.id, "thumbnail delete error").await;
+        return false;
     }
 
     let Some(policy) = state.policy_snapshot.get_policy(current_blob.policy_id) else {

--- a/src/services/file_service/deletion/blob_cleanup.rs
+++ b/src/services/file_service/deletion/blob_cleanup.rs
@@ -1,8 +1,10 @@
 use crate::db::repository::file_repo;
-use crate::entities::file_blob;
+use crate::entities::{file_blob, storage_policy};
 use crate::errors::AsterError;
 use crate::runtime::PrimaryAppState;
 use crate::services::media_processing_service;
+use crate::storage::StorageDriver;
+use std::sync::Arc;
 
 pub(crate) async fn ensure_blob_cleanup_if_unreferenced(
     state: &PrimaryAppState,
@@ -33,7 +35,12 @@ pub(crate) async fn ensure_blob_cleanup_if_unreferenced(
     }
 
     match file_repo::claim_blob_cleanup(state.writer_db(), current_blob.id).await {
-        Ok(true) => cleanup_claimed_blob(state, &current_blob).await,
+        Ok(true) => {
+            cleanup_claimed_blob(state, &current_blob, &mut |policy| {
+                state.driver_registry.get_driver(policy)
+            })
+            .await
+        }
         Ok(false) => true,
         Err(error) => {
             tracing::warn!(
@@ -49,6 +56,20 @@ pub(crate) async fn cleanup_unreferenced_blob(
     state: &PrimaryAppState,
     blob: &file_blob::Model,
 ) -> bool {
+    cleanup_unreferenced_blob_with_driver(state, blob, &mut |policy| {
+        state.driver_registry.get_driver(policy)
+    })
+    .await
+}
+
+pub(crate) async fn cleanup_unreferenced_blob_with_driver<F>(
+    state: &PrimaryAppState,
+    blob: &file_blob::Model,
+    driver_for_policy: &mut F,
+) -> bool
+where
+    F: FnMut(&storage_policy::Model) -> crate::errors::Result<Arc<dyn StorageDriver>>,
+{
     let current_blob = match file_repo::find_blob_by_id(state.writer_db(), blob.id).await {
         Ok(current_blob) => current_blob,
         Err(AsterError::RecordNotFound(_)) => return true,
@@ -96,10 +117,17 @@ pub(crate) async fn cleanup_unreferenced_blob(
         }
     }
 
-    cleanup_claimed_blob(state, &current_blob).await
+    cleanup_claimed_blob(state, &current_blob, driver_for_policy).await
 }
 
-async fn cleanup_claimed_blob(state: &PrimaryAppState, current_blob: &file_blob::Model) -> bool {
+async fn cleanup_claimed_blob<F>(
+    state: &PrimaryAppState,
+    current_blob: &file_blob::Model,
+    driver_for_policy: &mut F,
+) -> bool
+where
+    F: FnMut(&storage_policy::Model) -> crate::errors::Result<Arc<dyn StorageDriver>>,
+{
     async fn restore_cleanup_claim(state: &PrimaryAppState, blob_id: i64, reason: &str) {
         match file_repo::restore_blob_cleanup_claim(state.writer_db(), blob_id).await {
             Ok(true) => {}
@@ -118,19 +146,6 @@ async fn cleanup_claimed_blob(state: &PrimaryAppState, current_blob: &file_blob:
         }
     }
 
-    if let Err(error) = media_processing_service::delete_thumbnail(state, current_blob).await {
-        tracing::warn!(
-            blob_id = current_blob.id,
-            "failed to delete thumbnail during blob cleanup: {error}"
-        );
-        // Keep the blob row until every derived object is gone. If we deleted
-        // the primary object and row after a thumbnail delete failure, that
-        // thumbnail would become an untracked storage object with no normal
-        // maintenance path left to retry it.
-        restore_cleanup_claim(state, current_blob.id, "thumbnail delete error").await;
-        return false;
-    }
-
     let Some(policy) = state.policy_snapshot.get_policy(current_blob.policy_id) else {
         tracing::warn!(
             blob_id = current_blob.id,
@@ -141,7 +156,7 @@ async fn cleanup_claimed_blob(state: &PrimaryAppState, current_blob: &file_blob:
         return false;
     };
 
-    let driver = match state.driver_registry.get_driver(&policy) {
+    let driver = match driver_for_policy(&policy) {
         Ok(driver) => driver,
         Err(error) => {
             tracing::warn!(
@@ -153,6 +168,22 @@ async fn cleanup_claimed_blob(state: &PrimaryAppState, current_blob: &file_blob:
             return false;
         }
     };
+
+    if let Err(error) =
+        media_processing_service::delete_thumbnail_with_driver(state, current_blob, driver.clone())
+            .await
+    {
+        tracing::warn!(
+            blob_id = current_blob.id,
+            "failed to delete thumbnail during blob cleanup: {error}"
+        );
+        // Keep the blob row until every derived object is gone. If we deleted
+        // the primary object and row after a thumbnail delete failure, that
+        // thumbnail would become an untracked storage object with no normal
+        // maintenance path left to retry it.
+        restore_cleanup_claim(state, current_blob.id, "thumbnail delete error").await;
+        return false;
+    }
 
     let object_deleted = match driver.delete(&current_blob.storage_path).await {
         Ok(()) => true,

--- a/src/services/file_service/deletion/mod.rs
+++ b/src/services/file_service/deletion/mod.rs
@@ -4,7 +4,10 @@ mod blob_cleanup;
 mod purge;
 mod soft_delete;
 
-pub(crate) use blob_cleanup::{cleanup_unreferenced_blob, ensure_blob_cleanup_if_unreferenced};
+pub(crate) use blob_cleanup::{
+    cleanup_unreferenced_blob, cleanup_unreferenced_blob_with_driver,
+    ensure_blob_cleanup_if_unreferenced,
+};
 pub(crate) use purge::{
     BatchPurgeSummary, batch_purge_in_resource_scope, batch_purge_in_resource_scope_silent,
     batch_purge_in_scope,

--- a/src/services/file_service/deletion/tests.rs
+++ b/src/services/file_service/deletion/tests.rs
@@ -27,6 +27,8 @@ use crate::types::{
 #[derive(Clone, Default)]
 struct TrackingDeleteDriver {
     objects: Arc<Mutex<HashSet<String>>>,
+    fail_delete_paths: Arc<Mutex<HashSet<String>>>,
+    delete_attempts: Arc<Mutex<Vec<String>>>,
     delete_calls: Arc<AtomicUsize>,
 }
 
@@ -38,8 +40,22 @@ impl TrackingDeleteDriver {
             .insert(path.to_string());
     }
 
+    fn fail_delete_for(&self, path: &str) {
+        self.fail_delete_paths
+            .lock()
+            .expect("tracking delete driver lock should succeed")
+            .insert(path.to_string());
+    }
+
     fn delete_calls(&self) -> usize {
         self.delete_calls.load(Ordering::SeqCst)
+    }
+
+    fn delete_attempts(&self) -> Vec<String> {
+        self.delete_attempts
+            .lock()
+            .expect("tracking delete driver lock should succeed")
+            .clone()
     }
 
     fn contains(&self, path: &str) -> bool {
@@ -70,6 +86,20 @@ impl StorageDriver for TrackingDeleteDriver {
 
     async fn delete(&self, path: &str) -> crate::errors::Result<()> {
         self.delete_calls.fetch_add(1, Ordering::SeqCst);
+        self.delete_attempts
+            .lock()
+            .expect("tracking delete driver lock should succeed")
+            .push(path.to_string());
+        if self
+            .fail_delete_paths
+            .lock()
+            .expect("tracking delete driver lock should succeed")
+            .contains(path)
+        {
+            return Err(crate::errors::AsterError::storage_driver_error(format!(
+                "forced delete failure for {path}"
+            )));
+        }
         self.objects
             .lock()
             .expect("tracking delete driver lock should succeed")
@@ -391,6 +421,67 @@ async fn cleanup_unreferenced_blob_skips_cleanup_claimed_blob() {
     assert_eq!(
         reloaded_blob.ref_count,
         file_repo::BLOB_CLEANUP_CLAIMED_REF_COUNT
+    );
+}
+
+#[tokio::test]
+async fn cleanup_unreferenced_blob_keeps_row_and_primary_object_when_thumbnail_delete_fails() {
+    let (state, _user, policy, driver) = build_deletion_test_state().await;
+    let blob = create_blob(
+        state.writer_db(),
+        policy.id,
+        "files/thumbnail-delete-failed.bin",
+        9,
+        0,
+    )
+    .await;
+    let thumbnail_path = "thumbs/thumbnail-delete-failed.webp";
+    let mut active_blob: file_blob::ActiveModel = blob.clone().into();
+    active_blob.thumbnail_path = Set(Some(thumbnail_path.to_string()));
+    let blob = active_blob
+        .update(state.writer_db())
+        .await
+        .expect("test blob thumbnail metadata should update");
+    driver.insert_object(&blob.storage_path);
+    driver.insert_object(thumbnail_path);
+    driver.fail_delete_for(thumbnail_path);
+
+    let cleaned = cleanup_unreferenced_blob(&state, &blob).await;
+
+    assert!(
+        !cleaned,
+        "cleanup must report failure when a derived thumbnail object cannot be deleted"
+    );
+    let reloaded_blob = file_blob::Entity::find_by_id(blob.id)
+        .one(state.writer_db())
+        .await
+        .expect("blob lookup should succeed")
+        .expect("blob row should remain for a later cleanup retry");
+    assert_eq!(
+        reloaded_blob.ref_count, 0,
+        "failed cleanup should release the cleanup claim instead of leaving the blob stuck"
+    );
+    assert_eq!(
+        reloaded_blob.thumbnail_path.as_deref(),
+        Some(thumbnail_path),
+        "thumbnail metadata should remain so the next cleanup retry still knows the derived object"
+    );
+    assert!(
+        driver.contains(&blob.storage_path),
+        "primary blob object must remain when thumbnail cleanup fails"
+    );
+    assert!(
+        driver.contains(thumbnail_path),
+        "failed thumbnail object should remain tracked for retry"
+    );
+    let attempts = driver.delete_attempts();
+    assert!(
+        attempts.iter().any(|path| path == thumbnail_path),
+        "cleanup should attempt to delete the thumbnail object first"
+    );
+    assert!(
+        !attempts.iter().any(|path| path == &blob.storage_path),
+        "primary object delete must not be attempted after thumbnail cleanup fails"
     );
 }
 

--- a/src/services/file_service/mod.rs
+++ b/src/services/file_service/mod.rs
@@ -32,8 +32,8 @@ pub(crate) use content::{
 };
 pub(crate) use deletion::{
     BatchPurgeSummary, batch_purge_in_resource_scope, batch_purge_in_resource_scope_silent,
-    batch_purge_in_scope, cleanup_unreferenced_blob, delete_in_scope,
-    ensure_blob_cleanup_if_unreferenced,
+    batch_purge_in_scope, cleanup_unreferenced_blob, cleanup_unreferenced_blob_with_driver,
+    delete_in_scope, ensure_blob_cleanup_if_unreferenced,
 };
 pub use deletion::{batch_purge, delete, purge};
 pub use download::range::ResolvedDownloadRange;

--- a/src/services/file_service/thumbnail.rs
+++ b/src/services/file_service/thumbnail.rs
@@ -19,7 +19,7 @@ pub struct ThumbnailResult {
 }
 
 pub struct ImagePreviewResult {
-    pub data: Vec<u8>,
+    pub data: Bytes,
     pub blob_hash: String,
     pub image_preview_processor: String,
     pub image_preview_version: String,

--- a/src/services/file_service/thumbnail.rs
+++ b/src/services/file_service/thumbnail.rs
@@ -6,12 +6,13 @@ use crate::runtime::PrimaryAppState;
 use crate::services::{
     media_processing_service, task_service, workspace_storage_service::WorkspaceStorageScope,
 };
+use bytes::Bytes;
 
 use super::get_info_in_scope;
 
 /// 缩略图查询结果：有数据直接返回，正在生成则标记 pending
 pub struct ThumbnailResult {
-    pub data: Vec<u8>,
+    pub data: Bytes,
     pub blob_hash: String,
     pub thumbnail_processor: Option<String>,
     pub thumbnail_version: Option<String>,

--- a/src/services/maintenance_service.rs
+++ b/src/services/maintenance_service.rs
@@ -1,6 +1,6 @@
 //! 服务模块：`maintenance_service`。
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 use chrono::Utc;
 
@@ -48,24 +48,31 @@ pub async fn cleanup_expired_completed_upload_sessions(
         }
         last_id = sessions.last().map(|session| session.id.clone());
 
-        let broken_temp_keys: Vec<String> = sessions
+        let completed_temp_keys: Vec<String> = sessions
             .iter()
-            .filter(|session| session.file_id.is_none())
             .filter_map(|session| session.s3_temp_key.clone())
             .collect::<HashSet<_>>()
             .into_iter()
             .collect();
         let tracked_blob_paths = file_repo::find_blob_storage_paths_by_storage_paths(
             state.writer_db(),
-            &broken_temp_keys,
+            &completed_temp_keys,
         )
         .await?;
 
         for session in sessions {
             let broken_completed = session.file_id.is_none();
 
-            if broken_completed {
-                cleanup_broken_completed_session_object(state, &session, &tracked_blob_paths).await;
+            if session_stale_temp_key(&session, &tracked_blob_paths).is_some() {
+                let cleanup_complete =
+                    cleanup_completed_session_stale_temp_object(state, &session).await;
+                if !cleanup_complete {
+                    tracing::warn!(
+                        session_id = %session.id,
+                        "keeping completed upload session because stale temp object cleanup is incomplete"
+                    );
+                    continue;
+                }
             }
 
             let temp_dir = crate::utils::paths::upload_temp_dir(
@@ -94,8 +101,20 @@ pub async fn cleanup_expired_completed_upload_sessions(
     Ok(stats)
 }
 
+fn session_stale_temp_key<'a>(
+    session: &'a upload_session::Model,
+    tracked_blob_paths: &HashSet<String>,
+) -> Option<&'a str> {
+    let temp_key = session.s3_temp_key.as_deref()?;
+    // Completed presigned uploads can have both a real file_id and the original
+    // PUT temp key. Only skip cleanup when that key is still the tracked blob.
+    if tracked_blob_paths.contains(temp_key) {
+        return None;
+    }
+    Some(temp_key)
+}
+
 pub async fn reconcile_blob_state(state: &PrimaryAppState) -> Result<BlobMaintenanceStats> {
-    let mut actual_ref_counts = load_actual_blob_ref_counts(state).await?;
     let mut last_blob_id: Option<i64> = None;
     let mut stats = BlobMaintenanceStats::default();
 
@@ -112,17 +131,14 @@ pub async fn reconcile_blob_state(state: &PrimaryAppState) -> Result<BlobMainten
             break;
         }
         last_blob_id = blobs.last().map(|blob| blob.id);
+        let blob_ids: Vec<i64> = blobs.iter().map(|blob| blob.id).collect();
+        // Keep reconcile memory bounded to the current blob page. Loading every
+        // file/version reference count up front can spike memory on large
+        // installs even though blob rows themselves are paginated.
+        let actual_ref_counts = current_blob_ref_counts(state, &blob_ids).await?;
 
         for blob in blobs {
-            let actual_refs = match actual_ref_counts.remove(&blob.id) {
-                Some(count) => i32::try_from(count).map_err(|_| {
-                    AsterError::internal_error(format!(
-                        "actual ref count overflow for blob {}",
-                        blob.id
-                    ))
-                })?,
-                None => 0,
-            };
+            let actual_refs = actual_ref_counts.get(&blob.id).copied().unwrap_or(0);
 
             if blob.ref_count == actual_refs && actual_refs > 0 {
                 continue;
@@ -216,14 +232,26 @@ async fn current_blob_ref_count<C: sea_orm::ConnectionTrait>(db: &C, blob_id: i6
     })
 }
 
-async fn load_actual_blob_ref_counts(
+async fn current_blob_ref_counts(
     state: &PrimaryAppState,
-) -> Result<std::collections::HashMap<i64, i64>> {
-    let mut actual = file_repo::count_blob_refs_from_files(state.writer_db()).await?;
+    blob_ids: &[i64],
+) -> Result<HashMap<i64, i32>> {
+    let file_refs =
+        file_repo::count_blob_refs_from_files_for_blobs(state.writer_db(), blob_ids).await?;
+    let version_refs =
+        version_repo::count_blob_refs_from_versions_for_blobs(state.writer_db(), blob_ids).await?;
+    let mut actual = HashMap::with_capacity(blob_ids.len());
 
-    let version_refs = version_repo::count_blob_refs_from_versions(state.writer_db()).await?;
-    for (blob_id, ref_count) in version_refs {
-        *actual.entry(blob_id).or_insert(0) += ref_count;
+    for blob_id in blob_ids {
+        let file_count = file_refs.get(blob_id).copied().unwrap_or(0);
+        let version_count = version_refs.get(blob_id).copied().unwrap_or(0);
+        let total_refs = file_count.checked_add(version_count).ok_or_else(|| {
+            AsterError::internal_error("blob ref count overflow during batch reconcile")
+        })?;
+        actual.insert(
+            *blob_id,
+            crate::utils::numbers::i64_to_i32(total_refs, "blob actual reference count")?,
+        );
     }
 
     Ok(actual)
@@ -236,18 +264,13 @@ fn blob_cleanup_claim_is_stale(blob: &file_blob::Model) -> bool {
         >= BLOB_CLEANUP_CLAIM_TIMEOUT_SECS
 }
 
-async fn cleanup_broken_completed_session_object(
+async fn cleanup_completed_session_stale_temp_object(
     state: &PrimaryAppState,
     session: &upload_session::Model,
-    tracked_blob_paths: &HashSet<String>,
-) {
+) -> bool {
     let Some(temp_key) = session.s3_temp_key.as_deref() else {
-        return;
+        return true;
     };
-
-    if tracked_blob_paths.contains(temp_key) {
-        return;
-    }
 
     let Some(policy) = state.policy_snapshot.get_policy(session.policy_id) else {
         tracing::warn!(
@@ -255,7 +278,7 @@ async fn cleanup_broken_completed_session_object(
             policy_id = session.policy_id,
             "failed to load storage policy for completed upload session cleanup"
         );
-        return;
+        return false;
     };
 
     let Ok(driver) = state.driver_registry.get_driver(&policy) else {
@@ -264,36 +287,34 @@ async fn cleanup_broken_completed_session_object(
             policy_id = session.policy_id,
             "failed to resolve storage driver for completed upload session cleanup"
         );
-        return;
+        return false;
     };
 
     if let Some(multipart_id) = session.s3_multipart_id.as_deref() {
         let Ok(multipart) = state.driver_registry.get_multipart_driver(&policy) else {
             // 策略不支持 multipart（如已切换为 Local），跳过 abort 直接删 key
-            if let Err(e) = driver.delete(temp_key).await {
-                tracing::warn!(
-                    session_id = %session.id,
-                    temp_key = %temp_key,
-                    "failed to delete stale temp object for completed session: {e}"
-                );
-            }
-            return;
+            return delete_completed_stale_temp_object(&*driver, session, temp_key).await;
         };
 
-        let mut abort_error = None;
         for attempt in 1..=MULTIPART_ABORT_MAX_ATTEMPTS {
             match multipart
                 .abort_multipart_upload(temp_key, multipart_id)
                 .await
             {
                 Ok(()) => {
-                    abort_error = None;
-                    break;
+                    return delete_completed_stale_temp_object(&*driver, session, temp_key).await;
                 }
                 Err(err) => {
                     if attempt == MULTIPART_ABORT_MAX_ATTEMPTS {
-                        abort_error = Some(err);
-                        break;
+                        tracing::warn!(
+                            session_id = %session.id,
+                            temp_key = %temp_key,
+                            max_attempts = MULTIPART_ABORT_MAX_ATTEMPTS,
+                            "failed to abort stale multipart upload for completed session after retries: {err}"
+                        );
+                        // Keep the session as the retry handle. Deleting an object key is not
+                        // enough to guarantee incomplete multipart parts were released.
+                        return false;
                     }
                     let backoff_ms = MULTIPART_ABORT_INITIAL_BACKOFF_MS * (1_u64 << (attempt - 1));
                     tracing::warn!(
@@ -309,29 +330,37 @@ async fn cleanup_broken_completed_session_object(
             }
         }
 
-        if let Some(e) = abort_error {
-            tracing::warn!(
-                session_id = %session.id,
-                temp_key = %temp_key,
-                max_attempts = MULTIPART_ABORT_MAX_ATTEMPTS,
-                "failed to abort stale multipart upload for completed session after retries: {e}"
-            );
+        return false;
+    }
 
-            // 删除对象 key 不能回收仍在进行中的 multipart parts；生产环境仍应配置
-            // S3/MinIO 生命周期规则来清理 incomplete multipart uploads。
-            if let Err(delete_err) = driver.delete(temp_key).await {
+    delete_completed_stale_temp_object(&*driver, session, temp_key).await
+}
+
+async fn delete_completed_stale_temp_object(
+    driver: &dyn crate::storage::StorageDriver,
+    session: &upload_session::Model,
+    temp_key: &str,
+) -> bool {
+    match driver.delete(temp_key).await {
+        Ok(()) => true,
+        Err(e) => match driver.exists(temp_key).await {
+            Ok(false) => true,
+            Ok(true) => {
                 tracing::warn!(
                     session_id = %session.id,
                     temp_key = %temp_key,
-                    "failed to delete stale completed multipart object after abort retries exhausted: {delete_err}"
+                    "failed to delete stale temp object for completed session: {e}"
                 );
+                false
             }
-        }
-    } else if let Err(e) = driver.delete(temp_key).await {
-        tracing::warn!(
-            session_id = %session.id,
-            temp_key = %temp_key,
-            "failed to delete stale temp object for completed session: {e}"
-        );
+            Err(exists_error) => {
+                tracing::warn!(
+                    session_id = %session.id,
+                    temp_key = %temp_key,
+                    "failed to delete stale temp object and verify existence for completed session: delete_error={e}, exists_error={exists_error}"
+                );
+                false
+            }
+        },
     }
 }

--- a/src/services/maintenance_service.rs
+++ b/src/services/maintenance_service.rs
@@ -329,8 +329,6 @@ async fn cleanup_completed_session_stale_temp_object(
                 }
             }
         }
-
-        return false;
     }
 
     delete_completed_stale_temp_object(&*driver, session, temp_key).await

--- a/src/services/media_processing_service/mod.rs
+++ b/src/services/media_processing_service/mod.rs
@@ -18,8 +18,10 @@ pub use shared::{
 };
 pub(crate) use shared::{cli_output_detail, run_cli_command_with_timeout};
 pub(crate) use shared::{known_image_preview_cache_paths, known_thumbnail_cache_paths};
-pub(crate) use thumbnail::generate_and_store_thumbnail_with_processor;
 pub use thumbnail::{
     delete_thumbnail, generate_and_store_image_preview, generate_and_store_thumbnail,
     get_or_generate_thumbnail, load_thumbnail_if_exists, probe_ffmpeg_cli_command,
+};
+pub(crate) use thumbnail::{
+    delete_thumbnail_with_driver, generate_and_store_thumbnail_with_processor,
 };

--- a/src/services/media_processing_service/shared.rs
+++ b/src/services/media_processing_service/shared.rs
@@ -4,6 +4,8 @@ use std::process::{Command, Output, Stdio};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
+use bytes::Bytes;
+
 use crate::config::media_processing as media_processing_config;
 use crate::errors::{AsterError, Result};
 use crate::storage::StorageDriver;
@@ -217,7 +219,7 @@ impl ResolvedMediaProcessor {
 }
 
 pub struct ThumbnailData {
-    pub data: Vec<u8>,
+    pub data: Bytes,
     pub thumbnail_processor: String,
     pub thumbnail_version: String,
 }

--- a/src/services/media_processing_service/shared.rs
+++ b/src/services/media_processing_service/shared.rs
@@ -232,7 +232,7 @@ pub struct StoredThumbnail {
 }
 
 pub struct ImagePreviewData {
-    pub data: Vec<u8>,
+    pub data: Bytes,
     pub image_preview_processor: String,
     pub image_preview_version: String,
 }

--- a/src/services/media_processing_service/thumbnail/cache.rs
+++ b/src/services/media_processing_service/thumbnail/cache.rs
@@ -196,7 +196,7 @@ async fn read_thumbnail_from_path(
         },
     }
 
-    let mut stream = match driver.get_range(path, 0, Some(range_limit)).await {
+    let stream = match driver.get_range(path, 0, Some(range_limit)).await {
         Ok(stream) => stream,
         Err(error) if error.storage_error_kind() == Some(StorageErrorKind::NotFound) => {
             return Ok(None);
@@ -216,10 +216,14 @@ async fn read_thumbnail_from_path(
     };
 
     let mut data = Vec::new();
-    stream.read_to_end(&mut data).await.map_aster_err_ctx(
-        "read cached thumbnail range",
-        AsterError::storage_driver_error,
-    )?;
+    stream
+        .take(range_limit)
+        .read_to_end(&mut data)
+        .await
+        .map_aster_err_ctx(
+            "read cached thumbnail range",
+            AsterError::storage_driver_error,
+        )?;
 
     if data.len() > max_cached_thumbnail_bytes {
         tracing::warn!(
@@ -303,11 +307,26 @@ mod tests {
         async fn get_range(
             &self,
             _path: &str,
-            _offset: u64,
-            _length: Option<u64>,
+            offset: u64,
+            length: Option<u64>,
         ) -> Result<Box<dyn AsyncRead + Unpin + Send>> {
             self.range_calls.fetch_add(1, Ordering::SeqCst);
-            Ok(Box::new(std::io::Cursor::new(vec![b'x'; self.data_len])))
+            let expected_length = MAX_CACHED_THUMBNAIL_BYTES
+                .checked_add(1)
+                .expect("thumbnail range limit should not overflow");
+            assert_eq!(offset, 0);
+            assert_eq!(length, Some(expected_length));
+            let offset = u64_to_usize(offset, "test thumbnail range offset")
+                .expect("thumbnail range offset should fit usize");
+            let length = length
+                .map(|value| {
+                    u64_to_usize(value, "test thumbnail range length")
+                        .expect("thumbnail range length should fit usize")
+                })
+                .unwrap_or(self.data_len);
+            let end = offset.saturating_add(length).min(self.data_len);
+            let returned_len = end.saturating_sub(offset);
+            Ok(Box::new(std::io::Cursor::new(vec![b'x'; returned_len])))
         }
 
         async fn delete(&self, _path: &str) -> Result<()> {

--- a/src/services/media_processing_service/thumbnail/cache.rs
+++ b/src/services/media_processing_service/thumbnail/cache.rs
@@ -15,7 +15,14 @@ use crate::services::media_processing_service::shared::{
 pub async fn delete_thumbnail(state: &PrimaryAppState, blob: &file_blob::Model) -> Result<()> {
     let policy = state.policy_snapshot.get_policy_or_err(blob.policy_id)?;
     let driver = state.driver_registry.get_driver(&policy)?;
+    delete_thumbnail_with_driver(state, blob, driver).await
+}
 
+pub(crate) async fn delete_thumbnail_with_driver(
+    state: &PrimaryAppState,
+    blob: &file_blob::Model,
+    driver: Arc<dyn StorageDriver>,
+) -> Result<()> {
     let mut paths = BTreeSet::new();
     if let Some(path) = blob.thumbnail_path.as_ref() {
         paths.insert(path.clone());

--- a/src/services/media_processing_service/thumbnail/cache.rs
+++ b/src/services/media_processing_service/thumbnail/cache.rs
@@ -167,34 +167,6 @@ async fn read_thumbnail_from_path(
     let range_limit = MAX_CACHED_THUMBNAIL_BYTES
         .checked_add(1)
         .ok_or_else(|| AsterError::internal_error("cached thumbnail range limit overflow"))?;
-    match driver.metadata(path).await {
-        Ok(metadata) if metadata.size > MAX_CACHED_THUMBNAIL_BYTES => {
-            tracing::warn!(
-                blob_id,
-                path,
-                size = metadata.size,
-                max_size = MAX_CACHED_THUMBNAIL_BYTES,
-                "ignoring oversized cached thumbnail"
-            );
-            return Ok(None);
-        }
-        Ok(_) => {}
-        Err(error) if error.storage_error_kind() == Some(StorageErrorKind::NotFound) => {
-            return Ok(None);
-        }
-        Err(error) => match driver.exists(path).await {
-            Ok(false) => return Ok(None),
-            Ok(true) => return Err(error),
-            Err(exists_error) => {
-                tracing::warn!(
-                    blob_id,
-                    path,
-                    "thumbnail metadata failed and existence recheck also failed: {exists_error}"
-                );
-                return Err(error);
-            }
-        },
-    }
 
     let stream = match driver.get_range(path, 0, Some(range_limit)).await {
         Ok(stream) => stream,
@@ -269,30 +241,99 @@ pub(super) async fn persist_thumbnail_metadata(
 #[cfg(test)]
 mod tests {
     use super::{MAX_CACHED_THUMBNAIL_BYTES, read_thumbnail_from_path};
-    use crate::errors::Result;
-    use crate::storage::StorageErrorKind;
+    use crate::errors::{AsterError, Result};
     use crate::storage::error::storage_driver_error;
-    use crate::storage::{BlobMetadata, StorageDriver};
+    use crate::storage::{BlobMetadata, StorageDriver, StorageErrorKind};
     use crate::utils::numbers::u64_to_usize;
     use async_trait::async_trait;
+    use bytes::Bytes;
     use std::sync::{
         Arc,
         atomic::{AtomicUsize, Ordering},
     };
-    use tokio::io::AsyncRead;
+    use tokio::io::{AsyncRead, AsyncReadExt};
 
     struct ThumbnailCacheDriver {
-        metadata_size: Option<u64>,
+        range_error_kind: Option<StorageErrorKind>,
         data_len: usize,
+        expected_offset: u64,
+        expected_length: Option<u64>,
+        exists_result: std::result::Result<bool, StorageErrorKind>,
         exists_calls: AtomicUsize,
         get_calls: AtomicUsize,
         range_calls: AtomicUsize,
+        metadata_calls: AtomicUsize,
+    }
+
+    impl ThumbnailCacheDriver {
+        fn new(data_len: usize) -> Self {
+            Self {
+                range_error_kind: None,
+                data_len,
+                expected_offset: 0,
+                expected_length: Some(
+                    MAX_CACHED_THUMBNAIL_BYTES
+                        .checked_add(1)
+                        .expect("thumbnail range limit should not overflow"),
+                ),
+                exists_result: Ok(false),
+                exists_calls: AtomicUsize::new(0),
+                get_calls: AtomicUsize::new(0),
+                range_calls: AtomicUsize::new(0),
+                metadata_calls: AtomicUsize::new(0),
+            }
+        }
+
+        fn not_found() -> Self {
+            Self {
+                range_error_kind: Some(StorageErrorKind::NotFound),
+                ..Self::new(0)
+            }
+        }
+
+        fn with_range_error(kind: StorageErrorKind, exists_result: bool) -> Self {
+            Self {
+                range_error_kind: Some(kind),
+                exists_result: Ok(exists_result),
+                ..Self::new(0)
+            }
+        }
+
+        fn with_range_error_and_exists_error(
+            kind: StorageErrorKind,
+            exists_error_kind: StorageErrorKind,
+        ) -> Self {
+            Self {
+                range_error_kind: Some(kind),
+                exists_result: Err(exists_error_kind),
+                ..Self::new(0)
+            }
+        }
+
+        fn with_expected_range(
+            data_len: usize,
+            expected_offset: u64,
+            expected_length: Option<u64>,
+        ) -> Self {
+            Self {
+                expected_offset,
+                expected_length,
+                ..Self::new(data_len)
+            }
+        }
+    }
+
+    fn unsupported_test_call(method: &str) -> AsterError {
+        storage_driver_error(
+            StorageErrorKind::Unsupported,
+            format!("thumbnail cache test driver does not support {method}"),
+        )
     }
 
     #[async_trait]
     impl StorageDriver for ThumbnailCacheDriver {
         async fn put(&self, _path: &str, _data: &[u8]) -> Result<String> {
-            unreachable!()
+            Err(unsupported_test_call("put"))
         }
 
         async fn get(&self, _path: &str) -> Result<Vec<u8>> {
@@ -301,7 +342,7 @@ mod tests {
         }
 
         async fn get_stream(&self, _path: &str) -> Result<Box<dyn AsyncRead + Unpin + Send>> {
-            unreachable!()
+            Err(unsupported_test_call("get_stream"))
         }
 
         async fn get_range(
@@ -311,11 +352,11 @@ mod tests {
             length: Option<u64>,
         ) -> Result<Box<dyn AsyncRead + Unpin + Send>> {
             self.range_calls.fetch_add(1, Ordering::SeqCst);
-            let expected_length = MAX_CACHED_THUMBNAIL_BYTES
-                .checked_add(1)
-                .expect("thumbnail range limit should not overflow");
-            assert_eq!(offset, 0);
-            assert_eq!(length, Some(expected_length));
+            if let Some(kind) = self.range_error_kind {
+                return Err(storage_driver_error(kind, "thumbnail range read failed"));
+            }
+            assert_eq!(offset, self.expected_offset);
+            assert_eq!(length, self.expected_length);
             let offset = u64_to_usize(offset, "test thumbnail range offset")
                 .expect("thumbnail range offset should fit usize");
             let length = length
@@ -330,110 +371,178 @@ mod tests {
         }
 
         async fn delete(&self, _path: &str) -> Result<()> {
-            unreachable!()
+            Err(unsupported_test_call("delete"))
         }
 
         async fn exists(&self, _path: &str) -> Result<bool> {
             self.exists_calls.fetch_add(1, Ordering::SeqCst);
-            Ok(false)
+            self.exists_result
+                .map_err(|kind| storage_driver_error(kind, "thumbnail existence check failed"))
         }
 
         async fn metadata(&self, _path: &str) -> Result<BlobMetadata> {
-            let Some(size) = self.metadata_size else {
-                return Err(storage_driver_error(
-                    StorageErrorKind::NotFound,
-                    "thumbnail not found",
-                ));
-            };
-            Ok(BlobMetadata {
-                size,
-                content_type: Some("image/webp".to_string()),
-            })
+            self.metadata_calls.fetch_add(1, Ordering::SeqCst);
+            Err(unsupported_test_call("metadata"))
         }
     }
 
-    #[tokio::test]
-    async fn read_thumbnail_from_path_treats_not_found_metadata_as_miss_without_exists_probe() {
-        let driver = Arc::new(ThumbnailCacheDriver {
-            metadata_size: None,
-            data_len: 0,
-            exists_calls: AtomicUsize::new(0),
-            get_calls: AtomicUsize::new(0),
-            range_calls: AtomicUsize::new(0),
-        });
+    async fn read_cache_with_driver(driver: &Arc<ThumbnailCacheDriver>) -> Option<Bytes> {
+        read_thumbnail_from_path(1, &(driver.clone() as Arc<dyn StorageDriver>), "thumb.webp")
+            .await
+            .expect("thumbnail cache read should not fail")
+    }
 
-        let loaded =
-            read_thumbnail_from_path(1, &(driver.clone() as Arc<dyn StorageDriver>), "thumb.webp")
-                .await
-                .expect("not found should be a cache miss");
+    fn assert_no_metadata_or_full_get(driver: &ThumbnailCacheDriver) {
+        assert_eq!(driver.metadata_calls.load(Ordering::SeqCst), 0);
+        assert_eq!(driver.get_calls.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn read_thumbnail_from_path_treats_not_found_range_as_miss_without_exists_probe() {
+        let driver = Arc::new(ThumbnailCacheDriver::not_found());
+
+        let loaded = read_cache_with_driver(&driver).await;
 
         assert!(loaded.is_none());
         assert_eq!(driver.exists_calls.load(Ordering::SeqCst), 0);
-        assert_eq!(driver.get_calls.load(Ordering::SeqCst), 0);
-        assert_eq!(driver.range_calls.load(Ordering::SeqCst), 0);
+        assert_no_metadata_or_full_get(&driver);
+        assert_eq!(driver.range_calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn read_thumbnail_from_path_treats_range_error_as_miss_when_exists_probe_is_false() {
+        let driver = Arc::new(ThumbnailCacheDriver::with_range_error(
+            StorageErrorKind::Transient,
+            false,
+        ));
+
+        let loaded = read_cache_with_driver(&driver).await;
+
+        assert!(loaded.is_none());
+        assert_eq!(driver.exists_calls.load(Ordering::SeqCst), 1);
+        assert_no_metadata_or_full_get(&driver);
+        assert_eq!(driver.range_calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn read_thumbnail_from_path_returns_range_error_when_exists_probe_is_true() {
+        let driver = Arc::new(ThumbnailCacheDriver::with_range_error(
+            StorageErrorKind::Transient,
+            true,
+        ));
+
+        let error =
+            read_thumbnail_from_path(1, &(driver.clone() as Arc<dyn StorageDriver>), "thumb.webp")
+                .await
+                .expect_err("range error should be preserved when object still exists");
+
+        assert_eq!(
+            error.storage_error_kind(),
+            Some(StorageErrorKind::Transient)
+        );
+        assert_eq!(driver.exists_calls.load(Ordering::SeqCst), 1);
+        assert_no_metadata_or_full_get(&driver);
+        assert_eq!(driver.range_calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn read_thumbnail_from_path_preserves_range_error_when_exists_probe_fails() {
+        let driver = Arc::new(ThumbnailCacheDriver::with_range_error_and_exists_error(
+            StorageErrorKind::Transient,
+            StorageErrorKind::Permission,
+        ));
+
+        let error =
+            read_thumbnail_from_path(1, &(driver.clone() as Arc<dyn StorageDriver>), "thumb.webp")
+                .await
+                .expect_err("range error should be preserved when existence probe fails");
+
+        assert_eq!(
+            error.storage_error_kind(),
+            Some(StorageErrorKind::Transient)
+        );
+        assert_eq!(driver.exists_calls.load(Ordering::SeqCst), 1);
+        assert_no_metadata_or_full_get(&driver);
+        assert_eq!(driver.range_calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn read_thumbnail_from_path_accepts_empty_cache_entry() {
+        let driver = Arc::new(ThumbnailCacheDriver::new(0));
+
+        let loaded = read_cache_with_driver(&driver).await;
+
+        assert_eq!(loaded.expect("cache hit expected").len(), 0);
+        assert_no_metadata_or_full_get(&driver);
+        assert_eq!(driver.range_calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn read_thumbnail_from_path_accepts_cache_entry_below_size_limit() {
+        let max_size = u64_to_usize(MAX_CACHED_THUMBNAIL_BYTES, "test thumbnail limit")
+            .expect("thumbnail limit should fit usize");
+        let driver = Arc::new(ThumbnailCacheDriver::new(max_size - 1));
+
+        let loaded = read_cache_with_driver(&driver).await;
+
+        assert_eq!(loaded.expect("cache hit expected").len(), max_size - 1);
+        assert_no_metadata_or_full_get(&driver);
+        assert_eq!(driver.range_calls.load(Ordering::SeqCst), 1);
     }
 
     #[tokio::test]
     async fn read_thumbnail_from_path_accepts_cache_entry_at_size_limit() {
         let max_size = u64_to_usize(MAX_CACHED_THUMBNAIL_BYTES, "test thumbnail limit")
             .expect("thumbnail limit should fit usize");
-        let driver = Arc::new(ThumbnailCacheDriver {
-            metadata_size: Some(MAX_CACHED_THUMBNAIL_BYTES),
-            data_len: max_size,
-            exists_calls: AtomicUsize::new(0),
-            get_calls: AtomicUsize::new(0),
-            range_calls: AtomicUsize::new(0),
-        });
+        let driver = Arc::new(ThumbnailCacheDriver::new(max_size));
 
-        let loaded =
-            read_thumbnail_from_path(1, &(driver.clone() as Arc<dyn StorageDriver>), "thumb.webp")
-                .await
-                .expect("thumbnail at cache size limit should load");
+        let loaded = read_cache_with_driver(&driver).await;
 
         assert_eq!(loaded.expect("cache hit expected").len(), max_size);
-        assert_eq!(driver.get_calls.load(Ordering::SeqCst), 0);
+        assert_no_metadata_or_full_get(&driver);
         assert_eq!(driver.range_calls.load(Ordering::SeqCst), 1);
-    }
-
-    #[tokio::test]
-    async fn read_thumbnail_from_path_rejects_cache_entry_above_metadata_limit_without_get() {
-        let driver = Arc::new(ThumbnailCacheDriver {
-            metadata_size: Some(MAX_CACHED_THUMBNAIL_BYTES + 1),
-            data_len: 1,
-            exists_calls: AtomicUsize::new(0),
-            get_calls: AtomicUsize::new(0),
-            range_calls: AtomicUsize::new(0),
-        });
-
-        let loaded =
-            read_thumbnail_from_path(1, &(driver.clone() as Arc<dyn StorageDriver>), "thumb.webp")
-                .await
-                .expect("oversized thumbnail cache should be ignored");
-
-        assert!(loaded.is_none());
-        assert_eq!(driver.get_calls.load(Ordering::SeqCst), 0);
-        assert_eq!(driver.range_calls.load(Ordering::SeqCst), 0);
     }
 
     #[tokio::test]
     async fn read_thumbnail_from_path_rejects_cache_entry_above_read_limit() {
         let max_size = u64_to_usize(MAX_CACHED_THUMBNAIL_BYTES, "test thumbnail limit")
             .expect("thumbnail limit should fit usize");
-        let driver = Arc::new(ThumbnailCacheDriver {
-            metadata_size: Some(MAX_CACHED_THUMBNAIL_BYTES),
-            data_len: max_size + 1,
-            exists_calls: AtomicUsize::new(0),
-            get_calls: AtomicUsize::new(0),
-            range_calls: AtomicUsize::new(0),
-        });
+        let driver = Arc::new(ThumbnailCacheDriver::new(max_size + 1));
 
-        let loaded =
-            read_thumbnail_from_path(1, &(driver.clone() as Arc<dyn StorageDriver>), "thumb.webp")
-                .await
-                .expect("oversized thumbnail read should be ignored");
+        let loaded = read_cache_with_driver(&driver).await;
 
         assert!(loaded.is_none());
-        assert_eq!(driver.get_calls.load(Ordering::SeqCst), 0);
+        assert_no_metadata_or_full_get(&driver);
         assert_eq!(driver.range_calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn thumbnail_cache_driver_range_respects_offset_and_length_boundaries() {
+        let cases = [
+            (10, 0, Some(0), 0),
+            (10, 0, Some(4), 4),
+            (10, 6, Some(4), 4),
+            (10, 6, Some(99), 4),
+            (10, 10, Some(4), 0),
+            (10, 12, Some(4), 0),
+            (10, 3, None, 7),
+        ];
+
+        for (data_len, offset, length, expected_len) in cases {
+            let driver = ThumbnailCacheDriver::with_expected_range(data_len, offset, length);
+            let mut stream = driver
+                .get_range("thumb.webp", offset, length)
+                .await
+                .expect("range read should succeed");
+            let mut data = Vec::new();
+            stream
+                .read_to_end(&mut data)
+                .await
+                .expect("range stream should read");
+
+            assert_eq!(data.len(), expected_len);
+            assert_eq!(driver.range_calls.load(Ordering::SeqCst), 1);
+            assert_eq!(driver.metadata_calls.load(Ordering::SeqCst), 0);
+        }
     }
 }

--- a/src/services/media_processing_service/thumbnail/cache.rs
+++ b/src/services/media_processing_service/thumbnail/cache.rs
@@ -7,10 +7,13 @@ use crate::entities::file_blob;
 use crate::errors::Result;
 use crate::runtime::PrimaryAppState;
 use crate::storage::{StorageDriver, StorageErrorKind};
+use crate::utils::numbers::u64_to_usize;
 
 use crate::services::media_processing_service::shared::{
     ThumbnailContext, ThumbnailData, requires_server_side_source_limit,
 };
+
+const MAX_CACHED_THUMBNAIL_BYTES: u64 = 16 * 1024 * 1024;
 
 pub async fn delete_thumbnail(state: &PrimaryAppState, blob: &file_blob::Model) -> Result<()> {
     let policy = state.policy_snapshot.get_policy_or_err(blob.policy_id)?;
@@ -156,8 +159,49 @@ async fn read_thumbnail_from_path(
     driver: &Arc<dyn StorageDriver>,
     path: &str,
 ) -> Result<Option<Vec<u8>>> {
+    let max_cached_thumbnail_bytes =
+        u64_to_usize(MAX_CACHED_THUMBNAIL_BYTES, "cached thumbnail size limit")?;
+    match driver.metadata(path).await {
+        Ok(metadata) if metadata.size > MAX_CACHED_THUMBNAIL_BYTES => {
+            tracing::warn!(
+                blob_id,
+                path,
+                size = metadata.size,
+                max_size = MAX_CACHED_THUMBNAIL_BYTES,
+                "ignoring oversized cached thumbnail"
+            );
+            return Ok(None);
+        }
+        Ok(_) => {}
+        Err(error) if error.storage_error_kind() == Some(StorageErrorKind::NotFound) => {
+            return Ok(None);
+        }
+        Err(error) => match driver.exists(path).await {
+            Ok(false) => return Ok(None),
+            Ok(true) => return Err(error),
+            Err(exists_error) => {
+                tracing::warn!(
+                    blob_id,
+                    path,
+                    "thumbnail metadata failed and existence recheck also failed: {exists_error}"
+                );
+                return Err(error);
+            }
+        },
+    }
+
     match driver.get(path).await {
-        Ok(data) => Ok(Some(data)),
+        Ok(data) if data.len() <= max_cached_thumbnail_bytes => Ok(Some(data)),
+        Ok(data) => {
+            tracing::warn!(
+                blob_id,
+                path,
+                size = data.len(),
+                max_size = MAX_CACHED_THUMBNAIL_BYTES,
+                "ignoring oversized cached thumbnail"
+            );
+            Ok(None)
+        }
         Err(error) if error.storage_error_kind() == Some(StorageErrorKind::NotFound) => Ok(None),
         Err(error) => match driver.exists(path).await {
             Ok(false) => Ok(None),
@@ -204,11 +248,12 @@ pub(super) async fn persist_thumbnail_metadata(
 
 #[cfg(test)]
 mod tests {
-    use super::read_thumbnail_from_path;
+    use super::{MAX_CACHED_THUMBNAIL_BYTES, read_thumbnail_from_path};
     use crate::errors::Result;
     use crate::storage::StorageErrorKind;
     use crate::storage::error::storage_driver_error;
     use crate::storage::{BlobMetadata, StorageDriver};
+    use crate::utils::numbers::u64_to_usize;
     use async_trait::async_trait;
     use std::sync::{
         Arc,
@@ -216,21 +261,22 @@ mod tests {
     };
     use tokio::io::AsyncRead;
 
-    struct MissingThumbnailDriver {
+    struct ThumbnailCacheDriver {
+        metadata_size: Option<u64>,
+        data_len: usize,
         exists_calls: AtomicUsize,
+        get_calls: AtomicUsize,
     }
 
     #[async_trait]
-    impl StorageDriver for MissingThumbnailDriver {
+    impl StorageDriver for ThumbnailCacheDriver {
         async fn put(&self, _path: &str, _data: &[u8]) -> Result<String> {
             unreachable!()
         }
 
         async fn get(&self, _path: &str) -> Result<Vec<u8>> {
-            Err(storage_driver_error(
-                StorageErrorKind::NotFound,
-                "thumbnail not found",
-            ))
+            self.get_calls.fetch_add(1, Ordering::SeqCst);
+            Ok(vec![b'x'; self.data_len])
         }
 
         async fn get_stream(&self, _path: &str) -> Result<Box<dyn AsyncRead + Unpin + Send>> {
@@ -247,14 +293,26 @@ mod tests {
         }
 
         async fn metadata(&self, _path: &str) -> Result<BlobMetadata> {
-            unreachable!()
+            let Some(size) = self.metadata_size else {
+                return Err(storage_driver_error(
+                    StorageErrorKind::NotFound,
+                    "thumbnail not found",
+                ));
+            };
+            Ok(BlobMetadata {
+                size,
+                content_type: Some("image/webp".to_string()),
+            })
         }
     }
 
     #[tokio::test]
-    async fn read_thumbnail_from_path_treats_not_found_get_as_miss_without_exists_probe() {
-        let driver = Arc::new(MissingThumbnailDriver {
+    async fn read_thumbnail_from_path_treats_not_found_metadata_as_miss_without_exists_probe() {
+        let driver = Arc::new(ThumbnailCacheDriver {
+            metadata_size: None,
+            data_len: 0,
             exists_calls: AtomicUsize::new(0),
+            get_calls: AtomicUsize::new(0),
         });
 
         let loaded =
@@ -264,5 +322,64 @@ mod tests {
 
         assert!(loaded.is_none());
         assert_eq!(driver.exists_calls.load(Ordering::SeqCst), 0);
+        assert_eq!(driver.get_calls.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn read_thumbnail_from_path_accepts_cache_entry_at_size_limit() {
+        let max_size = u64_to_usize(MAX_CACHED_THUMBNAIL_BYTES, "test thumbnail limit")
+            .expect("thumbnail limit should fit usize");
+        let driver = Arc::new(ThumbnailCacheDriver {
+            metadata_size: Some(MAX_CACHED_THUMBNAIL_BYTES),
+            data_len: max_size,
+            exists_calls: AtomicUsize::new(0),
+            get_calls: AtomicUsize::new(0),
+        });
+
+        let loaded =
+            read_thumbnail_from_path(1, &(driver.clone() as Arc<dyn StorageDriver>), "thumb.webp")
+                .await
+                .expect("thumbnail at cache size limit should load");
+
+        assert_eq!(loaded.expect("cache hit expected").len(), max_size);
+        assert_eq!(driver.get_calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn read_thumbnail_from_path_rejects_cache_entry_above_metadata_limit_without_get() {
+        let driver = Arc::new(ThumbnailCacheDriver {
+            metadata_size: Some(MAX_CACHED_THUMBNAIL_BYTES + 1),
+            data_len: 1,
+            exists_calls: AtomicUsize::new(0),
+            get_calls: AtomicUsize::new(0),
+        });
+
+        let loaded =
+            read_thumbnail_from_path(1, &(driver.clone() as Arc<dyn StorageDriver>), "thumb.webp")
+                .await
+                .expect("oversized thumbnail cache should be ignored");
+
+        assert!(loaded.is_none());
+        assert_eq!(driver.get_calls.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn read_thumbnail_from_path_rejects_cache_entry_above_read_limit() {
+        let max_size = u64_to_usize(MAX_CACHED_THUMBNAIL_BYTES, "test thumbnail limit")
+            .expect("thumbnail limit should fit usize");
+        let driver = Arc::new(ThumbnailCacheDriver {
+            metadata_size: Some(MAX_CACHED_THUMBNAIL_BYTES),
+            data_len: max_size + 1,
+            exists_calls: AtomicUsize::new(0),
+            get_calls: AtomicUsize::new(0),
+        });
+
+        let loaded =
+            read_thumbnail_from_path(1, &(driver.clone() as Arc<dyn StorageDriver>), "thumb.webp")
+                .await
+                .expect("oversized thumbnail read should be ignored");
+
+        assert!(loaded.is_none());
+        assert_eq!(driver.get_calls.load(Ordering::SeqCst), 1);
     }
 }

--- a/src/services/media_processing_service/thumbnail/cache.rs
+++ b/src/services/media_processing_service/thumbnail/cache.rs
@@ -1,10 +1,13 @@
 use std::collections::BTreeSet;
 use std::sync::Arc;
 
+use bytes::Bytes;
+use tokio::io::AsyncReadExt;
+
 use crate::config::operations;
 use crate::db::repository::file_repo;
 use crate::entities::file_blob;
-use crate::errors::Result;
+use crate::errors::{AsterError, MapAsterErr, Result};
 use crate::runtime::PrimaryAppState;
 use crate::storage::{StorageDriver, StorageErrorKind};
 use crate::utils::numbers::u64_to_usize;
@@ -146,7 +149,7 @@ pub(super) async fn load_thumbnail_from_path(
     driver: &Arc<dyn StorageDriver>,
     path: &str,
     clear_metadata_on_missing: bool,
-) -> Result<Option<Vec<u8>>> {
+) -> Result<Option<Bytes>> {
     let thumbnail = read_thumbnail_from_path(blob.id, driver, path).await?;
     if thumbnail.is_none() && clear_metadata_on_missing {
         clear_thumbnail_metadata(state, blob).await;
@@ -158,9 +161,12 @@ async fn read_thumbnail_from_path(
     blob_id: i64,
     driver: &Arc<dyn StorageDriver>,
     path: &str,
-) -> Result<Option<Vec<u8>>> {
+) -> Result<Option<Bytes>> {
     let max_cached_thumbnail_bytes =
         u64_to_usize(MAX_CACHED_THUMBNAIL_BYTES, "cached thumbnail size limit")?;
+    let range_limit = MAX_CACHED_THUMBNAIL_BYTES
+        .checked_add(1)
+        .ok_or_else(|| AsterError::internal_error("cached thumbnail range limit overflow"))?;
     match driver.metadata(path).await {
         Ok(metadata) if metadata.size > MAX_CACHED_THUMBNAIL_BYTES => {
             tracing::warn!(
@@ -190,32 +196,42 @@ async fn read_thumbnail_from_path(
         },
     }
 
-    match driver.get(path).await {
-        Ok(data) if data.len() <= max_cached_thumbnail_bytes => Ok(Some(data)),
-        Ok(data) => {
-            tracing::warn!(
-                blob_id,
-                path,
-                size = data.len(),
-                max_size = MAX_CACHED_THUMBNAIL_BYTES,
-                "ignoring oversized cached thumbnail"
-            );
-            Ok(None)
+    let mut stream = match driver.get_range(path, 0, Some(range_limit)).await {
+        Ok(stream) => stream,
+        Err(error) if error.storage_error_kind() == Some(StorageErrorKind::NotFound) => {
+            return Ok(None);
         }
-        Err(error) if error.storage_error_kind() == Some(StorageErrorKind::NotFound) => Ok(None),
         Err(error) => match driver.exists(path).await {
-            Ok(false) => Ok(None),
-            Ok(true) => Err(error),
+            Ok(false) => return Ok(None),
+            Ok(true) => return Err(error),
             Err(exists_error) => {
                 tracing::warn!(
                     blob_id,
                     path,
-                    "thumbnail get failed and existence recheck also failed: {exists_error}"
+                    "thumbnail range read failed and existence recheck also failed: {exists_error}"
                 );
-                Err(error)
+                return Err(error);
             }
         },
+    };
+
+    let mut data = Vec::new();
+    stream.read_to_end(&mut data).await.map_aster_err_ctx(
+        "read cached thumbnail range",
+        AsterError::storage_driver_error,
+    )?;
+
+    if data.len() > max_cached_thumbnail_bytes {
+        tracing::warn!(
+            blob_id,
+            path,
+            size = data.len(),
+            max_size = MAX_CACHED_THUMBNAIL_BYTES,
+            "ignoring oversized cached thumbnail"
+        );
+        return Ok(None);
     }
+    Ok(Some(Bytes::from(data)))
 }
 
 async fn clear_thumbnail_metadata(state: &PrimaryAppState, blob: &file_blob::Model) {
@@ -266,6 +282,7 @@ mod tests {
         data_len: usize,
         exists_calls: AtomicUsize,
         get_calls: AtomicUsize,
+        range_calls: AtomicUsize,
     }
 
     #[async_trait]
@@ -281,6 +298,16 @@ mod tests {
 
         async fn get_stream(&self, _path: &str) -> Result<Box<dyn AsyncRead + Unpin + Send>> {
             unreachable!()
+        }
+
+        async fn get_range(
+            &self,
+            _path: &str,
+            _offset: u64,
+            _length: Option<u64>,
+        ) -> Result<Box<dyn AsyncRead + Unpin + Send>> {
+            self.range_calls.fetch_add(1, Ordering::SeqCst);
+            Ok(Box::new(std::io::Cursor::new(vec![b'x'; self.data_len])))
         }
 
         async fn delete(&self, _path: &str) -> Result<()> {
@@ -313,6 +340,7 @@ mod tests {
             data_len: 0,
             exists_calls: AtomicUsize::new(0),
             get_calls: AtomicUsize::new(0),
+            range_calls: AtomicUsize::new(0),
         });
 
         let loaded =
@@ -323,6 +351,7 @@ mod tests {
         assert!(loaded.is_none());
         assert_eq!(driver.exists_calls.load(Ordering::SeqCst), 0);
         assert_eq!(driver.get_calls.load(Ordering::SeqCst), 0);
+        assert_eq!(driver.range_calls.load(Ordering::SeqCst), 0);
     }
 
     #[tokio::test]
@@ -334,6 +363,7 @@ mod tests {
             data_len: max_size,
             exists_calls: AtomicUsize::new(0),
             get_calls: AtomicUsize::new(0),
+            range_calls: AtomicUsize::new(0),
         });
 
         let loaded =
@@ -342,7 +372,8 @@ mod tests {
                 .expect("thumbnail at cache size limit should load");
 
         assert_eq!(loaded.expect("cache hit expected").len(), max_size);
-        assert_eq!(driver.get_calls.load(Ordering::SeqCst), 1);
+        assert_eq!(driver.get_calls.load(Ordering::SeqCst), 0);
+        assert_eq!(driver.range_calls.load(Ordering::SeqCst), 1);
     }
 
     #[tokio::test]
@@ -352,6 +383,7 @@ mod tests {
             data_len: 1,
             exists_calls: AtomicUsize::new(0),
             get_calls: AtomicUsize::new(0),
+            range_calls: AtomicUsize::new(0),
         });
 
         let loaded =
@@ -361,6 +393,7 @@ mod tests {
 
         assert!(loaded.is_none());
         assert_eq!(driver.get_calls.load(Ordering::SeqCst), 0);
+        assert_eq!(driver.range_calls.load(Ordering::SeqCst), 0);
     }
 
     #[tokio::test]
@@ -372,6 +405,7 @@ mod tests {
             data_len: max_size + 1,
             exists_calls: AtomicUsize::new(0),
             get_calls: AtomicUsize::new(0),
+            range_calls: AtomicUsize::new(0),
         });
 
         let loaded =
@@ -380,6 +414,7 @@ mod tests {
                 .expect("oversized thumbnail read should be ignored");
 
         assert!(loaded.is_none());
-        assert_eq!(driver.get_calls.load(Ordering::SeqCst), 1);
+        assert_eq!(driver.get_calls.load(Ordering::SeqCst), 0);
+        assert_eq!(driver.range_calls.load(Ordering::SeqCst), 1);
     }
 }

--- a/src/services/media_processing_service/thumbnail/mod.rs
+++ b/src/services/media_processing_service/thumbnail/mod.rs
@@ -11,6 +11,7 @@ use crate::entities::file_blob;
 use crate::errors::Result;
 use crate::runtime::PrimaryAppState;
 use crate::types::MediaProcessorKind;
+use bytes::Bytes;
 
 use super::resolve::{build_thumbnail_context, build_thumbnail_context_with_processor};
 use super::shared::{StoredThumbnail, ThumbnailContext, ThumbnailData};
@@ -73,7 +74,7 @@ pub async fn get_or_generate_thumbnail(
     }
 
     Ok(ThumbnailData {
-        data: webp_bytes,
+        data: Bytes::from(webp_bytes),
         thumbnail_processor,
         thumbnail_version,
     })

--- a/src/services/media_processing_service/thumbnail/mod.rs
+++ b/src/services/media_processing_service/thumbnail/mod.rs
@@ -16,6 +16,7 @@ use super::resolve::{build_thumbnail_context, build_thumbnail_context_with_proce
 use super::shared::{StoredThumbnail, ThumbnailContext, ThumbnailData};
 
 pub use cache::delete_thumbnail;
+pub(crate) use cache::delete_thumbnail_with_driver;
 pub use preview::generate_and_store_image_preview;
 pub use probe::probe_ffmpeg_cli_command;
 

--- a/src/services/media_processing_service/thumbnail/preview.rs
+++ b/src/services/media_processing_service/thumbnail/preview.rs
@@ -1,6 +1,7 @@
 use crate::entities::file_blob;
 use crate::errors::Result;
 use crate::runtime::PrimaryAppState;
+use bytes::Bytes;
 
 use crate::services::media_processing_service::resolve::build_thumbnail_context;
 use crate::services::media_processing_service::shared::ImagePreviewData;
@@ -32,7 +33,7 @@ pub async fn generate_and_store_image_preview(
             "image preview cache hit"
         );
         return Ok(ImagePreviewData {
-            data: data.to_vec(),
+            data,
             image_preview_processor: preview_processor,
             image_preview_version: preview_version,
         });
@@ -66,7 +67,7 @@ pub async fn generate_and_store_image_preview(
     }
 
     Ok(ImagePreviewData {
-        data: webp_bytes,
+        data: Bytes::from(webp_bytes),
         image_preview_processor: preview_processor,
         image_preview_version: preview_version,
     })

--- a/src/services/media_processing_service/thumbnail/preview.rs
+++ b/src/services/media_processing_service/thumbnail/preview.rs
@@ -32,7 +32,7 @@ pub async fn generate_and_store_image_preview(
             "image preview cache hit"
         );
         return Ok(ImagePreviewData {
-            data,
+            data: data.to_vec(),
             image_preview_processor: preview_processor,
             image_preview_version: preview_version,
         });

--- a/src/services/task_service/blob_maintenance.rs
+++ b/src/services/task_service/blob_maintenance.rs
@@ -1,6 +1,7 @@
 //! Admin-triggered file blob maintenance tasks.
 
 use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
 
 use sea_orm::{ColumnTrait, EntityTrait, PaginatorTrait, QueryFilter, QueryOrder, QuerySelect};
 
@@ -10,6 +11,7 @@ use crate::entities::{background_task, file_blob};
 use crate::errors::{AsterError, Result};
 use crate::runtime::PrimaryAppState;
 use crate::services::workspace_storage_service::WorkspaceStorageScope;
+use crate::storage::StorageDriver;
 
 const BLOB_MAINTENANCE_BATCH_SIZE: u64 = 1_000;
 const BLOB_MAINTENANCE_PROGRESS_INTERVAL: i64 = 1_000;
@@ -115,6 +117,7 @@ pub(super) async fn process_blob_maintenance_task(
         orphan_blobs_deleted: 0,
         skipped_blobs: 0,
     };
+    let mut driver_cache = MaintenanceDriverCache::default();
 
     match payload.action {
         BlobMaintenanceAction::IntegrityCheck => {
@@ -125,6 +128,7 @@ pub(super) async fn process_blob_maintenance_task(
                 &target_scope,
                 total,
                 &mut result,
+                &mut driver_cache,
             )
             .await?;
             skip_reconcile_and_cleanup_steps(&mut steps)?;
@@ -142,6 +146,7 @@ pub(super) async fn process_blob_maintenance_task(
                 &target_scope,
                 total,
                 &mut result,
+                &mut driver_cache,
             )
             .await?;
             set_task_step_skipped(
@@ -163,6 +168,7 @@ pub(super) async fn process_blob_maintenance_task(
                 &target_scope,
                 total,
                 &mut result,
+                &mut driver_cache,
             )
             .await?;
             run_orphan_cleanup(
@@ -172,6 +178,7 @@ pub(super) async fn process_blob_maintenance_task(
                 &target_scope,
                 total,
                 &mut result,
+                &mut driver_cache,
             )
             .await?;
         }
@@ -203,6 +210,7 @@ async fn run_integrity_check(
     target_scope: &BlobTargetScope<'_>,
     total: i64,
     result: &mut BlobMaintenanceTaskResult,
+    driver_cache: &mut MaintenanceDriverCache,
 ) -> Result<()> {
     let lease_guard = context.lease_guard();
     context.ensure_active()?;
@@ -226,7 +234,7 @@ async fn run_integrity_check(
         for blob in blobs {
             context.ensure_active()?;
             progress += 1;
-            match check_blob_object(state, &blob).await {
+            match check_blob_object(state, driver_cache, &blob).await {
                 Ok(BlobObjectCheck::Present) => {
                     result.checked_objects += 1;
                 }
@@ -277,6 +285,7 @@ async fn run_ref_count_reconcile(
     target_scope: &BlobTargetScope<'_>,
     total: i64,
     result: &mut BlobMaintenanceTaskResult,
+    _driver_cache: &mut MaintenanceDriverCache,
 ) -> Result<()> {
     let lease_guard = context.lease_guard();
     context.ensure_active()?;
@@ -375,6 +384,7 @@ async fn run_orphan_cleanup(
     target_scope: &BlobTargetScope<'_>,
     total: i64,
     result: &mut BlobMaintenanceTaskResult,
+    driver_cache: &mut MaintenanceDriverCache,
 ) -> Result<()> {
     let lease_guard = context.lease_guard();
     context.ensure_active()?;
@@ -429,9 +439,10 @@ async fn run_orphan_cleanup(
                 Some(reconciled)
                     if reconciled.actual_refs == 0
                         && reconciled.blob.ref_count == 0
-                        && crate::services::file_service::cleanup_unreferenced_blob(
+                        && crate::services::file_service::cleanup_unreferenced_blob_with_driver(
                             state,
                             &reconciled.blob,
+                            &mut |policy| driver_cache.driver_for_policy(state, policy),
                         )
                         .await =>
                 {
@@ -479,12 +490,42 @@ enum BlobObjectCheck {
     SizeMismatch,
 }
 
+#[derive(Default)]
+struct MaintenanceDriverCache {
+    drivers: HashMap<i64, Arc<dyn StorageDriver>>,
+}
+
+impl MaintenanceDriverCache {
+    fn driver_for_policy(
+        &mut self,
+        state: &PrimaryAppState,
+        policy: &crate::entities::storage_policy::Model,
+    ) -> Result<Arc<dyn StorageDriver>> {
+        if let Some(driver) = state.driver_registry.get_cached_driver(policy.id) {
+            return Ok(driver);
+        }
+
+        if let Some(driver) = self.drivers.get(&policy.id) {
+            return Ok(driver.clone());
+        }
+
+        // Blob maintenance may scan every object on a cold COS/S3 policy. If
+        // normal traffic has already warmed the shared registry, reuse that
+        // Arc; otherwise keep the driver only for this task so maintenance does
+        // not turn a cold policy into a process-lifetime HTTP client cache.
+        let driver = state.driver_registry.build_uncached_driver(policy)?;
+        self.drivers.insert(policy.id, driver.clone());
+        Ok(driver)
+    }
+}
+
 async fn check_blob_object(
     state: &PrimaryAppState,
+    driver_cache: &mut MaintenanceDriverCache,
     blob: &file_blob::Model,
 ) -> Result<BlobObjectCheck> {
     let policy = state.policy_snapshot.get_policy_or_err(blob.policy_id)?;
-    let driver = state.driver_registry.get_driver(&policy)?;
+    let driver = driver_cache.driver_for_policy(state, &policy)?;
     let metadata = match driver.metadata(&blob.storage_path).await {
         Ok(metadata) => metadata,
         Err(error) => {

--- a/src/services/task_service/dispatch/execute.rs
+++ b/src/services/task_service/dispatch/execute.rs
@@ -80,11 +80,13 @@ async fn process_claimed_task(
         lease_guard.clone(),
         heartbeat_stop.clone(),
     );
+    let heartbeat_cancel_guard = heartbeat_stop.clone().drop_guard();
 
     let task_result = match context.ensure_active() {
         Ok(()) => registry::process_task(state, &task, context).await,
         Err(error) => Err(error),
     };
+    drop(heartbeat_cancel_guard);
     stop_task_heartbeat(heartbeat_stop, heartbeat_handle).await;
 
     match task_result {

--- a/src/services/task_service/dispatch/execute.rs
+++ b/src/services/task_service/dispatch/execute.rs
@@ -1,8 +1,10 @@
 use std::future::Future;
+use std::time::Duration as StdDuration;
 
 use chrono::{Duration, Utc};
 use futures::stream::{self, StreamExt};
 use sea_orm::ActiveEnum;
+use tokio::task::JoinHandle;
 use tokio::time::MissedTickBehavior;
 use tokio_util::sync::CancellationToken;
 
@@ -64,54 +66,26 @@ async fn process_claimed_task(
     lease: TaskLease,
     shutdown_token: CancellationToken,
 ) -> Result<TaskDispatchOutcome> {
-    let mut heartbeat =
-        tokio::time::interval(std::time::Duration::from_secs(TASK_HEARTBEAT_INTERVAL_SECS));
-    heartbeat.set_missed_tick_behavior(MissedTickBehavior::Delay);
-    heartbeat.tick().await;
     let context = TaskExecutionContext::new(lease, shutdown_token);
     let lease_guard = context.lease_guard().clone();
+    let heartbeat_stop = CancellationToken::new();
+    // Heartbeat must run in its own task. With SQLite the writer pool has one
+    // connection; keeping heartbeat in a select! with the business future can
+    // pause a future that already acquired that connection, then wait forever
+    // for a second writer connection.
+    let heartbeat_handle = spawn_task_heartbeat(
+        state.clone(),
+        task.id,
+        lease.processing_token,
+        lease_guard.clone(),
+        heartbeat_stop.clone(),
+    );
 
-    // 外层 select! 同时盯两件事：
-    // 1. 真实业务流程是否完成；
-    // 2. heartbeat 是否还能继续证明“我还是当前合法 worker”。
-    //
-    // 注意这里只能取消 async 外壳。真正耗时的压缩/解压是在 spawn_blocking 里，
-    // 所以业务代码内部也必须周期性检查 lease guard，才能把旧 worker 真正停下来。
     let task_result = match context.ensure_active() {
-        Ok(()) => {
-            let process_future = registry::process_task(state, &task, context);
-            tokio::pin!(process_future);
-
-            loop {
-                tokio::select! {
-                    biased;
-                    result = &mut process_future => break result,
-                    _ = heartbeat.tick() => {
-                        // 心跳写入返回 Err 时不能直接把 worker 判死，否则一次瞬时 DB 抖动
-                        // 就会在 60 秒后把长任务误判成 stale 并触发二次认领。
-                        match evaluate_heartbeat_result(
-                            &lease_guard,
-                            {
-                                let now = Utc::now();
-                                background_task_repo::touch_heartbeat(
-                                    state.writer_db(),
-                                    task.id,
-                                    lease.processing_token,
-                                    now,
-                                    task_lease_expires_at(now),
-                                )
-                                .await
-                            },
-                        ) {
-                            Ok(()) => {}
-                            Err(error) => break Err(error),
-                        }
-                    }
-                }
-            }
-        }
+        Ok(()) => registry::process_task(state, &task, context).await,
         Err(error) => Err(error),
     };
+    stop_task_heartbeat(heartbeat_stop, heartbeat_handle).await;
 
     match task_result {
         Ok(()) => {
@@ -225,6 +199,90 @@ async fn process_claimed_task(
                 })
             }
         }
+    }
+}
+
+fn spawn_task_heartbeat(
+    state: PrimaryAppState,
+    task_id: i64,
+    processing_token: i64,
+    lease_guard: TaskLeaseGuard,
+    stop_token: CancellationToken,
+) -> JoinHandle<()> {
+    spawn_task_heartbeat_with_interval(
+        state,
+        task_id,
+        processing_token,
+        lease_guard,
+        stop_token,
+        StdDuration::from_secs(TASK_HEARTBEAT_INTERVAL_SECS),
+    )
+}
+
+pub(super) fn spawn_task_heartbeat_with_interval(
+    state: PrimaryAppState,
+    task_id: i64,
+    processing_token: i64,
+    lease_guard: TaskLeaseGuard,
+    stop_token: CancellationToken,
+    interval: StdDuration,
+) -> JoinHandle<()> {
+    tokio::spawn(async move {
+        run_task_heartbeat_loop(
+            state,
+            task_id,
+            processing_token,
+            lease_guard,
+            stop_token,
+            interval,
+        )
+        .await;
+    })
+}
+
+async fn run_task_heartbeat_loop(
+    state: PrimaryAppState,
+    task_id: i64,
+    processing_token: i64,
+    lease_guard: TaskLeaseGuard,
+    stop_token: CancellationToken,
+    interval: StdDuration,
+) {
+    let mut heartbeat = tokio::time::interval(interval);
+    heartbeat.set_missed_tick_behavior(MissedTickBehavior::Delay);
+    heartbeat.tick().await;
+
+    loop {
+        tokio::select! {
+            _ = stop_token.cancelled() => return,
+            _ = heartbeat.tick() => {
+                let now = Utc::now();
+                // Let task completion cancel an in-flight pool acquire quickly.
+                // This keeps shutdown/finish paths from waiting on a heartbeat
+                // write that is no longer useful.
+                let result = tokio::select! {
+                    _ = stop_token.cancelled() => return,
+                    result = background_task_repo::touch_heartbeat(
+                        state.writer_db(),
+                        task_id,
+                        processing_token,
+                        now,
+                        task_lease_expires_at(now),
+                    ) => result,
+                };
+
+                if evaluate_heartbeat_result(&lease_guard, result).is_err() {
+                    return;
+                }
+            }
+        }
+    }
+}
+
+async fn stop_task_heartbeat(stop_token: CancellationToken, heartbeat_handle: JoinHandle<()>) {
+    stop_token.cancel();
+    if let Err(error) = heartbeat_handle.await {
+        tracing::warn!(error = %error, "background task heartbeat worker stopped unexpectedly");
     }
 }
 

--- a/src/services/task_service/dispatch/tests.rs
+++ b/src/services/task_service/dispatch/tests.rs
@@ -9,7 +9,7 @@ use tokio::time::{Duration, sleep};
 
 use crate::config::DatabaseConfig;
 use crate::db::repository::background_task_repo;
-use crate::db::{self, repository::config_repo};
+use crate::db::{self, repository::config_repo, transaction};
 use crate::entities::background_task;
 use crate::errors::AsterError;
 use crate::services::task_service::{
@@ -23,7 +23,8 @@ use tokio_util::sync::CancellationToken;
 
 use super::claim::{TaskClaimCandidate, available_lane_capacity, claim_candidates_for_lane};
 use super::execute::{
-    evaluate_heartbeat_result, run_claimed_tasks, run_with_concurrency_limit, task_retry_class,
+    evaluate_heartbeat_result, run_claimed_tasks, run_with_concurrency_limit,
+    spawn_task_heartbeat_with_interval, task_retry_class,
 };
 use super::lane::{TaskLane, TaskLaneConfig, task_lane};
 
@@ -288,6 +289,41 @@ async fn run_claimed_tasks_releases_pre_cancelled_task_without_running_handler()
     assert_eq!(stored.last_error, None);
     assert_eq!(stored.failure_can_retry, None);
     assert_eq!(stored.finished_at, None);
+}
+
+#[tokio::test]
+async fn task_heartbeat_can_stop_while_sqlite_writer_pool_is_busy() {
+    let state = build_dispatch_test_state().await;
+    let task = insert_processing_system_runtime_task(state.writer_db()).await;
+    let lease = TaskLease::new(task.id, task.processing_token);
+    let lease_guard = TaskLeaseGuard::with_renewal_timeout(lease, Duration::from_secs(60));
+    let stop_token = CancellationToken::new();
+    let writer_txn = transaction::begin(state.writer_db())
+        .await
+        .expect("test should acquire the only SQLite writer connection");
+
+    // Regression guard for SQLite single-writer deployments: heartbeat may be
+    // waiting in pool acquire while task code holds the only writer connection,
+    // but cancelling the heartbeat must still let task completion proceed.
+    let heartbeat = spawn_task_heartbeat_with_interval(
+        state.clone(),
+        task.id,
+        task.processing_token,
+        lease_guard,
+        stop_token.clone(),
+        Duration::from_millis(10),
+    );
+    sleep(Duration::from_millis(30)).await;
+
+    stop_token.cancel();
+    tokio::time::timeout(Duration::from_millis(200), heartbeat)
+        .await
+        .expect("heartbeat should stop without waiting for the busy SQLite writer pool")
+        .expect("heartbeat task should not panic");
+
+    transaction::rollback(writer_txn)
+        .await
+        .expect("test writer transaction should roll back");
 }
 
 #[test]

--- a/src/services/task_service/storage_migration.rs
+++ b/src/services/task_service/storage_migration.rs
@@ -3,6 +3,7 @@
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
+use bytes::Bytes;
 use tokio::io::{AsyncRead, AsyncReadExt, ReadBuf};
 
 use crate::db::repository::{
@@ -12,10 +13,10 @@ use crate::db::transaction;
 use crate::entities::{background_task, file_blob, storage_policy};
 use crate::errors::{AsterError, MapAsterErr, Result};
 use crate::runtime::PrimaryAppState;
-use crate::storage::StorageDriver;
+use crate::storage::{MultipartStorageDriver, StorageDriver, StorageErrorKind};
 use crate::types::BackgroundTaskKind;
 use crate::utils::hash::{new_sha256, sha256_digest_to_hex, sha256_hex};
-use crate::utils::numbers::u64_to_i64;
+use crate::utils::numbers::{bytes_to_usize, u64_to_i64};
 
 use super::spec::{self, StoragePolicyMigrationTask, decode_payload_as};
 use super::steps::{
@@ -33,6 +34,10 @@ use super::{
 };
 
 const MIGRATION_BATCH_SIZE: u64 = 100;
+const MIGRATION_MULTIPART_MIN_PART_SIZE: i64 = 5 * 1024 * 1024;
+const MIGRATION_MULTIPART_PREFERRED_MAX_PART_SIZE: i64 = 64 * 1024 * 1024;
+const MIGRATION_MULTIPART_MAX_PARTS: i64 = 10_000;
+const MIGRATION_MULTIPART_PART_UPLOAD_MAX_ATTEMPTS: usize = 3;
 const CHECKPOINT_STAGE_PREPARE_POLICIES: &str = "prepare_policies";
 const CHECKPOINT_STAGE_MIGRATE_BLOBS: &str = "migrate_blobs";
 const CHECKPOINT_STAGE_COMPLETE: &str = "complete";
@@ -62,6 +67,7 @@ struct BlobMigrationContext<'a> {
     task_id: i64,
     source_policy_id: i64,
     target_policy_id: i64,
+    target_multipart_part_size: i64,
     source_driver: &'a dyn StorageDriver,
     target_driver: &'a dyn StorageDriver,
 }
@@ -425,6 +431,7 @@ pub(super) async fn process_storage_policy_migration_task(
         task_id: task.id,
         source_policy_id: payload.source_policy_id,
         target_policy_id: payload.target_policy_id,
+        target_multipart_part_size: target_policy.chunk_size,
         source_driver: source_driver.as_ref(),
         target_driver: target_driver.as_ref(),
     };
@@ -552,6 +559,7 @@ async fn migrate_one_blob(
         task_id,
         source_policy_id,
         target_policy_id,
+        target_multipart_part_size,
         source_driver,
         target_driver,
     } = *migration;
@@ -618,6 +626,7 @@ async fn migrate_one_blob(
         source_driver,
         target_driver,
         target_policy_id,
+        target_multipart_part_size,
         &latest,
         &target_path,
     )
@@ -776,10 +785,32 @@ async fn copy_blob_streaming(
     source_driver: &dyn StorageDriver,
     target_driver: &dyn StorageDriver,
     target_policy_id: i64,
+    target_multipart_part_size: i64,
     blob: &file_blob::Model,
     target_path: &str,
 ) -> Result<()> {
     context.ensure_active()?;
+    if let Some(multipart) = target_driver.as_multipart()
+        && should_use_multipart_migration(blob.size, target_multipart_part_size)?
+    {
+        // Large single PUT streams are not safely retryable: the S3 SDK cannot
+        // clone an in-flight reader after a timeout. Multipart migration keeps
+        // each retryable unit bounded and aborts the upload before the blob row
+        // is moved if any part fails.
+        return copy_blob_multipart(
+            state,
+            context,
+            source_driver,
+            target_driver,
+            multipart,
+            target_policy_id,
+            target_multipart_part_size,
+            blob,
+            target_path,
+        )
+        .await;
+    }
+
     let source_stream = source_driver.get_stream(&blob.storage_path).await?;
     context.ensure_active()?;
     let hashing_reader = HashingReader::new(source_stream, context.clone());
@@ -820,6 +851,249 @@ async fn copy_blob_streaming(
     }
 
     Ok(())
+}
+
+async fn copy_blob_multipart(
+    state: &PrimaryAppState,
+    context: &TaskExecutionContext,
+    source_driver: &dyn StorageDriver,
+    target_driver: &dyn StorageDriver,
+    multipart: &dyn MultipartStorageDriver,
+    target_policy_id: i64,
+    target_multipart_part_size: i64,
+    blob: &file_blob::Model,
+    target_path: &str,
+) -> Result<()> {
+    context.ensure_active()?;
+    let mut source_stream = source_driver.get_stream(&blob.storage_path).await?;
+    let part_size = migration_multipart_part_size(blob.size, target_multipart_part_size)?;
+    let upload_id = multipart.create_multipart_upload(target_path).await?;
+    let mut completed_parts = Vec::new();
+    let mut hasher = new_sha256();
+    let mut remaining = blob.size;
+    let mut part_number = 1_i32;
+    let mut completed = false;
+
+    let result = async {
+        while remaining > 0 {
+            context.ensure_active()?;
+            let current_part_size = remaining.min(part_size);
+            let part_bytes =
+                read_multipart_part(&mut source_stream, current_part_size, &mut hasher).await?;
+            let etag = upload_multipart_part_with_retry(
+                multipart,
+                target_path,
+                &upload_id,
+                part_number,
+                part_bytes,
+            )
+            .await?;
+            completed_parts.push((part_number, etag));
+            remaining -= current_part_size;
+            part_number = part_number.checked_add(1).ok_or_else(|| {
+                AsterError::internal_error("storage migration multipart part number overflow")
+            })?;
+        }
+
+        ensure_source_stream_finished(&mut source_stream).await?;
+        context.ensure_active()?;
+        complete_migration_multipart_upload(
+            context,
+            target_driver,
+            multipart,
+            target_path,
+            &upload_id,
+            completed_parts,
+            blob.size,
+        )
+        .await?;
+        completed = true;
+
+        let copied_hash = sha256_digest_to_hex(&sha2::Digest::finalize(hasher));
+        if is_content_sha256_blob_key(&blob.hash) && copied_hash != blob.hash {
+            return Err(AsterError::storage_driver_error(format!(
+                "copied blob hash mismatch for blob #{}",
+                blob.id
+            )));
+        }
+        verify_target_object(context, target_driver, target_path, &copied_hash, blob.size).await
+    }
+    .await;
+
+    if let Err(error) = result {
+        if !completed {
+            abort_migration_multipart_upload(multipart, target_path, &upload_id).await;
+        }
+        cleanup_failed_target_object(state, context, target_driver, target_policy_id, target_path)
+            .await;
+        return Err(error);
+    }
+
+    Ok(())
+}
+
+fn should_use_multipart_migration(blob_size: i64, configured_part_size: i64) -> Result<bool> {
+    if blob_size < 0 {
+        return Err(AsterError::internal_error(format!(
+            "storage migration blob size cannot be negative: {blob_size}"
+        )));
+    }
+    Ok(blob_size > migration_multipart_part_size(blob_size, configured_part_size)?)
+}
+
+fn migration_multipart_part_size(blob_size: i64, configured_part_size: i64) -> Result<i64> {
+    if blob_size < 0 {
+        return Err(AsterError::internal_error(format!(
+            "storage migration blob size cannot be negative: {blob_size}"
+        )));
+    }
+    let configured_part_size = configured_part_size
+        .max(MIGRATION_MULTIPART_MIN_PART_SIZE)
+        .min(MIGRATION_MULTIPART_PREFERRED_MAX_PART_SIZE);
+    let count_limited_part_size = if blob_size == 0 {
+        MIGRATION_MULTIPART_MIN_PART_SIZE
+    } else {
+        blob_size
+            .checked_add(MIGRATION_MULTIPART_MAX_PARTS - 1)
+            .ok_or_else(|| {
+                AsterError::internal_error("storage migration multipart size overflow")
+            })?
+            / MIGRATION_MULTIPART_MAX_PARTS
+    };
+    // Prefer bounded memory during migration, but S3-compatible providers cap
+    // multipart uploads at 10,000 parts, so extremely large blobs may need a
+    // larger part size to stay within the protocol limit.
+    Ok(configured_part_size.max(count_limited_part_size))
+}
+
+async fn read_multipart_part(
+    stream: &mut Box<dyn AsyncRead + Unpin + Send>,
+    expected_size: i64,
+    hasher: &mut sha2::Sha256,
+) -> Result<Bytes> {
+    let expected_size = bytes_to_usize(expected_size, "storage migration multipart part size")?;
+    let mut data = Vec::with_capacity(expected_size);
+    let mut buffer = vec![0_u8; 64 * 1024];
+    while data.len() < expected_size {
+        let read_len = buffer.len().min(expected_size - data.len());
+        let read = stream
+            .read(&mut buffer[..read_len])
+            .await
+            .map_aster_err_ctx(
+                "read source object multipart part",
+                AsterError::storage_driver_error,
+            )?;
+        if read == 0 {
+            return Err(AsterError::storage_driver_error(format!(
+                "source object ended before expected multipart part size {expected_size}"
+            )));
+        }
+        sha2::Digest::update(hasher, &buffer[..read]);
+        data.extend_from_slice(&buffer[..read]);
+    }
+    Ok(Bytes::from(data))
+}
+
+async fn ensure_source_stream_finished(
+    stream: &mut Box<dyn AsyncRead + Unpin + Send>,
+) -> Result<()> {
+    let mut extra = [0_u8; 1];
+    let read = stream.read(&mut extra).await.map_aster_err_ctx(
+        "read source object after expected multipart size",
+        AsterError::storage_driver_error,
+    )?;
+    if read > 0 {
+        return Err(AsterError::storage_driver_error(
+            "source object exceeds expected blob size",
+        ));
+    }
+    Ok(())
+}
+
+async fn upload_multipart_part_with_retry(
+    multipart: &dyn MultipartStorageDriver,
+    target_path: &str,
+    upload_id: &str,
+    part_number: i32,
+    part_bytes: Bytes,
+) -> Result<String> {
+    for attempt in 1..=MIGRATION_MULTIPART_PART_UPLOAD_MAX_ATTEMPTS {
+        match multipart
+            .upload_multipart_part_bytes(target_path, upload_id, part_number, part_bytes.clone())
+            .await
+        {
+            Ok(etag) => return Ok(etag),
+            Err(error)
+                if storage_error_is_retryable(&error)
+                    && attempt < MIGRATION_MULTIPART_PART_UPLOAD_MAX_ATTEMPTS =>
+            {
+                tracing::warn!(
+                    target_path,
+                    part_number,
+                    attempt,
+                    error = %error,
+                    "storage migration multipart part upload failed; retrying"
+                );
+                tokio::time::sleep(std::time::Duration::from_millis(
+                    200_u64.saturating_mul(u64::try_from(attempt).unwrap_or(u64::MAX)),
+                ))
+                .await;
+            }
+            Err(error) => return Err(error),
+        }
+    }
+    Err(AsterError::internal_error(
+        "storage migration multipart retry loop exhausted unexpectedly",
+    ))
+}
+
+async fn complete_migration_multipart_upload(
+    context: &TaskExecutionContext,
+    target_driver: &dyn StorageDriver,
+    multipart: &dyn MultipartStorageDriver,
+    target_path: &str,
+    upload_id: &str,
+    completed_parts: Vec<(i32, String)>,
+    expected_size: i64,
+) -> Result<()> {
+    if let Err(error) = multipart
+        .complete_multipart_upload(target_path, upload_id, completed_parts)
+        .await
+    {
+        if storage_error_is_retryable(&error)
+            && let Ok(metadata) = target_driver.metadata(target_path).await
+            && u64_to_i64(metadata.size, "completed multipart object size")? == expected_size
+        {
+            context.ensure_active()?;
+            return Ok(());
+        }
+        return Err(error);
+    }
+    Ok(())
+}
+
+async fn abort_migration_multipart_upload(
+    multipart: &dyn MultipartStorageDriver,
+    target_path: &str,
+    upload_id: &str,
+) {
+    if let Err(error) = multipart
+        .abort_multipart_upload(target_path, upload_id)
+        .await
+    {
+        tracing::warn!(
+            target_path,
+            upload_id,
+            "failed to abort storage migration multipart upload: {error}"
+        );
+    }
+}
+
+fn storage_error_is_retryable(error: &AsterError) -> bool {
+    matches!(
+        error.storage_error_kind(),
+        Some(StorageErrorKind::Transient | StorageErrorKind::RateLimited)
+    )
 }
 
 async fn cleanup_failed_target_object(

--- a/src/services/task_service/storage_migration.rs
+++ b/src/services/task_service/storage_migration.rs
@@ -791,7 +791,13 @@ async fn copy_blob_streaming(
         .put_reader(target_path, Box::new(hashing_reader), blob.size)
         .await;
     if let Err(error) = upload_result {
+        // A streaming PUT can fail after the remote side has already accepted
+        // bytes, especially when the client times out waiting for the response.
+        // The blob row has not moved yet, so best-effort cleanup prevents
+        // repeated migration retries from leaving orphan target objects behind.
         context.ensure_active()?;
+        cleanup_failed_target_object(state, context, target_driver, target_policy_id, target_path)
+            .await;
         return Err(error);
     }
     context.ensure_active()?;
@@ -808,7 +814,8 @@ async fn copy_blob_streaming(
     .await;
 
     if let Err(error) = verify_result {
-        cleanup_failed_target_object(state, target_driver, target_policy_id, target_path).await;
+        cleanup_failed_target_object(state, context, target_driver, target_policy_id, target_path)
+            .await;
         return Err(error);
     }
 
@@ -817,11 +824,28 @@ async fn copy_blob_streaming(
 
 async fn cleanup_failed_target_object(
     state: &PrimaryAppState,
+    context: &TaskExecutionContext,
     target_driver: &dyn StorageDriver,
     target_policy_id: i64,
     target_path: &str,
 ) {
+    if let Err(error) = context.ensure_active() {
+        tracing::warn!(
+            target_path,
+            target_policy_id,
+            "skip target object cleanup because task lease is no longer active: {error}"
+        );
+        return;
+    }
     if target_object_is_referenced(state, target_policy_id, target_path).await {
+        return;
+    }
+    if let Err(error) = context.ensure_active() {
+        tracing::warn!(
+            target_path,
+            target_policy_id,
+            "skip target object cleanup after reference check because task lease is no longer active: {error}"
+        );
         return;
     }
     if let Err(cleanup_error) = target_driver.delete(target_path).await {

--- a/src/services/task_service/storage_migration.rs
+++ b/src/services/task_service/storage_migration.rs
@@ -959,25 +959,12 @@ async fn read_multipart_part(
     hasher: &mut sha2::Sha256,
 ) -> Result<Bytes> {
     let expected_size = bytes_to_usize(expected_size, "storage migration multipart part size")?;
-    let mut data = Vec::with_capacity(expected_size);
-    let mut buffer = vec![0_u8; 64 * 1024];
-    while data.len() < expected_size {
-        let read_len = buffer.len().min(expected_size - data.len());
-        let read = stream
-            .read(&mut buffer[..read_len])
-            .await
-            .map_aster_err_ctx(
-                "read source object multipart part",
-                AsterError::storage_driver_error,
-            )?;
-        if read == 0 {
-            return Err(AsterError::storage_driver_error(format!(
-                "source object ended before expected multipart part size {expected_size}"
-            )));
-        }
-        sha2::Digest::update(hasher, &buffer[..read]);
-        data.extend_from_slice(&buffer[..read]);
-    }
+    let mut data = vec![0_u8; expected_size];
+    stream.read_exact(&mut data).await.map_aster_err_ctx(
+        "read source object multipart part",
+        AsterError::storage_driver_error,
+    )?;
+    sha2::Digest::update(hasher, &data);
     Ok(Bytes::from(data))
 }
 

--- a/src/services/task_service/storage_migration.rs
+++ b/src/services/task_service/storage_migration.rs
@@ -559,9 +559,8 @@ async fn migrate_one_blob(
         task_id,
         source_policy_id,
         target_policy_id,
-        target_multipart_part_size,
-        source_driver,
         target_driver,
+        ..
     } = *migration;
     let latest = match file_repo::find_blob_by_id(state.writer_db(), blob.id).await {
         Ok(blob) => blob,
@@ -620,17 +619,7 @@ async fn migrate_one_blob(
     };
     let target_path = crate::utils::storage_path_from_blob_key(&target_hash);
 
-    copy_blob_streaming(
-        state,
-        context,
-        source_driver,
-        target_driver,
-        target_policy_id,
-        target_multipart_part_size,
-        &latest,
-        &target_path,
-    )
-    .await?;
+    copy_blob_streaming(migration, &latest, &target_path).await?;
     let moved = transaction::with_transaction(state.writer_db(), async |txn| {
         let moved = file_repo::move_blob_policy_if_current(
             txn,
@@ -780,15 +769,19 @@ fn checkpoint_delta(
 }
 
 async fn copy_blob_streaming(
-    state: &PrimaryAppState,
-    context: &TaskExecutionContext,
-    source_driver: &dyn StorageDriver,
-    target_driver: &dyn StorageDriver,
-    target_policy_id: i64,
-    target_multipart_part_size: i64,
+    migration: &BlobMigrationContext<'_>,
     blob: &file_blob::Model,
     target_path: &str,
 ) -> Result<()> {
+    let BlobMigrationContext {
+        state,
+        execution: context,
+        target_policy_id,
+        target_multipart_part_size,
+        source_driver,
+        target_driver,
+        ..
+    } = *migration;
     context.ensure_active()?;
     if let Some(multipart) = target_driver.as_multipart()
         && should_use_multipart_migration(blob.size, target_multipart_part_size)?
@@ -797,18 +790,7 @@ async fn copy_blob_streaming(
         // clone an in-flight reader after a timeout. Multipart migration keeps
         // each retryable unit bounded and aborts the upload before the blob row
         // is moved if any part fails.
-        return copy_blob_multipart(
-            state,
-            context,
-            source_driver,
-            target_driver,
-            multipart,
-            target_policy_id,
-            target_multipart_part_size,
-            blob,
-            target_path,
-        )
-        .await;
+        return copy_blob_multipart(migration, multipart, blob, target_path).await;
     }
 
     let source_stream = source_driver.get_stream(&blob.storage_path).await?;
@@ -854,16 +836,20 @@ async fn copy_blob_streaming(
 }
 
 async fn copy_blob_multipart(
-    state: &PrimaryAppState,
-    context: &TaskExecutionContext,
-    source_driver: &dyn StorageDriver,
-    target_driver: &dyn StorageDriver,
+    migration: &BlobMigrationContext<'_>,
     multipart: &dyn MultipartStorageDriver,
-    target_policy_id: i64,
-    target_multipart_part_size: i64,
     blob: &file_blob::Model,
     target_path: &str,
 ) -> Result<()> {
+    let BlobMigrationContext {
+        state,
+        execution: context,
+        target_policy_id,
+        target_multipart_part_size,
+        source_driver,
+        target_driver,
+        ..
+    } = *migration;
     context.ensure_active()?;
     let mut source_stream = source_driver.get_stream(&blob.storage_path).await?;
     let part_size = migration_multipart_part_size(blob.size, target_multipart_part_size)?;
@@ -947,9 +933,10 @@ fn migration_multipart_part_size(blob_size: i64, configured_part_size: i64) -> R
             "storage migration blob size cannot be negative: {blob_size}"
         )));
     }
-    let configured_part_size = configured_part_size
-        .max(MIGRATION_MULTIPART_MIN_PART_SIZE)
-        .min(MIGRATION_MULTIPART_PREFERRED_MAX_PART_SIZE);
+    let configured_part_size = configured_part_size.clamp(
+        MIGRATION_MULTIPART_MIN_PART_SIZE,
+        MIGRATION_MULTIPART_PREFERRED_MAX_PART_SIZE,
+    );
     let count_limited_part_size = if blob_size == 0 {
         MIGRATION_MULTIPART_MIN_PART_SIZE
     } else {

--- a/src/services/team_service/archive.rs
+++ b/src/services/team_service/archive.rs
@@ -77,8 +77,10 @@ async fn cleanup_team_upload_sessions(
                             "failed to abort team multipart upload during cleanup: {err}"
                         );
                         incomplete_cleanups += 1;
-                    } else {
+                    } else if cleanup_team_temp_object(driver.as_ref(), session, temp_key).await {
                         aborted_multipart_uploads += 1;
+                    } else {
+                        incomplete_cleanups += 1;
                     }
                 } else if cleanup_team_temp_object(driver.as_ref(), session, temp_key).await {
                     cleaned_temp_objects += 1;

--- a/src/services/team_service/archive.rs
+++ b/src/services/team_service/archive.rs
@@ -36,9 +36,10 @@ fn load_team_archive_retention_days(state: &PrimaryAppState) -> i64 {
 async fn cleanup_team_upload_sessions(
     state: &PrimaryAppState,
     sessions: &[upload_session::Model],
-) -> Result<()> {
+) -> Result<bool> {
     let mut cleaned_temp_objects = 0u64;
     let mut aborted_multipart_uploads = 0u64;
+    let mut incomplete_cleanups = 0u64;
     for session in sessions {
         let Some(temp_key) = session.s3_temp_key.as_deref() else {
             continue;
@@ -50,6 +51,7 @@ async fn cleanup_team_upload_sessions(
                 temp_key,
                 "failed to load storage policy while cleaning team upload session"
             );
+            incomplete_cleanups += 1;
             continue;
         };
         let Ok(driver) = state.driver_registry.get_driver(&policy) else {
@@ -59,6 +61,7 @@ async fn cleanup_team_upload_sessions(
                 temp_key,
                 "failed to resolve storage driver while cleaning team upload session"
             );
+            incomplete_cleanups += 1;
             continue;
         };
 
@@ -73,17 +76,19 @@ async fn cleanup_team_upload_sessions(
                             upload_id = %session.id,
                             "failed to abort team multipart upload during cleanup: {err}"
                         );
+                        incomplete_cleanups += 1;
                     } else {
                         aborted_multipart_uploads += 1;
                     }
+                } else if cleanup_team_temp_object(driver.as_ref(), session, temp_key).await {
+                    cleaned_temp_objects += 1;
+                } else {
+                    incomplete_cleanups += 1;
                 }
-            } else if let Err(err) = driver.delete(temp_key).await {
-                tracing::warn!(
-                    upload_id = %session.id,
-                    "failed to delete team temp upload object during cleanup: {err}"
-                );
-            } else {
+            } else if cleanup_team_temp_object(driver.as_ref(), session, temp_key).await {
                 cleaned_temp_objects += 1;
+            } else {
+                incomplete_cleanups += 1;
             }
         }
 
@@ -97,10 +102,40 @@ async fn cleanup_team_upload_sessions(
             upload_session_count = sessions.len(),
             cleaned_temp_objects,
             aborted_multipart_uploads,
+            incomplete_cleanups,
             "cleaned team upload sessions"
         );
     }
-    Ok(())
+    Ok(incomplete_cleanups == 0)
+}
+
+async fn cleanup_team_temp_object(
+    driver: &dyn crate::storage::StorageDriver,
+    session: &upload_session::Model,
+    temp_key: &str,
+) -> bool {
+    match driver.delete(temp_key).await {
+        Ok(()) => true,
+        Err(err) => match driver.exists(temp_key).await {
+            Ok(false) => true,
+            Ok(true) => {
+                tracing::warn!(
+                    upload_id = %session.id,
+                    temp_key,
+                    "failed to delete team temp upload object during cleanup: {err}"
+                );
+                false
+            }
+            Err(exists_err) => {
+                tracing::warn!(
+                    upload_id = %session.id,
+                    temp_key,
+                    "failed to delete team temp upload object and verify existence during cleanup: delete_error={err}, exists_error={exists_err}"
+                );
+                false
+            }
+        },
+    }
 }
 
 fn is_missing_cleanup_target(err: &AsterError) -> bool {
@@ -193,7 +228,13 @@ async fn force_delete_archived_team(state: &PrimaryAppState, team: team::Model) 
         "force deleting archived team"
     );
     let upload_sessions = upload_session_repo::find_by_team(state.writer_db(), team_id).await?;
-    cleanup_team_upload_sessions(state, &upload_sessions).await?;
+    if !cleanup_team_upload_sessions(state, &upload_sessions).await? {
+        // Upload sessions are the only durable handles for temp objects. Abort
+        // the team delete before removing those rows so the next cleanup run can retry.
+        return Err(AsterError::storage_driver_error(
+            "team upload session cleanup incomplete",
+        ));
+    }
 
     purge_archived_team_files(state, &team).await?;
 

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -18,7 +18,7 @@ pub use policy_snapshot::PolicySnapshot;
 pub use registry::DriverRegistry;
 pub use traits::driver::{
     BlobMetadata, PresignedDownloadOptions, StorageDriver, StoragePathVisitor,
-    driver_type_supports_native_thumbnail,
+    driver_type_supports_native_media_metadata, driver_type_supports_native_thumbnail,
 };
 pub use traits::{
     ListStorageDriver, LocalPathStorageDriver, MultipartStorageDriver, NativeMediaMetadataRequest,

--- a/src/storage/registry.rs
+++ b/src/storage/registry.rs
@@ -74,6 +74,12 @@ impl DriverRegistry {
         Ok(self.get_entry(policy)?.storage_driver())
     }
 
+    pub(crate) fn get_cached_driver(&self, policy_id: i64) -> Option<Arc<dyn StorageDriver>> {
+        self.drivers
+            .get(&policy_id)
+            .map(|entry| entry.storage_driver())
+    }
+
     /// 获取支持 multipart upload 的 driver。
     ///
     /// 如果策略对应的 driver 不支持 multipart（如 LocalDriver），返回 `Err`。
@@ -90,6 +96,17 @@ impl DriverRegistry {
                 ),
             )
         })
+    }
+
+    pub(crate) fn build_uncached_driver(
+        &self,
+        policy: &storage_policy::Model,
+    ) -> Result<Arc<dyn StorageDriver>> {
+        // Long-running maintenance jobs may touch cold object-storage policies once
+        // and then go idle for hours. Build a driver for that job without inserting
+        // it into the shared registry, so SDK clients and HTTP pools do not become
+        // process-lifetime cache entries just because maintenance scanned them.
+        Ok(self.create_entry(policy)?.storage_driver())
     }
 
     /// 策略更新后使缓存的 driver 失效
@@ -186,6 +203,11 @@ impl DriverRegistry {
                 multipart: Some(multipart),
             },
         );
+    }
+
+    #[cfg(any(test, debug_assertions))]
+    pub fn has_cached_driver_for_test(&self, policy_id: i64) -> bool {
+        self.drivers.contains_key(&policy_id)
     }
 
     fn get_entry(&self, policy: &storage_policy::Model) -> Result<DriverEntry> {
@@ -500,6 +522,56 @@ mod tests {
             Arc::ptr_eq(&driver1, &driver2),
             "metrics wrapper should be cached with the driver entry"
         );
+    }
+
+    #[test]
+    fn uncached_driver_build_does_not_populate_shared_cache() {
+        let registry = DriverRegistry::new(Arc::new(CapturingMetrics::default()));
+        let policy = local_policy();
+
+        let uncached = registry
+            .build_uncached_driver(&policy)
+            .expect("uncached local driver should be created");
+
+        assert!(
+            !registry.has_cached_driver_for_test(policy.id),
+            "uncached construction must not insert a shared registry entry"
+        );
+
+        let cached = registry
+            .get_driver(&policy)
+            .expect("cached local driver should be created separately");
+        assert!(
+            !Arc::ptr_eq(&uncached, &cached),
+            "the later shared-cache lookup should not reuse the task-local driver"
+        );
+        assert!(
+            registry.has_cached_driver_for_test(policy.id),
+            "normal get_driver should still populate the shared cache"
+        );
+    }
+
+    #[test]
+    fn cached_driver_lookup_is_read_only() {
+        let registry = DriverRegistry::new(Arc::new(CapturingMetrics::default()));
+        let policy = local_policy();
+
+        assert!(
+            registry.get_cached_driver(policy.id).is_none(),
+            "cold cache lookup must not construct a driver"
+        );
+        assert!(
+            !registry.has_cached_driver_for_test(policy.id),
+            "cold cache lookup must leave the shared cache empty"
+        );
+
+        let cached = registry
+            .get_driver(&policy)
+            .expect("driver should be cached by normal lookup");
+        let cached_lookup = registry
+            .get_cached_driver(policy.id)
+            .expect("cached lookup should return the existing driver");
+        assert!(Arc::ptr_eq(&cached, &cached_lookup));
     }
 
     #[tokio::test]

--- a/src/storage/traits/driver.rs
+++ b/src/storage/traits/driver.rs
@@ -27,6 +27,15 @@ pub fn driver_type_supports_native_thumbnail(driver_type: DriverType) -> bool {
     }
 }
 
+pub fn driver_type_supports_native_media_metadata(driver_type: DriverType) -> bool {
+    match driver_type {
+        DriverType::Local => false,
+        DriverType::S3 => false,
+        DriverType::TencentCos => true,
+        DriverType::Remote => false,
+    }
+}
+
 pub trait StoragePathVisitor: Send {
     fn visit_path(&mut self, path: String) -> Result<()>;
 }
@@ -240,6 +249,20 @@ mod tests {
             DriverType::TencentCos
         ));
         assert!(!driver_type_supports_native_thumbnail(DriverType::Remote));
+    }
+
+    #[test]
+    fn only_vendor_drivers_with_native_processors_support_native_media_metadata() {
+        assert!(!driver_type_supports_native_media_metadata(
+            DriverType::Local
+        ));
+        assert!(!driver_type_supports_native_media_metadata(DriverType::S3));
+        assert!(driver_type_supports_native_media_metadata(
+            DriverType::TencentCos
+        ));
+        assert!(!driver_type_supports_native_media_metadata(
+            DriverType::Remote
+        ));
     }
 
     #[tokio::test]

--- a/src/storage/traits/driver.rs
+++ b/src/storage/traits/driver.rs
@@ -51,7 +51,12 @@ pub trait StorageDriver: Send + Sync {
     /// 写入文件，返回最终存储路径
     async fn put(&self, path: &str, data: &[u8]) -> Result<String>;
 
-    /// 读取文件全部内容
+    /// 读取文件全部内容。
+    ///
+    /// 这个方法只适合缩略图、manifest、探测数据等有明确大小上限的小对象，
+    /// 或作为不支持 seek/read 优化的驱动兼容兜底。用户文件传输、复制、预览
+    /// 和后台任务处理大对象时应优先使用 `get_stream()` / `get_range()`，避免把
+    /// 整个 blob 读入内存。
     async fn get(&self, path: &str) -> Result<Vec<u8>>;
 
     /// 获取文件流（大文件下载）

--- a/src/storage/traits/mod.rs
+++ b/src/storage/traits/mod.rs
@@ -6,7 +6,7 @@ pub mod multipart;
 
 pub use driver::{
     BlobMetadata, PresignedDownloadOptions, StorageDriver, StoragePathVisitor,
-    driver_type_supports_native_thumbnail,
+    driver_type_supports_native_media_metadata, driver_type_supports_native_thumbnail,
 };
 pub use extensions::{
     ListStorageDriver, LocalPathStorageDriver, NativeMediaMetadataRequest,

--- a/src/webdav/mod.rs
+++ b/src/webdav/mod.rs
@@ -195,18 +195,6 @@ pub async fn webdav_handler(
     }
 }
 
-async fn collect_payload(payload: &mut web::Payload) -> Result<Vec<u8>, HttpResponse> {
-    let mut data = Vec::new();
-    while let Some(chunk) = payload.next().await {
-        let chunk = match chunk {
-            Ok(chunk) => chunk,
-            Err(_) => return Err(HttpResponse::BadRequest().body("Failed to read request body")),
-        };
-        data.extend_from_slice(&chunk);
-    }
-    Ok(data)
-}
-
 async fn collect_xml_payload(
     payload: &mut web::Payload,
     max_len: usize,

--- a/src/webdav/resources/mod.rs
+++ b/src/webdav/resources/mod.rs
@@ -169,64 +169,6 @@ async fn ensure_empty_body(payload: &mut web::Payload) -> Result<(), HttpRespons
     Ok(())
 }
 
-#[cfg(test)]
-mod tests {
-    use super::ensure_empty_body;
-    use actix_web::FromRequest;
-    use actix_web::http::StatusCode;
-    use actix_web::web;
-    use bytes::Bytes;
-
-    async fn payload_from_bytes(bytes: Bytes) -> web::Payload {
-        let (req, mut dev_payload) = actix_web::test::TestRequest::default()
-            .set_payload(bytes)
-            .to_http_parts();
-        web::Payload::from_request(&req, &mut dev_payload)
-            .await
-            .expect("test payload should extract")
-    }
-
-    #[actix_web::test]
-    async fn ensure_empty_body_accepts_empty_payload() {
-        let mut payload = payload_from_bytes(Bytes::new()).await;
-
-        ensure_empty_body(&mut payload)
-            .await
-            .expect("empty MKCOL body should be accepted");
-    }
-
-    #[actix_web::test]
-    async fn ensure_empty_body_ignores_empty_chunks() {
-        let mut payload = payload_from_bytes(Bytes::new()).await;
-
-        ensure_empty_body(&mut payload)
-            .await
-            .expect("empty MKCOL body chunks should be accepted");
-    }
-
-    #[actix_web::test]
-    async fn ensure_empty_body_rejects_first_non_empty_chunk() {
-        let mut payload = payload_from_bytes(Bytes::from_static(b"x")).await;
-
-        let response = ensure_empty_body(&mut payload)
-            .await
-            .expect_err("non-empty MKCOL body should be rejected");
-
-        assert_eq!(response.status(), StatusCode::UNSUPPORTED_MEDIA_TYPE);
-    }
-
-    #[actix_web::test]
-    async fn ensure_empty_body_stops_after_first_non_empty_chunk() {
-        let mut payload = payload_from_bytes(Bytes::from(vec![b'x'; 2 * 1024 * 1024])).await;
-
-        let response = ensure_empty_body(&mut payload)
-            .await
-            .expect_err("large non-empty MKCOL body should be rejected");
-
-        assert_eq!(response.status(), StatusCode::UNSUPPORTED_MEDIA_TYPE);
-    }
-}
-
 async fn ensure_parent_exists(dav_fs: &fs::AsterDavFs, relative: &str) -> Result<(), HttpResponse> {
     let Some(parent) = parent_relative_path(relative) else {
         return Err(HttpResponse::MethodNotAllowed().finish());
@@ -292,4 +234,62 @@ fn overwrite_enabled(headers: &header::HeaderMap) -> bool {
         .get("Overwrite")
         .and_then(|value| value.to_str().ok())
         .is_none_or(|value| !value.eq_ignore_ascii_case("F"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ensure_empty_body;
+    use actix_web::FromRequest;
+    use actix_web::http::StatusCode;
+    use actix_web::web;
+    use bytes::Bytes;
+
+    async fn payload_from_bytes(bytes: Bytes) -> web::Payload {
+        let (req, mut dev_payload) = actix_web::test::TestRequest::default()
+            .set_payload(bytes)
+            .to_http_parts();
+        web::Payload::from_request(&req, &mut dev_payload)
+            .await
+            .expect("test payload should extract")
+    }
+
+    #[actix_web::test]
+    async fn ensure_empty_body_accepts_empty_payload() {
+        let mut payload = payload_from_bytes(Bytes::new()).await;
+
+        ensure_empty_body(&mut payload)
+            .await
+            .expect("empty MKCOL body should be accepted");
+    }
+
+    #[actix_web::test]
+    async fn ensure_empty_body_ignores_empty_chunks() {
+        let mut payload = payload_from_bytes(Bytes::new()).await;
+
+        ensure_empty_body(&mut payload)
+            .await
+            .expect("empty MKCOL body chunks should be accepted");
+    }
+
+    #[actix_web::test]
+    async fn ensure_empty_body_rejects_first_non_empty_chunk() {
+        let mut payload = payload_from_bytes(Bytes::from_static(b"x")).await;
+
+        let response = ensure_empty_body(&mut payload)
+            .await
+            .expect_err("non-empty MKCOL body should be rejected");
+
+        assert_eq!(response.status(), StatusCode::UNSUPPORTED_MEDIA_TYPE);
+    }
+
+    #[actix_web::test]
+    async fn ensure_empty_body_stops_after_first_non_empty_chunk() {
+        let mut payload = payload_from_bytes(Bytes::from(vec![b'x'; 2 * 1024 * 1024])).await;
+
+        let response = ensure_empty_body(&mut payload)
+            .await
+            .expect_err("large non-empty MKCOL body should be rejected");
+
+        assert_eq!(response.status(), StatusCode::UNSUPPORTED_MEDIA_TYPE);
+    }
 }

--- a/src/webdav/resources/mod.rs
+++ b/src/webdav/resources/mod.rs
@@ -2,11 +2,12 @@
 
 use actix_web::http::header;
 use actix_web::{HttpRequest, HttpResponse, web};
+use futures::StreamExt;
 
 use crate::webdav::dav::{DavFileSystem, DavLockSystem, DavPath, FsError};
 use crate::webdav::{
-    collect_payload, decode_relative_path, decoded_path_string, ensure_system_file_name_allowed,
-    ensure_unlocked, fs, fs_error_response, href_for_relative, request_path, system_file,
+    decode_relative_path, decoded_path_string, ensure_system_file_name_allowed, ensure_unlocked,
+    fs, fs_error_response, href_for_relative, request_path, system_file,
 };
 
 pub(crate) async fn handle_mkcol(
@@ -158,10 +159,71 @@ pub(crate) async fn handle_copy_move(
 }
 
 async fn ensure_empty_body(payload: &mut web::Payload) -> Result<(), HttpResponse> {
-    if collect_payload(payload).await?.is_empty() {
-        Ok(())
-    } else {
-        Err(HttpResponse::UnsupportedMediaType().finish())
+    while let Some(chunk) = payload.next().await {
+        let chunk =
+            chunk.map_err(|_| HttpResponse::BadRequest().body("Failed to read request body"))?;
+        if !chunk.is_empty() {
+            return Err(HttpResponse::UnsupportedMediaType().finish());
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ensure_empty_body;
+    use actix_web::FromRequest;
+    use actix_web::http::StatusCode;
+    use actix_web::web;
+    use bytes::Bytes;
+
+    async fn payload_from_bytes(bytes: Bytes) -> web::Payload {
+        let (req, mut dev_payload) = actix_web::test::TestRequest::default()
+            .set_payload(bytes)
+            .to_http_parts();
+        web::Payload::from_request(&req, &mut dev_payload)
+            .await
+            .expect("test payload should extract")
+    }
+
+    #[actix_web::test]
+    async fn ensure_empty_body_accepts_empty_payload() {
+        let mut payload = payload_from_bytes(Bytes::new()).await;
+
+        ensure_empty_body(&mut payload)
+            .await
+            .expect("empty MKCOL body should be accepted");
+    }
+
+    #[actix_web::test]
+    async fn ensure_empty_body_ignores_empty_chunks() {
+        let mut payload = payload_from_bytes(Bytes::new()).await;
+
+        ensure_empty_body(&mut payload)
+            .await
+            .expect("empty MKCOL body chunks should be accepted");
+    }
+
+    #[actix_web::test]
+    async fn ensure_empty_body_rejects_first_non_empty_chunk() {
+        let mut payload = payload_from_bytes(Bytes::from_static(b"x")).await;
+
+        let response = ensure_empty_body(&mut payload)
+            .await
+            .expect_err("non-empty MKCOL body should be rejected");
+
+        assert_eq!(response.status(), StatusCode::UNSUPPORTED_MEDIA_TYPE);
+    }
+
+    #[actix_web::test]
+    async fn ensure_empty_body_stops_after_first_non_empty_chunk() {
+        let mut payload = payload_from_bytes(Bytes::from(vec![b'x'; 2 * 1024 * 1024])).await;
+
+        let response = ensure_empty_body(&mut payload)
+            .await
+            .expect_err("large non-empty MKCOL body should be rejected");
+
+        assert_eq!(response.status(), StatusCode::UNSUPPORTED_MEDIA_TYPE);
     }
 }
 

--- a/tests/test_admin.rs
+++ b/tests/test_admin.rs
@@ -2486,6 +2486,55 @@ async fn test_admin_overview_rejects_invalid_timezone() {
 }
 
 #[actix_web::test]
+async fn test_admin_overview_batches_large_audit_daily_reports() {
+    let state = common::setup().await;
+    let app = create_test_app!(state.clone());
+    let (token, _) = register_and_login!(app);
+    let target_day = Utc::now().date_naive() - Duration::days(1);
+    let target_at = target_day
+        .and_hms_opt(12, 0, 0)
+        .expect("midday should be valid")
+        .and_utc();
+    let marker = uuid::Uuid::new_v4();
+    let inserted_events = 1_005_u64;
+    let mut models = Vec::new();
+    for index in 0..inserted_events {
+        models.push(audit_log::ActiveModel {
+            user_id: Set(1),
+            action: Set(AuditAction::FileUpload),
+            entity_type: Set("file".to_string()),
+            entity_id: Set(Some(
+                i64::try_from(index).expect("test index should fit i64"),
+            )),
+            entity_name: Set(Some(format!("Overview batch {marker} #{index}"))),
+            details: Set(None),
+            ip_address: Set(None),
+            user_agent: Set(None),
+            created_at: Set(target_at),
+            ..Default::default()
+        });
+    }
+    for chunk in models.chunks(100) {
+        audit_log_repo::create_many(state.writer_db(), chunk.to_vec())
+            .await
+            .expect("audit log batch should be inserted");
+    }
+
+    let body: Value = admin_get_json!(
+        app,
+        token,
+        "/api/v1/admin/overview?days=3&timezone=UTC&event_limit=1"
+    );
+    let reports = body["data"]["daily_reports"].as_array().unwrap();
+    let target_report = reports
+        .iter()
+        .find(|report| report["date"] == target_day.to_string())
+        .expect("target day report should be present");
+    assert_eq!(target_report["uploads"], inserted_events);
+    assert_eq!(target_report["total_events"], inserted_events);
+}
+
+#[actix_web::test]
 async fn test_admin_tasks_lists_all_recorded_tasks() {
     let state = common::setup().await;
     let app = create_test_app!(state.clone());

--- a/tests/test_maintenance.rs
+++ b/tests/test_maintenance.rs
@@ -315,6 +315,70 @@ async fn test_cleanup_expired_completed_upload_sessions_removes_broken_completed
     assert!(!driver.exists(temp_key).await.unwrap());
 }
 
+#[cfg(unix)]
+#[actix_web::test]
+async fn test_cleanup_expired_completed_upload_sessions_keeps_session_when_temp_delete_fails() {
+    use aster_drive::db::repository::upload_session_repo;
+    use aster_drive::services::{auth_service, maintenance_service};
+
+    let state = common::setup().await;
+    let user = auth_service::register(&state, "maintfail1", "maintfail1@test.com", "password123")
+        .await
+        .unwrap();
+    let policy = default_policy(&state).await;
+    let driver = state.driver_registry.get_driver(&policy).unwrap();
+    let temp_key = "tmp/delete-fails/broken-completed.bin";
+    driver.put(temp_key, b"stale upload").await.unwrap();
+
+    create_upload_session(
+        &state,
+        user.id,
+        UploadSessionSpec::new(
+            "broken-completed-delete-fails",
+            aster_drive::types::UploadSessionStatus::Completed,
+            Utc::now() - Duration::hours(1),
+        )
+        .s3(Some(temp_key), None),
+    )
+    .await;
+
+    let object_parent = std::path::Path::new(&policy.base_path)
+        .join(temp_key)
+        .parent()
+        .unwrap()
+        .to_path_buf();
+    let guard = DirModeGuard::set_read_only(object_parent);
+
+    let stats = maintenance_service::cleanup_expired_completed_upload_sessions(&state)
+        .await
+        .unwrap();
+
+    assert_eq!(stats.completed_sessions_deleted, 0);
+    assert_eq!(stats.broken_completed_sessions_deleted, 0);
+    assert!(
+        upload_session_repo::find_by_id(state.writer_db(), "broken-completed-delete-fails")
+            .await
+            .is_ok(),
+        "session row must remain so the stale remote object has a retry handle"
+    );
+    assert!(driver.exists(temp_key).await.unwrap());
+
+    drop(guard);
+
+    let stats = maintenance_service::cleanup_expired_completed_upload_sessions(&state)
+        .await
+        .unwrap();
+
+    assert_eq!(stats.completed_sessions_deleted, 1);
+    assert_eq!(stats.broken_completed_sessions_deleted, 1);
+    assert!(
+        upload_session_repo::find_by_id(state.writer_db(), "broken-completed-delete-fails")
+            .await
+            .is_err()
+    );
+    assert!(!driver.exists(temp_key).await.unwrap());
+}
+
 #[actix_web::test]
 async fn test_cleanup_expired_completed_upload_sessions_keeps_live_blob() {
     use aster_drive::db::repository::{file_repo, upload_session_repo};
@@ -366,6 +430,57 @@ async fn test_cleanup_expired_completed_upload_sessions_keeps_live_blob() {
             .is_ok()
     );
     assert!(driver.exists(&blob.storage_path).await.unwrap());
+}
+
+#[actix_web::test]
+async fn test_cleanup_expired_completed_upload_sessions_removes_stale_temp_for_completed_file() {
+    use aster_drive::db::repository::{file_repo, upload_session_repo};
+    use aster_drive::services::{auth_service, maintenance_service};
+
+    let state = common::setup().await;
+    let user = auth_service::register(&state, "maintuser2b", "maint2b@test.com", "password123")
+        .await
+        .unwrap();
+    let file = store_test_file(&state, user.id, "presigned-kept.txt", b"kept blob").await;
+    let blob = file_repo::find_blob_by_id(state.writer_db(), file.blob_id)
+        .await
+        .unwrap();
+    let policy = default_policy(&state).await;
+    let driver = state.driver_registry.get_driver(&policy).unwrap();
+    let temp_key = "tmp/completed-file-stale-temp.bin";
+    driver.put(temp_key, b"stale temp").await.unwrap();
+
+    create_upload_session(
+        &state,
+        user.id,
+        UploadSessionSpec::new(
+            "completed-file-stale-temp",
+            aster_drive::types::UploadSessionStatus::Completed,
+            Utc::now() - Duration::hours(1),
+        )
+        .s3(Some(temp_key), None)
+        .file_id(file.id),
+    )
+    .await;
+
+    let stats = maintenance_service::cleanup_expired_completed_upload_sessions(&state)
+        .await
+        .unwrap();
+
+    assert_eq!(stats.completed_sessions_deleted, 1);
+    assert_eq!(stats.broken_completed_sessions_deleted, 0);
+    assert!(
+        upload_session_repo::find_by_id(state.writer_db(), "completed-file-stale-temp")
+            .await
+            .is_err()
+    );
+    assert!(
+        file_repo::find_blob_by_id(state.writer_db(), blob.id)
+            .await
+            .is_ok()
+    );
+    assert!(driver.exists(&blob.storage_path).await.unwrap());
+    assert!(!driver.exists(temp_key).await.unwrap());
 }
 
 #[actix_web::test]

--- a/tests/test_public_media_data_support.rs
+++ b/tests/test_public_media_data_support.rs
@@ -4,68 +4,60 @@
 mod common;
 
 use actix_web::test;
-use async_trait::async_trait;
 use sea_orm::Set;
 use serde_json::{Value, json};
-use tokio::io::AsyncRead;
-
-use aster_drive::errors::Result;
-use aster_drive::storage::{
-    BlobMetadata, NativeMediaMetadataRequest, NativeMediaMetadataResult,
-    NativeMediaMetadataStorageDriver, StorageDriver,
-};
-
-struct NativeMediaMetadataSupportDriver;
-
-#[async_trait]
-impl StorageDriver for NativeMediaMetadataSupportDriver {
-    async fn put(&self, path: &str, _data: &[u8]) -> Result<String> {
-        Ok(path.to_string())
-    }
-
-    async fn get(&self, _path: &str) -> Result<Vec<u8>> {
-        Ok(Vec::new())
-    }
-
-    async fn get_stream(&self, _path: &str) -> Result<Box<dyn AsyncRead + Unpin + Send>> {
-        Ok(Box::new(std::io::Cursor::new(Vec::new())))
-    }
-
-    async fn delete(&self, _path: &str) -> Result<()> {
-        Ok(())
-    }
-
-    async fn exists(&self, _path: &str) -> Result<bool> {
-        Ok(true)
-    }
-
-    async fn metadata(&self, _path: &str) -> Result<BlobMetadata> {
-        Ok(BlobMetadata {
-            size: 0,
-            content_type: None,
-        })
-    }
-
-    fn as_native_media_metadata(&self) -> Option<&dyn NativeMediaMetadataStorageDriver> {
-        Some(self)
-    }
-}
-
-#[async_trait]
-impl NativeMediaMetadataStorageDriver for NativeMediaMetadataSupportDriver {
-    async fn get_native_media_metadata(
-        &self,
-        _request: &NativeMediaMetadataRequest,
-    ) -> Result<Option<NativeMediaMetadataResult>> {
-        Ok(None)
-    }
-}
 
 fn available_test_command() -> String {
     std::env::current_exe()
         .expect("current test executable path should be available")
         .to_string_lossy()
         .into_owned()
+}
+
+async fn create_storage_native_media_metadata_policy(
+    state: &aster_drive::runtime::PrimaryAppState,
+    driver_type: aster_drive::types::DriverType,
+    name: &str,
+    extensions: Vec<String>,
+) -> aster_drive::entities::storage_policy::Model {
+    let now = chrono::Utc::now();
+    let options = aster_drive::types::serialize_storage_policy_options(
+        &aster_drive::types::StoragePolicyOptions {
+            storage_native_processing_enabled: Some(true),
+            storage_native_media_metadata_enabled: Some(true),
+            media_metadata_extensions: extensions,
+            ..Default::default()
+        },
+    )
+    .expect("storage policy options should serialize");
+    let policy = aster_drive::db::repository::policy_repo::create(
+        state.writer_db(),
+        aster_drive::entities::storage_policy::ActiveModel {
+            name: Set(name.to_string()),
+            driver_type: Set(driver_type),
+            endpoint: Set("https://bucket-1250000000.cos.ap-guangzhou.myqcloud.com".to_string()),
+            bucket: Set("bucket-1250000000".to_string()),
+            access_key: Set("AKID".to_string()),
+            secret_key: Set("SECRET".to_string()),
+            base_path: Set(String::new()),
+            max_file_size: Set(0),
+            allowed_types: Set(aster_drive::types::StoredStoragePolicyAllowedTypes::empty()),
+            options: Set(options),
+            is_default: Set(false),
+            chunk_size: Set(5_242_880),
+            created_at: Set(now),
+            updated_at: Set(now),
+            ..Default::default()
+        },
+    )
+    .await
+    .expect("policy should be created");
+    state
+        .policy_snapshot
+        .reload(state.reader_db())
+        .await
+        .expect("policy snapshot should reload");
+    policy
 }
 
 #[actix_web::test]
@@ -206,52 +198,13 @@ async fn test_public_media_data_support_cache_is_invalidated_after_config_update
 async fn test_public_media_data_support_includes_storage_native_policy_extensions() {
     let state = common::setup().await;
     let app = create_test_app!(state.clone());
-
-    let now = chrono::Utc::now();
-    let options = aster_drive::types::serialize_storage_policy_options(
-        &aster_drive::types::StoragePolicyOptions {
-            storage_native_processing_enabled: Some(true),
-            storage_native_media_metadata_enabled: Some(true),
-            media_metadata_extensions: vec![
-                " .MP4 ".to_string(),
-                "mp4".to_string(),
-                ".m4a".to_string(),
-            ],
-            ..Default::default()
-        },
+    let policy = create_storage_native_media_metadata_policy(
+        &state,
+        aster_drive::types::DriverType::TencentCos,
+        "Native Metadata",
+        vec![" .MP4 ".to_string(), "mp4".to_string(), ".m4a".to_string()],
     )
-    .expect("storage policy options should serialize");
-    let policy = aster_drive::db::repository::policy_repo::create(
-        state.writer_db(),
-        aster_drive::entities::storage_policy::ActiveModel {
-            name: Set("Native Metadata".to_string()),
-            driver_type: Set(aster_drive::types::DriverType::TencentCos),
-            endpoint: Set("https://bucket-1250000000.cos.ap-guangzhou.myqcloud.com".to_string()),
-            bucket: Set("bucket-1250000000".to_string()),
-            access_key: Set("AKID".to_string()),
-            secret_key: Set("SECRET".to_string()),
-            base_path: Set(String::new()),
-            max_file_size: Set(0),
-            allowed_types: Set(aster_drive::types::StoredStoragePolicyAllowedTypes::empty()),
-            options: Set(options),
-            is_default: Set(false),
-            chunk_size: Set(5_242_880),
-            created_at: Set(now),
-            updated_at: Set(now),
-            ..Default::default()
-        },
-    )
-    .await
-    .expect("policy should be created");
-    state
-        .policy_snapshot
-        .reload(state.reader_db())
-        .await
-        .expect("policy snapshot should reload");
-    state.driver_registry.insert_for_test(
-        policy.id,
-        std::sync::Arc::new(NativeMediaMetadataSupportDriver),
-    );
+    .await;
 
     let req = test::TestRequest::get()
         .uri("/api/v1/public/media-data-support")
@@ -272,5 +225,42 @@ async fn test_public_media_data_support_includes_storage_native_policy_extension
             .expect("audio extensions should be an array")
             .iter()
             .any(|value| value == "m4a")
+    );
+    assert!(
+        !state.driver_registry.has_cached_driver_for_test(policy.id),
+        "public media support must not instantiate a cold storage-native policy driver"
+    );
+}
+
+#[actix_web::test]
+async fn test_public_media_data_support_ignores_storage_native_options_for_unsupported_driver() {
+    let state = common::setup().await;
+    let app = create_test_app!(state.clone());
+    let policy = create_storage_native_media_metadata_policy(
+        &state,
+        aster_drive::types::DriverType::S3,
+        "Unsupported Native Metadata",
+        vec!["zzrawmedia".to_string()],
+    )
+    .await;
+
+    let req = test::TestRequest::get()
+        .uri("/api/v1/public/media-data-support")
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), 200);
+
+    let body: Value = test::read_body_json(resp).await;
+    let video_extensions = body["data"]["kinds"]["video"]["extensions"]
+        .as_array()
+        .expect("video extensions should be an array");
+    let audio_extensions = body["data"]["kinds"]["audio"]["extensions"]
+        .as_array()
+        .expect("audio extensions should be an array");
+    assert!(!video_extensions.iter().any(|value| value == "zzrawmedia"));
+    assert!(!audio_extensions.iter().any(|value| value == "zzrawmedia"));
+    assert!(
+        !state.driver_registry.has_cached_driver_for_test(policy.id),
+        "unsupported public media policy must not be instantiated just to reject capability"
     );
 }

--- a/tests/test_public_thumbnail_support.rs
+++ b/tests/test_public_thumbnail_support.rs
@@ -4,6 +4,7 @@
 mod common;
 
 use actix_web::test;
+use sea_orm::Set;
 use serde_json::{Value, json};
 
 fn available_test_command() -> String {
@@ -11,6 +12,52 @@ fn available_test_command() -> String {
         .expect("current test executable path should be available")
         .to_string_lossy()
         .into_owned()
+}
+
+async fn create_storage_native_thumbnail_policy(
+    state: &aster_drive::runtime::PrimaryAppState,
+    driver_type: aster_drive::types::DriverType,
+    name: &str,
+    extensions: Vec<String>,
+) -> aster_drive::entities::storage_policy::Model {
+    let now = chrono::Utc::now();
+    let options = aster_drive::types::serialize_storage_policy_options(
+        &aster_drive::types::StoragePolicyOptions {
+            storage_native_processing_enabled: Some(true),
+            thumbnail_processor: Some(aster_drive::types::MediaProcessorKind::StorageNative),
+            thumbnail_extensions: extensions,
+            ..Default::default()
+        },
+    )
+    .expect("storage policy options should serialize");
+    let policy = aster_drive::db::repository::policy_repo::create(
+        state.writer_db(),
+        aster_drive::entities::storage_policy::ActiveModel {
+            name: Set(name.to_string()),
+            driver_type: Set(driver_type),
+            endpoint: Set("https://bucket-1250000000.cos.ap-guangzhou.myqcloud.com".to_string()),
+            bucket: Set("bucket-1250000000".to_string()),
+            access_key: Set("AKID".to_string()),
+            secret_key: Set("SECRET".to_string()),
+            base_path: Set(String::new()),
+            max_file_size: Set(0),
+            allowed_types: Set(aster_drive::types::StoredStoragePolicyAllowedTypes::empty()),
+            options: Set(options),
+            is_default: Set(false),
+            chunk_size: Set(5_242_880),
+            created_at: Set(now),
+            updated_at: Set(now),
+            ..Default::default()
+        },
+    )
+    .await
+    .expect("policy should be created");
+    state
+        .policy_snapshot
+        .reload(state.reader_db())
+        .await
+        .expect("policy snapshot should reload");
+    policy
 }
 
 #[actix_web::test]
@@ -200,4 +247,62 @@ async fn test_public_thumbnail_support_cache_is_invalidated_after_config_update(
         .as_array()
         .expect("extensions should be an array");
     assert!(extensions.iter().any(|value| value == "heic"));
+}
+
+#[actix_web::test]
+async fn test_public_thumbnail_support_includes_storage_native_policy_without_caching_driver() {
+    let state = common::setup().await;
+    let app = create_test_app!(state.clone());
+    let policy = create_storage_native_thumbnail_policy(
+        &state,
+        aster_drive::types::DriverType::TencentCos,
+        "Native Thumbnail",
+        vec![" .HEIF ".to_string(), ".heif".to_string()],
+    )
+    .await;
+
+    let req = test::TestRequest::get()
+        .uri("/api/v1/public/thumbnail-support")
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), 200);
+
+    let body: Value = test::read_body_json(resp).await;
+    let extensions = body["data"]["extensions"]
+        .as_array()
+        .expect("extensions should be an array");
+    assert!(extensions.iter().any(|value| value == "heif"));
+    assert!(
+        !state.driver_registry.has_cached_driver_for_test(policy.id),
+        "public thumbnail support must not instantiate a cold storage-native policy driver"
+    );
+}
+
+#[actix_web::test]
+async fn test_public_thumbnail_support_ignores_storage_native_options_for_unsupported_driver() {
+    let state = common::setup().await;
+    let app = create_test_app!(state.clone());
+    let policy = create_storage_native_thumbnail_policy(
+        &state,
+        aster_drive::types::DriverType::S3,
+        "Unsupported Native Thumbnail",
+        vec!["zzrawthumb".to_string()],
+    )
+    .await;
+
+    let req = test::TestRequest::get()
+        .uri("/api/v1/public/thumbnail-support")
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), 200);
+
+    let body: Value = test::read_body_json(resp).await;
+    let extensions = body["data"]["extensions"]
+        .as_array()
+        .expect("extensions should be an array");
+    assert!(!extensions.iter().any(|value| value == "zzrawthumb"));
+    assert!(
+        !state.driver_registry.has_cached_driver_for_test(policy.id),
+        "unsupported public thumbnail policy must not be instantiated just to reject capability"
+    );
 }

--- a/tests/test_services.rs
+++ b/tests/test_services.rs
@@ -5,6 +5,38 @@ mod common;
 
 use aster_drive::services::file_service::StoreFromTempRequest;
 use std::collections::BTreeSet;
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
+
+#[cfg(unix)]
+struct DirModeGuard {
+    path: std::path::PathBuf,
+    mode: u32,
+}
+
+#[cfg(unix)]
+impl DirModeGuard {
+    fn set_read_only(path: impl Into<std::path::PathBuf>) -> Self {
+        let path = path.into();
+        let metadata = std::fs::metadata(&path).unwrap();
+        let mode = metadata.permissions().mode();
+        let mut perms = metadata.permissions();
+        perms.set_mode(0o555);
+        std::fs::set_permissions(&path, perms).unwrap();
+        Self { path, mode }
+    }
+}
+
+#[cfg(unix)]
+impl Drop for DirModeGuard {
+    fn drop(&mut self) {
+        if let Ok(metadata) = std::fs::metadata(&self.path) {
+            let mut perms = metadata.permissions();
+            perms.set_mode(self.mode);
+            let _ = std::fs::set_permissions(&self.path, perms);
+        }
+    }
+}
 
 fn assert_share_target_check_violation(db: &sea_orm::DatabaseConnection, err: &sea_orm::DbErr) {
     let message = err.to_string();
@@ -2865,6 +2897,127 @@ async fn test_team_archive_cleanup_deletes_expired_team_data() {
         .unwrap()
         .is_empty()
     );
+}
+
+#[cfg(unix)]
+#[actix_web::test]
+async fn test_team_archive_cleanup_keeps_team_when_upload_temp_delete_fails() {
+    use chrono::{Duration, Utc};
+    use sea_orm::{IntoActiveModel, Set};
+
+    let state = common::setup().await;
+    let owner = aster_drive::services::auth_service::register(
+        &state,
+        "cleanupfail",
+        "cleanup-fail-owner@example.com",
+        "password123",
+    )
+    .await
+    .unwrap();
+    let team = aster_drive::services::team_service::create_team(
+        &state,
+        owner.id,
+        aster_drive::services::team_service::CreateTeamInput {
+            name: "Cleanup Failure Team".to_string(),
+            description: None,
+        },
+    )
+    .await
+    .unwrap();
+
+    let policy = aster_drive::db::repository::policy_repo::find_default(state.writer_db())
+        .await
+        .unwrap()
+        .expect("default policy should exist");
+    let driver = state.driver_registry.get_driver(&policy).unwrap();
+    let upload_id = uuid::Uuid::new_v4().to_string();
+    let temp_key = format!("tmp/team-cleanup-fails/{upload_id}.bin");
+    driver.put(&temp_key, b"stale team upload").await.unwrap();
+    let now = Utc::now();
+    aster_drive::db::repository::upload_session_repo::create(
+        state.writer_db(),
+        aster_drive::entities::upload_session::ActiveModel {
+            id: Set(upload_id.clone()),
+            user_id: Set(owner.id),
+            team_id: Set(Some(team.id)),
+            frontend_client_id: Set(None),
+            filename: Set("pending.bin".to_string()),
+            total_size: Set(10),
+            chunk_size: Set(10),
+            total_chunks: Set(1),
+            received_count: Set(0),
+            folder_id: Set(None),
+            policy_id: Set(policy.id),
+            status: Set(aster_drive::types::UploadSessionStatus::Uploading),
+            s3_temp_key: Set(Some(temp_key.clone())),
+            s3_multipart_id: Set(None),
+            file_id: Set(None),
+            created_at: Set(now),
+            expires_at: Set(now + Duration::hours(1)),
+            updated_at: Set(now),
+        },
+    )
+    .await
+    .unwrap();
+
+    aster_drive::services::team_service::archive_team(&state, team.id, owner.id)
+        .await
+        .unwrap();
+    let mut archived_team =
+        aster_drive::db::repository::team_repo::find_by_id(state.writer_db(), team.id)
+            .await
+            .unwrap()
+            .into_active_model();
+    archived_team.archived_at = Set(Some(Utc::now() - Duration::days(8)));
+    archived_team.updated_at = Set(Utc::now() - Duration::days(8));
+    aster_drive::db::repository::team_repo::update(state.writer_db(), archived_team)
+        .await
+        .unwrap();
+
+    let object_parent = std::path::Path::new(&policy.base_path)
+        .join(&temp_key)
+        .parent()
+        .unwrap()
+        .to_path_buf();
+    let guard = DirModeGuard::set_read_only(object_parent);
+
+    let deleted = aster_drive::services::team_service::cleanup_expired_archived_teams(&state)
+        .await
+        .unwrap();
+
+    assert_eq!(deleted, 0);
+    assert!(
+        aster_drive::db::repository::team_repo::find_by_id(state.writer_db(), team.id)
+            .await
+            .is_ok(),
+        "team row must remain until upload temp cleanup can be retried"
+    );
+    assert!(
+        aster_drive::db::repository::upload_session_repo::find_by_id(state.writer_db(), &upload_id)
+            .await
+            .is_ok(),
+        "upload session must remain as the retry handle for the stale temp object"
+    );
+    assert!(driver.exists(&temp_key).await.unwrap());
+
+    drop(guard);
+
+    let deleted = aster_drive::services::team_service::cleanup_expired_archived_teams(&state)
+        .await
+        .unwrap();
+
+    assert_eq!(deleted, 1);
+    assert!(
+        aster_drive::db::repository::team_repo::find_by_id(state.writer_db(), team.id)
+            .await
+            .is_err()
+    );
+    assert!(
+        aster_drive::db::repository::upload_session_repo::find_by_id(state.writer_db(), &upload_id)
+            .await
+            .is_err()
+    );
+    assert!(!driver.exists(&temp_key).await.unwrap());
 }
 
 #[actix_web::test]

--- a/tests/test_storage_migration.rs
+++ b/tests/test_storage_migration.rs
@@ -3,22 +3,32 @@
 #[macro_use]
 mod common;
 
+use std::collections::HashMap;
+use std::io::Cursor;
+use std::sync::Arc;
+
 use actix_web::test;
+use async_trait::async_trait;
 use chrono::Utc;
+use parking_lot::Mutex;
 use sea_orm::{ActiveModelTrait, ColumnTrait, EntityTrait, QueryFilter, Set};
 use serde_json::Value;
 use testcontainers::{GenericImage, ImageExt, runners::AsyncRunner};
+use tokio::io::{AsyncRead, AsyncReadExt};
 
 use aster_drive::db::repository::{
     background_task_repo, file_repo, policy_repo, storage_migration_checkpoint_repo,
 };
 use aster_drive::entities::{file, file_blob, file_version, storage_policy};
+use aster_drive::errors::{AsterError, MapAsterErr, Result};
 use aster_drive::runtime::PrimaryAppState;
 use aster_drive::services::task_service;
+use aster_drive::storage::{BlobMetadata, StorageDriver, StreamUploadDriver};
 use aster_drive::types::{
     BackgroundTaskStatus, DriverType, FileCategory, StoredStoragePolicyAllowedTypes,
     StoredStoragePolicyOptions,
 };
+use aster_drive::utils::numbers::usize_to_u64;
 
 const RUSTFS_TEST_IMAGE_TAG: &str = "1.0.0-alpha.90";
 
@@ -26,6 +36,127 @@ struct RustFsTestContext {
     _container: testcontainers::ContainerAsync<GenericImage>,
     endpoint: String,
     bucket: String,
+}
+
+#[derive(Clone, Copy, Default)]
+enum StreamUploadFailureMode {
+    #[default]
+    AfterWrite,
+    BeforeWrite,
+}
+
+#[derive(Clone, Default)]
+struct FailingStreamUploadDriver {
+    objects: Arc<Mutex<HashMap<String, Vec<u8>>>>,
+    failure_mode: StreamUploadFailureMode,
+    fail_delete: bool,
+}
+
+impl FailingStreamUploadDriver {
+    fn before_write() -> Self {
+        Self {
+            failure_mode: StreamUploadFailureMode::BeforeWrite,
+            ..Default::default()
+        }
+    }
+
+    fn delete_fails() -> Self {
+        Self {
+            fail_delete: true,
+            ..Default::default()
+        }
+    }
+
+    fn contains(&self, path: &str) -> bool {
+        self.objects.lock().contains_key(path)
+    }
+
+    fn bytes(&self, path: &str) -> Option<Vec<u8>> {
+        self.objects.lock().get(path).cloned()
+    }
+}
+
+#[async_trait]
+impl StorageDriver for FailingStreamUploadDriver {
+    async fn put(&self, path: &str, data: &[u8]) -> Result<String> {
+        self.objects.lock().insert(path.to_string(), data.to_vec());
+        Ok(path.to_string())
+    }
+
+    async fn get(&self, path: &str) -> Result<Vec<u8>> {
+        self.objects
+            .lock()
+            .get(path)
+            .cloned()
+            .ok_or_else(|| AsterError::storage_driver_error(format!("missing object {path}")))
+    }
+
+    async fn get_stream(&self, path: &str) -> Result<Box<dyn AsyncRead + Unpin + Send>> {
+        Ok(Box::new(Cursor::new(self.get(path).await?)))
+    }
+
+    async fn delete(&self, path: &str) -> Result<()> {
+        if self.fail_delete && !path.starts_with("_aster_migration_preflight-") {
+            return Err(AsterError::storage_driver_error(
+                "simulated cleanup delete failure",
+            ));
+        }
+        self.objects.lock().remove(path);
+        Ok(())
+    }
+
+    async fn exists(&self, path: &str) -> Result<bool> {
+        Ok(self.contains(path))
+    }
+
+    async fn metadata(&self, path: &str) -> Result<BlobMetadata> {
+        let size =
+            self.objects.lock().get(path).map(Vec::len).ok_or_else(|| {
+                AsterError::storage_driver_error(format!("missing object {path}"))
+            })?;
+        Ok(BlobMetadata {
+            size: usize_to_u64(size, "test object size")?,
+            content_type: None,
+        })
+    }
+
+    fn as_stream_upload(&self) -> Option<&dyn StreamUploadDriver> {
+        Some(self)
+    }
+}
+
+#[async_trait]
+impl StreamUploadDriver for FailingStreamUploadDriver {
+    async fn put_reader(
+        &self,
+        storage_path: &str,
+        mut reader: Box<dyn AsyncRead + Unpin + Send + Sync>,
+        _size: i64,
+    ) -> Result<String> {
+        let mut bytes = Vec::new();
+        reader
+            .read_to_end(&mut bytes)
+            .await
+            .map_aster_err_ctx("read test upload stream", AsterError::storage_driver_error)?;
+        if matches!(self.failure_mode, StreamUploadFailureMode::AfterWrite) {
+            self.objects.lock().insert(storage_path.to_string(), bytes);
+        }
+        Err(AsterError::storage_driver_error(
+            "simulated timeout after remote write",
+        ))
+    }
+
+    async fn put_file(&self, storage_path: &str, local_path: &str) -> Result<String> {
+        let bytes = tokio::fs::read(local_path)
+            .await
+            .map_aster_err(AsterError::storage_driver_error)?;
+        if matches!(self.failure_mode, StreamUploadFailureMode::AfterWrite) {
+            self.objects.lock().insert(storage_path.to_string(), bytes);
+        }
+        Err(AsterError::storage_driver_error(
+            "simulated timeout after remote write",
+        ))
+    }
 }
 
 async fn start_rustfs_context(bucket_prefix: &str) -> RustFsTestContext {
@@ -239,6 +370,33 @@ async fn create_blob_with_object(
     .insert(state.writer_db())
     .await
     .expect("blob row should insert")
+}
+
+async fn create_blob_record_with_storage_path(
+    state: &PrimaryAppState,
+    policy: &storage_policy::Model,
+    hash: &str,
+    storage_path: &str,
+    bytes: &[u8],
+    ref_count: i32,
+) -> file_blob::Model {
+    let now = Utc::now();
+    file_blob::ActiveModel {
+        hash: Set(hash.to_string()),
+        size: Set(i64::try_from(bytes.len()).expect("test bytes len should fit i64")),
+        policy_id: Set(policy.id),
+        storage_path: Set(storage_path.to_string()),
+        thumbnail_path: Set(None),
+        thumbnail_processor: Set(None),
+        thumbnail_version: Set(None),
+        ref_count: Set(ref_count),
+        created_at: Set(now),
+        updated_at: Set(now),
+        ..Default::default()
+    }
+    .insert(state.writer_db())
+    .await
+    .expect("blob row with explicit storage path should insert")
 }
 
 async fn create_opaque_blob_with_object(
@@ -1387,6 +1545,192 @@ async fn test_storage_migration_cleans_target_object_when_verification_fails() {
     assert_eq!(checkpoint.last_processed_blob_id, 0);
     assert_eq!(checkpoint.scanned_blobs, 0);
     assert_eq!(checkpoint.migrated_blobs, 0);
+}
+
+#[actix_web::test]
+async fn test_storage_migration_cleans_target_object_when_stream_upload_returns_error() {
+    let state = common::setup().await;
+    let app = create_test_app!(state.clone());
+    let (token, _) = register_and_login!(app);
+    let source = create_local_policy(&state, "source-upload-error-cleanup").await;
+    let target = create_local_policy(&state, "target-upload-error-cleanup").await;
+    let target_driver = FailingStreamUploadDriver::default();
+    state
+        .driver_registry
+        .insert_for_test(target.id, Arc::new(target_driver.clone()));
+    let blob = create_blob_with_object(&state, &source, b"cleanup-after-upload-error", 1).await;
+    create_file_for_blob(&state, blob.id, "upload-error-cleanup.txt").await;
+
+    let body = create_migration_task_via_api(&app, &token, source.id, target.id, false).await;
+    let task_id = body["data"]["id"].as_i64().expect("task id should exist");
+    let target_path = aster_drive::utils::storage_path_from_blob_key(&blob.hash);
+
+    let stats = task_service::drain(&state)
+        .await
+        .expect("failed migration task should drain");
+    assert_eq!(stats.failed, 1);
+
+    let task = background_task_repo::find_by_id(state.writer_db(), task_id)
+        .await
+        .expect("task should exist");
+    assert_eq!(task.status, BackgroundTaskStatus::Failed);
+    assert!(
+        task.last_error
+            .as_deref()
+            .expect("failed task should store last_error")
+            .contains("simulated timeout after remote write")
+    );
+    assert!(
+        !target_driver.contains(&target_path),
+        "failed stream upload should cleanup the target object left before the error"
+    );
+
+    let source_blob = file_repo::find_blob_by_id(state.writer_db(), blob.id)
+        .await
+        .expect("source blob row should remain");
+    assert_eq!(source_blob.policy_id, source.id);
+}
+
+#[actix_web::test]
+async fn test_storage_migration_stream_upload_error_without_target_object_stays_failed() {
+    let state = common::setup().await;
+    let app = create_test_app!(state.clone());
+    let (token, _) = register_and_login!(app);
+    let source = create_local_policy(&state, "source-upload-error-no-object").await;
+    let target = create_local_policy(&state, "target-upload-error-no-object").await;
+    let target_driver = FailingStreamUploadDriver::before_write();
+    state
+        .driver_registry
+        .insert_for_test(target.id, Arc::new(target_driver.clone()));
+    let blob = create_blob_with_object(&state, &source, b"upload-error-before-write", 1).await;
+    create_file_for_blob(&state, blob.id, "upload-error-before-write.txt").await;
+
+    let body = create_migration_task_via_api(&app, &token, source.id, target.id, false).await;
+    let task_id = body["data"]["id"].as_i64().expect("task id should exist");
+    let target_path = aster_drive::utils::storage_path_from_blob_key(&blob.hash);
+
+    let stats = task_service::drain(&state)
+        .await
+        .expect("failed migration task should drain");
+    assert_eq!(stats.failed, 1);
+
+    let task = background_task_repo::find_by_id(state.writer_db(), task_id)
+        .await
+        .expect("task should exist");
+    assert_eq!(task.status, BackgroundTaskStatus::Failed);
+    assert!(
+        task.last_error
+            .as_deref()
+            .expect("failed task should store last_error")
+            .contains("simulated timeout after remote write")
+    );
+    assert!(
+        !target_driver.contains(&target_path),
+        "cleanup should tolerate upload errors that left no target object"
+    );
+}
+
+#[actix_web::test]
+async fn test_storage_migration_stream_upload_cleanup_error_preserves_upload_error() {
+    let state = common::setup().await;
+    let app = create_test_app!(state.clone());
+    let (token, _) = register_and_login!(app);
+    let source = create_local_policy(&state, "source-upload-cleanup-delete-error").await;
+    let target = create_local_policy(&state, "target-upload-cleanup-delete-error").await;
+    let target_driver = FailingStreamUploadDriver::delete_fails();
+    state
+        .driver_registry
+        .insert_for_test(target.id, Arc::new(target_driver.clone()));
+    let blob = create_blob_with_object(&state, &source, b"cleanup-delete-error", 1).await;
+    create_file_for_blob(&state, blob.id, "cleanup-delete-error.txt").await;
+
+    let body = create_migration_task_via_api(&app, &token, source.id, target.id, false).await;
+    let task_id = body["data"]["id"].as_i64().expect("task id should exist");
+    let target_path = aster_drive::utils::storage_path_from_blob_key(&blob.hash);
+
+    let stats = task_service::drain(&state)
+        .await
+        .expect("failed migration task should drain");
+    assert_eq!(stats.failed, 1);
+
+    let task = background_task_repo::find_by_id(state.writer_db(), task_id)
+        .await
+        .expect("task should exist");
+    assert_eq!(task.status, BackgroundTaskStatus::Failed);
+    let last_error = task
+        .last_error
+        .as_deref()
+        .expect("failed task should store last_error");
+    assert!(
+        last_error.contains("simulated timeout after remote write"),
+        "cleanup failure should not replace the original upload error"
+    );
+    assert!(
+        !last_error.contains("simulated cleanup delete failure"),
+        "cleanup failure should stay a warning, not the task failure reason"
+    );
+    assert!(
+        target_driver.contains(&target_path),
+        "object remains when best-effort cleanup itself fails"
+    );
+}
+
+#[actix_web::test]
+async fn test_storage_migration_stream_upload_error_does_not_delete_referenced_target_object() {
+    let state = common::setup().await;
+    let app = create_test_app!(state.clone());
+    let (token, _) = register_and_login!(app);
+    let source = create_local_policy(&state, "source-upload-cleanup-referenced").await;
+    let target = create_local_policy(&state, "target-upload-cleanup-referenced").await;
+    let target_driver = FailingStreamUploadDriver::default();
+    state
+        .driver_registry
+        .insert_for_test(target.id, Arc::new(target_driver.clone()));
+    let bytes = b"referenced-target-object";
+    let blob = create_blob_with_object(&state, &source, bytes, 1).await;
+    create_file_for_blob(&state, blob.id, "cleanup-referenced.txt").await;
+    let target_path = aster_drive::utils::storage_path_from_blob_key(&blob.hash);
+    target_driver
+        .put(&target_path, bytes)
+        .await
+        .expect("referenced target object should be seeded");
+    let referenced_hash = aster_drive::utils::hash::sha256_hex(b"separate referenced blob row");
+    let referenced = create_blob_record_with_storage_path(
+        &state,
+        &target,
+        &referenced_hash,
+        &target_path,
+        bytes,
+        1,
+    )
+    .await;
+
+    let body = create_migration_task_via_api(&app, &token, source.id, target.id, false).await;
+    let task_id = body["data"]["id"].as_i64().expect("task id should exist");
+
+    let stats = task_service::drain(&state)
+        .await
+        .expect("failed migration task should drain");
+    assert_eq!(stats.failed, 1);
+
+    let task = background_task_repo::find_by_id(state.writer_db(), task_id)
+        .await
+        .expect("task should exist");
+    assert_eq!(task.status, BackgroundTaskStatus::Failed);
+    assert!(
+        target_driver.contains(&target_path),
+        "cleanup must not delete a target object while a blob row still references its path"
+    );
+    assert_eq!(
+        target_driver.bytes(&target_path).as_deref(),
+        Some(bytes.as_slice()),
+        "referenced target object bytes should remain intact"
+    );
+    let referenced_after = file_repo::find_blob_by_id(state.writer_db(), referenced.id)
+        .await
+        .expect("referenced target blob row should remain");
+    assert_eq!(referenced_after.policy_id, target.id);
+    assert_eq!(referenced_after.storage_path, target_path);
 }
 
 #[actix_web::test]

--- a/tests/test_storage_migration.rs
+++ b/tests/test_storage_migration.rs
@@ -3,12 +3,14 @@
 #[macro_use]
 mod common;
 
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::io::Cursor;
 use std::sync::Arc;
+use std::time::Duration;
 
 use actix_web::test;
 use async_trait::async_trait;
+use bytes::Bytes;
 use chrono::Utc;
 use parking_lot::Mutex;
 use sea_orm::{ActiveModelTrait, ColumnTrait, EntityTrait, QueryFilter, Set};
@@ -23,7 +25,9 @@ use aster_drive::entities::{file, file_blob, file_version, storage_policy};
 use aster_drive::errors::{AsterError, MapAsterErr, Result};
 use aster_drive::runtime::PrimaryAppState;
 use aster_drive::services::task_service;
-use aster_drive::storage::{BlobMetadata, StorageDriver, StreamUploadDriver};
+use aster_drive::storage::{
+    BlobMetadata, MultipartStorageDriver, StorageDriver, StorageErrorKind, StreamUploadDriver,
+};
 use aster_drive::types::{
     BackgroundTaskStatus, DriverType, FileCategory, StoredStoragePolicyAllowedTypes,
     StoredStoragePolicyOptions,
@@ -156,6 +160,358 @@ impl StreamUploadDriver for FailingStreamUploadDriver {
         Err(AsterError::storage_driver_error(
             "simulated timeout after remote write",
         ))
+    }
+}
+
+#[derive(Clone, Copy)]
+enum MultipartCompleteMode {
+    Success,
+    TransientErrorAfterWrite,
+    CorruptObjectAfterWrite,
+}
+
+#[derive(Clone, Copy)]
+enum MultipartPartFailure {
+    TransientAttempts {
+        part_number: i32,
+        remaining_failures: usize,
+    },
+    Permanent {
+        part_number: i32,
+    },
+}
+
+struct MultipartUploadState {
+    path: String,
+    parts: BTreeMap<i32, Vec<u8>>,
+    aborted: bool,
+}
+
+#[derive(Default)]
+struct MultipartMigrationDriverState {
+    objects: HashMap<String, Vec<u8>>,
+    uploads: HashMap<String, MultipartUploadState>,
+    next_upload_id: usize,
+    part_attempts: HashMap<i32, usize>,
+    uploaded_part_sizes: Vec<usize>,
+    put_reader_calls: usize,
+    complete_calls: usize,
+    abort_calls: usize,
+    delete_calls: usize,
+    complete_mode: Option<MultipartCompleteMode>,
+    part_failure: Option<MultipartPartFailure>,
+}
+
+#[derive(Clone, Default)]
+struct MultipartMigrationTestDriver {
+    state: Arc<Mutex<MultipartMigrationDriverState>>,
+}
+
+impl MultipartMigrationTestDriver {
+    fn fail_part_transient_once(part_number: i32) -> Self {
+        let driver = Self::default();
+        driver.state.lock().part_failure = Some(MultipartPartFailure::TransientAttempts {
+            part_number,
+            remaining_failures: 1,
+        });
+        driver
+    }
+
+    fn fail_part_permanently(part_number: i32) -> Self {
+        let driver = Self::default();
+        driver.state.lock().part_failure = Some(MultipartPartFailure::Permanent { part_number });
+        driver
+    }
+
+    fn complete_transient_after_write() -> Self {
+        let driver = Self::default();
+        driver.state.lock().complete_mode = Some(MultipartCompleteMode::TransientErrorAfterWrite);
+        driver
+    }
+
+    fn complete_with_corrupt_object() -> Self {
+        let driver = Self::default();
+        driver.state.lock().complete_mode = Some(MultipartCompleteMode::CorruptObjectAfterWrite);
+        driver
+    }
+
+    fn object_bytes(&self, path: &str) -> Option<Vec<u8>> {
+        self.state.lock().objects.get(path).cloned()
+    }
+
+    fn uploaded_part_sizes(&self) -> Vec<usize> {
+        self.state.lock().uploaded_part_sizes.clone()
+    }
+
+    fn part_attempt_count(&self, part_number: i32) -> usize {
+        self.state
+            .lock()
+            .part_attempts
+            .get(&part_number)
+            .copied()
+            .unwrap_or_default()
+    }
+
+    fn put_reader_calls(&self) -> usize {
+        self.state.lock().put_reader_calls
+    }
+
+    fn complete_calls(&self) -> usize {
+        self.state.lock().complete_calls
+    }
+
+    fn abort_calls(&self) -> usize {
+        self.state.lock().abort_calls
+    }
+
+    fn delete_calls(&self) -> usize {
+        self.state.lock().delete_calls
+    }
+}
+
+#[async_trait]
+impl StorageDriver for MultipartMigrationTestDriver {
+    async fn put(&self, path: &str, data: &[u8]) -> Result<String> {
+        self.state
+            .lock()
+            .objects
+            .insert(path.to_string(), data.to_vec());
+        Ok(path.to_string())
+    }
+
+    async fn get(&self, path: &str) -> Result<Vec<u8>> {
+        self.state
+            .lock()
+            .objects
+            .get(path)
+            .cloned()
+            .ok_or_else(|| AsterError::storage_driver_error(format!("missing object {path}")))
+    }
+
+    async fn get_stream(&self, path: &str) -> Result<Box<dyn AsyncRead + Unpin + Send>> {
+        Ok(Box::new(Cursor::new(self.get(path).await?)))
+    }
+
+    async fn delete(&self, path: &str) -> Result<()> {
+        let mut state = self.state.lock();
+        state.delete_calls += 1;
+        state.objects.remove(path);
+        Ok(())
+    }
+
+    async fn exists(&self, path: &str) -> Result<bool> {
+        Ok(self.state.lock().objects.contains_key(path))
+    }
+
+    async fn metadata(&self, path: &str) -> Result<BlobMetadata> {
+        let size = self
+            .state
+            .lock()
+            .objects
+            .get(path)
+            .map(Vec::len)
+            .ok_or_else(|| AsterError::storage_driver_error(format!("missing object {path}")))?;
+        Ok(BlobMetadata {
+            size: usize_to_u64(size, "test multipart object size")?,
+            content_type: None,
+        })
+    }
+
+    fn as_stream_upload(&self) -> Option<&dyn StreamUploadDriver> {
+        Some(self)
+    }
+
+    fn as_multipart(&self) -> Option<&dyn MultipartStorageDriver> {
+        Some(self)
+    }
+}
+
+#[async_trait]
+impl StreamUploadDriver for MultipartMigrationTestDriver {
+    async fn put_reader(
+        &self,
+        storage_path: &str,
+        mut reader: Box<dyn AsyncRead + Unpin + Send + Sync>,
+        _size: i64,
+    ) -> Result<String> {
+        let mut bytes = Vec::new();
+        reader.read_to_end(&mut bytes).await.map_aster_err_ctx(
+            "read unexpected stream upload",
+            AsterError::storage_driver_error,
+        )?;
+        let mut state = self.state.lock();
+        state.put_reader_calls += 1;
+        state.objects.insert(storage_path.to_string(), bytes);
+        Ok(storage_path.to_string())
+    }
+
+    async fn put_file(&self, storage_path: &str, local_path: &str) -> Result<String> {
+        let bytes = tokio::fs::read(local_path)
+            .await
+            .map_aster_err(AsterError::storage_driver_error)?;
+        let mut state = self.state.lock();
+        state.put_reader_calls += 1;
+        state.objects.insert(storage_path.to_string(), bytes);
+        Ok(storage_path.to_string())
+    }
+}
+
+#[async_trait]
+impl MultipartStorageDriver for MultipartMigrationTestDriver {
+    async fn create_multipart_upload(&self, path: &str) -> Result<String> {
+        let mut state = self.state.lock();
+        state.next_upload_id += 1;
+        let upload_id = format!("upload-{}", state.next_upload_id);
+        state.uploads.insert(
+            upload_id.clone(),
+            MultipartUploadState {
+                path: path.to_string(),
+                parts: BTreeMap::new(),
+                aborted: false,
+            },
+        );
+        Ok(upload_id)
+    }
+
+    async fn presigned_upload_part_url(
+        &self,
+        _path: &str,
+        _upload_id: &str,
+        _part_number: i32,
+        _expires: Duration,
+    ) -> Result<String> {
+        Err(aster_drive::storage::error::storage_driver_error(
+            StorageErrorKind::Unsupported,
+            "test driver does not presign multipart parts",
+        ))
+    }
+
+    async fn complete_multipart_upload(
+        &self,
+        path: &str,
+        upload_id: &str,
+        parts: Vec<(i32, String)>,
+    ) -> Result<()> {
+        let mut state = self.state.lock();
+        state.complete_calls += 1;
+        let upload = state.uploads.get(upload_id).ok_or_else(|| {
+            AsterError::storage_driver_error(format!("missing upload {upload_id}"))
+        })?;
+        assert_eq!(upload.path, path);
+        assert!(
+            !upload.aborted,
+            "aborted multipart upload must not complete"
+        );
+
+        let mut assembled = Vec::new();
+        for (part_number, _etag) in parts {
+            let part = upload.parts.get(&part_number).ok_or_else(|| {
+                AsterError::storage_driver_error(format!("missing part {part_number}"))
+            })?;
+            assembled.extend_from_slice(part);
+        }
+
+        let complete_mode = state
+            .complete_mode
+            .unwrap_or(MultipartCompleteMode::Success);
+        let stored = match complete_mode {
+            MultipartCompleteMode::Success | MultipartCompleteMode::TransientErrorAfterWrite => {
+                assembled
+            }
+            MultipartCompleteMode::CorruptObjectAfterWrite => vec![0xA5; assembled.len()],
+        };
+        state.objects.insert(path.to_string(), stored);
+
+        if matches!(
+            complete_mode,
+            MultipartCompleteMode::TransientErrorAfterWrite
+        ) {
+            return Err(aster_drive::storage::error::storage_driver_error(
+                StorageErrorKind::Transient,
+                "simulated complete timeout after object write",
+            ));
+        }
+        Ok(())
+    }
+
+    async fn upload_multipart_part(
+        &self,
+        path: &str,
+        upload_id: &str,
+        part_number: i32,
+        data: &[u8],
+    ) -> Result<String> {
+        self.upload_multipart_part_bytes(path, upload_id, part_number, Bytes::copy_from_slice(data))
+            .await
+    }
+
+    async fn upload_multipart_part_bytes(
+        &self,
+        path: &str,
+        upload_id: &str,
+        part_number: i32,
+        data: Bytes,
+    ) -> Result<String> {
+        let mut state = self.state.lock();
+        let attempts = state.part_attempts.entry(part_number).or_default();
+        *attempts += 1;
+        let attempt = *attempts;
+
+        let failure = match state.part_failure.as_mut() {
+            Some(MultipartPartFailure::TransientAttempts {
+                part_number: failing_part,
+                remaining_failures,
+            }) if *failing_part == part_number && *remaining_failures > 0 => {
+                *remaining_failures -= 1;
+                Some(aster_drive::storage::error::storage_driver_error(
+                    StorageErrorKind::Transient,
+                    "simulated transient multipart part failure",
+                ))
+            }
+            Some(MultipartPartFailure::Permanent {
+                part_number: failing_part,
+            }) if *failing_part == part_number => {
+                Some(aster_drive::storage::error::storage_driver_error(
+                    StorageErrorKind::Permission,
+                    "simulated permanent multipart part failure",
+                ))
+            }
+            _ => None,
+        };
+        if let Some(error) = failure {
+            return Err(error);
+        }
+
+        let upload = state.uploads.get_mut(upload_id).ok_or_else(|| {
+            AsterError::storage_driver_error(format!("missing upload {upload_id}"))
+        })?;
+        assert_eq!(upload.path, path);
+        assert!(
+            !upload.aborted,
+            "aborted multipart upload must not accept parts"
+        );
+        upload.parts.insert(part_number, data.to_vec());
+        state.uploaded_part_sizes.push(data.len());
+        Ok(format!("etag-{part_number}-{attempt}"))
+    }
+
+    async fn abort_multipart_upload(&self, path: &str, upload_id: &str) -> Result<()> {
+        let mut state = self.state.lock();
+        state.abort_calls += 1;
+        let upload = state.uploads.get_mut(upload_id).ok_or_else(|| {
+            AsterError::storage_driver_error(format!("missing upload {upload_id}"))
+        })?;
+        assert_eq!(upload.path, path);
+        upload.aborted = true;
+        Ok(())
+    }
+
+    async fn list_uploaded_parts(&self, _path: &str, upload_id: &str) -> Result<Vec<i32>> {
+        let state = self.state.lock();
+        let upload = state.uploads.get(upload_id).ok_or_else(|| {
+            AsterError::storage_driver_error(format!("missing upload {upload_id}"))
+        })?;
+        Ok(upload.parts.keys().copied().collect())
     }
 }
 
@@ -336,6 +692,12 @@ async fn s3_object_exists(endpoint: &str, bucket: &str, key: &str) -> bool {
 
 fn policy_object_key(policy: &storage_policy::Model, storage_path: &str) -> String {
     format!("{}/{}", policy.base_path.trim_matches('/'), storage_path)
+}
+
+fn multipart_test_bytes(size: usize) -> Vec<u8> {
+    (0..size)
+        .map(|index| u8::try_from(index % 251).expect("test byte pattern should fit u8"))
+        .collect()
 }
 
 async fn create_blob_with_object(
@@ -1731,6 +2093,209 @@ async fn test_storage_migration_stream_upload_error_does_not_delete_referenced_t
         .expect("referenced target blob row should remain");
     assert_eq!(referenced_after.policy_id, target.id);
     assert_eq!(referenced_after.storage_path, target_path);
+}
+
+#[actix_web::test]
+async fn test_storage_migration_large_blob_uses_multipart_upload() {
+    let state = common::setup().await;
+    let app = create_test_app!(state.clone());
+    let (token, _) = register_and_login!(app);
+    let source = create_local_policy(&state, "source-multipart-success").await;
+    let target = create_local_policy(&state, "target-multipart-success").await;
+    let target_driver = MultipartMigrationTestDriver::default();
+    state
+        .driver_registry
+        .insert_for_test(target.id, Arc::new(target_driver.clone()));
+    let bytes = multipart_test_bytes(5 * 1024 * 1024 + 17);
+    let blob = create_blob_with_object(&state, &source, &bytes, 1).await;
+    create_file_for_blob(&state, blob.id, "multipart-success.7z").await;
+
+    let body = create_migration_task_via_api(&app, &token, source.id, target.id, false).await;
+    let task_id = body["data"]["id"].as_i64().expect("task id should exist");
+    let target_path = aster_drive::utils::storage_path_from_blob_key(&blob.hash);
+    let stats = task_service::drain(&state)
+        .await
+        .expect("multipart migration task should drain");
+    assert_eq!(stats.succeeded, 1);
+
+    let migrated = file_repo::find_blob_by_id(state.writer_db(), blob.id)
+        .await
+        .expect("blob should remain after multipart migration");
+    assert_eq!(migrated.policy_id, target.id);
+    assert_eq!(target_driver.put_reader_calls(), 0);
+    assert_eq!(
+        target_driver.uploaded_part_sizes(),
+        vec![5 * 1024 * 1024, 17]
+    );
+    assert_eq!(
+        target_driver.object_bytes(&target_path),
+        Some(bytes.clone())
+    );
+
+    let task = background_task_repo::find_by_id(state.writer_db(), task_id)
+        .await
+        .expect("task should exist");
+    assert_eq!(task.status, BackgroundTaskStatus::Succeeded);
+    let checkpoint = storage_migration_checkpoint_repo::get_by_task_id(state.writer_db(), task_id)
+        .await
+        .expect("checkpoint should exist");
+    assert_eq!(checkpoint.stage, "complete");
+    assert_eq!(checkpoint.migrated_blobs, 1);
+    assert_eq!(checkpoint.migrated_bytes, blob.size);
+}
+
+#[actix_web::test]
+async fn test_storage_migration_multipart_retries_transient_part_upload() {
+    let state = common::setup().await;
+    let app = create_test_app!(state.clone());
+    let (token, _) = register_and_login!(app);
+    let source = create_local_policy(&state, "source-multipart-retry").await;
+    let target = create_local_policy(&state, "target-multipart-retry").await;
+    let target_driver = MultipartMigrationTestDriver::fail_part_transient_once(1);
+    state
+        .driver_registry
+        .insert_for_test(target.id, Arc::new(target_driver.clone()));
+    let bytes = multipart_test_bytes(5 * 1024 * 1024 + 3);
+    let blob = create_blob_with_object(&state, &source, &bytes, 1).await;
+    create_file_for_blob(&state, blob.id, "multipart-retry.7z").await;
+
+    create_migration_task_via_api(&app, &token, source.id, target.id, false).await;
+    let target_path = aster_drive::utils::storage_path_from_blob_key(&blob.hash);
+    let stats = task_service::drain(&state)
+        .await
+        .expect("multipart retry migration task should drain");
+    assert_eq!(stats.succeeded, 1);
+
+    assert_eq!(target_driver.part_attempt_count(1), 2);
+    assert_eq!(target_driver.part_attempt_count(2), 1);
+    assert_eq!(target_driver.abort_calls(), 0);
+    assert_eq!(target_driver.object_bytes(&target_path), Some(bytes));
+    let migrated = file_repo::find_blob_by_id(state.writer_db(), blob.id)
+        .await
+        .expect("blob should move after retry succeeds");
+    assert_eq!(migrated.policy_id, target.id);
+}
+
+#[actix_web::test]
+async fn test_storage_migration_multipart_part_failure_aborts_and_keeps_source_blob() {
+    let state = common::setup().await;
+    let app = create_test_app!(state.clone());
+    let (token, _) = register_and_login!(app);
+    let source = create_local_policy(&state, "source-multipart-part-fail").await;
+    let target = create_local_policy(&state, "target-multipart-part-fail").await;
+    let target_driver = MultipartMigrationTestDriver::fail_part_permanently(2);
+    state
+        .driver_registry
+        .insert_for_test(target.id, Arc::new(target_driver.clone()));
+    let bytes = multipart_test_bytes(5 * 1024 * 1024 + 9);
+    let blob = create_blob_with_object(&state, &source, &bytes, 1).await;
+    create_file_for_blob(&state, blob.id, "multipart-part-fail.7z").await;
+
+    let body = create_migration_task_via_api(&app, &token, source.id, target.id, false).await;
+    let task_id = body["data"]["id"].as_i64().expect("task id should exist");
+    let target_path = aster_drive::utils::storage_path_from_blob_key(&blob.hash);
+    let stats = task_service::drain(&state)
+        .await
+        .expect("multipart failing task should drain");
+    assert_eq!(stats.failed, 1);
+
+    let task = background_task_repo::find_by_id(state.writer_db(), task_id)
+        .await
+        .expect("task should exist");
+    assert_eq!(task.status, BackgroundTaskStatus::Failed);
+    assert!(
+        task.last_error
+            .as_deref()
+            .expect("failed task should store last_error")
+            .contains("simulated permanent multipart part failure")
+    );
+    assert_eq!(target_driver.abort_calls(), 1);
+    assert_eq!(target_driver.complete_calls(), 0);
+    assert_eq!(target_driver.object_bytes(&target_path), None);
+    let source_blob = file_repo::find_blob_by_id(state.writer_db(), blob.id)
+        .await
+        .expect("source blob row should remain when multipart part fails");
+    assert_eq!(source_blob.policy_id, source.id);
+}
+
+#[actix_web::test]
+async fn test_storage_migration_multipart_complete_timeout_accepts_existing_object() {
+    let state = common::setup().await;
+    let app = create_test_app!(state.clone());
+    let (token, _) = register_and_login!(app);
+    let source = create_local_policy(&state, "source-multipart-complete-timeout").await;
+    let target = create_local_policy(&state, "target-multipart-complete-timeout").await;
+    let target_driver = MultipartMigrationTestDriver::complete_transient_after_write();
+    state
+        .driver_registry
+        .insert_for_test(target.id, Arc::new(target_driver.clone()));
+    let bytes = multipart_test_bytes(5 * 1024 * 1024 + 11);
+    let blob = create_blob_with_object(&state, &source, &bytes, 1).await;
+    create_file_for_blob(&state, blob.id, "multipart-complete-timeout.7z").await;
+
+    create_migration_task_via_api(&app, &token, source.id, target.id, false).await;
+    let target_path = aster_drive::utils::storage_path_from_blob_key(&blob.hash);
+    let stats = task_service::drain(&state)
+        .await
+        .expect("multipart complete-timeout task should drain");
+    assert_eq!(stats.succeeded, 1);
+
+    assert_eq!(target_driver.complete_calls(), 1);
+    assert_eq!(target_driver.abort_calls(), 0);
+    assert_eq!(target_driver.object_bytes(&target_path), Some(bytes));
+    let migrated = file_repo::find_blob_by_id(state.writer_db(), blob.id)
+        .await
+        .expect("blob should move when complete timeout is proven successful");
+    assert_eq!(migrated.policy_id, target.id);
+}
+
+#[actix_web::test]
+async fn test_storage_migration_multipart_verification_failure_cleans_object_and_rolls_back_row() {
+    let state = common::setup().await;
+    let app = create_test_app!(state.clone());
+    let (token, _) = register_and_login!(app);
+    let source = create_local_policy(&state, "source-multipart-verify-fail").await;
+    let target = create_local_policy(&state, "target-multipart-verify-fail").await;
+    let target_driver = MultipartMigrationTestDriver::complete_with_corrupt_object();
+    state
+        .driver_registry
+        .insert_for_test(target.id, Arc::new(target_driver.clone()));
+    let bytes = multipart_test_bytes(5 * 1024 * 1024 + 5);
+    let blob = create_blob_with_object(&state, &source, &bytes, 1).await;
+    create_file_for_blob(&state, blob.id, "multipart-verify-fail.7z").await;
+
+    let body = create_migration_task_via_api(&app, &token, source.id, target.id, false).await;
+    let task_id = body["data"]["id"].as_i64().expect("task id should exist");
+    let target_path = aster_drive::utils::storage_path_from_blob_key(&blob.hash);
+    let stats = task_service::drain(&state)
+        .await
+        .expect("multipart verification failure task should drain");
+    assert_eq!(stats.failed, 1);
+
+    let task = background_task_repo::find_by_id(state.writer_db(), task_id)
+        .await
+        .expect("task should exist");
+    assert_eq!(task.status, BackgroundTaskStatus::Failed);
+    assert!(
+        task.last_error
+            .as_deref()
+            .expect("failed task should store last_error")
+            .contains("target object hash mismatch")
+    );
+    assert_eq!(target_driver.abort_calls(), 0);
+    assert_eq!(target_driver.delete_calls(), 2);
+    assert_eq!(target_driver.object_bytes(&target_path), None);
+    let source_blob = file_repo::find_blob_by_id(state.writer_db(), blob.id)
+        .await
+        .expect("source blob row should remain after verification failure");
+    assert_eq!(source_blob.policy_id, source.id);
+
+    let checkpoint = storage_migration_checkpoint_repo::get_by_task_id(state.writer_db(), task_id)
+        .await
+        .expect("checkpoint should exist");
+    assert_eq!(checkpoint.stage, "migrate_blobs");
+    assert_eq!(checkpoint.last_processed_blob_id, 0);
+    assert_eq!(checkpoint.migrated_blobs, 0);
 }
 
 #[actix_web::test]

--- a/tests/test_tasks.rs
+++ b/tests/test_tasks.rs
@@ -4,11 +4,17 @@
 mod common;
 
 use actix_web::{App, test, web};
+use async_trait::async_trait;
 use chrono::{Duration, Utc};
 use sea_orm::{ActiveModelTrait, ColumnTrait, EntityTrait, IntoActiveModel, QueryFilter, Set};
 use serde_json::Value;
 use std::io::{Cursor, Read, Write};
 use std::path::Path;
+use std::sync::{
+    Arc,
+    atomic::{AtomicUsize, Ordering},
+};
+use tokio::io::{AsyncRead, empty};
 use tokio::sync::broadcast;
 
 use aster_drive::config::operations::{
@@ -20,8 +26,8 @@ use aster_drive::config::operations::{
     OFFLINE_DOWNLOAD_MAX_MB_PER_SEC_KEY, OFFLINE_DOWNLOAD_REQUEST_TIMEOUT_SECS_KEY,
     OFFLINE_DOWNLOAD_TEMP_DIR_KEY,
 };
-use aster_drive::db::repository::{background_task_repo, file_repo};
-use aster_drive::entities::{background_task, file_blob};
+use aster_drive::db::repository::{background_task_repo, file_repo, policy_repo};
+use aster_drive::entities::{background_task, file_blob, storage_policy};
 use aster_drive::services::task_service::{
     self, RuntimeTaskRunOutcome, SystemRuntimeTaskKind,
     types::{
@@ -29,6 +35,7 @@ use aster_drive::services::task_service::{
         RuntimeTaskName, RuntimeTaskPayload,
     },
 };
+use aster_drive::storage::{BlobMetadata, StorageDriver};
 use aster_drive::types::{BackgroundTaskKind, BackgroundTaskStatus, StoredTaskPayload};
 
 const OLD_BACKGROUND_TASK_DISPLAY_NAME_LIMIT: usize = 255;
@@ -39,6 +46,51 @@ struct Aria2TestContext {
     _container: testcontainers::ContainerAsync<testcontainers::GenericImage>,
     rpc_url: String,
     rpc_secret: String,
+}
+
+#[derive(Default)]
+struct MetadataCountingDriver {
+    metadata_calls: AtomicUsize,
+}
+
+impl MetadataCountingDriver {
+    fn metadata_calls(&self) -> usize {
+        self.metadata_calls.load(Ordering::SeqCst)
+    }
+}
+
+#[async_trait]
+impl StorageDriver for MetadataCountingDriver {
+    async fn put(&self, path: &str, _data: &[u8]) -> aster_drive::errors::Result<String> {
+        Ok(path.to_string())
+    }
+
+    async fn get(&self, _path: &str) -> aster_drive::errors::Result<Vec<u8>> {
+        Ok(Vec::new())
+    }
+
+    async fn get_stream(
+        &self,
+        _path: &str,
+    ) -> aster_drive::errors::Result<Box<dyn AsyncRead + Unpin + Send>> {
+        Ok(Box::new(empty()))
+    }
+
+    async fn delete(&self, _path: &str) -> aster_drive::errors::Result<()> {
+        Ok(())
+    }
+
+    async fn exists(&self, _path: &str) -> aster_drive::errors::Result<bool> {
+        Ok(true)
+    }
+
+    async fn metadata(&self, _path: &str) -> aster_drive::errors::Result<BlobMetadata> {
+        self.metadata_calls.fetch_add(1, Ordering::SeqCst);
+        Ok(BlobMetadata {
+            size: 11,
+            content_type: Some("application/octet-stream".to_string()),
+        })
+    }
 }
 
 macro_rules! register_user {
@@ -1530,6 +1582,370 @@ async fn test_blob_maintenance_integrity_check_reports_missing_and_size_mismatch
     assert_eq!(result["size_mismatches"], 1);
     assert_eq!(result["ref_counts_fixed"], 0);
     assert_eq!(result["orphan_blobs_deleted"], 0);
+}
+
+#[actix_web::test]
+async fn test_blob_maintenance_uses_uncached_driver_without_replacing_existing_handles() {
+    let state = common::setup().await;
+    let app = create_test_app!(state.clone());
+    let (token, _) = register_and_login!(app);
+    let file_id = upload_test_file_named!(app, token, "blob-driver-release.txt");
+    let file = file_repo::find_by_id(state.writer_db(), file_id)
+        .await
+        .expect("uploaded file should load");
+    let blob = file_repo::find_blob_by_id(state.writer_db(), file.blob_id)
+        .await
+        .expect("uploaded blob should load");
+    let policy = policy_repo::find_by_id(state.writer_db(), blob.policy_id)
+        .await
+        .expect("blob policy should load");
+    let driver_before = state
+        .driver_registry
+        .get_driver(&policy)
+        .expect("driver should resolve before maintenance");
+    assert!(
+        driver_before
+            .exists(&blob.storage_path)
+            .await
+            .expect("old driver should read object before maintenance")
+    );
+
+    let req = test::TestRequest::post()
+        .uri("/api/v1/admin/file-blobs/maintenance")
+        .insert_header(("Cookie", common::access_cookie_header(&token)))
+        .insert_header(common::csrf_header_for(&token))
+        .set_json(serde_json::json!({
+            "action": "integrity_check",
+            "blob_ids": [blob.id]
+        }))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), 200);
+
+    let stats = task_service::drain(&state)
+        .await
+        .expect("blob maintenance task should drain");
+    assert_eq!(stats.succeeded, 1);
+    assert_eq!(stats.failed, 0);
+
+    let driver_after = state
+        .driver_registry
+        .get_driver(&policy)
+        .expect("driver should resolve after maintenance");
+    assert!(
+        std::sync::Arc::ptr_eq(&driver_before, &driver_after),
+        "blob maintenance must not evict or replace an existing cached driver"
+    );
+    assert!(
+        driver_before
+            .exists(&blob.storage_path)
+            .await
+            .expect("old Arc handle should remain usable after registry invalidation"),
+        "registry invalidation must not break in-flight users that already cloned the driver"
+    );
+    assert!(
+        driver_after
+            .exists(&blob.storage_path)
+            .await
+            .expect("cached driver should read object after maintenance"),
+        "cached driver should keep working after maintenance"
+    );
+}
+
+#[actix_web::test]
+async fn test_blob_maintenance_reuses_existing_shared_driver_cache() {
+    let state = common::setup().await;
+    let app = create_test_app!(state.clone());
+    let (token, _) = register_and_login!(app);
+    let file_id = upload_test_file_named!(app, token, "blob-driver-cache-hit.txt");
+    let file = file_repo::find_by_id(state.writer_db(), file_id)
+        .await
+        .expect("uploaded file should load");
+    let blob = file_repo::find_blob_by_id(state.writer_db(), file.blob_id)
+        .await
+        .expect("uploaded blob should load");
+    let counting_driver = Arc::new(MetadataCountingDriver::default());
+    state
+        .driver_registry
+        .insert_for_test(blob.policy_id, counting_driver.clone());
+
+    let req = test::TestRequest::post()
+        .uri("/api/v1/admin/file-blobs/maintenance")
+        .insert_header(("Cookie", common::access_cookie_header(&token)))
+        .insert_header(common::csrf_header_for(&token))
+        .set_json(serde_json::json!({
+            "action": "integrity_check",
+            "blob_ids": [blob.id]
+        }))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), 200);
+
+    let stats = task_service::drain(&state)
+        .await
+        .expect("blob maintenance task should drain");
+    assert_eq!(stats.succeeded, 1);
+    assert_eq!(stats.failed, 0);
+    assert_eq!(
+        counting_driver.metadata_calls(),
+        1,
+        "maintenance should reuse an already-cached shared driver Arc"
+    );
+}
+
+#[actix_web::test]
+async fn test_blob_maintenance_keeps_cached_policy_drivers_stable() {
+    let state = common::setup().await;
+    let app = create_test_app!(state.clone());
+    let (token, _) = register_and_login!(app);
+    let file_id = upload_test_file_named!(app, token, "blob-driver-release-one-policy.txt");
+    let file = file_repo::find_by_id(state.writer_db(), file_id)
+        .await
+        .expect("uploaded file should load");
+    let blob = file_repo::find_blob_by_id(state.writer_db(), file.blob_id)
+        .await
+        .expect("uploaded blob should load");
+    let touched_policy = policy_repo::find_by_id(state.writer_db(), blob.policy_id)
+        .await
+        .expect("blob policy should load");
+    let untouched_policy_root = std::env::temp_dir().join(format!(
+        "asterdrive-untouched-policy-{}",
+        uuid::Uuid::new_v4()
+    ));
+    std::fs::create_dir_all(&untouched_policy_root)
+        .expect("untouched policy root should be created");
+    let now = Utc::now();
+    let untouched_policy = storage_policy::ActiveModel {
+        name: Set("Untouched maintenance policy".to_string()),
+        driver_type: Set(aster_drive::types::DriverType::Local),
+        endpoint: Set(String::new()),
+        bucket: Set(String::new()),
+        access_key: Set(String::new()),
+        secret_key: Set(String::new()),
+        base_path: Set(untouched_policy_root.to_string_lossy().into_owned()),
+        remote_node_id: Set(None),
+        max_file_size: Set(0),
+        allowed_types: Set(aster_drive::types::StoredStoragePolicyAllowedTypes::empty()),
+        options: Set(aster_drive::types::StoredStoragePolicyOptions::empty()),
+        is_default: Set(false),
+        chunk_size: Set(0),
+        created_at: Set(now),
+        updated_at: Set(now),
+        ..Default::default()
+    }
+    .insert(state.writer_db())
+    .await
+    .expect("untouched policy should insert");
+
+    let touched_driver_before = state
+        .driver_registry
+        .get_driver(&touched_policy)
+        .expect("touched driver should resolve before maintenance");
+    let untouched_driver_before = state
+        .driver_registry
+        .get_driver(&untouched_policy)
+        .expect("untouched driver should resolve before maintenance");
+
+    let req = test::TestRequest::post()
+        .uri("/api/v1/admin/file-blobs/maintenance")
+        .insert_header(("Cookie", common::access_cookie_header(&token)))
+        .insert_header(common::csrf_header_for(&token))
+        .set_json(serde_json::json!({
+            "action": "integrity_check",
+            "blob_ids": [blob.id]
+        }))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), 200);
+
+    let stats = task_service::drain(&state)
+        .await
+        .expect("blob maintenance task should drain");
+    assert_eq!(stats.succeeded, 1);
+    assert_eq!(stats.failed, 0);
+
+    let touched_driver_after = state
+        .driver_registry
+        .get_driver(&touched_policy)
+        .expect("touched driver should be recreated after maintenance");
+    let untouched_driver_after = state
+        .driver_registry
+        .get_driver(&untouched_policy)
+        .expect("untouched driver should still resolve after maintenance");
+
+    assert!(
+        std::sync::Arc::ptr_eq(&touched_driver_before, &touched_driver_after),
+        "maintenance should leave existing cached drivers in place"
+    );
+    assert!(
+        std::sync::Arc::ptr_eq(&untouched_driver_before, &untouched_driver_after),
+        "maintenance must not evict drivers for policies it did not touch"
+    );
+}
+
+#[actix_web::test]
+async fn test_blob_maintenance_integrity_check_does_not_warm_shared_driver_cache() {
+    let state = common::setup().await;
+    let app = create_test_app!(state.clone());
+    let (token, _) = register_and_login!(app);
+    let file_id = upload_test_file_named!(app, token, "blob-driver-cache-cold.txt");
+    let file = file_repo::find_by_id(state.writer_db(), file_id)
+        .await
+        .expect("uploaded file should load");
+    let blob = file_repo::find_blob_by_id(state.writer_db(), file.blob_id)
+        .await
+        .expect("uploaded blob should load");
+    let policy = policy_repo::find_by_id(state.writer_db(), blob.policy_id)
+        .await
+        .expect("blob policy should load");
+    state.driver_registry.invalidate(policy.id);
+    assert!(
+        !state.driver_registry.has_cached_driver_for_test(policy.id),
+        "test must start with a cold shared driver cache"
+    );
+
+    let req = test::TestRequest::post()
+        .uri("/api/v1/admin/file-blobs/maintenance")
+        .insert_header(("Cookie", common::access_cookie_header(&token)))
+        .insert_header(common::csrf_header_for(&token))
+        .set_json(serde_json::json!({
+            "action": "integrity_check",
+            "blob_ids": [blob.id]
+        }))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), 200);
+
+    let stats = task_service::drain(&state)
+        .await
+        .expect("blob maintenance task should drain");
+    assert_eq!(stats.succeeded, 1);
+    assert_eq!(stats.failed, 0);
+    assert!(
+        !state.driver_registry.has_cached_driver_for_test(policy.id),
+        "blob maintenance should use task-local drivers instead of warming the shared driver cache"
+    );
+
+    let driver_after = state
+        .driver_registry
+        .get_driver(&policy)
+        .expect("driver should be built on demand after maintenance");
+    let driver_again = state
+        .driver_registry
+        .get_driver(&policy)
+        .expect("driver should be cached after explicit registry access");
+    assert!(
+        std::sync::Arc::ptr_eq(&driver_after, &driver_again),
+        "maintenance should not pre-warm the shared cache; explicit access should create the first cached driver"
+    );
+}
+
+#[actix_web::test]
+async fn test_blob_maintenance_orphan_cleanup_does_not_warm_shared_driver_cache() {
+    let state = common::setup().await;
+    let app = create_test_app!(state.clone());
+    let (token, _) = register_and_login!(app);
+    let policy = policy_repo::find_default(state.writer_db())
+        .await
+        .expect("default policy query should succeed")
+        .expect("default policy should exist");
+    let blob_path = format!("admin-maintenance/cache-cold-{}.txt", uuid::Uuid::new_v4());
+    let driver = state
+        .driver_registry
+        .get_driver(&policy)
+        .expect("driver should resolve for fixture setup");
+    driver
+        .put(&blob_path, b"orphan")
+        .await
+        .expect("orphan object should be written");
+    let now = Utc::now();
+    let blob = file_blob::ActiveModel {
+        hash: Set(format!("orphan-cache-cold-{}", uuid::Uuid::new_v4())),
+        size: Set(6),
+        policy_id: Set(policy.id),
+        storage_path: Set(blob_path),
+        ref_count: Set(0),
+        created_at: Set(now),
+        updated_at: Set(now),
+        ..Default::default()
+    }
+    .insert(state.writer_db())
+    .await
+    .expect("orphan blob should insert");
+    state.driver_registry.invalidate(policy.id);
+    assert!(
+        !state.driver_registry.has_cached_driver_for_test(policy.id),
+        "test must start with a cold shared driver cache"
+    );
+
+    let req = test::TestRequest::post()
+        .uri("/api/v1/admin/file-blobs/maintenance")
+        .insert_header(("Cookie", common::access_cookie_header(&token)))
+        .insert_header(common::csrf_header_for(&token))
+        .set_json(serde_json::json!({
+            "action": "orphan_cleanup",
+            "blob_ids": [blob.id]
+        }))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), 200);
+
+    let stats = task_service::drain(&state)
+        .await
+        .expect("blob maintenance task should drain");
+    assert_eq!(stats.succeeded, 1);
+    assert_eq!(stats.failed, 0);
+    assert!(
+        !state.driver_registry.has_cached_driver_for_test(policy.id),
+        "orphan cleanup should delete through task-local drivers, not the shared cache"
+    );
+    assert!(
+        file_repo::find_blob_by_id(state.writer_db(), blob.id)
+            .await
+            .is_err(),
+        "orphan blob row should be deleted"
+    );
+}
+
+#[actix_web::test]
+async fn test_blob_maintenance_empty_scan_keeps_untouched_cached_driver() {
+    let state = common::setup().await;
+    let app = create_test_app!(state.clone());
+    let (token, _) = register_and_login!(app);
+    let policy = policy_repo::find_default(state.writer_db())
+        .await
+        .expect("default policy query should succeed")
+        .expect("default policy should exist");
+    let driver_before = state
+        .driver_registry
+        .get_driver(&policy)
+        .expect("driver should resolve before empty maintenance");
+
+    let req = test::TestRequest::post()
+        .uri("/api/v1/admin/file-blobs/maintenance")
+        .insert_header(("Cookie", common::access_cookie_header(&token)))
+        .insert_header(common::csrf_header_for(&token))
+        .set_json(serde_json::json!({
+            "action": "ref_count_reconcile"
+        }))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), 200);
+
+    let stats = task_service::drain(&state)
+        .await
+        .expect("empty blob maintenance task should drain");
+    assert_eq!(stats.succeeded, 1);
+    assert_eq!(stats.failed, 0);
+
+    let driver_after = state
+        .driver_registry
+        .get_driver(&policy)
+        .expect("driver should still resolve after empty maintenance");
+    assert!(
+        std::sync::Arc::ptr_eq(&driver_before, &driver_after),
+        "empty maintenance should not evict storage drivers it did not touch"
+    );
 }
 
 #[actix_web::test]

--- a/tests/test_webdav.rs
+++ b/tests/test_webdav.rs
@@ -369,6 +369,46 @@ async fn test_webdav_mkcol_and_list() {
 }
 
 #[actix_web::test]
+async fn test_webdav_mkcol_body_boundaries() {
+    let app = setup_with_webdav!();
+
+    let (token, _) = register_and_login!(app);
+    let auth = create_webdav_basic_auth!(app, token);
+
+    let req = test::TestRequest::with_uri("/webdav/body-empty/")
+        .method(actix_web::http::Method::from_bytes(b"MKCOL").unwrap())
+        .insert_header(("Authorization", auth.clone()))
+        .set_payload(Vec::<u8>::new())
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), 201, "empty MKCOL body should be accepted");
+
+    let req = test::TestRequest::with_uri("/webdav/body-non-empty/")
+        .method(actix_web::http::Method::from_bytes(b"MKCOL").unwrap())
+        .insert_header(("Authorization", auth.clone()))
+        .set_payload("x")
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(
+        resp.status(),
+        415,
+        "non-empty MKCOL body should be rejected"
+    );
+
+    let req = test::TestRequest::with_uri("/webdav/body-large/")
+        .method(actix_web::http::Method::from_bytes(b"MKCOL").unwrap())
+        .insert_header(("Authorization", auth.clone()))
+        .set_payload(vec![b'x'; 2 * 1024 * 1024])
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(
+        resp.status(),
+        415,
+        "large non-empty MKCOL body should be rejected without requiring full body collection"
+    );
+}
+
+#[actix_web::test]
 async fn test_webdav_propfind_rejects_xml_body_over_limit() {
     let webdav_config = WebDavConfig {
         xml_payload_limit: 8,


### PR DESCRIPTION
This pull request introduces several improvements and refactorings across configuration management, database querying, and file cleanup logic. The main focus is on enforcing concurrency limits for background tasks, optimizing audit log queries for admin reporting, and making the file blob cleanup process more flexible and testable.

**Configuration and Concurrency Limits**

* Introduced a constant `MAX_BACKGROUND_TASK_CONCURRENCY` (set to 16) and updated configuration normalization and reading logic to enforce this maximum for all background task concurrency settings. If a configured value exceeds this limit, it is clamped and a warning is logged. Additional tests were added to ensure correct boundary handling. [[1]](diffhunk://#diff-4023ef572a01ca8f475d47710b233e5b08e1f6c999e7c6f886463ecd2517d63eR47) [[2]](diffhunk://#diff-4023ef572a01ca8f475d47710b233e5b08e1f6c999e7c6f886463ecd2517d63eL145-R153) [[3]](diffhunk://#diff-4023ef572a01ca8f475d47710b233e5b08e1f6c999e7c6f886463ecd2517d63eL854-R875) [[4]](diffhunk://#diff-4023ef572a01ca8f475d47710b233e5b08e1f6c999e7c6f886463ecd2517d63eL903-R938) [[5]](diffhunk://#diff-4023ef572a01ca8f475d47710b233e5b08e1f6c999e7c6f886463ecd2517d63eR1141-R1229) [[6]](diffhunk://#diff-4023ef572a01ca8f475d47710b233e5b08e1f6c999e7c6f886463ecd2517d63eR1443-R1457)

**Database and Admin Reporting**

* Added a new paginated query `find_action_page_in_range` to `audit_log_repo.rs` for efficiently fetching audit log actions with cursor-based pagination. This enables the admin overview report to process large audit logs in batches, keeping memory usage bounded. The admin service now uses this paginated approach for daily reports. [[1]](diffhunk://#diff-734e74842750ad052fd02ac077454d8e22d25f7daa1627f73e90ae2b7d013d2dL5-R6) [[2]](diffhunk://#diff-734e74842750ad052fd02ac077454d8e22d25f7daa1627f73e90ae2b7d013d2dR158-R200) [[3]](diffhunk://#diff-dcc03bc1ef4b33c7641aaa7463a134ab6f1290ad782e06dd23e9aca9cb24dbfeR32) [[4]](diffhunk://#diff-dcc03bc1ef4b33c7641aaa7463a134ab6f1290ad782e06dd23e9aca9cb24dbfeL494-R519)

**File Blob Cleanup Refactor**

* Refactored the blob cleanup logic to allow dependency injection of the storage driver lookup function. This makes the cleanup process more flexible and easier to test, decoupling it from the global driver registry. [[1]](diffhunk://#diff-9f174bdba37b84165faa86a30b9eddde565445a45d8f38ad3bf7bcc3da1fe3c9L2-R7) [[2]](diffhunk://#diff-9f174bdba37b84165faa86a30b9eddde565445a45d8f38ad3bf7bcc3da1fe3c9L36-R43) [[3]](diffhunk://#diff-9f174bdba37b84165faa86a30b9eddde565445a45d8f38ad3bf7bcc3da1fe3c9R59-R72) [[4]](diffhunk://#diff-9f174bdba37b84165faa86a30b9eddde565445a45d8f38ad3bf7bcc3da1fe3c9L99-R130) [[5]](diffhunk://#diff-9f174bdba37b84165faa86a30b9eddde565445a45d8f38ad3bf7bcc3da1fe3c9L138-R159)

**Public Config Service Optimization**

* Optimized the logic for determining public support for native thumbnails and media metadata by checking driver type statically, avoiding unnecessary instantiation of storage drivers and the associated resource usage. [[1]](diffhunk://#diff-daba7033d4df42604a2821141e8c52492bc8e0089b055026d8fd0e65ecbf5a76R8-R10) [[2]](diffhunk://#diff-daba7033d4df42604a2821141e8c52492bc8e0089b055026d8fd0e65ecbf5a76L142-L153) [[3]](diffhunk://#diff-daba7033d4df42604a2821141e8c52492bc8e0089b055026d8fd0e65ecbf5a76L177-L188)

**Test and Minor Improvements**

* Updated a test in the file access route to use `web::Bytes::from_static` for thumbnail data, aligning with production code expectations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 审计日志支持基于游标的分页查询；后台任务并发上限为16；存储迁移新增分片（multipart）上传支持；公开媒体/缩略图能力计算增强对存储原生能力的识别。

* **Bug Fixes**
  * 任务心跳改为独立协程以提升取消响应性；清理流程在删除失败场景下更稳健，避免误删或卡死。

* **Tests**
  * 大量集成与单元测试新增，覆盖并发、迁移、缓存、WebDAV 请求体边界与失败场景。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->