### PR TITLE
feat(files): add storage usage tracking to file and folder details

### DIFF
--- a/frontend-panel/src/components/files/FileInfoDialog.test.tsx
+++ b/frontend-panel/src/components/files/FileInfoDialog.test.tsx
@@ -159,6 +159,27 @@ describe("FileInfoDialog", () => {
 		mockState.getFolderInfo.mockReset();
 		mockState.getMediaMetadata.mockReset();
 		mockState.listFolder.mockReset();
+		mockState.getFile.mockResolvedValue({
+			blob_id: 88,
+			created_at: "2026-01-01T00:00:00Z",
+			file_category: "document",
+			id: 1,
+			is_locked: false,
+			mime_type: "text/plain",
+			name: "resolved.txt",
+			size: 512,
+			storage_used: 512,
+			updated_at: "2026-01-02T00:00:00Z",
+		});
+		mockState.getFolderInfo.mockResolvedValue({
+			created_at: "2026-02-01T00:00:00Z",
+			id: 3,
+			is_locked: false,
+			name: "Projects",
+			policy_id: null,
+			storage_used: 0,
+			updated_at: "2026-02-02T00:00:00Z",
+		});
 		mockState.mediaDataSupportStore.isLoaded = true;
 		mockState.mediaDataSupportStore.load.mockReset();
 	});
@@ -177,6 +198,7 @@ describe("FileInfoDialog", () => {
 						mime_type: "text/markdown",
 						name: "notes.md",
 						size: 512,
+						storage_used: 1536,
 						updated_at: "2026-01-02T00:00:00Z",
 					} as never
 				}
@@ -190,6 +212,7 @@ describe("FileInfoDialog", () => {
 			"thumbnail:notes.md:lg",
 		);
 		expect(screen.getAllByText("bytes:512").length).toBe(2);
+		expect(screen.getByText("bytes:1536")).toBeInTheDocument();
 		expect(screen.getByText("text/markdown")).toBeInTheDocument();
 		expect(screen.getByText("date:2026-01-01T00:00:00Z")).toBeInTheDocument();
 		expect(screen.getByText("date:2026-01-02T00:00:00Z")).toBeInTheDocument();
@@ -222,6 +245,7 @@ describe("FileInfoDialog", () => {
 			is_locked: false,
 			name: "Projects",
 			policy_id: null,
+			storage_used: 4096,
 			updated_at: "2026-02-02T00:00:00Z",
 		});
 		mockState.listFolder.mockImplementationOnce(
@@ -258,6 +282,7 @@ describe("FileInfoDialog", () => {
 		resolveList?.({ files_total: 5, folders_total: 2 });
 
 		expect((await screen.findAllByText("folders:2 files:5")).length).toBe(2);
+		expect(screen.getByText("bytes:4096")).toBeInTheDocument();
 	});
 
 	it("shows shared status for folder list items", async () => {
@@ -267,6 +292,7 @@ describe("FileInfoDialog", () => {
 			is_locked: false,
 			name: "Projects",
 			policy_id: null,
+			storage_used: 4096,
 			updated_at: "2026-02-02T00:00:00Z",
 		});
 		mockState.listFolder.mockResolvedValueOnce({
@@ -302,6 +328,7 @@ describe("FileInfoDialog", () => {
 				is_locked: true,
 				name: "Archive",
 				policy_id: 12,
+				storage_used: 8192,
 				updated_at: "2026-03-02T00:00:00Z",
 			})
 			.mockRejectedValueOnce(new Error("unavailable"));
@@ -346,6 +373,7 @@ describe("FileInfoDialog", () => {
 			mime_type: "text/markdown",
 			name: "notes.md",
 			size: 512,
+			storage_used: 2048,
 			updated_at: "2026-01-02T00:00:00Z",
 		});
 
@@ -371,6 +399,7 @@ describe("FileInfoDialog", () => {
 		expect(
 			await screen.findByText("date:2026-01-01T00:00:00Z"),
 		).toBeInTheDocument();
+		expect(screen.getByText("bytes:2048")).toBeInTheDocument();
 	});
 
 	it("shows image EXIF metadata in the details panel", async () => {

--- a/frontend-panel/src/components/files/FileInfoDialog.tsx
+++ b/frontend-panel/src/components/files/FileInfoDialog.tsx
@@ -94,11 +94,20 @@ function buildOverviewRows({
 	t: ReturnType<typeof useTranslation>["t"];
 }): DetailRow[] {
 	if (renderedFile) {
+		const fileStorageUsed = activeFile?.storage_used;
 		return [
 			{ label: t("info_type"), value: t("core:file") },
 			{
 				label: t("info_size"),
 				value: formatBytes((activeFile ?? renderedFile).size),
+			},
+			{
+				label: t("info_storage_used"),
+				value: formatValueOrFallback(
+					fileStorageUsed != null ? formatBytes(fileStorageUsed) : null,
+					fileDetailsLoading,
+					loadingText,
+				),
 			},
 			{
 				label: t("info_mime"),
@@ -125,8 +134,17 @@ function buildOverviewRows({
 		return [];
 	}
 
+	const folderStorageUsed = activeFolder?.storage_used;
 	return [
 		{ label: t("info_type"), value: t("core:folder") },
+		{
+			label: t("info_storage_used"),
+			value: formatValueOrFallback(
+				folderStorageUsed != null ? formatBytes(folderStorageUsed) : null,
+				folderDetailsLoading,
+				loadingText,
+			),
+		},
 		{
 			label: t("info_children"),
 			value:

--- a/frontend-panel/src/components/files/file-info-dialog/fileInfoDialogUtils.ts
+++ b/frontend-panel/src/components/files/file-info-dialog/fileInfoDialogUtils.ts
@@ -8,13 +8,13 @@ import type {
 export function hasFileDetails(
 	file: FileInfo | FileListItem,
 ): file is FileInfo {
-	return "blob_id" in file && "created_at" in file;
+	return "blob_id" in file && "created_at" in file && "storage_used" in file;
 }
 
 export function hasFolderDetails(
 	folder: FolderInfo | FolderListItem,
 ): folder is FolderInfo {
-	return "created_at" in folder;
+	return "created_at" in folder && "storage_used" in folder;
 }
 
 export function formatValueOrFallback(

--- a/frontend-panel/src/components/files/file-info-dialog/useFileInfoDialogData.test.tsx
+++ b/frontend-panel/src/components/files/file-info-dialog/useFileInfoDialogData.test.tsx
@@ -76,6 +76,7 @@ function fileInfo(overrides: Partial<FileInfo> = {}): FileInfo {
 		name: "Song.mp3",
 		owner_user_id: 1,
 		size: 128,
+		storage_used: 128,
 		team_id: null,
 		updated_at: "2026-01-02T00:00:00Z",
 		...overrides,
@@ -110,6 +111,7 @@ function folderInfo(overrides: Partial<FolderInfo> = {}): FolderInfo {
 		owner_user_id: 1,
 		parent_id: null,
 		policy_id: null,
+		storage_used: 0,
 		team_id: null,
 		updated_at: "2026-02-02T00:00:00Z",
 		...overrides,
@@ -249,6 +251,39 @@ describe("useFileInfoDialogData", () => {
 		expect(result.current.resolvedFile).toBeNull();
 		expect(result.current.resolvedFolder).toBeNull();
 		expect(result.current.childCount).toBeNull();
+	});
+
+	it("refreshes legacy detail records that do not include storage usage", async () => {
+		const renderedFile = {
+			...fileInfo({ name: "Legacy.mp3", storage_used: undefined }),
+		};
+		delete renderedFile.storage_used;
+		const renderedFolder = {
+			...folderInfo({ name: "Legacy Folder", storage_used: undefined }),
+		};
+		delete renderedFolder.storage_used;
+		mockState.getFile.mockResolvedValueOnce(
+			fileInfo({ name: "Resolved Legacy.mp3", storage_used: 256 }),
+		);
+		mockState.getFolderInfo.mockResolvedValueOnce(
+			folderInfo({ name: "Resolved Legacy Folder", storage_used: 512 }),
+		);
+		mockState.getMediaMetadata.mockResolvedValueOnce(audioMetadata());
+
+		const { result } = renderHook(() =>
+			useFileInfoDialogData({
+				open: true,
+				renderedFile,
+				renderedFolder,
+			}),
+		);
+
+		await waitFor(() => {
+			expect(result.current.resolvedFile?.storage_used).toBe(256);
+			expect(result.current.resolvedFolder?.storage_used).toBe(512);
+		});
+		expect(mockState.getFile).toHaveBeenCalledWith(7);
+		expect(mockState.getFolderInfo).toHaveBeenCalledWith(3);
 	});
 
 	it("loads media support before requesting metadata and resets unsupported files", () => {

--- a/frontend-panel/src/i18n/locales/en/files/info.json
+++ b/frontend-panel/src/i18n/locales/en/files/info.json
@@ -2,6 +2,7 @@
 	"info": "Details",
 	"info_name": "Name",
 	"info_size": "Size",
+	"info_storage_used": "Storage Used",
 	"info_type": "Type",
 	"info_mime": "MIME Type",
 	"info_created": "Created",

--- a/frontend-panel/src/i18n/locales/zh/files/info.json
+++ b/frontend-panel/src/i18n/locales/zh/files/info.json
@@ -2,6 +2,7 @@
 	"info": "详细信息",
 	"info_name": "名称",
 	"info_size": "大小",
+	"info_storage_used": "占用空间",
 	"info_type": "类型",
 	"info_mime": "MIME 类型",
 	"info_created": "创建时间",

--- a/frontend-panel/src/services/api.generated.ts
+++ b/frontend-panel/src/services/api.generated.ts
@@ -4936,7 +4936,7 @@ export interface components {
             /** @description 排序字段值（序列化为字符串） */
             value: string;
         };
-        FileInfo: {
+        FileEntity: {
             /** Format: int64 */
             blob_id: number;
             /**
@@ -4964,6 +4964,34 @@ export interface components {
             owner_user_id?: number | null;
             /** Format: int64 */
             size: number;
+            /** Format: int64 */
+            team_id?: number | null;
+            updated_at: string;
+        };
+        FileInfo: {
+            /** Format: int64 */
+            blob_id: number;
+            compound_extension?: string | null;
+            created_at: string;
+            /** Format: int64 */
+            created_by_user_id?: number | null;
+            created_by_username: string;
+            deleted_at?: string | null;
+            extension: string;
+            file_category: components["schemas"]["FileCategory"];
+            /** Format: int64 */
+            folder_id?: number | null;
+            /** Format: int64 */
+            id: number;
+            is_locked: boolean;
+            mime_type: string;
+            name: string;
+            /** Format: int64 */
+            owner_user_id?: number | null;
+            /** Format: int64 */
+            size: number;
+            /** Format: int64 */
+            storage_used?: number | null;
             /** Format: int64 */
             team_id?: number | null;
             updated_at: string;
@@ -5047,7 +5075,7 @@ export interface components {
             folders_total: number;
             next_file_cursor?: null | components["schemas"]["FileCursor"];
         };
-        FolderInfo: {
+        FolderEntity: {
             created_at: string;
             /** Format: int64 */
             created_by_user_id?: number | null;
@@ -5063,6 +5091,28 @@ export interface components {
             parent_id?: number | null;
             /** Format: int64 */
             policy_id?: number | null;
+            /** Format: int64 */
+            team_id?: number | null;
+            updated_at: string;
+        };
+        FolderInfo: {
+            created_at: string;
+            /** Format: int64 */
+            created_by_user_id?: number | null;
+            created_by_username: string;
+            deleted_at?: string | null;
+            /** Format: int64 */
+            id: number;
+            is_locked: boolean;
+            name: string;
+            /** Format: int64 */
+            owner_user_id?: number | null;
+            /** Format: int64 */
+            parent_id?: number | null;
+            /** Format: int64 */
+            policy_id?: number | null;
+            /** Format: int64 */
+            storage_used?: number | null;
             /** Format: int64 */
             team_id?: number | null;
             updated_at: string;
@@ -14320,6 +14370,8 @@ export interface operations {
                             /** Format: int64 */
                             size: number;
                             /** Format: int64 */
+                            storage_used?: number | null;
+                            /** Format: int64 */
                             team_id?: number | null;
                             updated_at: string;
                         };
@@ -14392,6 +14444,8 @@ export interface operations {
                             owner_user_id?: number | null;
                             /** Format: int64 */
                             size: number;
+                            /** Format: int64 */
+                            storage_used?: number | null;
                             /** Format: int64 */
                             team_id?: number | null;
                             updated_at: string;
@@ -14630,6 +14684,8 @@ export interface operations {
                             /** Format: int64 */
                             size: number;
                             /** Format: int64 */
+                            storage_used?: number | null;
+                            /** Format: int64 */
                             team_id?: number | null;
                             updated_at: string;
                         };
@@ -14798,6 +14854,8 @@ export interface operations {
                             /** Format: int64 */
                             size: number;
                             /** Format: int64 */
+                            storage_used?: number | null;
+                            /** Format: int64 */
                             team_id?: number | null;
                             updated_at: string;
                         };
@@ -14903,6 +14961,8 @@ export interface operations {
                             owner_user_id?: number | null;
                             /** Format: int64 */
                             size: number;
+                            /** Format: int64 */
+                            storage_used?: number | null;
                             /** Format: int64 */
                             team_id?: number | null;
                             updated_at: string;
@@ -15066,6 +15126,8 @@ export interface operations {
                             /** Format: int64 */
                             size: number;
                             /** Format: int64 */
+                            storage_used?: number | null;
+                            /** Format: int64 */
                             team_id?: number | null;
                             updated_at: string;
                         };
@@ -15150,6 +15212,8 @@ export interface operations {
                             owner_user_id?: number | null;
                             /** Format: int64 */
                             size: number;
+                            /** Format: int64 */
+                            storage_used?: number | null;
                             /** Format: int64 */
                             team_id?: number | null;
                             updated_at: string;
@@ -15457,6 +15521,8 @@ export interface operations {
                             owner_user_id?: number | null;
                             /** Format: int64 */
                             size: number;
+                            /** Format: int64 */
+                            storage_used?: number | null;
                             /** Format: int64 */
                             team_id?: number | null;
                             updated_at: string;
@@ -15788,6 +15854,8 @@ export interface operations {
                             /** Format: int64 */
                             size: number;
                             /** Format: int64 */
+                            storage_used?: number | null;
+                            /** Format: int64 */
                             team_id?: number | null;
                             updated_at: string;
                         };
@@ -15963,6 +16031,8 @@ export interface operations {
                             /** Format: int64 */
                             policy_id?: number | null;
                             /** Format: int64 */
+                            storage_used?: number | null;
+                            /** Format: int64 */
                             team_id?: number | null;
                             updated_at: string;
                         };
@@ -16121,6 +16191,8 @@ export interface operations {
                             /** Format: int64 */
                             policy_id?: number | null;
                             /** Format: int64 */
+                            storage_used?: number | null;
+                            /** Format: int64 */
                             team_id?: number | null;
                             updated_at: string;
                         };
@@ -16232,6 +16304,8 @@ export interface operations {
                             /** Format: int64 */
                             policy_id?: number | null;
                             /** Format: int64 */
+                            storage_used?: number | null;
+                            /** Format: int64 */
                             team_id?: number | null;
                             updated_at: string;
                         };
@@ -16292,6 +16366,8 @@ export interface operations {
                             parent_id?: number | null;
                             /** Format: int64 */
                             policy_id?: number | null;
+                            /** Format: int64 */
+                            storage_used?: number | null;
                             /** Format: int64 */
                             team_id?: number | null;
                             updated_at: string;
@@ -16357,6 +16433,8 @@ export interface operations {
                             parent_id?: number | null;
                             /** Format: int64 */
                             policy_id?: number | null;
+                            /** Format: int64 */
+                            storage_used?: number | null;
                             /** Format: int64 */
                             team_id?: number | null;
                             updated_at: string;
@@ -19553,6 +19631,8 @@ export interface operations {
                             /** Format: int64 */
                             size: number;
                             /** Format: int64 */
+                            storage_used?: number | null;
+                            /** Format: int64 */
                             team_id?: number | null;
                             updated_at: string;
                         };
@@ -19628,6 +19708,8 @@ export interface operations {
                             owner_user_id?: number | null;
                             /** Format: int64 */
                             size: number;
+                            /** Format: int64 */
+                            storage_used?: number | null;
                             /** Format: int64 */
                             team_id?: number | null;
                             updated_at: string;
@@ -19929,6 +20011,8 @@ export interface operations {
                             /** Format: int64 */
                             size: number;
                             /** Format: int64 */
+                            storage_used?: number | null;
+                            /** Format: int64 */
                             team_id?: number | null;
                             updated_at: string;
                         };
@@ -20124,6 +20208,8 @@ export interface operations {
                             /** Format: int64 */
                             size: number;
                             /** Format: int64 */
+                            storage_used?: number | null;
+                            /** Format: int64 */
                             team_id?: number | null;
                             updated_at: string;
                         };
@@ -20247,6 +20333,8 @@ export interface operations {
                             owner_user_id?: number | null;
                             /** Format: int64 */
                             size: number;
+                            /** Format: int64 */
+                            storage_used?: number | null;
                             /** Format: int64 */
                             team_id?: number | null;
                             updated_at: string;
@@ -20421,6 +20509,8 @@ export interface operations {
                             /** Format: int64 */
                             size: number;
                             /** Format: int64 */
+                            storage_used?: number | null;
+                            /** Format: int64 */
                             team_id?: number | null;
                             updated_at: string;
                         };
@@ -20514,6 +20604,8 @@ export interface operations {
                             owner_user_id?: number | null;
                             /** Format: int64 */
                             size: number;
+                            /** Format: int64 */
+                            storage_used?: number | null;
                             /** Format: int64 */
                             team_id?: number | null;
                             updated_at: string;
@@ -20866,6 +20958,8 @@ export interface operations {
                             owner_user_id?: number | null;
                             /** Format: int64 */
                             size: number;
+                            /** Format: int64 */
+                            storage_used?: number | null;
                             /** Format: int64 */
                             team_id?: number | null;
                             updated_at: string;
@@ -21251,6 +21345,8 @@ export interface operations {
                             /** Format: int64 */
                             size: number;
                             /** Format: int64 */
+                            storage_used?: number | null;
+                            /** Format: int64 */
                             team_id?: number | null;
                             updated_at: string;
                         };
@@ -21455,6 +21551,8 @@ export interface operations {
                             /** Format: int64 */
                             policy_id?: number | null;
                             /** Format: int64 */
+                            storage_used?: number | null;
+                            /** Format: int64 */
                             team_id?: number | null;
                             updated_at: string;
                         };
@@ -21640,6 +21738,8 @@ export interface operations {
                             /** Format: int64 */
                             policy_id?: number | null;
                             /** Format: int64 */
+                            storage_used?: number | null;
+                            /** Format: int64 */
                             team_id?: number | null;
                             updated_at: string;
                         };
@@ -21769,6 +21869,8 @@ export interface operations {
                             /** Format: int64 */
                             policy_id?: number | null;
                             /** Format: int64 */
+                            storage_used?: number | null;
+                            /** Format: int64 */
                             team_id?: number | null;
                             updated_at: string;
                         };
@@ -21838,6 +21940,8 @@ export interface operations {
                             parent_id?: number | null;
                             /** Format: int64 */
                             policy_id?: number | null;
+                            /** Format: int64 */
+                            storage_used?: number | null;
                             /** Format: int64 */
                             team_id?: number | null;
                             updated_at: string;
@@ -21912,6 +22016,8 @@ export interface operations {
                             parent_id?: number | null;
                             /** Format: int64 */
                             policy_id?: number | null;
+                            /** Format: int64 */
+                            storage_used?: number | null;
                             /** Format: int64 */
                             team_id?: number | null;
                             updated_at: string;

--- a/src/api/openapi.rs
+++ b/src/api/openapi.rs
@@ -444,6 +444,8 @@ use utoipa::{Modify, OpenApi};
             // services::folder_service / entities::{file,folder,file_version}：个人空间文件树、文件实体和版本信息模型。
             crate::services::folder_service::FolderContents,
             crate::services::folder_service::FolderAncestorItem,
+            crate::services::workspace_models::FileInfo,
+            crate::services::workspace_models::FolderInfo,
             crate::entities::file::Model,
             crate::entities::folder::Model,
             crate::entities::file_version::Model,

--- a/src/api/routes/files/access.rs
+++ b/src/api/routes/files/access.rs
@@ -11,7 +11,6 @@ use crate::services::{
     auth_service::Claims,
     direct_link_service, file_service, media_metadata_service, media_processing_service,
     preview_link_service, wopi_service,
-    workspace_models::FileInfo,
     workspace_storage_service::WorkspaceStorageScope,
 };
 use actix_web::http::header;
@@ -322,7 +321,7 @@ pub async fn get_image_preview(
         ("id" = i64, Path, description = "File ID")
     ),
     responses(
-        (status = 200, description = "Team file info", body = inline(ApiResponse<FileInfo>)),
+        (status = 200, description = "Team file info", body = inline(ApiResponse<crate::services::workspace_models::FileInfo>)),
         (status = 401, description = crate::api::constants::OPENAPI_UNAUTHORIZED),
         (status = 403, description = "Forbidden"),
         (status = 404, description = "File not found"),
@@ -612,8 +611,8 @@ pub(crate) async fn get_file_response(
     scope: WorkspaceStorageScope,
     file_id: i64,
 ) -> Result<HttpResponse> {
-    let file = file_service::get_info_in_scope(state, scope, file_id).await?;
-    Ok(HttpResponse::Ok().json(ApiResponse::ok(FileInfo::from(file))))
+    let file = file_service::get_info_with_storage_used_in_scope(state, scope, file_id).await?;
+    Ok(HttpResponse::Ok().json(ApiResponse::ok(file)))
 }
 
 pub(crate) async fn archive_preview_response(

--- a/src/api/routes/folders.rs
+++ b/src/api/routes/folders.rs
@@ -12,7 +12,7 @@ use crate::errors::Result;
 use crate::runtime::PrimaryAppState;
 use crate::services::{
     audit_service::AuditContext, auth_service::Claims, folder_service,
-    workspace_models::FolderInfo, workspace_storage_service::WorkspaceStorageScope,
+    workspace_storage_service::WorkspaceStorageScope,
 };
 use actix_governor::Governor;
 use actix_web::middleware::Condition;
@@ -366,7 +366,7 @@ pub(crate) async fn team_list_root(
     params(("team_id" = i64, Path, description = "Team ID")),
     request_body = CreateFolderReq,
     responses(
-        (status = 201, description = "Team folder created", body = inline(ApiResponse<FolderInfo>)),
+        (status = 201, description = "Team folder created", body = inline(ApiResponse<crate::services::workspace_models::FolderInfo>)),
         (status = 401, description = crate::api::constants::OPENAPI_UNAUTHORIZED),
         (status = 403, description = "Forbidden"),
     ),
@@ -433,7 +433,7 @@ pub(crate) async fn team_list_folder(
         ("id" = i64, Path, description = "Folder ID")
     ),
     responses(
-        (status = 200, description = "Team folder info", body = inline(ApiResponse<FolderInfo>)),
+        (status = 200, description = "Team folder info", body = inline(ApiResponse<crate::services::workspace_models::FolderInfo>)),
         (status = 401, description = crate::api::constants::OPENAPI_UNAUTHORIZED),
         (status = 403, description = "Forbidden"),
         (status = 404, description = "Folder not found"),
@@ -520,7 +520,7 @@ pub(crate) async fn team_delete_folder(
     ),
     request_body = PatchFolderReq,
     responses(
-        (status = 200, description = "Team folder updated", body = inline(ApiResponse<FolderInfo>)),
+        (status = 200, description = "Team folder updated", body = inline(ApiResponse<crate::services::workspace_models::FolderInfo>)),
         (status = 401, description = crate::api::constants::OPENAPI_UNAUTHORIZED),
         (status = 403, description = "Forbidden"),
         (status = 404, description = "Folder not found"),
@@ -557,7 +557,7 @@ pub(crate) async fn team_patch_folder(
     ),
     request_body = CopyFolderReq,
     responses(
-        (status = 201, description = "Team folder copied", body = inline(ApiResponse<FolderInfo>)),
+        (status = 201, description = "Team folder copied", body = inline(ApiResponse<crate::services::workspace_models::FolderInfo>)),
         (status = 401, description = crate::api::constants::OPENAPI_UNAUTHORIZED),
         (status = 403, description = "Forbidden"),
         (status = 404, description = "Folder not found"),
@@ -594,7 +594,7 @@ pub(crate) async fn team_copy_folder(
     ),
     request_body = SetLockReq,
     responses(
-        (status = 200, description = "Lock state updated", body = inline(ApiResponse<FolderInfo>)),
+        (status = 200, description = "Lock state updated", body = inline(ApiResponse<crate::services::workspace_models::FolderInfo>)),
         (status = 401, description = crate::api::constants::OPENAPI_UNAUTHORIZED),
         (status = 403, description = "Forbidden"),
         (status = 404, description = "Folder not found"),
@@ -660,8 +660,9 @@ pub(crate) async fn get_folder_info_response(
     scope: WorkspaceStorageScope,
     folder_id: i64,
 ) -> Result<HttpResponse> {
-    let folder = folder_service::get_info_in_scope(state, scope, folder_id).await?;
-    Ok(HttpResponse::Ok().json(ApiResponse::ok(FolderInfo::from(folder))))
+    let folder =
+        folder_service::get_info_with_storage_used_in_scope(state, scope, folder_id).await?;
+    Ok(HttpResponse::Ok().json(ApiResponse::ok(folder)))
 }
 
 pub(crate) async fn delete_folder_response(

--- a/src/db/repository/file_repo/common.rs
+++ b/src/db/repository/file_repo/common.rs
@@ -45,7 +45,7 @@ pub fn is_any_duplicate_name_error(err: &AsterError) -> bool {
 }
 
 #[derive(Clone, Copy)]
-pub(super) enum FileScope {
+pub(crate) enum FileScope {
     Personal { user_id: i64 },
     Team { team_id: i64 },
 }

--- a/src/db/repository/file_repo/mod.rs
+++ b/src/db/repository/file_repo/mod.rs
@@ -24,6 +24,7 @@ pub use blob::{
     sum_blob_bytes_by_policy, summarize_blob_hash_kinds_by_policy, summarize_blobs_by_policy,
     summarize_missing_blobs_between_policies,
 };
+pub(crate) use common::FileScope;
 pub use common::{
     duplicate_name_error, duplicate_name_message, is_any_duplicate_name_error,
     is_duplicate_name_error, is_name_conflict_db_err, map_bulk_name_db_err, map_name_db_err,
@@ -42,6 +43,7 @@ pub use query::{
     find_by_team_folders, lock_by_id, resolve_unique_filename, resolve_unique_team_filename,
     sum_live_file_bytes,
 };
+pub(crate) use query::{FileIdSize, find_id_size_by_folders};
 pub use trash::{
     delete, delete_many, find_all_by_team, find_all_by_team_paginated, find_all_by_user,
     find_all_by_user_paginated, find_deleted_by_user, find_deleted_in_folder, find_expired_deleted,

--- a/src/db/repository/file_repo/query/basic.rs
+++ b/src/db/repository/file_repo/query/basic.rs
@@ -10,6 +10,8 @@ use crate::db::repository::file_repo::common::{
     FileScope, active_scope_condition, apply_folder_condition, scope_condition,
 };
 
+pub(crate) type FileIdSize = (i64, i64);
+
 fn sum_as_i64_expr(
     backend: DbBackend,
     column: impl sea_orm::sea_query::IntoColumnRef + Copy,
@@ -132,6 +134,38 @@ pub async fn find_by_team_folders<C: ConnectionTrait>(
     folder_ids: &[i64],
 ) -> Result<Vec<file::Model>> {
     find_by_folders_in_scope(db, FileScope::Team { team_id }, folder_ids).await
+}
+
+/// 详情占用统计专用的轻量 cursor 查询。
+///
+/// 只返回 `(file_id, size)`，并按 `files.id` 做 cursor 分页；调用方应逐页累加并释放
+/// `file_ids`，避免打开大目录详情时把整棵树的文件记录或所有文件 ID 留在内存里。
+pub(crate) async fn find_id_size_by_folders<C: ConnectionTrait>(
+    db: &C,
+    scope: FileScope,
+    folder_ids: &[i64],
+    after_id: Option<i64>,
+    limit: u64,
+) -> Result<Vec<FileIdSize>> {
+    if folder_ids.is_empty() || limit == 0 {
+        return Ok(vec![]);
+    }
+    let mut query = File::find()
+        .select_only()
+        .column(file::Column::Id)
+        .column(file::Column::Size)
+        .filter(active_scope_condition(scope))
+        .filter(file::Column::FolderId.is_in(folder_ids.iter().copied()))
+        .order_by_asc(file::Column::Id)
+        .limit(limit);
+    if let Some(after_id) = after_id {
+        query = query.filter(file::Column::Id.gt(after_id));
+    }
+    query
+        .into_tuple::<FileIdSize>()
+        .all(db)
+        .await
+        .map_err(AsterError::from)
 }
 
 /// 批量查询多个文件夹下的文件（含已删除）

--- a/src/db/repository/file_repo/query/mod.rs
+++ b/src/db/repository/file_repo/query/mod.rs
@@ -11,6 +11,7 @@ pub use admin::{
     AdminBlobUploaderRef, AdminFileFilters, find_admin_blob_uploader_refs_for_blobs,
     find_admin_file_by_id, find_admin_files_paginated, find_by_blob_id,
 };
+pub(crate) use basic::{FileIdSize, find_id_size_by_folders};
 pub use basic::{
     count_live_files, find_all_in_folders, find_by_folder, find_by_folders, find_by_id,
     find_by_ids, find_by_ids_in_personal_scope, find_by_ids_in_team_scope, find_by_team_folder,

--- a/src/db/repository/folder_repo/common.rs
+++ b/src/db/repository/folder_repo/common.rs
@@ -45,7 +45,7 @@ pub fn is_any_duplicate_name_error(err: &AsterError) -> bool {
 }
 
 #[derive(Clone, Copy)]
-pub(super) enum FolderScope {
+pub(crate) enum FolderScope {
     Personal { user_id: i64 },
     Team { team_id: i64 },
 }

--- a/src/db/repository/folder_repo/mod.rs
+++ b/src/db/repository/folder_repo/mod.rs
@@ -6,6 +6,7 @@ mod path;
 mod query;
 mod trash;
 
+pub(crate) use common::FolderScope;
 pub use common::{
     duplicate_name_error, duplicate_name_message, is_any_duplicate_name_error,
     is_duplicate_name_error, is_name_conflict_db_err, map_bulk_name_db_err, map_name_db_err,
@@ -15,6 +16,7 @@ pub use mutation::{
 };
 pub(crate) use path::{find_ancestor_models, find_team_ancestor_models};
 pub use path::{find_ancestors, resolve_path_chain};
+pub(crate) use query::find_child_ids_in_parents;
 pub use query::{
     find_all_children, find_all_children_in_parents, find_all_files_in_folder, find_by_id,
     find_by_ids, find_by_ids_in_personal_scope, find_by_ids_in_team_scope, find_by_name_in_parent,

--- a/src/db/repository/folder_repo/query.rs
+++ b/src/db/repository/folder_repo/query.rs
@@ -146,6 +146,29 @@ pub async fn find_team_children_in_parents<C: ConnectionTrait>(
     find_children_in_parents_in_scope(db, FolderScope::Team { team_id }, parent_ids).await
 }
 
+/// 详情占用统计专用的轻量子目录查询。
+///
+/// 只返回子目录 id；调用方按当前 BFS 层分批调用，避免为了统计占用空间加载完整
+/// folder 记录或累计整棵树的目录模型。
+pub(crate) async fn find_child_ids_in_parents<C: ConnectionTrait>(
+    db: &C,
+    scope: FolderScope,
+    parent_ids: &[i64],
+) -> Result<Vec<i64>> {
+    if parent_ids.is_empty() {
+        return Ok(vec![]);
+    }
+    Folder::find()
+        .select_only()
+        .column(folder::Column::Id)
+        .filter(active_scope_condition(scope))
+        .filter(folder::Column::ParentId.is_in(parent_ids.iter().copied()))
+        .into_tuple::<i64>()
+        .all(db)
+        .await
+        .map_err(AsterError::from)
+}
+
 /// 查询子文件夹（排除已删除，分页）
 async fn find_children_paginated_in_scope<C: ConnectionTrait>(
     db: &C,

--- a/src/db/repository/version_repo.rs
+++ b/src/db/repository/version_repo.rs
@@ -13,7 +13,14 @@ fn sum_version_size_as_i64_expr(backend: DbBackend) -> sea_orm::sea_query::Simpl
     let type_name = match backend {
         DbBackend::Postgres => "bigint",
         DbBackend::MySql => "signed",
-        _ => "integer",
+        DbBackend::Sqlite => "integer",
+        other => {
+            tracing::warn!(
+                backend = ?other,
+                "unknown database backend for file version size sum cast; using integer"
+            );
+            "integer"
+        }
     };
     Expr::col(file_version::Column::Size)
         .sum()

--- a/src/db/repository/version_repo.rs
+++ b/src/db/repository/version_repo.rs
@@ -1,19 +1,66 @@
 //! 仓储模块：`version_repo`。
 
 use sea_orm::{
-    ActiveModelTrait, ColumnTrait, ConnectionTrait, EntityTrait, ExprTrait, PaginatorTrait,
-    QueryFilter, QueryOrder, QuerySelect, sea_query::Expr,
+    ActiveModelTrait, ColumnTrait, ConnectionTrait, DbBackend, EntityTrait, ExprTrait,
+    PaginatorTrait, QueryFilter, QueryOrder, QuerySelect, sea_query::Expr,
 };
 use std::collections::HashMap;
 
 use crate::entities::file_version::{self, Entity as FileVersion};
 use crate::errors::{AsterError, Result};
 
+fn sum_version_size_as_i64_expr(backend: DbBackend) -> sea_orm::sea_query::SimpleExpr {
+    let type_name = match backend {
+        DbBackend::Postgres => "bigint",
+        DbBackend::MySql => "signed",
+        _ => "integer",
+    };
+    Expr::col(file_version::Column::Size)
+        .sum()
+        .cast_as(type_name)
+}
+
 pub async fn create<C: ConnectionTrait>(
     db: &C,
     model: file_version::ActiveModel,
 ) -> Result<file_version::Model> {
     model.insert(db).await.map_err(AsterError::from)
+}
+
+pub async fn sum_sizes_by_file_id<C: ConnectionTrait>(db: &C, file_id: i64) -> Result<i64> {
+    Ok(FileVersion::find()
+        .select_only()
+        .column_as(
+            sum_version_size_as_i64_expr(db.get_database_backend()),
+            "sum",
+        )
+        .filter(file_version::Column::FileId.eq(file_id))
+        .into_tuple::<Option<i64>>()
+        .one(db)
+        .await
+        .map_err(AsterError::from)?
+        .flatten()
+        .unwrap_or(0))
+}
+
+pub async fn sum_sizes_by_file_ids<C: ConnectionTrait>(db: &C, file_ids: &[i64]) -> Result<i64> {
+    if file_ids.is_empty() {
+        return Ok(0);
+    }
+
+    Ok(FileVersion::find()
+        .select_only()
+        .column_as(
+            sum_version_size_as_i64_expr(db.get_database_backend()),
+            "sum",
+        )
+        .filter(file_version::Column::FileId.is_in(file_ids.iter().copied()))
+        .into_tuple::<Option<i64>>()
+        .one(db)
+        .await
+        .map_err(AsterError::from)?
+        .flatten()
+        .unwrap_or(0))
 }
 
 /// 按 file_id 查询所有版本（version DESC）

--- a/src/entities/file.rs
+++ b/src/entities/file.rs
@@ -8,7 +8,7 @@ use utoipa::ToSchema;
 
 #[derive(Clone, Debug, PartialEq, DeriveEntityModel, Serialize, Deserialize)]
 #[cfg_attr(all(debug_assertions, feature = "openapi"), derive(ToSchema))]
-#[cfg_attr(all(debug_assertions, feature = "openapi"), schema(as = FileInfo))]
+#[cfg_attr(all(debug_assertions, feature = "openapi"), schema(as = FileEntity))]
 #[sea_orm(table_name = "files")]
 pub struct Model {
     #[sea_orm(primary_key)]

--- a/src/entities/folder.rs
+++ b/src/entities/folder.rs
@@ -7,7 +7,7 @@ use utoipa::ToSchema;
 
 #[derive(Clone, Debug, PartialEq, DeriveEntityModel, Serialize, Deserialize)]
 #[cfg_attr(all(debug_assertions, feature = "openapi"), derive(ToSchema))]
-#[cfg_attr(all(debug_assertions, feature = "openapi"), schema(as = FolderInfo))]
+#[cfg_attr(all(debug_assertions, feature = "openapi"), schema(as = FolderEntity))]
 #[sea_orm(table_name = "folders")]
 pub struct Model {
     #[sea_orm(primary_key)]

--- a/src/services/file_service/metadata.rs
+++ b/src/services/file_service/metadata.rs
@@ -3,7 +3,7 @@
 use chrono::Utc;
 use sea_orm::{ActiveModelTrait, Set};
 
-use crate::db::repository::file_repo;
+use crate::db::repository::{file_repo, version_repo};
 use crate::entities::file;
 use crate::errors::{AsterError, Result};
 use crate::runtime::PrimaryAppState;
@@ -20,6 +20,22 @@ pub(crate) async fn get_info_in_scope(
     id: i64,
 ) -> Result<file::Model> {
     workspace_storage_service::verify_file_access_for_read(state, scope, id).await
+}
+
+pub(crate) async fn get_info_with_storage_used_in_scope(
+    state: &PrimaryAppState,
+    scope: WorkspaceStorageScope,
+    id: i64,
+) -> Result<FileInfo> {
+    let file = get_info_in_scope(state, scope, id).await?;
+    let version_bytes = version_repo::sum_sizes_by_file_id(state.reader_db(), file.id).await?;
+    let storage_used = file.size.checked_add(version_bytes).ok_or_else(|| {
+        AsterError::internal_error(format!(
+            "file storage_used overflow while reading file #{}",
+            file.id
+        ))
+    })?;
+    Ok(FileInfo::from_model_with_storage_used(file, storage_used))
 }
 
 pub(crate) async fn update_in_scope(
@@ -113,9 +129,8 @@ pub(crate) async fn update_in_scope(
 
 /// 获取文件信息
 pub async fn get_info(state: &PrimaryAppState, id: i64, user_id: i64) -> Result<FileInfo> {
-    get_info_in_scope(state, WorkspaceStorageScope::Personal { user_id }, id)
+    get_info_with_storage_used_in_scope(state, WorkspaceStorageScope::Personal { user_id }, id)
         .await
-        .map(Into::into)
 }
 
 /// 更新文件（重命名/移动）

--- a/src/services/file_service/mod.rs
+++ b/src/services/file_service/mod.rs
@@ -47,7 +47,9 @@ pub(crate) use download::{
 pub use lock::set_lock;
 pub(crate) use lock::set_lock_in_scope;
 pub use metadata::{get_info, move_file, update};
-pub(crate) use metadata::{get_info_in_scope, update_in_scope};
+pub(crate) use metadata::{
+    get_info_in_scope, get_info_with_storage_used_in_scope, update_in_scope,
+};
 pub use thumbnail::{ImagePreviewResult, ThumbnailResult, get_thumbnail_data};
 pub(crate) use thumbnail::{
     get_image_preview_data_in_scope, get_thumbnail_data_in_scope, image_preview_for_file,

--- a/src/services/folder_service/mod.rs
+++ b/src/services/folder_service/mod.rs
@@ -41,7 +41,8 @@ pub(crate) use hierarchy::{
 };
 pub(crate) use listing::list_in_scope;
 pub(crate) use mutation::{
-    create_in_scope, delete_in_scope, get_info_in_scope, set_lock_in_scope, update_in_scope,
+    create_in_scope, delete_in_scope, get_info_with_storage_used_in_scope, set_lock_in_scope,
+    update_in_scope,
 };
 pub(crate) use tree::{
     collect_folder_forest_in_resource_scope, collect_folder_forest_in_scope,

--- a/src/services/folder_service/mutation.rs
+++ b/src/services/folder_service/mutation.rs
@@ -1,4 +1,9 @@
 //! 文件夹服务子模块：`mutation`。
+//!
+//! 这里负责文件夹的写操作以及详情页的派生信息：
+//! - 创建、软删除、更新/移动、锁定状态。
+//! - 为个人空间和团队空间共用同一套 scope-aware 实现。
+//! - 详情接口额外计算 `storage_used`，但列表接口不走这段递归统计。
 
 use std::collections::BTreeSet;
 
@@ -22,13 +27,26 @@ const STORAGE_USED_VERSION_SUM_CHUNK_SIZE: usize = 500;
 const STORAGE_USED_FOLDER_QUERY_CHUNK_SIZE: usize = 500;
 const STORAGE_USED_FILE_PAGE_SIZE: u64 = 500;
 
-fn add_checked(total: &mut i64, value: i64, context: impl std::fmt::Display) -> Result<()> {
+/// `storage_used` 是配额口径，不是物理 blob 占用。
+///
+/// 文件夹统计需要把当前文件大小和历史版本大小都加进去；这里用 checked add，
+/// 避免极端脏数据把 i64 加爆后静默回绕。`context` 用闭包是因为正常路径不会溢出，
+/// 不该在热循环里为每个文件提前分配错误消息字符串。
+fn add_checked<F, D>(total: &mut i64, value: i64, context: F) -> Result<()>
+where
+    F: FnOnce() -> D,
+    D: std::fmt::Display,
+{
     *total = total.checked_add(value).ok_or_else(|| {
-        AsterError::internal_error(format!("folder storage_used overflow: {context}"))
+        AsterError::internal_error(format!("folder storage_used overflow: {}", context()))
     })?;
     Ok(())
 }
 
+/// 读取一批文件夹下的活跃文件 id 和当前大小。
+///
+/// 只查 `(id, size)`，并通过 `after_id` 做 cursor 分页；调用方处理完当前页后
+/// 立即释放 file ids，避免大目录详情把整棵树文件记录压进内存。
 async fn load_file_id_size_page(
     state: &PrimaryAppState,
     scope: WorkspaceStorageScope,
@@ -49,6 +67,9 @@ async fn load_file_id_size_page(
     .await
 }
 
+/// 读取当前 BFS 层的下一层子目录 id。
+///
+/// 这里同样只拿 id，不加载完整 folder model；详情页只需要继续向下遍历。
 async fn load_child_folder_ids(
     state: &PrimaryAppState,
     scope: WorkspaceStorageScope,
@@ -63,6 +84,16 @@ async fn load_child_folder_ids(
     folder_repo::find_child_ids_in_parents(state.reader_db(), folder_scope, folder_ids).await
 }
 
+/// 递归计算文件夹详情页展示的占用空间。
+///
+/// 算法是分层 BFS：
+/// - `frontier` 是当前层文件夹 id，按固定 chunk 查询，避免过大的 `IN (...)`。
+/// - 每个 chunk 内的文件按 `files.id` cursor 分页，避免 `Vec<i64>` 随目录规模膨胀。
+/// - 当前文件大小即时累加；版本大小按当前页 file ids 分块汇总。
+/// - 子目录 id 进入下一层，再重复。
+///
+/// 这段逻辑刻意不复用 `collect_folder_tree_in_scope()`：那个 helper 会收集完整树，
+/// 删除/复制场景可以接受，详情页统计大目录时不该这么做。
 async fn compute_folder_storage_used(
     state: &PrimaryAppState,
     scope: WorkspaceStorageScope,
@@ -87,11 +118,9 @@ async fn compute_folder_storage_used(
 
                 let mut file_ids = Vec::with_capacity(files.len());
                 for (file_id, size) in &files {
-                    add_checked(
-                        &mut total,
-                        *size,
-                        format!("current file bytes for file #{file_id}"),
-                    )?;
+                    add_checked(&mut total, *size, || {
+                        format!("current file bytes for file #{file_id}")
+                    })?;
                     file_ids.push(*file_id);
                 }
                 after_file_id = files.last().map(|(file_id, _)| *file_id);
@@ -100,11 +129,9 @@ async fn compute_folder_storage_used(
                     let version_bytes =
                         version_repo::sum_sizes_by_file_ids(state.reader_db(), file_id_chunk)
                             .await?;
-                    add_checked(
-                        &mut total,
-                        version_bytes,
-                        format!("version bytes for folder #{folder_id}"),
-                    )?;
+                    add_checked(&mut total, version_bytes, || {
+                        format!("version bytes for folder #{folder_id}")
+                    })?;
                 }
 
                 if files.len() < STORAGE_USED_FILE_PAGE_SIZE as usize {
@@ -228,6 +255,8 @@ pub(crate) async fn delete_in_scope(
     tracing::debug!(scope = ?scope, folder_id, "soft deleting folder tree");
     let now = Utc::now();
 
+    // 删除整棵树时先锁目录树，再确认树结构没有变化；否则并发移动/创建子目录
+    // 可能导致只删除到遍历时看到的一部分节点。
     let (folder, file_count, folder_count) =
         crate::db::transaction::with_transaction(state.writer_db(), async |txn| {
             let folder = folder_repo::lock_by_id(txn, folder_id).await?;
@@ -286,6 +315,7 @@ pub(crate) async fn get_info_with_storage_used_in_scope(
     scope: WorkspaceStorageScope,
     folder_id: i64,
 ) -> Result<FolderInfo> {
+    // 先走普通详情权限校验；`storage_used` 只在用户确实能读这个文件夹时计算。
     let folder = get_info_in_scope(state, scope, folder_id).await?;
     let storage_used = compute_folder_storage_used(state, scope, folder_id).await?;
     Ok(FolderInfo::from_model_with_storage_used(
@@ -334,6 +364,7 @@ pub(crate) async fn update_in_scope(
         };
         let initial_target_chain =
             load_folder_chain_in_scope(txn, scope, preview_target_parent).await?;
+        // 固定按 id 顺序加锁，降低多个移动操作互相等待时形成死锁的概率。
         let mut lock_ids = vec![id];
         lock_ids.extend(initial_target_chain.iter().map(|folder| folder.id));
         lock_folder_ids_in_order(txn, &lock_ids).await?;
@@ -350,6 +381,7 @@ pub(crate) async fn update_in_scope(
             NullablePatch::Value(pid) => Some(pid),
         };
         let target_chain = load_folder_chain_in_scope(txn, scope, target_parent).await?;
+        // 目标父目录链里不能出现自己，否则会制造目录环。
         if target_chain.iter().any(|folder| folder.id == id) {
             return Err(AsterError::validation_error(
                 "cannot move folder into its own subfolder",
@@ -434,6 +466,8 @@ async fn collect_locked_folder_tree_in_scope<C: ConnectionTrait>(
 ) -> Result<(Vec<file::Model>, Vec<i64>)> {
     const MAX_STABILIZATION_ATTEMPTS: usize = 8;
 
+    // 第一次遍历拿候选树，锁住目录后再遍历确认；如果目录树在加锁前后变了，
+    // 重新来一轮。这样软删除不会漏掉并发插入/移动进来的子目录。
     for _ in 0..MAX_STABILIZATION_ATTEMPTS {
         let (_files, folder_ids) =
             collect_folder_tree_in_scope(db, scope, folder_id, false).await?;
@@ -458,6 +492,7 @@ async fn load_folder_chain_in_scope<C: ConnectionTrait>(
     scope: WorkspaceStorageScope,
     start_id: Option<i64>,
 ) -> Result<Vec<folder::Model>> {
+    // 从目标父目录一路向根走，用于校验 scope、检测环，以及决定移动时要锁哪些目录。
     let mut chain = Vec::new();
     let mut seen = BTreeSet::new();
     let mut cursor = start_id;

--- a/src/services/folder_service/mutation.rs
+++ b/src/services/folder_service/mutation.rs
@@ -5,7 +5,7 @@ use std::collections::BTreeSet;
 use chrono::Utc;
 use sea_orm::{ActiveModelTrait, ConnectionTrait, Set};
 
-use crate::db::repository::{file_repo, folder_repo};
+use crate::db::repository::{file_repo, folder_repo, version_repo};
 use crate::entities::{file, folder};
 use crate::errors::{AsterError, Result};
 use crate::runtime::PrimaryAppState;
@@ -17,6 +17,110 @@ use crate::services::{
 use crate::types::NullablePatch;
 
 use super::{collect_folder_tree_in_scope, ensure_folder_model_in_scope};
+
+const STORAGE_USED_VERSION_SUM_CHUNK_SIZE: usize = 500;
+const STORAGE_USED_FOLDER_QUERY_CHUNK_SIZE: usize = 500;
+const STORAGE_USED_FILE_PAGE_SIZE: u64 = 500;
+
+fn add_checked(total: &mut i64, value: i64, context: impl std::fmt::Display) -> Result<()> {
+    *total = total.checked_add(value).ok_or_else(|| {
+        AsterError::internal_error(format!("folder storage_used overflow: {context}"))
+    })?;
+    Ok(())
+}
+
+async fn load_file_id_size_page(
+    state: &PrimaryAppState,
+    scope: WorkspaceStorageScope,
+    folder_ids: &[i64],
+    after_id: Option<i64>,
+) -> Result<Vec<file_repo::FileIdSize>> {
+    let file_scope = match scope {
+        WorkspaceStorageScope::Personal { user_id } => file_repo::FileScope::Personal { user_id },
+        WorkspaceStorageScope::Team { team_id, .. } => file_repo::FileScope::Team { team_id },
+    };
+    file_repo::find_id_size_by_folders(
+        state.reader_db(),
+        file_scope,
+        folder_ids,
+        after_id,
+        STORAGE_USED_FILE_PAGE_SIZE,
+    )
+    .await
+}
+
+async fn load_child_folder_ids(
+    state: &PrimaryAppState,
+    scope: WorkspaceStorageScope,
+    folder_ids: &[i64],
+) -> Result<Vec<i64>> {
+    let folder_scope = match scope {
+        WorkspaceStorageScope::Personal { user_id } => {
+            folder_repo::FolderScope::Personal { user_id }
+        }
+        WorkspaceStorageScope::Team { team_id, .. } => folder_repo::FolderScope::Team { team_id },
+    };
+    folder_repo::find_child_ids_in_parents(state.reader_db(), folder_scope, folder_ids).await
+}
+
+async fn compute_folder_storage_used(
+    state: &PrimaryAppState,
+    scope: WorkspaceStorageScope,
+    folder_id: i64,
+) -> Result<i64> {
+    let mut total = 0i64;
+    let mut frontier = vec![folder_id];
+
+    while !frontier.is_empty() {
+        frontier.sort_unstable();
+        frontier.dedup();
+        let mut next_frontier = Vec::new();
+
+        for folder_chunk in frontier.chunks(STORAGE_USED_FOLDER_QUERY_CHUNK_SIZE) {
+            let mut after_file_id = None;
+            loop {
+                let files =
+                    load_file_id_size_page(state, scope, folder_chunk, after_file_id).await?;
+                if files.is_empty() {
+                    break;
+                }
+
+                let mut file_ids = Vec::with_capacity(files.len());
+                for (file_id, size) in &files {
+                    add_checked(
+                        &mut total,
+                        *size,
+                        format!("current file bytes for file #{file_id}"),
+                    )?;
+                    file_ids.push(*file_id);
+                }
+                after_file_id = files.last().map(|(file_id, _)| *file_id);
+
+                for file_id_chunk in file_ids.chunks(STORAGE_USED_VERSION_SUM_CHUNK_SIZE) {
+                    let version_bytes =
+                        version_repo::sum_sizes_by_file_ids(state.reader_db(), file_id_chunk)
+                            .await?;
+                    add_checked(
+                        &mut total,
+                        version_bytes,
+                        format!("version bytes for folder #{folder_id}"),
+                    )?;
+                }
+
+                if files.len() < STORAGE_USED_FILE_PAGE_SIZE as usize {
+                    break;
+                }
+            }
+
+            let child_ids = load_child_folder_ids(state, scope, folder_chunk).await?;
+            next_frontier.extend(child_ids);
+        }
+
+        frontier = next_frontier;
+    }
+
+    Ok(total)
+}
 
 pub(crate) async fn create_in_scope(
     state: &PrimaryAppState,
@@ -175,6 +279,19 @@ pub(crate) async fn get_info_in_scope(
     folder_id: i64,
 ) -> Result<folder::Model> {
     workspace_storage_service::verify_folder_access_for_read(state, scope, folder_id).await
+}
+
+pub(crate) async fn get_info_with_storage_used_in_scope(
+    state: &PrimaryAppState,
+    scope: WorkspaceStorageScope,
+    folder_id: i64,
+) -> Result<FolderInfo> {
+    let folder = get_info_in_scope(state, scope, folder_id).await?;
+    let storage_used = compute_folder_storage_used(state, scope, folder_id).await?;
+    Ok(FolderInfo::from_model_with_storage_used(
+        folder,
+        storage_used,
+    ))
 }
 
 pub(crate) async fn update_in_scope(

--- a/src/services/workspace_models.rs
+++ b/src/services/workspace_models.rs
@@ -14,6 +14,8 @@ pub struct FileInfo {
     pub team_id: Option<i64>,
     pub blob_id: i64,
     pub size: i64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub storage_used: Option<i64>,
     pub owner_user_id: Option<i64>,
     pub created_by_user_id: Option<i64>,
     pub created_by_username: String,
@@ -40,6 +42,7 @@ impl From<crate::entities::file::Model> for FileInfo {
             team_id: model.team_id,
             blob_id: model.blob_id,
             size: model.size,
+            storage_used: None,
             owner_user_id: model.owner_user_id,
             created_by_user_id: model.created_by_user_id,
             created_by_username: model.created_by_username,
@@ -55,6 +58,17 @@ impl From<crate::entities::file::Model> for FileInfo {
     }
 }
 
+impl FileInfo {
+    pub fn from_model_with_storage_used(
+        model: crate::entities::file::Model,
+        storage_used: i64,
+    ) -> Self {
+        let mut info = Self::from(model);
+        info.storage_used = Some(storage_used);
+        info
+    }
+}
+
 #[derive(Clone, Debug, Serialize)]
 #[cfg_attr(all(debug_assertions, feature = "openapi"), derive(ToSchema))]
 pub struct FolderInfo {
@@ -66,6 +80,8 @@ pub struct FolderInfo {
     pub created_by_user_id: Option<i64>,
     pub created_by_username: String,
     pub policy_id: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub storage_used: Option<i64>,
     #[cfg_attr(all(debug_assertions, feature = "openapi"), schema(value_type = String))]
     pub created_at: DateTime<Utc>,
     #[cfg_attr(all(debug_assertions, feature = "openapi"), schema(value_type = String))]
@@ -87,11 +103,23 @@ impl From<crate::entities::folder::Model> for FolderInfo {
             created_by_user_id: model.created_by_user_id,
             created_by_username: model.created_by_username,
             policy_id: model.policy_id,
+            storage_used: None,
             created_at: model.created_at,
             updated_at: model.updated_at,
             deleted_at: model.deleted_at,
             is_locked: model.is_locked,
         }
+    }
+}
+
+impl FolderInfo {
+    pub fn from_model_with_storage_used(
+        model: crate::entities::folder::Model,
+        storage_used: i64,
+    ) -> Self {
+        let mut info = Self::from(model);
+        info.storage_used = Some(storage_used);
+        info
     }
 }
 

--- a/src/services/workspace_models.rs
+++ b/src/services/workspace_models.rs
@@ -14,6 +14,8 @@ pub struct FileInfo {
     pub team_id: Option<i64>,
     pub blob_id: i64,
     pub size: i64,
+    /// Total quota bytes for the file detail view: current `size` plus all
+    /// historical version sizes. `size` is only the current version size.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub storage_used: Option<i64>,
     pub owner_user_id: Option<i64>,
@@ -59,6 +61,8 @@ impl From<crate::entities::file::Model> for FileInfo {
 }
 
 impl FileInfo {
+    /// Builds a detail `FileInfo` from a file model and attaches explicit
+    /// quota bytes (`storage_used`) for the current file plus its versions.
     pub fn from_model_with_storage_used(
         model: crate::entities::file::Model,
         storage_used: i64,
@@ -80,6 +84,8 @@ pub struct FolderInfo {
     pub created_by_user_id: Option<i64>,
     pub created_by_username: String,
     pub policy_id: Option<i64>,
+    /// Recursive quota bytes for the folder detail view: all live files in the
+    /// folder tree, including current file sizes plus historical versions.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub storage_used: Option<i64>,
     #[cfg_attr(all(debug_assertions, feature = "openapi"), schema(value_type = String))]
@@ -113,6 +119,8 @@ impl From<crate::entities::folder::Model> for FolderInfo {
 }
 
 impl FolderInfo {
+    /// Builds a detail `FolderInfo` via `FolderInfo::from` and sets recursive
+    /// quota bytes (`storage_used`) for the details endpoint.
     pub fn from_model_with_storage_used(
         model: crate::entities::folder::Model,
         storage_used: i64,

--- a/tests/test_files.rs
+++ b/tests/test_files.rs
@@ -5,7 +5,11 @@ mod common;
 
 use actix_web::http::{StatusCode, header};
 use actix_web::test;
-use aster_drive::db::repository::{file_repo, user_repo};
+use aster_drive::db::repository::{file_repo, policy_repo, user_repo};
+use aster_drive::entities::{file, file_blob};
+use aster_drive::types::FileCategory;
+use chrono::Utc;
+use sea_orm::{ActiveModelTrait, Set};
 use serde_json::Value;
 
 macro_rules! upload_test_file_with_name_and_mime {
@@ -41,8 +45,8 @@ macro_rules! upload_test_file_with_name_and_mime {
     }};
 }
 
-macro_rules! upload_test_file_to_folder_with_content {
-    ($app:expr, $token:expr, $folder_id:expr, $name:expr, $content:expr) => {{
+macro_rules! upload_test_file_to_uri_with_content {
+    ($app:expr, $token:expr, $uri:expr, $name:expr, $content:expr, $message:expr) => {{
         use actix_web::test;
         use serde_json::Value;
 
@@ -57,7 +61,7 @@ macro_rules! upload_test_file_to_folder_with_content {
             content = $content
         );
         let req = test::TestRequest::post()
-            .uri(&format!("/api/v1/files/upload?folder_id={}", $folder_id))
+            .uri($uri)
             .insert_header(("Cookie", common::access_cookie_header(&$token)))
             .insert_header(common::csrf_header_for(&$token))
             .insert_header((
@@ -67,41 +71,35 @@ macro_rules! upload_test_file_to_folder_with_content {
             .set_payload(payload)
             .to_request();
         let resp = test::call_service(&$app, req).await;
-        assert_eq!(resp.status(), 201, "upload to folder should return 201");
+        assert_eq!(resp.status(), 201, $message);
         let body: Value = test::read_body_json(resp).await;
         body["data"]["id"].as_i64().unwrap()
     }};
 }
 
+macro_rules! upload_test_file_to_folder_with_content {
+    ($app:expr, $token:expr, $folder_id:expr, $name:expr, $content:expr) => {{
+        upload_test_file_to_uri_with_content!(
+            $app,
+            $token,
+            &format!("/api/v1/files/upload?folder_id={}", $folder_id),
+            $name,
+            $content,
+            "upload to folder should return 201"
+        )
+    }};
+}
+
 macro_rules! upload_test_file_with_content {
     ($app:expr, $token:expr, $name:expr, $content:expr) => {{
-        use actix_web::test;
-        use serde_json::Value;
-
-        let boundary = "----StorageUsedRootBoundary";
-        let payload = format!(
-            "------StorageUsedRootBoundary\r\n\
-             Content-Disposition: form-data; name=\"file\"; filename=\"{name}\"\r\n\
-             Content-Type: text/plain\r\n\r\n\
-             {content}\r\n\
-             ------StorageUsedRootBoundary--\r\n",
-            name = $name,
-            content = $content
-        );
-        let req = test::TestRequest::post()
-            .uri("/api/v1/files/upload")
-            .insert_header(("Cookie", common::access_cookie_header(&$token)))
-            .insert_header(common::csrf_header_for(&$token))
-            .insert_header((
-                "Content-Type",
-                format!("multipart/form-data; boundary={boundary}"),
-            ))
-            .set_payload(payload)
-            .to_request();
-        let resp = test::call_service(&$app, req).await;
-        assert_eq!(resp.status(), 201, "upload should return 201");
-        let body: Value = test::read_body_json(resp).await;
-        body["data"]["id"].as_i64().unwrap()
+        upload_test_file_to_uri_with_content!(
+            $app,
+            $token,
+            "/api/v1/files/upload",
+            $name,
+            $content,
+            "upload should return 201"
+        )
     }};
 }
 
@@ -1305,7 +1303,7 @@ async fn test_folder_detail_storage_used_is_recursive_and_excludes_trashed_files
 #[actix_web::test]
 async fn test_folder_detail_storage_used_handles_paginated_file_batches() {
     let state = common::setup().await;
-    let app = create_test_app!(state);
+    let app = create_test_app!(state.clone());
     let (token, _) = register_and_login!(app);
 
     let req = test::TestRequest::post()
@@ -1319,13 +1317,58 @@ async fn test_folder_detail_storage_used_handles_paginated_file_batches() {
     let body: Value = test::read_body_json(resp).await;
     let folder_id = body["data"]["id"].as_i64().unwrap();
 
-    let mut expected = 0i64;
-    for index in 0..501 {
-        let name = format!("wide-{index}.txt");
-        let content = if index % 2 == 0 { "aa" } else { "bbb" };
-        upload_test_file_to_folder_with_content!(app, token, folder_id, &name, content);
-        expected += content.len() as i64;
+    let user = user_repo::find_by_username(state.writer_db(), "testuser")
+        .await
+        .unwrap()
+        .expect("registered test user should exist");
+    let policy = policy_repo::find_default(state.writer_db())
+        .await
+        .unwrap()
+        .expect("default policy should exist");
+    let now = Utc::now();
+    let blob = file_blob::ActiveModel {
+        hash: Set("storage-used-pagination-blob".to_string()),
+        size: Set(3),
+        policy_id: Set(policy.id),
+        storage_path: Set("storage-used-pagination-blob".to_string()),
+        ref_count: Set(501),
+        created_at: Set(now),
+        updated_at: Set(now),
+        ..Default::default()
     }
+    .insert(state.writer_db())
+    .await
+    .expect("pagination test blob should insert");
+
+    let mut expected = 0i64;
+    let files = (0..501)
+        .map(|index| {
+            let size = if index % 2 == 0 { 2 } else { 3 };
+            expected += size;
+            file::ActiveModel {
+                name: Set(format!("wide-{index}.txt")),
+                folder_id: Set(Some(folder_id)),
+                team_id: Set(None),
+                blob_id: Set(blob.id),
+                size: Set(size),
+                owner_user_id: Set(Some(user.id)),
+                created_by_user_id: Set(Some(user.id)),
+                created_by_username: Set(user.username.clone()),
+                mime_type: Set("text/plain".to_string()),
+                extension: Set("txt".to_string()),
+                compound_extension: Set(None),
+                file_category: Set(FileCategory::Document),
+                created_at: Set(now),
+                updated_at: Set(now),
+                deleted_at: Set(None),
+                is_locked: Set(false),
+                ..Default::default()
+            }
+        })
+        .collect();
+    file_repo::create_many(state.writer_db(), files)
+        .await
+        .expect("pagination test files should insert");
 
     let req = test::TestRequest::get()
         .uri(&format!("/api/v1/folders/{folder_id}/info"))

--- a/tests/test_files.rs
+++ b/tests/test_files.rs
@@ -41,6 +41,70 @@ macro_rules! upload_test_file_with_name_and_mime {
     }};
 }
 
+macro_rules! upload_test_file_to_folder_with_content {
+    ($app:expr, $token:expr, $folder_id:expr, $name:expr, $content:expr) => {{
+        use actix_web::test;
+        use serde_json::Value;
+
+        let boundary = "----StorageUsedBoundary";
+        let payload = format!(
+            "------StorageUsedBoundary\r\n\
+             Content-Disposition: form-data; name=\"file\"; filename=\"{name}\"\r\n\
+             Content-Type: text/plain\r\n\r\n\
+             {content}\r\n\
+             ------StorageUsedBoundary--\r\n",
+            name = $name,
+            content = $content
+        );
+        let req = test::TestRequest::post()
+            .uri(&format!("/api/v1/files/upload?folder_id={}", $folder_id))
+            .insert_header(("Cookie", common::access_cookie_header(&$token)))
+            .insert_header(common::csrf_header_for(&$token))
+            .insert_header((
+                "Content-Type",
+                format!("multipart/form-data; boundary={boundary}"),
+            ))
+            .set_payload(payload)
+            .to_request();
+        let resp = test::call_service(&$app, req).await;
+        assert_eq!(resp.status(), 201, "upload to folder should return 201");
+        let body: Value = test::read_body_json(resp).await;
+        body["data"]["id"].as_i64().unwrap()
+    }};
+}
+
+macro_rules! upload_test_file_with_content {
+    ($app:expr, $token:expr, $name:expr, $content:expr) => {{
+        use actix_web::test;
+        use serde_json::Value;
+
+        let boundary = "----StorageUsedRootBoundary";
+        let payload = format!(
+            "------StorageUsedRootBoundary\r\n\
+             Content-Disposition: form-data; name=\"file\"; filename=\"{name}\"\r\n\
+             Content-Type: text/plain\r\n\r\n\
+             {content}\r\n\
+             ------StorageUsedRootBoundary--\r\n",
+            name = $name,
+            content = $content
+        );
+        let req = test::TestRequest::post()
+            .uri("/api/v1/files/upload")
+            .insert_header(("Cookie", common::access_cookie_header(&$token)))
+            .insert_header(common::csrf_header_for(&$token))
+            .insert_header((
+                "Content-Type",
+                format!("multipart/form-data; boundary={boundary}"),
+            ))
+            .set_payload(payload)
+            .to_request();
+        let resp = test::call_service(&$app, req).await;
+        assert_eq!(resp.status(), 201, "upload should return 201");
+        let body: Value = test::read_body_json(resp).await;
+        body["data"]["id"].as_i64().unwrap()
+    }};
+}
+
 fn upload_payload(filename: &str, content: &str) -> String {
     format!(
         "------UnicodeBoundary123\r\n\
@@ -1014,6 +1078,264 @@ async fn test_file_versions() {
         .to_request();
     let resp = test::call_service(&app, req).await;
     assert_eq!(resp.status(), 200);
+}
+
+#[actix_web::test]
+async fn test_file_detail_storage_used_equals_size_without_versions() {
+    let state = common::setup().await;
+    let app = create_test_app!(state);
+    let (token, _) = register_and_login!(app);
+
+    let content = "plain-current";
+    let file_id = upload_test_file_with_content!(app, token, "plain.txt", content);
+
+    let req = test::TestRequest::get()
+        .uri(&format!("/api/v1/files/{file_id}"))
+        .insert_header(("Cookie", common::access_cookie_header(&token)))
+        .insert_header(common::csrf_header_for(&token))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body: Value = test::read_body_json(resp).await;
+    assert_eq!(body["data"]["size"], content.len() as i64);
+    assert_eq!(body["data"]["storage_used"], content.len() as i64);
+}
+
+#[actix_web::test]
+async fn test_file_detail_storage_used_includes_all_history_versions() {
+    let state = common::setup().await;
+    let app = create_test_app!(state);
+    let (token, _) = register_and_login!(app);
+
+    let initial = "v1";
+    let second = "version-two";
+    let current = "version-three";
+    let file_id = upload_test_file_with_content!(app, token, "versioned.txt", initial);
+
+    for content in [second, current] {
+        let req = test::TestRequest::put()
+            .uri(&format!("/api/v1/files/{file_id}/content"))
+            .insert_header(("Cookie", common::access_cookie_header(&token)))
+            .insert_header(common::csrf_header_for(&token))
+            .insert_header(("Content-Type", "application/octet-stream"))
+            .set_payload(content)
+            .to_request();
+        let resp = test::call_service(&app, req).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    let req = test::TestRequest::get()
+        .uri(&format!("/api/v1/files/{file_id}/versions"))
+        .insert_header(("Cookie", common::access_cookie_header(&token)))
+        .insert_header(common::csrf_header_for(&token))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body: Value = test::read_body_json(resp).await;
+    assert_eq!(body["data"].as_array().unwrap().len(), 2);
+
+    let req = test::TestRequest::get()
+        .uri(&format!("/api/v1/files/{file_id}"))
+        .insert_header(("Cookie", common::access_cookie_header(&token)))
+        .insert_header(common::csrf_header_for(&token))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body: Value = test::read_body_json(resp).await;
+    assert_eq!(body["data"]["size"], current.len() as i64);
+    assert_eq!(
+        body["data"]["storage_used"],
+        (initial.len() + second.len() + current.len()) as i64
+    );
+}
+
+#[actix_web::test]
+async fn test_empty_folder_detail_storage_used_is_zero() {
+    let state = common::setup().await;
+    let app = create_test_app!(state);
+    let (token, _) = register_and_login!(app);
+
+    let req = test::TestRequest::post()
+        .uri("/api/v1/folders")
+        .insert_header(("Cookie", common::access_cookie_header(&token)))
+        .insert_header(common::csrf_header_for(&token))
+        .set_json(serde_json::json!({ "name": "Empty Storage" }))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), StatusCode::CREATED);
+    let body: Value = test::read_body_json(resp).await;
+    let folder_id = body["data"]["id"].as_i64().unwrap();
+
+    let req = test::TestRequest::get()
+        .uri(&format!("/api/v1/folders/{folder_id}/info"))
+        .insert_header(("Cookie", common::access_cookie_header(&token)))
+        .insert_header(common::csrf_header_for(&token))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body: Value = test::read_body_json(resp).await;
+    assert_eq!(body["data"]["storage_used"], 0);
+}
+
+#[actix_web::test]
+async fn test_folder_detail_storage_used_is_recursive_and_excludes_trashed_files() {
+    let state = common::setup().await;
+    let app = create_test_app!(state);
+    let (token, _) = register_and_login!(app);
+
+    let req = test::TestRequest::post()
+        .uri("/api/v1/folders")
+        .insert_header(("Cookie", common::access_cookie_header(&token)))
+        .insert_header(common::csrf_header_for(&token))
+        .set_json(serde_json::json!({ "name": "Storage Used" }))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), StatusCode::CREATED);
+    let body: Value = test::read_body_json(resp).await;
+    let root_folder_id = body["data"]["id"].as_i64().unwrap();
+
+    let req = test::TestRequest::post()
+        .uri("/api/v1/folders")
+        .insert_header(("Cookie", common::access_cookie_header(&token)))
+        .insert_header(common::csrf_header_for(&token))
+        .set_json(serde_json::json!({
+            "name": "Nested",
+            "parent_id": root_folder_id,
+        }))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), StatusCode::CREATED);
+    let body: Value = test::read_body_json(resp).await;
+    let nested_folder_id = body["data"]["id"].as_i64().unwrap();
+
+    let root_initial = "alpha";
+    let root_updated = "longer-alpha";
+    let nested_initial = "beta!";
+    let nested_updated = "longer-beta";
+    let trashed_initial = "trashed";
+    let trashed_updated = "trashed-updated";
+    let root_file_id = upload_test_file_to_folder_with_content!(
+        app,
+        token,
+        root_folder_id,
+        "root.txt",
+        root_initial
+    );
+    let nested_file_id = upload_test_file_to_folder_with_content!(
+        app,
+        token,
+        nested_folder_id,
+        "nested.txt",
+        nested_initial
+    );
+    let trashed_file_id = upload_test_file_to_folder_with_content!(
+        app,
+        token,
+        nested_folder_id,
+        "trashed.txt",
+        trashed_initial
+    );
+
+    let req = test::TestRequest::put()
+        .uri(&format!("/api/v1/files/{root_file_id}/content"))
+        .insert_header(("Cookie", common::access_cookie_header(&token)))
+        .insert_header(common::csrf_header_for(&token))
+        .insert_header(("Content-Type", "application/octet-stream"))
+        .set_payload(root_updated)
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let req = test::TestRequest::put()
+        .uri(&format!("/api/v1/files/{nested_file_id}/content"))
+        .insert_header(("Cookie", common::access_cookie_header(&token)))
+        .insert_header(common::csrf_header_for(&token))
+        .insert_header(("Content-Type", "application/octet-stream"))
+        .set_payload(nested_updated)
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let req = test::TestRequest::put()
+        .uri(&format!("/api/v1/files/{trashed_file_id}/content"))
+        .insert_header(("Cookie", common::access_cookie_header(&token)))
+        .insert_header(common::csrf_header_for(&token))
+        .insert_header(("Content-Type", "application/octet-stream"))
+        .set_payload(trashed_updated)
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let req = test::TestRequest::delete()
+        .uri(&format!("/api/v1/files/{trashed_file_id}"))
+        .insert_header(("Cookie", common::access_cookie_header(&token)))
+        .insert_header(common::csrf_header_for(&token))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let root_file_storage_used = root_initial.len() as i64 + root_updated.len() as i64;
+    let nested_file_storage_used = nested_initial.len() as i64 + nested_updated.len() as i64;
+
+    let req = test::TestRequest::get()
+        .uri(&format!("/api/v1/files/{root_file_id}"))
+        .insert_header(("Cookie", common::access_cookie_header(&token)))
+        .insert_header(common::csrf_header_for(&token))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body: Value = test::read_body_json(resp).await;
+    assert_eq!(body["data"]["size"], root_updated.len() as i64);
+    assert_eq!(body["data"]["storage_used"], root_file_storage_used);
+
+    let req = test::TestRequest::get()
+        .uri(&format!("/api/v1/folders/{root_folder_id}/info"))
+        .insert_header(("Cookie", common::access_cookie_header(&token)))
+        .insert_header(common::csrf_header_for(&token))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body: Value = test::read_body_json(resp).await;
+    assert_eq!(
+        body["data"]["storage_used"],
+        root_file_storage_used + nested_file_storage_used
+    );
+}
+
+#[actix_web::test]
+async fn test_folder_detail_storage_used_handles_paginated_file_batches() {
+    let state = common::setup().await;
+    let app = create_test_app!(state);
+    let (token, _) = register_and_login!(app);
+
+    let req = test::TestRequest::post()
+        .uri("/api/v1/folders")
+        .insert_header(("Cookie", common::access_cookie_header(&token)))
+        .insert_header(common::csrf_header_for(&token))
+        .set_json(serde_json::json!({ "name": "Wide Storage" }))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), StatusCode::CREATED);
+    let body: Value = test::read_body_json(resp).await;
+    let folder_id = body["data"]["id"].as_i64().unwrap();
+
+    let mut expected = 0i64;
+    for index in 0..501 {
+        let name = format!("wide-{index}.txt");
+        let content = if index % 2 == 0 { "aa" } else { "bbb" };
+        upload_test_file_to_folder_with_content!(app, token, folder_id, &name, content);
+        expected += content.len() as i64;
+    }
+
+    let req = test::TestRequest::get()
+        .uri(&format!("/api/v1/folders/{folder_id}/info"))
+        .insert_header(("Cookie", common::access_cookie_header(&token)))
+        .insert_header(common::csrf_header_for(&token))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body: Value = test::read_body_json(resp).await;
+    assert_eq!(body["data"]["storage_used"], expected);
 }
 
 #[actix_web::test]

--- a/tests/test_team_space.rs
+++ b/tests/test_team_space.rs
@@ -236,6 +236,7 @@ async fn test_team_space_upload_browse_download_and_personal_separation() {
     assert_eq!(body["data"]["name"], "Docs");
     assert!(body["data"]["created_at"].is_string());
     assert_eq!(body["data"]["team_id"], team_id);
+    assert_eq!(body["data"]["storage_used"], "hello team".len() as i64);
 
     let req = test::TestRequest::get()
         .uri("/api/v1/folders")
@@ -1325,7 +1326,26 @@ async fn test_team_versions_enforce_scope_and_membership() {
     assert_eq!(body["data"].as_array().unwrap().len(), 1);
     let version_id = body["data"][0]["id"].as_i64().unwrap();
 
+    let req = test::TestRequest::get()
+        .uri(&format!("/api/v1/teams/{team_id}/files/{file_id}"))
+        .insert_header(("Cookie", common::access_cookie_header(&owner_token)))
+        .insert_header(common::csrf_header_for(&owner_token))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), 200);
+    let body: Value = test::read_body_json(resp).await;
+    assert_eq!(body["data"]["size"], "team-v2".len() as i64);
+    assert_eq!(
+        body["data"]["storage_used"],
+        ("team-v1".len() + "team-v2".len()) as i64
+    );
+
     for req in [
+        test::TestRequest::get()
+            .uri(&format!("/api/v1/files/{file_id}"))
+            .insert_header(("Cookie", common::access_cookie_header(&owner_token)))
+            .insert_header(common::csrf_header_for(&owner_token))
+            .to_request(),
         test::TestRequest::get()
             .uri(&format!("/api/v1/files/{file_id}/versions"))
             .insert_header(("Cookie", common::access_cookie_header(&owner_token)))
@@ -1349,6 +1369,11 @@ async fn test_team_versions_enforce_scope_and_membership() {
     }
 
     for req in [
+        test::TestRequest::get()
+            .uri(&format!("/api/v1/teams/{team_id}/files/{file_id}"))
+            .insert_header(("Cookie", common::access_cookie_header(&outsider_token)))
+            .insert_header(common::csrf_header_for(&outsider_token))
+            .to_request(),
         test::TestRequest::get()
             .uri(&format!("/api/v1/teams/{team_id}/files/{file_id}/versions"))
             .insert_header(("Cookie", common::access_cookie_header(&outsider_token)))


### PR DESCRIPTION
Add `storage_used` field to file and folder info endpoints that includes current file size plus all version history. Display storage usage in the file info dialog UI.

**Backend changes:**
- Add `storage_used` optional field to `FileInfo` and `FolderInfo` response models
- Implement `sum_sizes_by_file_id` and `sum_sizes_by_file_ids` in version repository to calculate total version storage
- Add `get_info_with_storage_used_in_scope` methods that compute storage including all versions
- Implement recursive folder storage calculation with pagination support (500 files per page, 500 file IDs per version sum batch)
- Add `find_id_size_by_folders` and `find_child_ids_in_parents` lightweight queries to avoid loading full models during recursive traversal
- Separate `FileEntity`/`FolderEntity` from `FileInfo`/`FolderInfo` in OpenAPI schema to distinguish database models from API responses
- Update file and folder detail endpoints to return storage usage

**Frontend changes:**
- Add `storage_used` field to `FileInfo` and `FolderInfo` TypeScript types
- Update type guards to check for `storage_used` presence to distinguish detail records from list items
- Add automatic refresh for legacy detail records missing storage usage
- Display "Storage Used" row in file and folder overview panels
- Add i18n keys `info_storage_used` for English and Chinese

**Test coverage:**
- File detail storage equals size when no versions exist
- File detail storage includes all history versions
- Empty folder storage is zero
- Folder storage is recursive and excludes trashed files
- Folder storage handles paginated file batches (501 files)
- Team versions enforce scope and include storage usage

closed #271 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 文件和文件夹详情面板新增"已占用空间"字段，综合显示当前内容与版本历史的总存储占用。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->