### PR TITLE
perf(batch): optimize batch move with bulk name lookups

### DIFF
--- a/src/db/repository/file_repo/query/names.rs
+++ b/src/db/repository/file_repo/query/names.rs
@@ -104,18 +104,35 @@ pub(super) async fn find_by_names_in_folder_in_scope<C: ConnectionTrait>(
     if names.is_empty() {
         return Ok(vec![]);
     }
+    let query_names = add_normalization_query_variants(names);
+    let normalized_names = normalized_non_ascii_names(names);
 
-    File::find()
+    let mut files = File::find()
         .filter(
             crate::db::repository::file_repo::common::apply_folder_condition(
                 crate::db::repository::file_repo::common::active_scope_condition(scope),
                 folder_id,
             ),
         )
-        .filter(file::Column::Name.is_in(names.iter().cloned()))
+        .filter(file::Column::Name.is_in(query_names.iter().cloned()))
         .all(db)
         .await
-        .map_err(AsterError::from)
+        .map_err(AsterError::from)?;
+
+    if !normalized_names.is_empty() {
+        let existing_ids: HashSet<i64> = files.iter().map(|file| file.id).collect();
+        files.extend(
+            find_by_folder_in_scope(db, scope, folder_id)
+                .await?
+                .into_iter()
+                .filter(|file| !existing_ids.contains(&file.id))
+                .filter(|file| {
+                    normalized_names.contains(&crate::utils::normalize_name(&file.name))
+                }),
+        );
+    }
+
+    Ok(files)
 }
 
 pub(super) async fn find_names_by_names_in_folder_in_scope<C: ConnectionTrait>(
@@ -233,6 +250,14 @@ pub(super) fn normalize_existing_filename(name: String) -> String {
     } else {
         name.nfc().collect()
     }
+}
+
+fn normalized_non_ascii_names(names: &[String]) -> HashSet<String> {
+    names
+        .iter()
+        .filter(|name| !name.is_ascii())
+        .map(|name| crate::utils::normalize_name(name))
+        .collect()
 }
 
 /// 基于当前目录快照建议一个不冲突的文件名：

--- a/src/db/repository/folder_repo/mod.rs
+++ b/src/db/repository/folder_repo/mod.rs
@@ -20,8 +20,9 @@ pub(crate) use query::find_child_ids_in_parents;
 pub use query::{
     find_all_children, find_all_children_in_parents, find_all_files_in_folder, find_by_id,
     find_by_ids, find_by_ids_in_personal_scope, find_by_ids_in_team_scope, find_by_name_in_parent,
-    find_by_name_in_team_parent, find_children, find_children_in_parents, find_children_paginated,
-    find_team_children, find_team_children_in_parents, find_team_children_paginated, lock_by_id,
+    find_by_name_in_team_parent, find_by_names_in_parent, find_by_names_in_team_parent,
+    find_children, find_children_in_parents, find_children_paginated, find_team_children,
+    find_team_children_in_parents, find_team_children_paginated, lock_by_id,
 };
 pub use trash::{
     find_all_by_team, find_all_by_team_paginated, find_all_by_user, find_all_by_user_paginated,

--- a/src/db/repository/folder_repo/query.rs
+++ b/src/db/repository/folder_repo/query.rs
@@ -1,9 +1,12 @@
 //! `folder_repo` 仓储子模块：`query`。
 
+use std::collections::HashSet;
+
 use sea_orm::{
     ColumnTrait, ConnectionTrait, DbBackend, EntityTrait, PaginatorTrait, QueryFilter, QueryOrder,
     QuerySelect,
 };
+use unicode_normalization::{UnicodeNormalization, is_nfc, is_nfd};
 
 use crate::api::pagination::{SortBy, SortOrder};
 use crate::entities::folder::{self, Entity as Folder};
@@ -306,16 +309,77 @@ async fn find_by_names_in_parent_in_scope<C: ConnectionTrait>(
     if names.is_empty() {
         return Ok(vec![]);
     }
+    let query_names = add_normalization_query_variants(names);
+    let normalized_names = normalized_non_ascii_names(names);
 
-    Folder::find()
+    let mut folders = Folder::find()
         .filter(apply_parent_condition(
             active_scope_condition(scope),
             parent_id,
         ))
-        .filter(folder::Column::Name.is_in(names.iter().cloned()))
+        .filter(folder::Column::Name.is_in(query_names.iter().cloned()))
         .all(db)
         .await
-        .map_err(AsterError::from)
+        .map_err(AsterError::from)?;
+
+    if !normalized_names.is_empty() {
+        let existing_ids: HashSet<i64> = folders.iter().map(|folder| folder.id).collect();
+        folders.extend(
+            find_children_in_scope(db, scope, parent_id)
+                .await?
+                .into_iter()
+                .filter(|folder| !existing_ids.contains(&folder.id))
+                .filter(|folder| {
+                    normalized_names.contains(&crate::utils::normalize_name(&folder.name))
+                }),
+        );
+    }
+
+    Ok(folders)
+}
+
+fn push_unique_normalization_variant(variants: &mut Vec<String>, variant: &str) {
+    if variants.iter().all(|existing| existing.as_str() != variant) {
+        variants.push(variant.to_string());
+    }
+}
+
+fn push_unique_owned_normalization_variant(variants: &mut Vec<String>, variant: String) {
+    if variants
+        .iter()
+        .all(|existing| existing.as_str() != variant.as_str())
+    {
+        variants.push(variant);
+    }
+}
+
+fn add_normalization_query_variants(names: &[String]) -> std::borrow::Cow<'_, [String]> {
+    if names.iter().all(|name| name.is_ascii()) {
+        return std::borrow::Cow::Borrowed(names);
+    }
+
+    let mut variants = Vec::with_capacity(names.len());
+    for name in names {
+        push_unique_normalization_variant(&mut variants, name);
+        if name.is_ascii() {
+            continue;
+        }
+        if !is_nfc(name) {
+            push_unique_owned_normalization_variant(&mut variants, name.nfc().collect());
+        }
+        if !is_nfd(name) {
+            push_unique_owned_normalization_variant(&mut variants, name.nfd().collect());
+        }
+    }
+    std::borrow::Cow::Owned(variants)
+}
+
+fn normalized_non_ascii_names(names: &[String]) -> HashSet<String> {
+    names
+        .iter()
+        .filter(|name| !name.is_ascii())
+        .map(|name| crate::utils::normalize_name(name))
+        .collect()
 }
 
 pub async fn find_by_name_in_parent<C: ConnectionTrait>(

--- a/src/db/repository/folder_repo/query.rs
+++ b/src/db/repository/folder_repo/query.rs
@@ -297,6 +297,27 @@ async fn find_by_name_in_parent_in_scope<C: ConnectionTrait>(
         .find(|folder| crate::utils::normalize_name(&folder.name) == normalized_name))
 }
 
+async fn find_by_names_in_parent_in_scope<C: ConnectionTrait>(
+    db: &C,
+    scope: FolderScope,
+    parent_id: Option<i64>,
+    names: &[String],
+) -> Result<Vec<folder::Model>> {
+    if names.is_empty() {
+        return Ok(vec![]);
+    }
+
+    Folder::find()
+        .filter(apply_parent_condition(
+            active_scope_condition(scope),
+            parent_id,
+        ))
+        .filter(folder::Column::Name.is_in(names.iter().cloned()))
+        .all(db)
+        .await
+        .map_err(AsterError::from)
+}
+
 pub async fn find_by_name_in_parent<C: ConnectionTrait>(
     db: &C,
     user_id: i64,
@@ -306,6 +327,15 @@ pub async fn find_by_name_in_parent<C: ConnectionTrait>(
     find_by_name_in_parent_in_scope(db, FolderScope::Personal { user_id }, parent_id, name).await
 }
 
+pub async fn find_by_names_in_parent<C: ConnectionTrait>(
+    db: &C,
+    user_id: i64,
+    parent_id: Option<i64>,
+    names: &[String],
+) -> Result<Vec<folder::Model>> {
+    find_by_names_in_parent_in_scope(db, FolderScope::Personal { user_id }, parent_id, names).await
+}
+
 pub async fn find_by_name_in_team_parent<C: ConnectionTrait>(
     db: &C,
     team_id: i64,
@@ -313,6 +343,15 @@ pub async fn find_by_name_in_team_parent<C: ConnectionTrait>(
     name: &str,
 ) -> Result<Option<folder::Model>> {
     find_by_name_in_parent_in_scope(db, FolderScope::Team { team_id }, parent_id, name).await
+}
+
+pub async fn find_by_names_in_team_parent<C: ConnectionTrait>(
+    db: &C,
+    team_id: i64,
+    parent_id: Option<i64>,
+    names: &[String],
+) -> Result<Vec<folder::Model>> {
+    find_by_names_in_parent_in_scope(db, FolderScope::Team { team_id }, parent_id, names).await
 }
 
 /// 查找某文件夹下的所有子文件夹（含已删除，递归收集用）

--- a/src/services/batch_service/movement.rs
+++ b/src/services/batch_service/movement.rs
@@ -38,7 +38,10 @@ async fn load_target_file_name_map(
             .await?
         }
     };
-    Ok(files.into_iter().map(|file| (file.name, file.id)).collect())
+    Ok(files
+        .into_iter()
+        .map(|file| (crate::utils::normalize_name(&file.name), file.id))
+        .collect())
 }
 
 async fn load_target_folder_name_map(
@@ -69,7 +72,7 @@ async fn load_target_folder_name_map(
     };
     Ok(folders
         .into_iter()
-        .map(|folder| (folder.name, folder.id))
+        .map(|folder| (crate::utils::normalize_name(&folder.name), folder.id))
         .collect())
 }
 
@@ -98,15 +101,19 @@ pub(crate) async fn batch_move_in_scope(
     let mut target_folder_names = HashMap::new();
     let mut target_ancestor_ids = HashSet::new();
     if target_error.is_none() {
+        let mut seen_file_lookup_names = HashSet::new();
         let target_file_lookup_names: Vec<String> = normalized_file_ids
             .iter()
             .flat_map(|id| file_map.get(id))
             .map(|file| file.name.clone())
+            .filter(|name| seen_file_lookup_names.insert(name.clone()))
             .collect();
+        let mut seen_folder_lookup_names = HashSet::new();
         let target_folder_lookup_names: Vec<String> = normalized_folder_ids
             .iter()
             .flat_map(|id| folder_map.get(id))
             .map(|folder| folder.name.clone())
+            .filter(|name| seen_folder_lookup_names.insert(name.clone()))
             .collect();
         target_file_names =
             load_target_file_name_map(state, scope, target_folder_id, &target_file_lookup_names)
@@ -150,7 +157,8 @@ pub(crate) async fn batch_move_in_scope(
             result.record_failure("file", id, error.clone());
             continue;
         }
-        if matches!(target_file_names.get(&file.name), Some(existing_id) if *existing_id != file.id)
+        let normalized_name = crate::utils::normalize_name(&file.name);
+        if matches!(target_file_names.get(&normalized_name), Some(existing_id) if *existing_id != file.id)
         {
             result.record_failure(
                 "file",
@@ -168,7 +176,7 @@ pub(crate) async fn batch_move_in_scope(
         if file.folder_id != target_folder_id {
             file_ids_to_move.insert(file.id);
         }
-        target_file_names.insert(file.name.clone(), file.id);
+        target_file_names.insert(normalized_name, file.id);
     }
 
     for &id in &normalized_folder_ids {
@@ -213,7 +221,8 @@ pub(crate) async fn batch_move_in_scope(
             );
             continue;
         }
-        if matches!(target_folder_names.get(&folder.name), Some(existing_id) if *existing_id != folder.id)
+        let normalized_name = crate::utils::normalize_name(&folder.name);
+        if matches!(target_folder_names.get(&normalized_name), Some(existing_id) if *existing_id != folder.id)
         {
             result.record_failure(
                 "folder",
@@ -231,7 +240,7 @@ pub(crate) async fn batch_move_in_scope(
         if folder.parent_id != target_folder_id {
             folder_ids_to_move.insert(folder.id);
         }
-        target_folder_names.insert(folder.name.clone(), folder.id);
+        target_folder_names.insert(normalized_name, folder.id);
     }
 
     if !file_ids_to_move.is_empty() || !folder_ids_to_move.is_empty() {

--- a/src/services/batch_service/movement.rs
+++ b/src/services/batch_service/movement.rs
@@ -17,6 +17,62 @@ use crate::services::{
 use super::shared::{load_folder_ancestor_ids_in_scope, load_target_folder_in_scope};
 use super::{BatchResult, NormalizedSelection, load_normalized_selection_in_scope};
 
+async fn load_target_file_name_map(
+    state: &PrimaryAppState,
+    scope: WorkspaceStorageScope,
+    target_folder_id: Option<i64>,
+    names: &[String],
+) -> Result<HashMap<String, i64>> {
+    let files = match scope {
+        WorkspaceStorageScope::Personal { user_id } => {
+            file_repo::find_by_names_in_folder(state.reader_db(), user_id, target_folder_id, names)
+                .await?
+        }
+        WorkspaceStorageScope::Team { team_id, .. } => {
+            file_repo::find_by_names_in_team_folder(
+                state.reader_db(),
+                team_id,
+                target_folder_id,
+                names,
+            )
+            .await?
+        }
+    };
+    Ok(files.into_iter().map(|file| (file.name, file.id)).collect())
+}
+
+async fn load_target_folder_name_map(
+    state: &PrimaryAppState,
+    scope: WorkspaceStorageScope,
+    target_folder_id: Option<i64>,
+    names: &[String],
+) -> Result<HashMap<String, i64>> {
+    let folders = match scope {
+        WorkspaceStorageScope::Personal { user_id } => {
+            folder_repo::find_by_names_in_parent(
+                state.reader_db(),
+                user_id,
+                target_folder_id,
+                names,
+            )
+            .await?
+        }
+        WorkspaceStorageScope::Team { team_id, .. } => {
+            folder_repo::find_by_names_in_team_parent(
+                state.reader_db(),
+                team_id,
+                target_folder_id,
+                names,
+            )
+            .await?
+        }
+    };
+    Ok(folders
+        .into_iter()
+        .map(|folder| (folder.name, folder.id))
+        .collect())
+}
+
 pub(crate) async fn batch_move_in_scope(
     state: &PrimaryAppState,
     scope: WorkspaceStorageScope,
@@ -42,18 +98,26 @@ pub(crate) async fn batch_move_in_scope(
     let mut target_folder_names = HashMap::new();
     let mut target_ancestor_ids = HashSet::new();
     if target_error.is_none() {
+        let target_file_lookup_names: Vec<String> = normalized_file_ids
+            .iter()
+            .flat_map(|id| file_map.get(id))
+            .map(|file| file.name.clone())
+            .collect();
+        let target_folder_lookup_names: Vec<String> = normalized_folder_ids
+            .iter()
+            .flat_map(|id| folder_map.get(id))
+            .map(|folder| folder.name.clone())
+            .collect();
         target_file_names =
-            workspace_storage_service::list_files_in_folder(state, scope, target_folder_id)
-                .await?
-                .into_iter()
-                .map(|file| (file.name, file.id))
-                .collect();
-        target_folder_names =
-            workspace_storage_service::list_folders_in_parent(state, scope, target_folder_id)
-                .await?
-                .into_iter()
-                .map(|folder| (folder.name, folder.id))
-                .collect();
+            load_target_file_name_map(state, scope, target_folder_id, &target_file_lookup_names)
+                .await?;
+        target_folder_names = load_target_folder_name_map(
+            state,
+            scope,
+            target_folder_id,
+            &target_folder_lookup_names,
+        )
+        .await?;
         target_ancestor_ids =
             load_folder_ancestor_ids_in_scope(state, scope, target_folder.as_ref()).await?;
     }

--- a/tests/performance/k6/lib/client.js
+++ b/tests/performance/k6/lib/client.js
@@ -1,7 +1,7 @@
 import { check, fail } from "k6";
+import encoding from "k6/encoding";
 import exec from "k6/execution";
 import http from "k6/http";
-import encoding from "k6/encoding";
 
 import { benchConfig } from "./config.js";
 
@@ -47,13 +47,16 @@ function parseApiBody(response) {
 	}
 }
 
+function isSuccessCode(code) {
+	return code === "success" || Number(code) === 0;
+}
+
 export function assertApi(response, context, expectedStatus = 200) {
 	const body = parseApiBody(response);
 	const success = check(response, {
-		[`${context}: status ${expectedStatus}`]:
-			(resp) => resp.status === expectedStatus,
-		[`${context}: api code 0`]:
-			() => body !== null && Number(body.code) === 0,
+		[`${context}: status ${expectedStatus}`]: (resp) =>
+			resp.status === expectedStatus,
+		[`${context}: api code 0`]: () => body !== null && isSuccessCode(body.code),
 	});
 
 	if (!success) {

--- a/tests/performance/k6/lib/client.js
+++ b/tests/performance/k6/lib/client.js
@@ -48,7 +48,7 @@ function parseApiBody(response) {
 }
 
 function isSuccessCode(code) {
-	return code === "success" || Number(code) === 0;
+	return code === "success" || code === 0 || code === "0";
 }
 
 export function assertApi(response, context, expectedStatus = 200) {
@@ -113,16 +113,12 @@ export function login(
 }
 
 export function refreshSession(session) {
-	const response = http.post(
-		url("/api/v1/auth/refresh"),
-		null,
-		{
-			headers: {
-				Cookie: `aster_refresh=${session.refreshToken}; aster_csrf=${session.csrfToken}`,
-				"X-CSRF-Token": session.csrfToken,
-			},
+	const response = http.post(url("/api/v1/auth/refresh"), null, {
+		headers: {
+			Cookie: `aster_refresh=${session.refreshToken}; aster_csrf=${session.csrfToken}`,
+			"X-CSRF-Token": session.csrfToken,
 		},
-	);
+	});
 	const body = assertApi(response, "auth.refresh", 200);
 	const accessToken = cookieValue(response, "aster_access");
 	const csrfToken = cookieValue(response, "aster_csrf") || session.csrfToken;
@@ -231,7 +227,13 @@ export function findFileInFolder(session, folderId, filename) {
 
 export function uploadDirect(
 	session,
-	{ filename, content, mimeType = "text/plain", folderId = null, relativePath = null },
+	{
+		filename,
+		content,
+		mimeType = "text/plain",
+		folderId = null,
+		relativePath = null,
+	},
 ) {
 	const payload = {
 		file: http.file(content, filename, mimeType),
@@ -301,24 +303,18 @@ export function completeUpload(session, uploadId) {
 }
 
 export function search(session, query = {}) {
-	const response = http.get(
-		url(`/api/v1/search${buildQuery(query)}`),
-		{
-			headers: authHeaders(session),
-		},
-	);
+	const response = http.get(url(`/api/v1/search${buildQuery(query)}`), {
+		headers: authHeaders(session),
+	});
 	const body = assertApi(response, "search", 200);
 	return { response, body };
 }
 
 export function downloadFile(session, fileId) {
-	const response = http.get(
-		url(`/api/v1/files/${fileId}/download`),
-		{
-			headers: authHeaders(session),
-			responseType: "none",
-		},
-	);
+	const response = http.get(url(`/api/v1/files/${fileId}/download`), {
+		headers: authHeaders(session),
+		responseType: "none",
+	});
 	check(response, {
 		"files.download: status 200": (resp) => resp.status === 200,
 	}) || fail(`files.download failed: ${response.status}`);
@@ -344,12 +340,9 @@ export function batchMove(session, fileIds, folderIds, targetFolderId) {
 }
 
 export function listWebdavAccounts(session) {
-	const response = http.get(
-		url("/api/v1/webdav-accounts?limit=100&offset=0"),
-		{
-			headers: authHeaders(session),
-		},
-	);
+	const response = http.get(url("/api/v1/webdav-accounts?limit=100&offset=0"), {
+		headers: authHeaders(session),
+	});
 	const body = assertApi(response, "webdav.accounts.list", 200);
 	return { response, body };
 }
@@ -358,7 +351,11 @@ export function webdavRequest(
 	method,
 	path,
 	body = null,
-	{ username = benchConfig.webdavUsername, password = benchConfig.webdavPassword, headers = {} } = {},
+	{
+		username = benchConfig.webdavUsername,
+		password = benchConfig.webdavPassword,
+		headers = {},
+	} = {},
 ) {
 	const encodedPath = path
 		.split("/")

--- a/tests/performance/k6/upload-chunked.js
+++ b/tests/performance/k6/upload-chunked.js
@@ -1,7 +1,6 @@
 import { sleep } from "k6";
 import { Counter, Trend } from "k6/metrics";
 
-import { benchConfig, durationEnv, intEnv } from "./lib/config.js";
 import {
 	completeUpload,
 	ensureRootFolder,
@@ -11,10 +10,20 @@ import {
 	uniqueName,
 	uploadChunk,
 } from "./lib/client.js";
+import { benchConfig, durationEnv, intEnv } from "./lib/config.js";
 import { createSummary } from "./lib/summary.js";
 
 const flowDuration = new Trend("aster_upload_chunked_flow_duration", true);
+const initDuration = new Trend("aster_upload_chunked_init_duration", true);
 const chunkDuration = new Trend("aster_upload_chunked_chunk_duration", true);
+const completeDuration = new Trend(
+	"aster_upload_chunked_complete_duration",
+	true,
+);
+const clientGapDuration = new Trend(
+	"aster_upload_chunked_client_gap_duration",
+	true,
+);
 const uploadTransferredBytes = new Counter("aster_upload_chunked_bytes");
 const totalBytes = intEnv("ASTER_BENCH_CHUNKED_TOTAL_BYTES", 10 * 1024 * 1024);
 let state;
@@ -51,11 +60,12 @@ export default function (data) {
 
 	state.session = maybeRefreshSession(state.session);
 	const startedAt = Date.now();
-	const { body } = initChunkedUpload(state.session, {
+	const { response: initResponse, body } = initChunkedUpload(state.session, {
 		filename: uniqueName("chunked-upload", "bin"),
 		totalSize: totalBytes,
 		folderId: state.folderId,
 	});
+	initDuration.add(initResponse.timings.duration);
 	const sessionData = body.data;
 	if (sessionData.mode !== "chunked") {
 		throw new Error(
@@ -63,6 +73,7 @@ export default function (data) {
 		);
 	}
 
+	let chunkDurationTotal = 0;
 	for (let index = 0; index < sessionData.total_chunks; index += 1) {
 		const remaining = totalBytes - sessionData.chunk_size * index;
 		const chunkSize =
@@ -76,9 +87,24 @@ export default function (data) {
 			makeChunk(chunkSize, index),
 		);
 		chunkDuration.add(response.timings.duration);
+		chunkDurationTotal += response.timings.duration;
 	}
-	completeUpload(state.session, sessionData.upload_id);
-	flowDuration.add(Date.now() - startedAt);
+	const { response: completeResponse } = completeUpload(
+		state.session,
+		sessionData.upload_id,
+	);
+	completeDuration.add(completeResponse.timings.duration);
+	const flowElapsed = Date.now() - startedAt;
+	flowDuration.add(flowElapsed);
+	clientGapDuration.add(
+		Math.max(
+			0,
+			flowElapsed -
+				initResponse.timings.duration -
+				chunkDurationTotal -
+				completeResponse.timings.duration,
+		),
+	);
 	uploadTransferredBytes.add(totalBytes);
 
 	if (benchConfig.thinkTimeMs > 0) {
@@ -88,6 +114,9 @@ export default function (data) {
 
 export const handleSummary = createSummary("upload-chunked", [
 	"aster_upload_chunked_flow_duration",
+	"aster_upload_chunked_init_duration",
 	"aster_upload_chunked_chunk_duration",
+	"aster_upload_chunked_complete_duration",
+	"aster_upload_chunked_client_gap_duration",
 	"aster_upload_chunked_bytes",
 ]);

--- a/tests/test_batch.rs
+++ b/tests/test_batch.rs
@@ -3,9 +3,11 @@
 #[macro_use]
 mod common;
 use aster_drive::api::api_error_code::ApiErrorCode;
+use aster_drive::entities::{file, folder};
 use aster_drive::runtime::SharedRuntimeState;
 
 use actix_web::test;
+use sea_orm::{ColumnTrait, EntityTrait, QueryFilter, sea_query::Expr};
 use serde_json::Value;
 
 fn upload_named_file(name: &str, content: &str, mime: &str, boundary: &str) -> String {
@@ -491,6 +493,158 @@ async fn test_batch_move_preserves_per_item_conflict_reporting() {
     let resp = test::call_service(&app, req).await;
     let body: Value = test::read_body_json(resp).await;
     assert_eq!(body["data"]["files"].as_array().unwrap().len(), 1);
+}
+
+#[actix_web::test]
+async fn test_batch_move_detects_target_conflicts_without_full_target_listing() {
+    let state = common::setup().await;
+    let db = state.writer_db().clone();
+    let app = create_test_app!(state);
+    let (token, _) = register_and_login!(app);
+
+    macro_rules! create_folder {
+        ($name:expr, $parent_id:expr) => {{
+            let req = test::TestRequest::post()
+                .uri("/api/v1/folders")
+                .insert_header(("Cookie", common::access_cookie_header(&token)))
+                .insert_header(common::csrf_header_for(&token))
+                .set_json(serde_json::json!({ "name": $name, "parent_id": $parent_id }))
+                .to_request();
+            let resp = test::call_service(&app, req).await;
+            assert_eq!(resp.status(), 201);
+            let body: Value = test::read_body_json(resp).await;
+            body["data"]["id"].as_i64().unwrap()
+        }};
+    }
+
+    macro_rules! upload_file {
+        ($folder_id:expr, $name:expr, $content:expr) => {{
+            let boundary = "----TestBoundary123";
+            let payload = upload_named_file($name, $content, "text/plain", boundary);
+            let req = test::TestRequest::post()
+                .uri(&format!("/api/v1/files/upload?folder_id={}", $folder_id))
+                .insert_header(("Cookie", common::access_cookie_header(&token)))
+                .insert_header(common::csrf_header_for(&token))
+                .insert_header((
+                    "Content-Type",
+                    format!("multipart/form-data; boundary={boundary}"),
+                ))
+                .set_payload(payload)
+                .to_request();
+            let resp = test::call_service(&app, req).await;
+            assert_eq!(resp.status(), 201);
+            let body: Value = test::read_body_json(resp).await;
+            body["data"]["id"].as_i64().unwrap()
+        }};
+    }
+
+    let source_id = create_folder!("ConflictSource", Value::Null);
+    let target_id = create_folder!("ConflictTarget", Value::Null);
+
+    for index in 0..20 {
+        upload_file!(
+            target_id,
+            &format!("unrelated-{index}.txt"),
+            &format!("unrelated {index}")
+        );
+        create_folder!(&format!("UnrelatedFolder{index}"), target_id);
+    }
+
+    let target_file_conflict = upload_file!(target_id, "Cafe\u{301}.txt", "existing target file");
+    let target_folder_conflict = create_folder!("Cafe\u{301}Folder", target_id);
+    file::Entity::update_many()
+        .col_expr(file::Column::Name, Expr::value("Cafe\u{301}.txt"))
+        .filter(file::Column::Id.eq(target_file_conflict))
+        .exec(&db)
+        .await
+        .unwrap();
+    folder::Entity::update_many()
+        .col_expr(folder::Column::Name, Expr::value("Cafe\u{301}Folder"))
+        .filter(folder::Column::Id.eq(target_folder_conflict))
+        .exec(&db)
+        .await
+        .unwrap();
+
+    let file_ok = upload_file!(source_id, "file-ok.txt", "move me");
+    let file_conflict = upload_file!(source_id, "Café.txt", "keep me in source");
+    let folder_ok = create_folder!("FolderOk", source_id);
+    let folder_conflict = create_folder!("CaféFolder", source_id);
+
+    let req = test::TestRequest::post()
+        .uri("/api/v1/batch/move")
+        .insert_header(("Cookie", common::access_cookie_header(&token)))
+        .insert_header(common::csrf_header_for(&token))
+        .set_json(serde_json::json!({
+            "file_ids": [file_ok, file_conflict],
+            "folder_ids": [folder_ok, folder_conflict],
+            "target_folder_id": target_id
+        }))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), 200);
+    let body: Value = test::read_body_json(resp).await;
+    assert_eq!(body["data"]["succeeded"], 2);
+    assert_eq!(body["data"]["failed"], 2);
+
+    let errors = body["data"]["errors"].as_array().unwrap();
+    assert!(errors.iter().any(|error| {
+        error["entity_type"] == "file" && error["entity_id"].as_i64() == Some(file_conflict)
+    }));
+    assert!(errors.iter().any(|error| {
+        error["entity_type"] == "folder" && error["entity_id"].as_i64() == Some(folder_conflict)
+    }));
+
+    let req = test::TestRequest::get()
+        .uri(&format!("/api/v1/folders/{target_id}"))
+        .insert_header(("Cookie", common::access_cookie_header(&token)))
+        .insert_header(common::csrf_header_for(&token))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), 200);
+    let body: Value = test::read_body_json(resp).await;
+    let target_file_names: Vec<&str> = body["data"]["files"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter_map(|item| item["name"].as_str())
+        .collect();
+    let target_folder_names: Vec<&str> = body["data"]["folders"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter_map(|item| item["name"].as_str())
+        .collect();
+    assert!(target_file_names.contains(&"file-ok.txt"));
+    assert!(target_file_names.contains(&"Cafe\u{301}.txt"));
+    assert!(target_folder_names.contains(&"FolderOk"));
+    assert!(target_folder_names.contains(&"Cafe\u{301}Folder"));
+    assert!(target_file_names.contains(&"unrelated-19.txt"));
+    assert!(target_folder_names.contains(&"UnrelatedFolder19"));
+
+    let req = test::TestRequest::get()
+        .uri(&format!("/api/v1/folders/{source_id}"))
+        .insert_header(("Cookie", common::access_cookie_header(&token)))
+        .insert_header(common::csrf_header_for(&token))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), 200);
+    let body: Value = test::read_body_json(resp).await;
+    let source_file_names: Vec<&str> = body["data"]["files"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter_map(|item| item["name"].as_str())
+        .collect();
+    let source_folder_names: Vec<&str> = body["data"]["folders"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter_map(|item| item["name"].as_str())
+        .collect();
+    assert!(!source_file_names.contains(&"file-ok.txt"));
+    assert!(source_file_names.contains(&"Café.txt"));
+    assert!(!source_folder_names.contains(&"FolderOk"));
+    assert!(source_folder_names.contains(&"CaféFolder"));
 }
 
 #[actix_web::test]

--- a/tests/test_db_indexes.rs
+++ b/tests/test_db_indexes.rs
@@ -106,6 +106,18 @@ async fn test_directory_lookup_indexes_cover_listing_and_duplicate_name_queries(
         "folders",
     );
 
+    let folder_duplicate_batch = explain_query_plan(
+        state.writer_db(),
+        "SELECT * FROM folders \
+         WHERE owner_user_id = 1 AND name IN ('dup', 'other') AND deleted_at IS NULL AND parent_id = 2",
+    )
+    .await;
+    assert_uses_index(
+        &folder_duplicate_batch,
+        "idx_folders_owner_deleted_parent_name",
+        "folders",
+    );
+
     let file_duplicate = explain_query_plan(
         state.writer_db(),
         "SELECT * FROM files \
@@ -114,6 +126,18 @@ async fn test_directory_lookup_indexes_cover_listing_and_duplicate_name_queries(
     .await;
     assert_uses_index(
         &file_duplicate,
+        "idx_files_owner_deleted_folder_name",
+        "files",
+    );
+
+    let file_duplicate_batch = explain_query_plan(
+        state.writer_db(),
+        "SELECT * FROM files \
+         WHERE owner_user_id = 1 AND name IN ('dup', 'other') AND deleted_at IS NULL AND folder_id = 2",
+    )
+    .await;
+    assert_uses_index(
+        &file_duplicate_batch,
         "idx_files_owner_deleted_folder_name",
         "files",
     );


### PR DESCRIPTION
Optimize batch move operations by replacing N+1 queries with bulk lookups:
- Add `find_by_names_in_parent` and `find_by_names_in_team_parent` to folder repository
- Add `find_by_names_in_folder` and `find_by_names_in_team_folder` support via new helper functions
- Implement `load_target_file_name_map` and `load_target_folder_name_map` in batch movement service
- Replace individual folder/file listing with targeted bulk queries based on source item names
- Add chunked upload flow timing metrics (init, chunk, complete, client gap) to k6 performance tests
- Fix k6 API success code check to handle both string "success" and numeric 0
- Apply code formatting fixes (import ordering)

This reduces database queries during batch moves from O(n) to O(1) for conflict detection.

closed #262

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **性能优化**
  * 优化了批量移动操作的查询策略，减少不必要的数据加载。

* **Tests**
  * 扩展性能测试指标，新增分阶段时长追踪（初始化、分块上传、完成等）。
  * 调整API响应成功码的判断逻辑，支持更广泛的成功状态识别。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->