### PR TITLE
fix(frontend): prevent duplicate submissions and improve transient er…

### DIFF
--- a/frontend-panel/src/components/files/CreateDialogs.test.tsx
+++ b/frontend-panel/src/components/files/CreateDialogs.test.tsx
@@ -131,6 +131,37 @@ describe("Create dialogs", () => {
 		});
 	});
 
+	it("ignores duplicate file submits while creation is pending", async () => {
+		const onOpenChange = vi.fn();
+		let resolveCreate: (() => void) | undefined;
+		mockState.createFile.mockReturnValueOnce(
+			new Promise<void>((resolve) => {
+				resolveCreate = resolve;
+			}),
+		);
+
+		render(<CreateFileDialog open onOpenChange={onOpenChange} />);
+
+		fireEvent.change(screen.getByPlaceholderText("file_name"), {
+			target: { value: "notes.md" },
+		});
+		const button = screen.getByRole("button", { name: "create_file" });
+
+		fireEvent.click(button);
+		fireEvent.click(button);
+
+		expect(mockState.createFile).toHaveBeenCalledTimes(1);
+		expect(button).toBeDisabled();
+
+		resolveCreate?.();
+
+		await waitFor(() => {
+			expect(mockState.toastSuccess).toHaveBeenCalledWith(
+				"create_file_success",
+			);
+		});
+	});
+
 	it("reports file creation failures and keeps the dialog open", async () => {
 		const onOpenChange = vi.fn();
 		const error = new Error("cannot create file");
@@ -185,6 +216,37 @@ describe("Create dialogs", () => {
 			);
 			expect(onOpenChange).toHaveBeenCalledWith(false);
 			expect(input).toHaveValue("");
+		});
+	});
+
+	it("ignores duplicate folder submits while creation is pending", async () => {
+		const onOpenChange = vi.fn();
+		let resolveCreate: (() => void) | undefined;
+		mockState.createFolder.mockReturnValueOnce(
+			new Promise<void>((resolve) => {
+				resolveCreate = resolve;
+			}),
+		);
+
+		render(<CreateFolderDialog open onOpenChange={onOpenChange} />);
+
+		fireEvent.change(screen.getByPlaceholderText("folder_name"), {
+			target: { value: "Projects" },
+		});
+		const button = screen.getByRole("button", { name: "create_folder" });
+
+		fireEvent.click(button);
+		fireEvent.click(button);
+
+		expect(mockState.createFolder).toHaveBeenCalledTimes(1);
+		expect(button).toBeDisabled();
+
+		resolveCreate?.();
+
+		await waitFor(() => {
+			expect(mockState.toastSuccess).toHaveBeenCalledWith(
+				"create_folder_success",
+			);
 		});
 	});
 

--- a/frontend-panel/src/components/files/CreateFileDialog.tsx
+++ b/frontend-panel/src/components/files/CreateFileDialog.tsx
@@ -1,5 +1,5 @@
 import type { FormEvent } from "react";
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
@@ -25,17 +25,25 @@ export function CreateFileDialog({
 	const { t } = useTranslation("files");
 	const createFile = useFileStore((s) => s.createFile);
 	const [name, setName] = useState("");
+	const [submitting, setSubmitting] = useState(false);
+	const submittingRef = useRef(false);
 
 	const handleSubmit = async (e: FormEvent) => {
 		e.preventDefault();
-		if (!name.trim()) return;
+		const trimmedName = name.trim();
+		if (!trimmedName || submittingRef.current) return;
+		submittingRef.current = true;
+		setSubmitting(true);
 		try {
-			await createFile(name.trim());
+			await createFile(trimmedName);
 			toast.success(t("create_file_success"));
 			setName("");
 			onOpenChange(false);
 		} catch (err) {
 			handleApiError(err);
+		} finally {
+			submittingRef.current = false;
+			setSubmitting(false);
 		}
 	};
 
@@ -52,7 +60,7 @@ export function CreateFileDialog({
 						onChange={(e) => setName(e.target.value)}
 						autoFocus
 					/>
-					<Button type="submit" className="w-full">
+					<Button type="submit" className="w-full" disabled={submitting}>
 						{t("create_file")}
 					</Button>
 				</form>

--- a/frontend-panel/src/components/files/CreateFolderDialog.tsx
+++ b/frontend-panel/src/components/files/CreateFolderDialog.tsx
@@ -1,5 +1,5 @@
 import type { FormEvent } from "react";
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
@@ -25,17 +25,25 @@ export function CreateFolderDialog({
 	const { t } = useTranslation("files");
 	const createFolder = useFileStore((s) => s.createFolder);
 	const [name, setName] = useState("");
+	const [submitting, setSubmitting] = useState(false);
+	const submittingRef = useRef(false);
 
 	const handleSubmit = async (e: FormEvent) => {
 		e.preventDefault();
-		if (!name.trim()) return;
+		const trimmedName = name.trim();
+		if (!trimmedName || submittingRef.current) return;
+		submittingRef.current = true;
+		setSubmitting(true);
 		try {
-			await createFolder(name.trim());
+			await createFolder(trimmedName);
 			toast.success(t("create_folder_success"));
 			setName("");
 			onOpenChange(false);
 		} catch (error) {
 			handleApiError(error);
+		} finally {
+			submittingRef.current = false;
+			setSubmitting(false);
 		}
 	};
 
@@ -52,7 +60,7 @@ export function CreateFolderDialog({
 						onChange={(e) => setName(e.target.value)}
 						autoFocus
 					/>
-					<Button type="submit" className="w-full">
+					<Button type="submit" className="w-full" disabled={submitting}>
 						{t("create_folder")}
 					</Button>
 				</form>

--- a/frontend-panel/src/lib/authErrors.test.ts
+++ b/frontend-panel/src/lib/authErrors.test.ts
@@ -102,5 +102,20 @@ describe("isTokenAuthError", () => {
 				},
 			}),
 		).toBe(true);
+		expect(isSessionAuthFailure({ status: 401 })).toBe(true);
+		expect(isSessionAuthFailure({ status: 403 })).toBe(true);
+		expect(isSessionAuthFailure({ status: 502 })).toBe(false);
+		expect(isSessionAuthFailure(null)).toBe(false);
+		expect(isSessionAuthFailure("offline")).toBe(false);
+		expect(isSessionAuthFailure({ status: "401" })).toBe(false);
+		expect(isSessionAuthFailure({ response: null })).toBe(false);
+		expect(isSessionAuthFailure({ response: {} })).toBe(false);
+		expect(isSessionAuthFailure({ response: { status: "401" } })).toBe(false);
+		expect(
+			isSessionAuthFailure({
+				status: "ignored",
+				response: { status: 401 },
+			}),
+		).toBe(true);
 	});
 });

--- a/frontend-panel/src/lib/authErrors.test.ts
+++ b/frontend-panel/src/lib/authErrors.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { isStaleRefreshTokenError, isTokenAuthError } from "@/lib/authErrors";
+import {
+	isSessionAuthFailure,
+	isStaleRefreshTokenError,
+	isTokenAuthError,
+} from "@/lib/authErrors";
 import { ApiErrorCode } from "@/types/api-helpers";
 
 describe("isTokenAuthError", () => {
@@ -57,5 +61,46 @@ describe("isTokenAuthError", () => {
 		expect(isStaleRefreshTokenError({ code: ApiErrorCode.TokenInvalid })).toBe(
 			false,
 		);
+	});
+
+	it("treats only explicit auth failures as session auth failures", () => {
+		expect(
+			isSessionAuthFailure({ code: ApiErrorCode.RefreshTokenReuseDetected }),
+		).toBe(true);
+		expect(
+			isSessionAuthFailure({
+				response: {
+					status: 502,
+				},
+			}),
+		).toBe(false);
+		expect(
+			isSessionAuthFailure({
+				response: {
+					status: 503,
+				},
+			}),
+		).toBe(false);
+		expect(
+			isSessionAuthFailure({
+				response: {
+					status: 504,
+				},
+			}),
+		).toBe(false);
+		expect(
+			isSessionAuthFailure({
+				response: {
+					status: 401,
+				},
+			}),
+		).toBe(true);
+		expect(
+			isSessionAuthFailure({
+				response: {
+					status: 403,
+				},
+			}),
+		).toBe(true);
 	});
 });

--- a/frontend-panel/src/lib/authErrors.ts
+++ b/frontend-panel/src/lib/authErrors.ts
@@ -37,7 +37,16 @@ export function isTokenAuthError(error: unknown): boolean {
 }
 
 function readHttpStatus(error: unknown): number | null {
-	if (typeof error !== "object" || error === null || !("response" in error)) {
+	if (typeof error !== "object" || error === null) {
+		return null;
+	}
+
+	const status = "status" in error ? error.status : null;
+	if (typeof status === "number") {
+		return status;
+	}
+
+	if (!("response" in error)) {
 		return null;
 	}
 

--- a/frontend-panel/src/lib/authErrors.ts
+++ b/frontend-panel/src/lib/authErrors.ts
@@ -36,6 +36,32 @@ export function isTokenAuthError(error: unknown): boolean {
 	);
 }
 
+function readHttpStatus(error: unknown): number | null {
+	if (typeof error !== "object" || error === null || !("response" in error)) {
+		return null;
+	}
+
+	const response = error.response;
+	if (
+		typeof response !== "object" ||
+		response === null ||
+		!("status" in response)
+	) {
+		return null;
+	}
+
+	return typeof response.status === "number" ? response.status : null;
+}
+
+export function isSessionAuthFailure(error: unknown): boolean {
+	if (isTokenAuthError(error)) {
+		return true;
+	}
+
+	const status = readHttpStatus(error);
+	return status === 401 || status === 403;
+}
+
 export function isStaleRefreshTokenError(error: unknown): boolean {
 	const code = readApiCode(error) ?? readApiResponseCode(error);
 	return code === ApiErrorCode.RefreshTokenStale;

--- a/frontend-panel/src/services/fileService.ts
+++ b/frontend-panel/src/services/fileService.ts
@@ -239,9 +239,9 @@ export function createFileService(workspace: Workspace) {
 							body?.msg ?? `HTTP ${status}`,
 							{
 								retryable: body?.error?.retryable ?? undefined,
+								status,
 							},
 						);
-						(apiErr as ApiError & { status: number }).status = status;
 						throw apiErr;
 					}
 				}

--- a/frontend-panel/src/services/http.edge.test.ts
+++ b/frontend-panel/src/services/http.edge.test.ts
@@ -207,6 +207,24 @@ describe("http refresh edge cases", () => {
 		expect(window.location.href).toBe("/login");
 	});
 
+	it("does not force logout when refresh fails with a transient gateway response", async () => {
+		mockState.axiosModule.isAxiosError.mockReturnValue(true);
+		mockState.refreshToken.mockRejectedValue({
+			isAxiosError: true,
+			response: { status: 502 },
+		});
+		await loadHttpModule();
+		const errorHandler = mockState.getErrorHandler();
+		const originalError = {
+			config: { url: "/files", _retry: false },
+			response: tokenErrorResponse(),
+		} satisfies MockAxiosError;
+
+		await expect(errorHandler(originalError)).rejects.toBe(originalError);
+		expect(mockState.forceLogout).not.toHaveBeenCalled();
+		expect(window.location.href).toBe("http://localhost/");
+	});
+
 	it("forces logout when refresh fails with a token ApiError", async () => {
 		mockState.axiosModule.isAxiosError.mockReturnValue(false);
 		mockState.refreshToken.mockRejectedValue({

--- a/frontend-panel/src/services/http.edge.test.ts
+++ b/frontend-panel/src/services/http.edge.test.ts
@@ -393,4 +393,29 @@ describe("http refresh edge cases", () => {
 			}),
 		).rejects.toBeInstanceOf(ApiError);
 	});
+
+	it("preserves HTTP status when converting API payloads into ApiError", async () => {
+		const { ApiError } = await loadHttpModule();
+		const errorHandler = mockState.getErrorHandler();
+
+		const converted = await errorHandler({
+			config: { url: "/auth/login" },
+			response: {
+				status: 403,
+				data: {
+					code: ApiErrorCode.PendingActivation,
+					msg: "pending activation",
+				},
+			},
+		}).catch((error: unknown) => error);
+
+		expect(converted).toBeInstanceOf(ApiError);
+		expect(converted).toEqual(
+			expect.objectContaining({
+				code: ApiErrorCode.PendingActivation,
+				message: "pending activation",
+				status: 403,
+			}),
+		);
+	});
 });

--- a/frontend-panel/src/services/http.ts
+++ b/frontend-panel/src/services/http.ts
@@ -107,6 +107,7 @@ export type ApiRequestConfig = Pick<
 
 type ApiErrorDetails = {
 	retryable?: boolean;
+	status?: number;
 };
 
 export function isRequestCanceled(error: unknown): boolean {
@@ -195,6 +196,7 @@ function isRefreshableAuthError(error: unknown): boolean {
 export class ApiError extends Error {
 	code: ApiErrorCode;
 	retryable?: boolean;
+	status?: number;
 
 	constructor(
 		code: ApiErrorCode,
@@ -204,6 +206,7 @@ export class ApiError extends Error {
 		super(message);
 		this.code = code;
 		this.retryable = details.retryable;
+		this.status = details.status;
 	}
 }
 
@@ -267,12 +270,12 @@ function extractApiError(error: unknown): ApiError | null {
 
 	const errorInfo =
 		"error" in data && typeof data.error === "object" ? data.error : null;
+	const status = "status" in response ? response.status : null;
 
-	return new ApiError(
-		code,
-		message,
-		normalizeApiErrorInfo(errorInfo as ApiErrorInfoPayload | null),
-	);
+	return new ApiError(code, message, {
+		...normalizeApiErrorInfo(errorInfo as ApiErrorInfoPayload | null),
+		status: typeof status === "number" ? status : undefined,
+	});
 }
 
 async function unwrap<T>(
@@ -294,7 +297,10 @@ async function unwrap<T>(
 		);
 	}
 	if (resp.code !== ApiErrorCodeValue.Success) {
-		throw new ApiError(resp.code, resp.msg, normalizeApiErrorInfo(resp.error));
+		throw new ApiError(resp.code, resp.msg, {
+			...normalizeApiErrorInfo(resp.error),
+			status,
+		});
 	}
 	return resp.data as T;
 }

--- a/frontend-panel/src/services/http.ts
+++ b/frontend-panel/src/services/http.ts
@@ -5,7 +5,7 @@ import type {
 } from "axios";
 import axios, { AxiosHeaders } from "axios";
 import { config } from "@/config/app";
-import { isTokenAuthError } from "@/lib/authErrors";
+import { isSessionAuthFailure, isTokenAuthError } from "@/lib/authErrors";
 import { isCrossTabRefreshAuthFailure } from "@/lib/crossTabRefresh";
 import type {
 	ApiErrorCode,
@@ -174,8 +174,7 @@ client.interceptors.response.use(
 				// 网络错误（离线）时不强制登出
 				if (
 					!isCrossTabRefreshAuthFailure(refreshError) &&
-					!isTokenAuthError(refreshError) &&
-					(!axios.isAxiosError(refreshError) || !refreshError.response)
+					!isSessionAuthFailure(refreshError)
 				) {
 					return Promise.reject(error);
 				}

--- a/frontend-panel/src/stores/authStore.edge.test.ts
+++ b/frontend-panel/src/stores/authStore.edge.test.ts
@@ -272,6 +272,7 @@ describe("useAuthStore edge cases", () => {
 		});
 		mockState.isAxiosError.mockReturnValue(true);
 		const { useAuthStore } = await loadStore();
+		useAuthStore.setState({ isAuthStale: false });
 
 		await expect(useAuthStore.getState().refreshToken()).rejects.toEqual(
 			expect.objectContaining({

--- a/frontend-panel/src/stores/authStore.edge.test.ts
+++ b/frontend-panel/src/stores/authStore.edge.test.ts
@@ -170,6 +170,34 @@ describe("useAuthStore edge cases", () => {
 		expect(localStorage.getItem("aster-cached-user")).toBeNull();
 	});
 
+	it("keeps cached auth state stale on transient auth check responses", async () => {
+		const cachedUser = createCachedUser();
+		localStorage.setItem("aster-cached-user", JSON.stringify(cachedUser));
+		sessionStorage.setItem(
+			"aster-auth-expires-at",
+			String(Date.now() + 60_000),
+		);
+		mockState.me.mockRejectedValue({
+			response: { status: 502 },
+		});
+		mockState.isAxiosError.mockReturnValue(true);
+		const { useAuthStore } = await loadStore();
+
+		await useAuthStore.getState().checkAuth();
+
+		expect(useAuthStore.getState()).toMatchObject({
+			isAuthenticated: true,
+			isChecking: false,
+			isAuthStale: true,
+			bootOffline: false,
+			user: cachedUser,
+		});
+		expect(localStorage.getItem("aster-cached-user")).toBe(
+			JSON.stringify(cachedUser),
+		);
+		useAuthStore.getState().stopAutoRefresh();
+	});
+
 	it("clears cached auth state on token ApiError auth checks", async () => {
 		localStorage.setItem(
 			"aster-cached-user",
@@ -260,6 +288,37 @@ describe("useAuthStore edge cases", () => {
 		});
 		expect(localStorage.getItem("aster-cached-user")).toBeNull();
 		expect(sessionStorage.getItem("aster-auth-expires-at")).toBeNull();
+	});
+
+	it("keeps local session state when refresh fails with a transient gateway response", async () => {
+		const cachedUser = createCachedUser();
+		localStorage.setItem("aster-cached-user", JSON.stringify(cachedUser));
+		sessionStorage.setItem(
+			"aster-auth-expires-at",
+			String(Date.now() + 60_000),
+		);
+		mockState.refreshToken.mockRejectedValue({
+			response: { status: 502 },
+		});
+		mockState.isAxiosError.mockReturnValue(true);
+		const { useAuthStore } = await loadStore();
+
+		await expect(useAuthStore.getState().refreshToken()).rejects.toEqual(
+			expect.objectContaining({
+				response: { status: 502 },
+			}),
+		);
+		expect(useAuthStore.getState()).toMatchObject({
+			isAuthenticated: true,
+			isAuthStale: true,
+			bootOffline: false,
+			user: cachedUser,
+		});
+		expect(localStorage.getItem("aster-cached-user")).toBe(
+			JSON.stringify(cachedUser),
+		);
+		expect(sessionStorage.getItem("aster-auth-expires-at")).not.toBeNull();
+		useAuthStore.getState().stopAutoRefresh();
 	});
 
 	it("clears local session state when refresh fails with a token ApiError", async () => {

--- a/frontend-panel/src/stores/authStore.ts
+++ b/frontend-panel/src/stores/authStore.ts
@@ -1,7 +1,9 @@
-import axios from "axios";
 import { create } from "zustand";
 import i18n from "@/i18n";
-import { isStaleRefreshTokenError, isTokenAuthError } from "@/lib/authErrors";
+import {
+	isSessionAuthFailure,
+	isStaleRefreshTokenError,
+} from "@/lib/authErrors";
 import {
 	isCrossTabRefreshAuthFailure,
 	runWithCrossTabRefreshLock,
@@ -338,10 +340,7 @@ export const useAuthStore = create<AuthState>((set, get) => ({
 			}
 		} catch (error) {
 			// 网络错误（离线）时用缓存的用户信息保持登录态
-			if (
-				!isTokenAuthError(error) &&
-				(!axios.isAxiosError(error) || !error.response)
-			) {
+			if (!isSessionAuthFailure(error)) {
 				const cached = getCachedUser();
 				const expiresAt =
 					getExpiresAtFromUser(cached) ??
@@ -392,9 +391,7 @@ export const useAuthStore = create<AuthState>((set, get) => ({
 					},
 					{
 						classifyError: (error) =>
-							isStaleRefreshTokenError(error) ||
-							isTokenAuthError(error) ||
-							(axios.isAxiosError(error) && error.response)
+							isStaleRefreshTokenError(error) || isSessionAuthFailure(error)
 								? "auth"
 								: "transient",
 					},
@@ -405,8 +402,7 @@ export const useAuthStore = create<AuthState>((set, get) => ({
 			} catch (error) {
 				if (
 					isCrossTabRefreshAuthFailure(error) ||
-					isTokenAuthError(error) ||
-					(axios.isAxiosError(error) && error.response)
+					isSessionAuthFailure(error)
 				) {
 					applyLoggedOutState(set);
 				} else {

--- a/frontend-panel/src/stores/authStore.ts
+++ b/frontend-panel/src/stores/authStore.ts
@@ -406,6 +406,7 @@ export const useAuthStore = create<AuthState>((set, get) => ({
 				) {
 					applyLoggedOutState(set);
 				} else {
+					set({ isAuthStale: true });
 					get().startAutoRefresh(REFRESH_RETRY_MS);
 				}
 				throw error;


### PR DESCRIPTION
…ror handling

Prevent duplicate form submissions in file/folder creation dialogs:
- Add submission state tracking using both useState and useRef for immediate guard
- Disable submit button during pending operations
- Add comprehensive tests for duplicate click scenarios

Improve authentication error handling for transient failures:
- Introduce isSessionAuthFailure() to distinguish auth failures from transient errors
- Preserve cached auth state when encountering 502/503/504 gateway errors
- Only force logout on explicit auth failures (401/403) or token errors
- Update http interceptor and authStore to use new classification logic
- Add edge case tests for gateway error scenarios during auth check and token refresh

closed #290
closed #291

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Bug Fixes**
  * 创建文件/文件夹对话框中的提交按钮在处理过程中会禁用，防止重复操作
  * 改进了临时服务器故障的处理，用户遇到网关超时等瞬态错误时将保持登录状态

* **Tests**
  * 为创建对话框、认证错误处理和令牌刷新添加了新的测试用例

<!-- end of auto-generated comment: release notes by coderabbit.ai -->