### PR TITLE
Enhance PWA route warmup and add startup performance audit

### DIFF
--- a/frontend-panel/package.json
+++ b/frontend-panel/package.json
@@ -9,6 +9,7 @@
 		"dev": "vite",
 		"prebuild": "bun run extract:pdfjs-cmaps",
 		"build": "tsgo -b && vite build",
+		"postbuild": "node ./scripts/audit-startup.mjs",
 		"generate-api": "openapi-typescript ./generated/openapi.json -o ./src/services/api.generated.ts",
 		"check": "tsgo -b && biome check .",
 		"check:fix": "biome check --write .",

--- a/frontend-panel/scripts/audit-startup.mjs
+++ b/frontend-panel/scripts/audit-startup.mjs
@@ -188,7 +188,7 @@ function readdirSyncCompat(dir) {
 function extractPrecacheEntries() {
 	const sw = readDistFile("sw.js");
 	const entries = [];
-	for (const match of sw.matchAll(/url:"([^"]+)"/g)) {
+	for (const match of sw.matchAll(/(?:"url"|url)\s*:\s*"([^"]+)"/g)) {
 		entries.push(normalizeAssetPath(match[1]));
 	}
 	if (entries.length === 0) fail("could not find precache entries in sw.js");

--- a/frontend-panel/scripts/audit-startup.mjs
+++ b/frontend-panel/scripts/audit-startup.mjs
@@ -1,0 +1,308 @@
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import path from "node:path";
+import { gzipSync } from "node:zlib";
+
+const DIST_DIR = path.resolve("dist");
+const ASSET_PREFIX = "assets/";
+const ROUTER_SOURCE = path.resolve("src/router/index.tsx");
+const WARMUP_SOURCE = path.resolve("src/lib/pwaWarmupLoaders.ts");
+
+const BUDGETS = {
+	entryRawBytes: 25 * 1024,
+	entryGzipBytes: 8 * 1024,
+	loginRawBytes: 65 * 1024,
+	loginGzipBytes: 20 * 1024,
+	precacheEntries: 12,
+	precacheBytes: 700 * 1024,
+};
+
+const PRECACHE_FORBIDDEN = [
+	/Admin/,
+	/FileBrowser/,
+	/MusicPlayer/,
+	/PdfPreview/,
+	/WorkspaceOutlet/,
+	/pwaWarmup/,
+	/vendor-react-icons-/,
+	/pdf\.worker/,
+	/^pdfjs\//,
+	/^static\/preview-apps\//,
+	/^static\/external-auth\//,
+];
+
+const STARTUP_FORBIDDEN = [
+	/Admin/,
+	/FileBrowser/,
+	/MusicPlayer/,
+	/PdfPreview/,
+	/WorkspaceOutlet/,
+	/pwaWarmup/,
+	/settings-common/,
+	/preview-apps/,
+	/archive-preview/,
+	/office-preview/,
+	/wopi/i,
+];
+
+const LOGIN_FORBIDDEN = [
+	/Admin/,
+	/FileBrowser/,
+	/MusicPlayer/,
+	/PdfPreview/,
+	/WorkspaceOutlet/,
+	/pwaWarmup/,
+	/settings-common/,
+	/preview-apps/,
+	/archive-preview/,
+	/office-preview/,
+	/wopi/i,
+];
+
+function fail(message) {
+	throw new Error(`[startup-audit] ${message}`);
+}
+
+function readDistFile(relativePath) {
+	const filePath = path.join(DIST_DIR, relativePath);
+	if (!existsSync(filePath)) fail(`missing dist file: ${relativePath}`);
+	return readFileSync(filePath, "utf8");
+}
+
+function readSourceFile(filePath) {
+	if (!existsSync(filePath)) fail(`missing source file: ${filePath}`);
+	return readFileSync(filePath, "utf8");
+}
+
+function fileSize(relativePath) {
+	return statSync(path.join(DIST_DIR, relativePath)).size;
+}
+
+function gzipSize(relativePath) {
+	return gzipSync(readFileSync(path.join(DIST_DIR, relativePath))).length;
+}
+
+function formatBytes(bytes) {
+	return `${(bytes / 1024).toFixed(2)} KiB`;
+}
+
+function assertBudget(label, actual, max) {
+	if (actual > max) {
+		fail(`${label} is ${formatBytes(actual)}, over budget ${formatBytes(max)}`);
+	}
+}
+
+function assertCountBudget(label, actual, max) {
+	if (actual > max) {
+		fail(`${label} is ${actual}, over budget ${max}`);
+	}
+}
+
+function extractEntryScript() {
+	const html = readDistFile("index.html");
+	const match = html.match(/<script[^>]+type="module"[^>]+src="([^"]+)"/);
+	if (!match) fail("could not find module entry script in index.html");
+	return normalizeAssetPath(match[1]);
+}
+
+function normalizeAssetPath(value, fromDir = "") {
+	const withoutQuery = value.split("?")[0];
+	const normalized = path.posix.normalize(
+		withoutQuery.startsWith("/")
+			? withoutQuery.slice(1)
+			: path.posix.join(fromDir, withoutQuery),
+	);
+	if (normalized.startsWith("..")) {
+		fail(`asset path escaped dist: ${value}`);
+	}
+	return normalized;
+}
+
+function extractStaticImports(relativePath) {
+	const source = readDistFile(relativePath);
+	const dir = path.posix.dirname(relativePath);
+	const imports = new Set();
+	const patterns = [
+		/import\s+(?:[^"'()]+?\s+from\s*)?["']([^"']+)["']/g,
+		/export\s+[^"'()]+?\s+from\s*["']([^"']+)["']/g,
+	];
+
+	for (const pattern of patterns) {
+		for (const match of source.matchAll(pattern)) {
+			const specifier = match[1];
+			if (!specifier.startsWith(".")) continue;
+			imports.add(normalizeAssetPath(specifier, dir));
+		}
+	}
+
+	return imports;
+}
+
+function collectStaticGraph(entryPath) {
+	const seen = new Set();
+	const queue = [entryPath];
+
+	while (queue.length > 0) {
+		const current = queue.shift();
+		if (!current || seen.has(current)) continue;
+		seen.add(current);
+
+		for (const imported of extractStaticImports(current)) {
+			if (!seen.has(imported)) queue.push(imported);
+		}
+	}
+
+	return seen;
+}
+
+function findAsset(prefix) {
+	const entryHtml = readDistFile("index.html");
+	const entryNames = [
+		...entryHtml.matchAll(/(?:src|href)="\/?(assets\/[^"]+)"/g),
+	]
+		.map((match) => match[1])
+		.filter((name) => name.startsWith(`${ASSET_PREFIX}${prefix}`));
+	if (entryNames.length > 0) return entryNames[0];
+
+	const assetDir = path.join(DIST_DIR, ASSET_PREFIX);
+	const candidates = [];
+	for (const name of readdirSyncCompat(assetDir)) {
+		if (name.startsWith(prefix) && name.endsWith(".js")) {
+			candidates.push(`${ASSET_PREFIX}${name}`);
+		}
+	}
+	if (candidates.length === 0)
+		fail(`could not find asset with prefix: ${prefix}`);
+	if (candidates.length > 1) {
+		fail(
+			`multiple assets found for prefix ${prefix}: ${candidates.join(", ")}`,
+		);
+	}
+	return candidates[0];
+}
+
+function readdirSyncCompat(dir) {
+	if (!existsSync(dir)) fail(`missing asset directory: ${dir}`);
+	return readdirSync(dir);
+}
+
+function extractPrecacheEntries() {
+	const sw = readDistFile("sw.js");
+	const entries = [];
+	for (const match of sw.matchAll(/url:"([^"]+)"/g)) {
+		entries.push(normalizeAssetPath(match[1]));
+	}
+	if (entries.length === 0) fail("could not find precache entries in sw.js");
+	return entries;
+}
+
+function assertNoForbidden(label, entries, patterns) {
+	const violations = [...entries].filter((entry) =>
+		patterns.some((pattern) => pattern.test(entry)),
+	);
+	if (violations.length > 0) {
+		fail(`${label} contains forbidden assets: ${violations.join(", ")}`);
+	}
+}
+
+function auditPrecache() {
+	const entries = extractPrecacheEntries();
+	const totalBytes = entries.reduce((sum, entry) => sum + fileSize(entry), 0);
+
+	assertCountBudget(
+		"service worker precache entry count",
+		entries.length,
+		BUDGETS.precacheEntries,
+	);
+	assertBudget(
+		"service worker precache size",
+		totalBytes,
+		BUDGETS.precacheBytes,
+	);
+	assertNoForbidden("service worker precache", entries, PRECACHE_FORBIDDEN);
+
+	return { entries, totalBytes };
+}
+
+function auditStartupGraphs() {
+	const entry = extractEntryScript();
+	const login = findAsset("LoginPage-");
+	const entryGraph = collectStaticGraph(entry);
+	const loginGraph = new Set([...entryGraph, ...collectStaticGraph(login)]);
+
+	assertNoForbidden("startup graph", entryGraph, STARTUP_FORBIDDEN);
+	assertNoForbidden("login graph", loginGraph, LOGIN_FORBIDDEN);
+
+	assertBudget("entry chunk raw size", fileSize(entry), BUDGETS.entryRawBytes);
+	assertBudget(
+		"entry chunk gzip size",
+		gzipSize(entry),
+		BUDGETS.entryGzipBytes,
+	);
+	assertBudget("login chunk raw size", fileSize(login), BUDGETS.loginRawBytes);
+	assertBudget(
+		"login chunk gzip size",
+		gzipSize(login),
+		BUDGETS.loginGzipBytes,
+	);
+
+	return { entry, entryGraph, login, loginGraph };
+}
+
+function auditWarmupCoverage() {
+	const routerSource = readSourceFile(ROUTER_SOURCE);
+	const warmupSource = readSourceFile(WARMUP_SOURCE);
+	const routeImports = new Set();
+	const warmupImports = new Set();
+
+	for (const match of routerSource.matchAll(/import\("@\/pages\/([^"]+)"\)/g)) {
+		routeImports.add(match[1]);
+	}
+	for (const match of warmupSource.matchAll(/import\("@\/pages\/([^"]+)"\)/g)) {
+		warmupImports.add(match[1]);
+	}
+
+	const missing = [...routeImports].filter((page) => !warmupImports.has(page));
+	if (missing.length > 0) {
+		fail(`warmup is missing lazy route pages: ${missing.join(", ")}`);
+	}
+
+	return {
+		routeCount: routeImports.size,
+		warmupRouteCount: warmupImports.size,
+	};
+}
+
+function main() {
+	if (!existsSync(DIST_DIR))
+		fail("dist directory does not exist; run build first");
+
+	const precache = auditPrecache();
+	const startup = auditStartupGraphs();
+	const warmup = auditWarmupCoverage();
+
+	console.log("[startup-audit] ok");
+	console.log(
+		`[startup-audit] precache: ${precache.entries.length} entries, ${formatBytes(
+			precache.totalBytes,
+		)}`,
+	);
+	console.log(
+		`[startup-audit] entry: ${startup.entry} (${formatBytes(
+			fileSize(startup.entry),
+		)} raw, ${formatBytes(gzipSize(startup.entry))} gzip), static graph ${
+			startup.entryGraph.size
+		} files`,
+	);
+	console.log(
+		`[startup-audit] login: ${startup.login} (${formatBytes(
+			fileSize(startup.login),
+		)} raw, ${formatBytes(gzipSize(startup.login))} gzip), graph ${
+			startup.loginGraph.size
+		} files`,
+	);
+	console.log(
+		`[startup-audit] warmup coverage: ${warmup.routeCount}/${warmup.warmupRouteCount} route pages covered`,
+	);
+}
+
+main();

--- a/frontend-panel/src/App.test.tsx
+++ b/frontend-panel/src/App.test.tsx
@@ -19,6 +19,7 @@ const mockState = vi.hoisted(() => ({
 		preference: "browser",
 	},
 	ensureAllI18nNamespaces: vi.fn(),
+	loggerWarn: vi.fn(),
 	previewAppsLoad: vi.fn(),
 	mediaDataSupportLoad: vi.fn(),
 	musicPlayerHostMountRequested: false,
@@ -64,6 +65,12 @@ vi.mock("@/lib/idleTask", () => ({
 	runWhenIdle: (task: () => void) => {
 		const timer = window.setTimeout(task, 1200);
 		return () => window.clearTimeout(timer);
+	},
+}));
+
+vi.mock("@/lib/logger", () => ({
+	logger: {
+		warn: (...args: unknown[]) => mockState.loggerWarn(...args),
 	},
 }));
 
@@ -158,6 +165,7 @@ describe("App", () => {
 		mockState.displayTimeZoneStore.preference = "browser";
 		mockState.ensureAllI18nNamespaces.mockReset();
 		mockState.ensureAllI18nNamespaces.mockResolvedValue(undefined);
+		mockState.loggerWarn.mockReset();
 		mockState.musicPlayerHostMountRequested = false;
 		mockState.frontendConfigLoad.mockReset();
 		mockState.initFrontendConfigRuntime.mockReset();
@@ -295,6 +303,24 @@ describe("App", () => {
 			expect(screen.getByTestId("router-provider")).toBeInTheDocument();
 			expect(mockState.warmupRouteChunks).toHaveBeenCalledWith("user");
 		});
+	});
+
+	it("mounts authenticated routes when full locale bundle loading fails", async () => {
+		const error = new Error("locale load failed");
+		mockState.ensureAllI18nNamespaces.mockRejectedValueOnce(error);
+		mockState.authStore.isAuthenticated = true;
+		mockState.authStore.isChecking = false;
+
+		render(<App />);
+
+		await waitFor(() => {
+			expect(screen.getByTestId("router-provider")).toBeInTheDocument();
+			expect(mockState.warmupRouteChunks).toHaveBeenCalledWith("user");
+		});
+		expect(mockState.loggerWarn).toHaveBeenCalledWith(
+			"failed to load authenticated locale namespaces",
+			error,
+		);
 	});
 
 	it("renders the offline boot fallback instead of the router", async () => {

--- a/frontend-panel/src/App.test.tsx
+++ b/frontend-panel/src/App.test.tsx
@@ -8,7 +8,10 @@ const mockState = vi.hoisted(() => ({
 		checkAuth: vi.fn(),
 		isAuthenticated: false,
 		isChecking: false,
-		user: null as { role?: string } | null,
+		user: null as {
+			preferences?: { storage_event_stream_enabled?: boolean };
+			role?: string;
+		} | null,
 	},
 	frontendConfigLoad: vi.fn(),
 	initFrontendConfigRuntime: vi.fn(),
@@ -23,6 +26,7 @@ const mockState = vi.hoisted(() => ({
 	themeInit: vi.fn(),
 	thumbnailSupportLoad: vi.fn(),
 	toastSuccess: vi.fn(),
+	warmupRouteChunks: vi.fn(),
 }));
 
 vi.mock("react-router-dom", () => ({
@@ -74,6 +78,11 @@ vi.mock("@/components/music/MusicPlayerHost", () => ({
 vi.mock("@/lib/musicPlayerMountSignal", () => ({
 	useMusicPlayerHostMountRequested: () =>
 		mockState.musicPlayerHostMountRequested,
+}));
+
+vi.mock("@/lib/pwaWarmup", () => ({
+	warmupRouteChunks: (...args: unknown[]) =>
+		mockState.warmupRouteChunks(...args),
 }));
 
 vi.mock("@/stores/frontendConfigStore", () => ({
@@ -158,6 +167,7 @@ describe("App", () => {
 		mockState.themeInit.mockReset();
 		mockState.thumbnailSupportLoad.mockReset();
 		mockState.toastSuccess.mockReset();
+		mockState.warmupRouteChunks.mockReset();
 		vi.useRealTimers();
 	});
 
@@ -219,10 +229,11 @@ describe("App", () => {
 
 		await vi.advanceTimersByTimeAsync(1200);
 
-		expect(mockState.ensureAllI18nNamespaces).toHaveBeenCalledTimes(1);
+		expect(mockState.ensureAllI18nNamespaces).not.toHaveBeenCalled();
 		expect(mockState.previewAppsLoad).not.toHaveBeenCalled();
 		expect(mockState.thumbnailSupportLoad).not.toHaveBeenCalled();
 		expect(mockState.mediaDataSupportLoad).not.toHaveBeenCalled();
+		expect(mockState.warmupRouteChunks).not.toHaveBeenCalled();
 
 		Object.defineProperty(document, "visibilityState", {
 			configurable: true,
@@ -254,10 +265,35 @@ describe("App", () => {
 		await vi.advanceTimersByTimeAsync(300_000);
 
 		expect(mockState.frontendConfigLoad).toHaveBeenCalledTimes(1);
+		expect(mockState.warmupRouteChunks).toHaveBeenCalledWith("user");
 		await vi.waitFor(() => {
+			expect(mockState.ensureAllI18nNamespaces).toHaveBeenCalledTimes(1);
 			expect(mockState.previewAppsLoad).toHaveBeenCalledTimes(1);
 			expect(mockState.thumbnailSupportLoad).toHaveBeenCalledTimes(1);
 			expect(mockState.mediaDataSupportLoad).toHaveBeenCalledTimes(1);
+		});
+	});
+
+	it("holds authenticated routes until the full locale bundle is ready", async () => {
+		let resolveLocale!: () => void;
+		mockState.ensureAllI18nNamespaces.mockReturnValueOnce(
+			new Promise<void>((resolve) => {
+				resolveLocale = resolve;
+			}),
+		);
+		mockState.authStore.isAuthenticated = true;
+		mockState.authStore.isChecking = false;
+
+		render(<App />);
+
+		expect(screen.queryByTestId("router-provider")).not.toBeInTheDocument();
+		expect(mockState.warmupRouteChunks).not.toHaveBeenCalled();
+
+		resolveLocale();
+
+		await waitFor(() => {
+			expect(screen.getByTestId("router-provider")).toBeInTheDocument();
+			expect(mockState.warmupRouteChunks).toHaveBeenCalledWith("user");
 		});
 	});
 
@@ -327,15 +363,29 @@ describe("App", () => {
 		expect(window.location.search).toBe("");
 	});
 
-	it("does not warm route chunks after auth is ready", async () => {
+	it("warms route chunks after auth is ready", async () => {
 		mockState.authStore.isAuthenticated = true;
 		mockState.authStore.isChecking = false;
 
 		render(<App />);
 
-		await Promise.resolve();
+		await waitFor(() => {
+			expect(mockState.warmupRouteChunks).toHaveBeenCalledWith("user");
+		});
 
 		expect(screen.queryByTestId("music-player-host")).not.toBeInTheDocument();
+	});
+
+	it("warms admin route chunks for admin users", async () => {
+		mockState.authStore.isAuthenticated = true;
+		mockState.authStore.isChecking = false;
+		mockState.authStore.user = { role: "admin" };
+
+		render(<App />);
+
+		await waitFor(() => {
+			expect(mockState.warmupRouteChunks).toHaveBeenCalledWith("admin");
+		});
 	});
 
 	it("loads the music player host only after it is requested", async () => {

--- a/frontend-panel/src/App.tsx
+++ b/frontend-panel/src/App.tsx
@@ -1,4 +1,4 @@
-import { lazy, Suspense, useEffect } from "react";
+import { lazy, Suspense, useEffect, useState } from "react";
 import { RouterProvider } from "react-router-dom";
 import { Toaster, toast } from "sonner";
 import { usePwaUpdate } from "@/hooks/usePwaUpdate";
@@ -6,6 +6,7 @@ import i18n, { ensureAllI18nNamespaces } from "@/i18n";
 import { runWhenIdle } from "@/lib/idleTask";
 import { useMusicPlayerHostMountRequested } from "@/lib/musicPlayerMountSignal";
 import { router } from "@/router";
+import { Loading } from "@/router/Loading";
 import { useAuthStore } from "@/stores/authStore";
 import {
 	resolveActiveDisplayTimeZone,
@@ -65,13 +66,10 @@ function scheduleSupportConfigLoads() {
 	);
 }
 
-function scheduleFullLocaleLoad() {
-	return runWhenIdle(
-		() => {
-			void ensureAllI18nNamespaces();
-		},
-		{ fallbackDelayMs: 1_200, timeoutMs: 3_000 },
-	);
+function warmupPwaChunks(role: string | undefined) {
+	void import("@/lib/pwaWarmup").then(({ warmupRouteChunks }) => {
+		warmupRouteChunks(role === "admin" ? "admin" : "user");
+	});
 }
 
 async function consumeExternalAuthSuccessRedirect() {
@@ -92,10 +90,13 @@ async function consumeExternalAuthSuccessRedirect() {
 }
 
 function App() {
+	const [authenticatedLocaleReady, setAuthenticatedLocaleReady] =
+		useState(false);
 	const checkAuth = useAuthStore((s) => s.checkAuth);
 	const isChecking = useAuthStore((s) => s.isChecking);
 	const isAuthenticated = useAuthStore((s) => s.isAuthenticated);
 	const bootOffline = useAuthStore((s) => s.bootOffline);
+	const userRole = useAuthStore((s) => s.user?.role);
 	const storageEventStreamEnabled = useAuthStore(
 		(s) => s.user?.preferences?.storage_event_stream_enabled !== false,
 	);
@@ -104,12 +105,13 @@ function App() {
 	);
 	const shouldMountMusicPlayer = useMusicPlayerHostMountRequested();
 	usePwaUpdate();
+	const shouldHoldAuthenticatedRoute =
+		isAuthenticated && !isChecking && !authenticatedLocaleReady;
 
 	useEffect(() => {
 		const skipInitialAuthCheck = shouldSkipInitialAuthCheck(
 			window.location.pathname,
 		);
-		const cancelFullLocaleLoad = scheduleFullLocaleLoad();
 		loadPublicConfig();
 		if (!skipInitialAuthCheck) {
 			checkAuth();
@@ -117,13 +119,34 @@ function App() {
 			useAuthStore.setState({ isChecking: false });
 		}
 		useThemeStore.getState().init();
-		return cancelFullLocaleLoad;
 	}, [checkAuth]);
 
 	useEffect(() => {
 		if (isChecking || !isAuthenticated) return;
 		return scheduleSupportConfigLoads();
 	}, [isAuthenticated, isChecking]);
+
+	useEffect(() => {
+		if (isChecking || !isAuthenticated) {
+			setAuthenticatedLocaleReady(false);
+			return;
+		}
+
+		let cancelled = false;
+		void ensureAllI18nNamespaces().then(() => {
+			if (cancelled) return;
+			setAuthenticatedLocaleReady(true);
+		});
+
+		return () => {
+			cancelled = true;
+		};
+	}, [isAuthenticated, isChecking]);
+
+	useEffect(() => {
+		if (isChecking || !isAuthenticated || !authenticatedLocaleReady) return;
+		warmupPwaChunks(userRole);
+	}, [authenticatedLocaleReady, isAuthenticated, isChecking, userRole]);
 
 	useEffect(() => {
 		if (isChecking || !isAuthenticated) return;
@@ -147,6 +170,8 @@ function App() {
 				<Suspense fallback={null}>
 					<OfflineBootFallback />
 				</Suspense>
+			) : shouldHoldAuthenticatedRoute ? (
+				<Loading />
 			) : (
 				<RouterProvider router={router} />
 			)}

--- a/frontend-panel/src/App.tsx
+++ b/frontend-panel/src/App.tsx
@@ -4,6 +4,7 @@ import { Toaster, toast } from "sonner";
 import { usePwaUpdate } from "@/hooks/usePwaUpdate";
 import i18n, { ensureAllI18nNamespaces } from "@/i18n";
 import { runWhenIdle } from "@/lib/idleTask";
+import { logger } from "@/lib/logger";
 import { useMusicPlayerHostMountRequested } from "@/lib/musicPlayerMountSignal";
 import { router } from "@/router";
 import { Loading } from "@/router/Loading";
@@ -133,10 +134,17 @@ function App() {
 		}
 
 		let cancelled = false;
-		void ensureAllI18nNamespaces().then(() => {
+		void (async () => {
+			try {
+				await ensureAllI18nNamespaces();
+			} catch (error) {
+				if (!cancelled) {
+					logger.warn("failed to load authenticated locale namespaces", error);
+				}
+			}
 			if (cancelled) return;
 			setAuthenticatedLocaleReady(true);
-		});
+		})();
 
 		return () => {
 			cancelled = true;

--- a/frontend-panel/src/lib/pwaWarmupLoaders.test.ts
+++ b/frontend-panel/src/lib/pwaWarmupLoaders.test.ts
@@ -7,6 +7,7 @@ import {
 } from "@/lib/pwaWarmupLoaders";
 
 vi.mock("@/pages/LoginPage", () => ({ default: "LoginPage" }));
+vi.mock("@/pages/ErrorPage", () => ({ default: "ErrorPage" }));
 vi.mock("@/pages/FileBrowserPage", () => ({ default: "FileBrowserPage" }));
 vi.mock("@/pages/CategoryBrowserPage", () => ({
 	default: "CategoryBrowserPage",
@@ -122,6 +123,7 @@ describe("pwaWarmupLoaders", () => {
 	it("defines stable keys for each warmup queue", () => {
 		expect(userRouteWarmupLoaders.map((loader) => loader.key)).toEqual([
 			"route:login",
+			"route:error",
 			"route:file-browser",
 			"route:category-browser",
 			"route:search-browser",

--- a/frontend-panel/src/lib/pwaWarmupLoaders.test.ts
+++ b/frontend-panel/src/lib/pwaWarmupLoaders.test.ts
@@ -7,21 +7,52 @@ import {
 } from "@/lib/pwaWarmupLoaders";
 
 vi.mock("@/pages/LoginPage", () => ({ default: "LoginPage" }));
+vi.mock("@/pages/FileBrowserPage", () => ({ default: "FileBrowserPage" }));
+vi.mock("@/pages/CategoryBrowserPage", () => ({
+	default: "CategoryBrowserPage",
+}));
+vi.mock("@/pages/SearchBrowserPage", () => ({ default: "SearchBrowserPage" }));
 vi.mock("@/pages/MySharesPage", () => ({ default: "MySharesPage" }));
+vi.mock("@/pages/TasksPage", () => ({ default: "TasksPage" }));
 vi.mock("@/pages/TrashPage", () => ({ default: "TrashPage" }));
 vi.mock("@/pages/SettingsPage", () => ({ default: "SettingsPage" }));
 vi.mock("@/pages/WebdavAccountsPage", () => ({
 	default: "WebdavAccountsPage",
 }));
+vi.mock("@/pages/TeamManagePage", () => ({ default: "TeamManagePage" }));
+vi.mock("@/pages/ForcePasswordChangePage", () => ({
+	default: "ForcePasswordChangePage",
+}));
+vi.mock("@/pages/ResetPasswordPage", () => ({ default: "ResetPasswordPage" }));
+vi.mock("@/pages/InviteRegisterPage", () => ({
+	default: "InviteRegisterPage",
+}));
+vi.mock("@/pages/ShareViewPage", () => ({ default: "ShareViewPage" }));
+vi.mock("@/pages/admin/AdminOverviewPage", () => ({
+	default: "AdminOverviewPage",
+}));
 vi.mock("@/pages/admin/AdminUsersPage", () => ({ default: "AdminUsersPage" }));
 vi.mock("@/pages/admin/AdminUserInvitationsPage", () => ({
 	default: "AdminUserInvitationsPage",
 }));
+vi.mock("@/pages/admin/AdminTeamsPage", () => ({ default: "AdminTeamsPage" }));
+vi.mock("@/pages/admin/AdminTeamDetailPage", () => ({
+	default: "AdminTeamDetailPage",
+}));
 vi.mock("@/pages/admin/AdminPoliciesPage", () => ({
 	default: "AdminPoliciesPage",
 }));
+vi.mock("@/pages/admin/AdminRemoteNodesPage", () => ({
+	default: "AdminRemoteNodesPage",
+}));
 vi.mock("@/pages/admin/AdminExternalAuthPage", () => ({
 	default: "AdminExternalAuthPage",
+}));
+vi.mock("@/pages/admin/AdminPolicyGroupsPage", () => ({
+	default: "AdminPolicyGroupsPage",
+}));
+vi.mock("@/pages/admin/AdminTasksPage", () => ({
+	default: "AdminTasksPage",
 }));
 vi.mock("@/pages/admin/AdminSettingsPage", () => ({
 	default: "AdminSettingsPage",
@@ -29,6 +60,7 @@ vi.mock("@/pages/admin/AdminSettingsPage", () => ({
 vi.mock("@/pages/admin/AdminSharesPage", () => ({
 	default: "AdminSharesPage",
 }));
+vi.mock("@/pages/admin/AdminFilesPage", () => ({ default: "AdminFilesPage" }));
 vi.mock("@/pages/admin/AdminLocksPage", () => ({ default: "AdminLocksPage" }));
 vi.mock("@/pages/admin/AdminAuditPage", () => ({ default: "AdminAuditPage" }));
 vi.mock("@/pages/admin/AdminAboutPage", () => ({ default: "AdminAboutPage" }));
@@ -90,18 +122,34 @@ describe("pwaWarmupLoaders", () => {
 	it("defines stable keys for each warmup queue", () => {
 		expect(userRouteWarmupLoaders.map((loader) => loader.key)).toEqual([
 			"route:login",
+			"route:file-browser",
+			"route:category-browser",
+			"route:search-browser",
 			"route:my-shares",
+			"route:tasks",
 			"route:trash",
 			"route:settings",
 			"route:webdav-accounts",
+			"route:team-manage",
+			"route:force-password-change",
+			"route:reset-password",
+			"route:invite-register",
+			"route:share-view",
 		]);
 		expect(adminRouteWarmupLoaders.map((loader) => loader.key)).toEqual([
+			"route:admin-overview",
 			"route:admin-users",
 			"route:admin-user-invitations",
+			"route:admin-teams",
+			"route:admin-team-detail",
 			"route:admin-policies",
+			"route:admin-remote-nodes",
 			"route:admin-external-auth",
+			"route:admin-policy-groups",
+			"route:admin-tasks",
 			"route:admin-settings",
 			"route:admin-shares",
+			"route:admin-files",
 			"route:admin-locks",
 			"route:admin-audit",
 			"route:admin-about",

--- a/frontend-panel/src/lib/pwaWarmupLoaders.ts
+++ b/frontend-panel/src/lib/pwaWarmupLoaders.ts
@@ -13,9 +13,29 @@ const loginRouteWarmupLoader = {
 export const userRouteWarmupLoaders = [
 	loginRouteWarmupLoader,
 	{
+		key: "route:file-browser",
+		label: "FileBrowserPage",
+		load: () => import("@/pages/FileBrowserPage"),
+	},
+	{
+		key: "route:category-browser",
+		label: "CategoryBrowserPage",
+		load: () => import("@/pages/CategoryBrowserPage"),
+	},
+	{
+		key: "route:search-browser",
+		label: "SearchBrowserPage",
+		load: () => import("@/pages/SearchBrowserPage"),
+	},
+	{
 		key: "route:my-shares",
 		label: "MySharesPage",
 		load: () => import("@/pages/MySharesPage"),
+	},
+	{
+		key: "route:tasks",
+		label: "TasksPage",
+		load: () => import("@/pages/TasksPage"),
 	},
 	{
 		key: "route:trash",
@@ -32,9 +52,39 @@ export const userRouteWarmupLoaders = [
 		label: "WebdavAccountsPage",
 		load: () => import("@/pages/WebdavAccountsPage"),
 	},
+	{
+		key: "route:team-manage",
+		label: "TeamManagePage",
+		load: () => import("@/pages/TeamManagePage"),
+	},
+	{
+		key: "route:force-password-change",
+		label: "ForcePasswordChangePage",
+		load: () => import("@/pages/ForcePasswordChangePage"),
+	},
+	{
+		key: "route:reset-password",
+		label: "ResetPasswordPage",
+		load: () => import("@/pages/ResetPasswordPage"),
+	},
+	{
+		key: "route:invite-register",
+		label: "InviteRegisterPage",
+		load: () => import("@/pages/InviteRegisterPage"),
+	},
+	{
+		key: "route:share-view",
+		label: "ShareViewPage",
+		load: () => import("@/pages/ShareViewPage"),
+	},
 ] satisfies WarmupLoaderEntry[];
 
 export const adminRouteWarmupLoaders = [
+	{
+		key: "route:admin-overview",
+		label: "AdminOverviewPage",
+		load: () => import("@/pages/admin/AdminOverviewPage"),
+	},
 	{
 		key: "route:admin-users",
 		label: "AdminUsersPage",
@@ -46,14 +96,39 @@ export const adminRouteWarmupLoaders = [
 		load: () => import("@/pages/admin/AdminUserInvitationsPage"),
 	},
 	{
+		key: "route:admin-teams",
+		label: "AdminTeamsPage",
+		load: () => import("@/pages/admin/AdminTeamsPage"),
+	},
+	{
+		key: "route:admin-team-detail",
+		label: "AdminTeamDetailPage",
+		load: () => import("@/pages/admin/AdminTeamDetailPage"),
+	},
+	{
 		key: "route:admin-policies",
 		label: "AdminPoliciesPage",
 		load: () => import("@/pages/admin/AdminPoliciesPage"),
 	},
 	{
+		key: "route:admin-remote-nodes",
+		label: "AdminRemoteNodesPage",
+		load: () => import("@/pages/admin/AdminRemoteNodesPage"),
+	},
+	{
 		key: "route:admin-external-auth",
 		label: "AdminExternalAuthPage",
 		load: () => import("@/pages/admin/AdminExternalAuthPage"),
+	},
+	{
+		key: "route:admin-policy-groups",
+		label: "AdminPolicyGroupsPage",
+		load: () => import("@/pages/admin/AdminPolicyGroupsPage"),
+	},
+	{
+		key: "route:admin-tasks",
+		label: "AdminTasksPage",
+		load: () => import("@/pages/admin/AdminTasksPage"),
 	},
 	{
 		key: "route:admin-settings",
@@ -64,6 +139,11 @@ export const adminRouteWarmupLoaders = [
 		key: "route:admin-shares",
 		label: "AdminSharesPage",
 		load: () => import("@/pages/admin/AdminSharesPage"),
+	},
+	{
+		key: "route:admin-files",
+		label: "AdminFilesPage",
+		load: () => import("@/pages/admin/AdminFilesPage"),
 	},
 	{
 		key: "route:admin-locks",

--- a/frontend-panel/src/lib/pwaWarmupLoaders.ts
+++ b/frontend-panel/src/lib/pwaWarmupLoaders.ts
@@ -13,6 +13,11 @@ const loginRouteWarmupLoader = {
 export const userRouteWarmupLoaders = [
 	loginRouteWarmupLoader,
 	{
+		key: "route:error",
+		label: "ErrorPage",
+		load: () => import("@/pages/ErrorPage"),
+	},
+	{
 		key: "route:file-browser",
 		label: "FileBrowserPage",
 		load: () => import("@/pages/FileBrowserPage"),

--- a/frontend-panel/src/router/index.tsx
+++ b/frontend-panel/src/router/index.tsx
@@ -1,6 +1,5 @@
 import { type ComponentType, lazy, Suspense } from "react";
 import { createBrowserRouter, Navigate } from "react-router-dom";
-import { ensureAllI18nNamespaces } from "@/i18n";
 import { AdminRoute } from "./AdminRoute";
 import { Loading } from "./Loading";
 import { LoginGuard } from "./LoginGuard";
@@ -10,22 +9,11 @@ import { TeamWorkspaceRoute } from "./TeamWorkspaceRoute";
 
 function lazyPage<TProps extends object>(
 	load: () => Promise<{ default: ComponentType<TProps> }>,
-	options: { preloadI18n?: boolean } = {},
 ) {
-	return lazy<ComponentType<TProps>>(async () => {
-		const [module] = await Promise.all([
-			load(),
-			options.preloadI18n === false
-				? Promise.resolve()
-				: ensureAllI18nNamespaces(),
-		]);
-		return module;
-	});
+	return lazy<ComponentType<TProps>>(load);
 }
 
-const LoginPage = lazyPage(() => import("@/pages/LoginPage"), {
-	preloadI18n: false,
-});
+const LoginPage = lazyPage(() => import("@/pages/LoginPage"));
 const ForcePasswordChangePage = lazyPage(
 	() => import("@/pages/ForcePasswordChangePage"),
 );

--- a/frontend-panel/vite.config.ts
+++ b/frontend-panel/vite.config.ts
@@ -135,6 +135,7 @@ export default defineConfig(({ command }) => {
 								"assets/PdfPreview-*.js",
 								"assets/PdfPreview-*.css",
 								"assets/pdf.worker.min-*.mjs",
+								"assets/vendor-react-icons-*.js",
 								"pdfjs/**",
 								"static/preview-apps/**",
 								"static/external-auth/**",


### PR DESCRIPTION
This pull request introduces a new post-build script to audit frontend startup performance and tightens the loading sequence for authenticated routes in the app. It also expands the set of route chunk warmups for both user and admin roles, ensuring that all necessary route bundles are preloaded after authentication and locale readiness. The test suite is updated accordingly to reflect these changes.

**Frontend build and startup auditing:**

* Adds a `postbuild` script (`audit-startup.mjs`) that checks service worker precache size/count, entry/login bundle sizes, and ensures only allowed assets are included in startup and precache graphs. It also verifies that all lazy-loaded route pages are covered by the PWA warmup logic. [[1]](diffhunk://#diff-1bb458722fd47afe36e0355bd1e5a200e32c477c9f765564bbfeebdf099d8be1R12) [[2]](diffhunk://#diff-306b5ea3924405f8bacf8dcd9718f165bb452af2d7bc2dfefde2c72f42b0756fR1-R308)

**App initialization and route chunk warmup:**

* Changes the app initialization to delay mounting authenticated routes until all locale bundles are loaded, showing a loading indicator in the meantime. Once ready, it triggers preloading of user/admin route chunks based on the authenticated user's role. [[1]](diffhunk://#diff-e5d7a92dd50f73f5a0649db22365cb4049a162e39b96afc1c93860b56fb22417L68-R72) [[2]](diffhunk://#diff-e5d7a92dd50f73f5a0649db22365cb4049a162e39b96afc1c93860b56fb22417R93-R99) [[3]](diffhunk://#diff-e5d7a92dd50f73f5a0649db22365cb4049a162e39b96afc1c93860b56fb22417R108-R150) [[4]](diffhunk://#diff-e5d7a92dd50f73f5a0649db22365cb4049a162e39b96afc1c93860b56fb22417R173-R174)

**Route warmup coverage:**

* Expands the list of preloaded route chunks for both user and admin roles in `pwaWarmupLoaders.ts` to include all relevant pages, and updates the corresponding tests to check for the new coverage. [[1]](diffhunk://#diff-9925b4ccf243ed778f2842d5f3104032755bee830eac41b3608f1f15dbf8f9c8R15-R44) [[2]](diffhunk://#diff-ffd10bad8892a9222ea4a7644e645e6adcdc9029214c98a6501de5dbbbfa8bf8R10-R64) [[3]](diffhunk://#diff-ffd10bad8892a9222ea4a7644e645e6adcdc9029214c98a6501de5dbbbfa8bf8R126-R154)

**Testing improvements:**

* Updates the test suite to mock the expanded set of route pages, verifies that route chunk warmup is correctly triggered after authentication and locale readiness, and adds/adjusts tests for the new loading sequence and warmup logic. [[1]](diffhunk://#diff-a7da2bb0b28281e957780be5e1e47fb1a6e8223d4198a960216563a6b7989aa2L11-R14) [[2]](diffhunk://#diff-a7da2bb0b28281e957780be5e1e47fb1a6e8223d4198a960216563a6b7989aa2R29) [[3]](diffhunk://#diff-a7da2bb0b28281e957780be5e1e47fb1a6e8223d4198a960216563a6b7989aa2R83-R87) [[4]](diffhunk://#diff-a7da2bb0b28281e957780be5e1e47fb1a6e8223d4198a960216563a6b7989aa2R170) [[5]](diffhunk://#diff-a7da2bb0b28281e957780be5e1e47fb1a6e8223d4198a960216563a6b7989aa2L222-R236) [[6]](diffhunk://#diff-a7da2bb0b28281e957780be5e1e47fb1a6e8223d4198a960216563a6b7989aa2R268-R299) [[7]](diffhunk://#diff-a7da2bb0b28281e957780be5e1e47fb1a6e8223d4198a960216563a6b7989aa2L330-R390)

closed #310 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **性能改进**
  * 扩展路由预热加载覆盖范围，涵盖更多页面和管理功能，提升应用启动和导航速度。
  * 优化已认证用户的语言初始化流程，减少首屏加载延迟。
  * 新增构建后验证机制，确保关键资源正确预缓存。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->