### PR TITLE
refactor(cache): extract cache logic into dedicated modules with comp…

### DIFF
--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -226,6 +226,67 @@ impl SharedRuntimeState for FollowerAppState {
 impl FollowerRuntimeState for FollowerAppState {}
 
 #[cfg(test)]
+pub(crate) mod test_support {
+    use super::SharedRuntimeState;
+    use crate::cache::CacheBackend;
+    use crate::config::{CacheConfig, Config, RuntimeConfig};
+    use crate::metrics_core::SharedMetricsRecorder;
+    use crate::storage::{DriverRegistry, PolicySnapshot};
+    use sea_orm::DatabaseConnection;
+    use std::sync::Arc;
+
+    pub(crate) struct CacheOnlyState {
+        cache: Arc<dyn CacheBackend>,
+    }
+
+    impl CacheOnlyState {
+        pub(crate) async fn new() -> Self {
+            Self {
+                cache: crate::cache::create_cache(&CacheConfig {
+                    backend: "memory".to_string(),
+                    ..Default::default()
+                })
+                .await,
+            }
+        }
+    }
+
+    impl SharedRuntimeState for CacheOnlyState {
+        fn writer_db(&self) -> &DatabaseConnection {
+            panic!("cache-only test state must not access writer_db")
+        }
+
+        fn reader_db(&self) -> &DatabaseConnection {
+            panic!("cache-only test state must not access reader_db")
+        }
+
+        fn driver_registry(&self) -> &Arc<DriverRegistry> {
+            panic!("cache-only test state must not access driver_registry")
+        }
+
+        fn runtime_config(&self) -> &Arc<RuntimeConfig> {
+            panic!("cache-only test state must not access runtime_config")
+        }
+
+        fn policy_snapshot(&self) -> &Arc<PolicySnapshot> {
+            panic!("cache-only test state must not access policy_snapshot")
+        }
+
+        fn config(&self) -> &Arc<Config> {
+            panic!("cache-only test state must not access config")
+        }
+
+        fn cache(&self) -> &Arc<dyn CacheBackend> {
+            &self.cache
+        }
+
+        fn metrics(&self) -> &SharedMetricsRecorder {
+            panic!("cache-only test state must not access metrics")
+        }
+    }
+}
+
+#[cfg(test)]
 mod tests {
     use super::{PrimaryAppState, SharedRuntimeState, TaskRuntimeState};
     use crate::config::{CacheConfig, Config, RuntimeConfig};

--- a/src/services/admin_service.rs
+++ b/src/services/admin_service.rs
@@ -1,5 +1,7 @@
 //! 服务模块：`admin_service`。
 
+mod cache;
+
 use chrono::{DateTime, Duration, LocalResult, NaiveDate, TimeZone, Utc};
 use chrono_tz::Tz;
 use serde::{Deserialize, Serialize};
@@ -7,7 +9,6 @@ use std::collections::HashMap;
 #[cfg(all(debug_assertions, feature = "openapi"))]
 use utoipa::{IntoParams, ToSchema};
 
-use crate::cache::CacheExt;
 use crate::db::repository::{
     audit_log_repo, background_task_repo, file_repo, share_repo, user_repo,
 };
@@ -28,7 +29,6 @@ const MAX_DAYS: u32 = 90;
 const DEFAULT_EVENT_LIMIT: u64 = 8;
 const MAX_EVENT_LIMIT: u64 = 50;
 const DEFAULT_TIMEZONE: &str = "UTC";
-const ADMIN_OVERVIEW_CACHE_TTL: u64 = 15;
 const ADMIN_OVERVIEW_AUDIT_ACTION_BATCH_SIZE: u64 = 1_000;
 
 #[derive(Clone, Debug, Deserialize)]
@@ -161,7 +161,7 @@ pub struct AdminOverview {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
-struct CachedAdminOverviewCore {
+pub(crate) struct AdminOverviewCore {
     generated_at: DateTimeUtc,
     timezone: String,
     days: u32,
@@ -170,7 +170,7 @@ struct CachedAdminOverviewCore {
     daily_reports: Vec<AdminOverviewDailyReport>,
 }
 
-impl CachedAdminOverviewCore {
+impl AdminOverviewCore {
     fn into_overview(
         self,
         recent_events: Vec<audit_service::AuditLogEntry>,
@@ -189,10 +189,6 @@ impl CachedAdminOverviewCore {
     }
 }
 
-fn admin_overview_cache_key(days: u32, timezone_name: &str) -> String {
-    format!("admin_overview_core:{days}:{timezone_name}")
-}
-
 pub async fn get_overview(
     state: &impl SharedRuntimeState,
     days: u32,
@@ -201,14 +197,9 @@ pub async fn get_overview(
 ) -> Result<AdminOverview> {
     let generated_at = Utc::now();
     let timezone = parse_timezone(timezone_name)?;
-    let cache_key = admin_overview_cache_key(days, timezone.name());
     let (recent_events, recent_background_tasks) =
         load_recent_overview_events(state, event_limit).await?;
-    if let Some(core) = state
-        .cache()
-        .get::<CachedAdminOverviewCore>(&cache_key)
-        .await
-    {
+    if let Some(core) = cache::load_overview_core(state, days, timezone.name()).await {
         tracing::debug!(
             days,
             timezone = timezone.name(),
@@ -260,7 +251,7 @@ pub async fn get_overview(
         });
     let system_health = build_system_health_summary(latest_health_task);
 
-    let core = CachedAdminOverviewCore {
+    let core = AdminOverviewCore {
         generated_at,
         timezone: timezone.name().to_string(),
         days,
@@ -281,10 +272,7 @@ pub async fn get_overview(
         system_health,
         daily_reports,
     };
-    state
-        .cache()
-        .set(&cache_key, &core, Some(ADMIN_OVERVIEW_CACHE_TTL))
-        .await;
+    cache::store_overview_core(state, days, timezone.name(), &core).await;
     tracing::debug!(
         days,
         timezone = timezone.name(),

--- a/src/services/admin_service/cache.rs
+++ b/src/services/admin_service/cache.rs
@@ -1,0 +1,104 @@
+//! 管理概览缓存。
+
+use crate::cache::CacheExt;
+use crate::runtime::SharedRuntimeState;
+
+use super::AdminOverviewCore;
+
+const ADMIN_OVERVIEW_CORE_CACHE_TTL: u64 = 15;
+
+fn overview_core_cache_key(days: u32, timezone_name: &str) -> String {
+    format!("admin_overview_core:{days}:{timezone_name}")
+}
+
+pub(super) async fn load_overview_core(
+    state: &impl SharedRuntimeState,
+    days: u32,
+    timezone_name: &str,
+) -> Option<AdminOverviewCore> {
+    state
+        .cache()
+        .get::<AdminOverviewCore>(&overview_core_cache_key(days, timezone_name))
+        .await
+}
+
+pub(super) async fn store_overview_core(
+    state: &impl SharedRuntimeState,
+    days: u32,
+    timezone_name: &str,
+    core: &AdminOverviewCore,
+) {
+    state
+        .cache()
+        .set(
+            &overview_core_cache_key(days, timezone_name),
+            core,
+            Some(ADMIN_OVERVIEW_CORE_CACHE_TTL),
+        )
+        .await;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runtime::test_support::CacheOnlyState;
+
+    fn core(days: u32, timezone: &str, total_users: u64) -> AdminOverviewCore {
+        AdminOverviewCore {
+            generated_at: chrono::Utc::now(),
+            timezone: timezone.to_string(),
+            days,
+            stats: super::super::AdminOverviewStats {
+                total_users,
+                active_users: total_users,
+                disabled_users: 0,
+                total_files: 0,
+                total_file_bytes: 0,
+                total_blobs: 0,
+                total_blob_bytes: 0,
+                total_shares: 0,
+                audit_events_today: 0,
+                new_users_today: 0,
+                uploads_today: 0,
+                shares_today: 0,
+            },
+            system_health: super::super::AdminSystemHealthSummary {
+                status: super::super::AdminSystemHealthStatus::Unknown,
+                summary: None,
+                details: None,
+                components: Vec::new(),
+                checked_at: None,
+                task_id: None,
+            },
+            daily_reports: Vec::new(),
+        }
+    }
+
+    #[tokio::test]
+    async fn overview_core_cache_is_scoped_by_days_and_timezone() {
+        let state = CacheOnlyState::new().await;
+
+        store_overview_core(&state, 7, "UTC", &core(7, "UTC", 7)).await;
+        store_overview_core(&state, 30, "UTC", &core(30, "UTC", 30)).await;
+        store_overview_core(&state, 7, "Asia/Shanghai", &core(7, "Asia/Shanghai", 70)).await;
+
+        assert_eq!(
+            load_overview_core(&state, 7, "UTC")
+                .await
+                .map(|cached| cached.stats.total_users),
+            Some(7)
+        );
+        assert_eq!(
+            load_overview_core(&state, 30, "UTC")
+                .await
+                .map(|cached| cached.stats.total_users),
+            Some(30)
+        );
+        assert_eq!(
+            load_overview_core(&state, 7, "Asia/Shanghai")
+                .await
+                .map(|cached| cached.stats.total_users),
+            Some(70)
+        );
+    }
+}

--- a/src/services/auth_service/cache.rs
+++ b/src/services/auth_service/cache.rs
@@ -1,0 +1,88 @@
+//! 认证领域缓存。
+
+use crate::cache::CacheExt;
+use crate::runtime::SharedRuntimeState;
+
+use super::AuthSnapshot;
+
+const AUTH_SNAPSHOT_TTL: u64 = 30;
+
+fn auth_snapshot_cache_key(user_id: i64) -> String {
+    format!("auth_snapshot:{user_id}")
+}
+
+pub(super) async fn load_auth_snapshot(
+    state: &impl SharedRuntimeState,
+    user_id: i64,
+) -> Option<AuthSnapshot> {
+    state.cache().get(&auth_snapshot_cache_key(user_id)).await
+}
+
+pub(super) async fn store_auth_snapshot(
+    state: &impl SharedRuntimeState,
+    user_id: i64,
+    snapshot: &AuthSnapshot,
+) {
+    state
+        .cache()
+        .set(
+            &auth_snapshot_cache_key(user_id),
+            snapshot,
+            Some(AUTH_SNAPSHOT_TTL),
+        )
+        .await;
+}
+
+pub(super) async fn invalidate_auth_snapshot(state: &impl SharedRuntimeState, user_id: i64) {
+    state
+        .cache()
+        .delete(&auth_snapshot_cache_key(user_id))
+        .await;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runtime::test_support::CacheOnlyState;
+    use crate::types::{UserRole, UserStatus};
+
+    fn snapshot(session_version: i64) -> AuthSnapshot {
+        AuthSnapshot {
+            status: UserStatus::Active,
+            role: UserRole::User,
+            session_version,
+            must_change_password: false,
+        }
+    }
+
+    #[tokio::test]
+    async fn auth_snapshot_is_scoped_by_user_and_can_be_invalidated() {
+        let state = CacheOnlyState::new().await;
+
+        store_auth_snapshot(&state, 1, &snapshot(10)).await;
+        store_auth_snapshot(&state, 2, &snapshot(20)).await;
+
+        assert_eq!(
+            load_auth_snapshot(&state, 1)
+                .await
+                .map(|value| value.session_version),
+            Some(10)
+        );
+        assert_eq!(
+            load_auth_snapshot(&state, 2)
+                .await
+                .map(|value| value.session_version),
+            Some(20)
+        );
+
+        invalidate_auth_snapshot(&state, 1).await;
+
+        assert!(load_auth_snapshot(&state, 1).await.is_none());
+        assert_eq!(
+            load_auth_snapshot(&state, 2)
+                .await
+                .map(|value| value.session_version),
+            Some(20)
+        );
+    }
+}

--- a/src/services/auth_service/mod.rs
+++ b/src/services/auth_service/mod.rs
@@ -1,5 +1,6 @@
 //! 认证服务聚合入口。
 
+mod cache;
 mod contact_verification;
 mod password;
 mod registration;
@@ -40,7 +41,6 @@ pub use tokens::{
 };
 pub(crate) use validation::{validate_email, validate_password, validate_username};
 
-pub const AUTH_SNAPSHOT_TTL: u64 = 30; // 秒
 const INITIAL_SESSION_VERSION: i64 = 1;
 const ACTIVE_VERIFICATION_REQUEST_MESSAGE: &str = "a verification request is already active";
 

--- a/src/services/auth_service/session.rs
+++ b/src/services/auth_service/session.rs
@@ -4,42 +4,30 @@ use chrono::Utc;
 use sea_orm::{ActiveModelTrait, ConnectionTrait, IntoActiveModel, Set};
 
 use crate::api::api_error_code::ApiErrorCode;
-use crate::cache::CacheExt;
 use crate::db::repository::{auth_session_repo, user_repo};
 use crate::errors::{AsterError, MapAsterErr, Result, auth_forbidden_with_code};
 use crate::runtime::SharedRuntimeState;
 
-use super::{AUTH_SNAPSHOT_TTL, AuthSessionInfo, AuthSnapshot, UserAuditInfo, user_audit_info};
-
-fn auth_snapshot_cache_key(user_id: i64) -> String {
-    format!("auth_snapshot:{user_id}")
-}
+use super::{AuthSessionInfo, AuthSnapshot, UserAuditInfo, cache, user_audit_info};
 
 pub async fn get_auth_snapshot(
     state: &impl SharedRuntimeState,
     user_id: i64,
 ) -> Result<AuthSnapshot> {
-    let cache_key = auth_snapshot_cache_key(user_id);
-    if let Some(snapshot) = state.cache().get(&cache_key).await {
+    if let Some(snapshot) = cache::load_auth_snapshot(state, user_id).await {
         tracing::debug!(user_id, "auth snapshot cache hit");
         return Ok(snapshot);
     }
 
     let user = user_repo::find_by_id(state.reader_db(), user_id).await?;
     let snapshot = AuthSnapshot::from_user(&user);
-    state
-        .cache()
-        .set(&cache_key, &snapshot, Some(AUTH_SNAPSHOT_TTL))
-        .await;
+    cache::store_auth_snapshot(state, user_id, &snapshot).await;
     tracing::debug!(user_id, "auth snapshot cache miss");
     Ok(snapshot)
 }
 
 pub async fn invalidate_auth_snapshot_cache(state: &impl SharedRuntimeState, user_id: i64) {
-    state
-        .cache()
-        .delete(&auth_snapshot_cache_key(user_id))
-        .await;
+    cache::invalidate_auth_snapshot(state, user_id).await;
 }
 
 pub(crate) async fn purge_all_auth_sessions_in_connection<C: ConnectionTrait>(

--- a/src/services/folder_service/cache.rs
+++ b/src/services/folder_service/cache.rs
@@ -1,0 +1,101 @@
+//! 文件夹层级缓存。
+
+use serde::{Deserialize, Serialize};
+
+use crate::cache::CacheExt;
+use crate::runtime::SharedRuntimeState;
+
+const FOLDER_PATH_CACHE_TTL: u64 = 300;
+pub(crate) const FOLDER_PATH_CACHE_PREFIX: &str = "folder_path:";
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(super) struct CachedFolderPathChain {
+    pub(super) chain_ids: Vec<i64>,
+}
+
+fn folder_path_cache_key(folder_id: i64) -> String {
+    format!("{FOLDER_PATH_CACHE_PREFIX}{folder_id}")
+}
+
+pub(super) async fn load_folder_path_chain(
+    state: &impl SharedRuntimeState,
+    folder_id: i64,
+) -> Option<CachedFolderPathChain> {
+    state
+        .cache()
+        .get::<CachedFolderPathChain>(&folder_path_cache_key(folder_id))
+        .await
+}
+
+pub(super) async fn store_folder_path_chain(
+    state: &impl SharedRuntimeState,
+    folder_id: i64,
+    chain_ids: Vec<i64>,
+) {
+    state
+        .cache()
+        .set(
+            &folder_path_cache_key(folder_id),
+            &CachedFolderPathChain { chain_ids },
+            Some(FOLDER_PATH_CACHE_TTL),
+        )
+        .await;
+}
+
+pub(super) async fn invalidate_folder_path_chain(state: &impl SharedRuntimeState, folder_id: i64) {
+    state
+        .cache()
+        .delete(&folder_path_cache_key(folder_id))
+        .await;
+}
+
+pub(crate) async fn invalidate_all_folder_path_chains(state: &impl SharedRuntimeState) {
+    state
+        .cache()
+        .invalidate_prefix(FOLDER_PATH_CACHE_PREFIX)
+        .await;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runtime::test_support::CacheOnlyState;
+
+    #[tokio::test]
+    async fn folder_path_chain_roundtrips_and_is_scoped_by_folder_id() {
+        let state = CacheOnlyState::new().await;
+
+        store_folder_path_chain(&state, 10, vec![1, 5, 10]).await;
+        store_folder_path_chain(&state, 11, vec![1, 11]).await;
+
+        assert_eq!(
+            load_folder_path_chain(&state, 10)
+                .await
+                .map(|cached| cached.chain_ids),
+            Some(vec![1, 5, 10])
+        );
+        assert_eq!(
+            load_folder_path_chain(&state, 11)
+                .await
+                .map(|cached| cached.chain_ids),
+            Some(vec![1, 11])
+        );
+    }
+
+    #[tokio::test]
+    async fn folder_path_chain_supports_single_and_global_invalidation() {
+        let state = CacheOnlyState::new().await;
+
+        store_folder_path_chain(&state, 10, vec![10]).await;
+        store_folder_path_chain(&state, 11, vec![11]).await;
+
+        invalidate_folder_path_chain(&state, 10).await;
+
+        assert!(load_folder_path_chain(&state, 10).await.is_none());
+        assert!(load_folder_path_chain(&state, 11).await.is_some());
+
+        invalidate_all_folder_path_chains(&state).await;
+
+        assert!(load_folder_path_chain(&state, 11).await.is_none());
+    }
+}

--- a/src/services/folder_service/hierarchy.rs
+++ b/src/services/folder_service/hierarchy.rs
@@ -3,39 +3,22 @@
 use std::collections::{HashMap, HashSet};
 
 use sea_orm::ConnectionTrait;
-use serde::{Deserialize, Serialize};
 
-use crate::cache::CacheExt;
 use crate::db::repository::folder_repo;
 use crate::entities::folder;
 use crate::errors::{AsterError, Result};
 use crate::runtime::SharedRuntimeState;
 use crate::services::workspace_storage_service::{self, WorkspaceStorageScope};
 
-use super::{FolderAncestorItem, ensure_folder_model_in_scope};
-
-const FOLDER_PATH_CACHE_TTL: u64 = 300;
-pub(crate) const FOLDER_PATH_CACHE_PREFIX: &str = "folder_path:";
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-struct CachedFolderPathChain {
-    chain_ids: Vec<i64>,
-}
+use super::{FolderAncestorItem, cache, ensure_folder_model_in_scope};
 
 struct FolderPathEntry {
     path: String,
     chain_ids: Vec<i64>,
 }
 
-fn folder_path_cache_key(folder_id: i64) -> String {
-    format!("{FOLDER_PATH_CACHE_PREFIX}{folder_id}")
-}
-
 pub(crate) async fn invalidate_folder_path_cache(state: &impl SharedRuntimeState) {
-    state
-        .cache()
-        .invalidate_prefix(FOLDER_PATH_CACHE_PREFIX)
-        .await;
+    cache::invalidate_all_folder_path_chains(state).await;
 }
 
 pub(super) async fn load_folder_chain_map<C: ConnectionTrait>(
@@ -140,8 +123,7 @@ pub async fn build_folder_paths_cached(
     let mut misses = Vec::new();
 
     for &id in &ids {
-        let cache_key = folder_path_cache_key(id);
-        if let Some(cached) = state.cache().get::<CachedFolderPathChain>(&cache_key).await {
+        if let Some(cached) = cache::load_folder_path_chain(state, id).await {
             if cached.chain_ids.is_empty() {
                 misses.push(id);
             } else {
@@ -175,21 +157,12 @@ pub async fn build_folder_paths_cached(
             ) {
                 Ok(entry) => {
                     if entry.chain_ids != cached.chain_ids {
-                        state
-                            .cache()
-                            .set(
-                                &folder_path_cache_key(id),
-                                &CachedFolderPathChain {
-                                    chain_ids: entry.chain_ids,
-                                },
-                                Some(FOLDER_PATH_CACHE_TTL),
-                            )
-                            .await;
+                        cache::store_folder_path_chain(state, id, entry.chain_ids).await;
                     }
                     paths.insert(id, entry.path);
                 }
                 Err(_) => {
-                    state.cache().delete(&folder_path_cache_key(id)).await;
+                    cache::invalidate_folder_path_chain(state, id).await;
                     misses.push(id);
                 }
             }
@@ -204,16 +177,7 @@ pub async fn build_folder_paths_cached(
     misses.dedup();
     let loaded = build_folder_path_entries(state.reader_db(), &misses).await?;
     for (&id, entry) in &loaded {
-        state
-            .cache()
-            .set(
-                &folder_path_cache_key(id),
-                &CachedFolderPathChain {
-                    chain_ids: entry.chain_ids.clone(),
-                },
-                Some(FOLDER_PATH_CACHE_TTL),
-            )
-            .await;
+        cache::store_folder_path_chain(state, id, entry.chain_ids.clone()).await;
     }
     paths.extend(
         loaded

--- a/src/services/folder_service/mod.rs
+++ b/src/services/folder_service/mod.rs
@@ -8,6 +8,7 @@
 //! - hierarchy: breadcrumb / ancestor
 
 mod access;
+mod cache;
 mod copy;
 mod hierarchy;
 mod listing;
@@ -40,10 +41,9 @@ pub use mutation::{create, delete, move_folder, set_lock, update};
 pub(crate) use access::{
     ensure_folder_model_in_scope, ensure_personal_folder_scope, verify_folder_in_scope,
 };
+pub(crate) use cache::FOLDER_PATH_CACHE_PREFIX;
 pub(crate) use copy::{copy_folder_in_scope, copy_folder_tree_in_scope};
-pub(crate) use hierarchy::{
-    FOLDER_PATH_CACHE_PREFIX, get_ancestors_in_scope, invalidate_folder_path_cache,
-};
+pub(crate) use hierarchy::{get_ancestors_in_scope, invalidate_folder_path_cache};
 pub(crate) use listing::list_in_scope;
 pub(crate) use mutation::{
     admin_set_policy, create_in_scope, delete_in_scope, get_info_in_scope,

--- a/src/services/passkey_service.rs
+++ b/src/services/passkey_service.rs
@@ -1,5 +1,7 @@
 //! Passkey / WebAuthn 业务逻辑。
 
+mod cache;
+
 use base64::Engine as _;
 use chrono::Utc;
 use sea_orm::{ActiveModelTrait, ActiveValue::Set, DatabaseConnection, DbErr, SqlErr};
@@ -12,7 +14,6 @@ use webauthn_rs::prelude::{
 use webauthn_rs_proto::{ResidentKeyRequirement, UserVerificationPolicy};
 
 use crate::api::api_error_code::ApiErrorCode;
-use crate::cache::CacheExt;
 use crate::config::{auth_runtime::RuntimeAuthPolicy, branding, site_url};
 use crate::db::repository::{passkey_repo, user_repo};
 use crate::entities::{passkey, user};
@@ -28,7 +29,6 @@ use crate::utils::{
     numbers::{u32_to_i64, u64_to_i64},
 };
 
-const PASSKEY_CHALLENGE_TTL_SECS: u64 = 300;
 const PASSKEY_NAME_MAX_LEN: usize = 128;
 
 #[derive(Debug, Clone, Serialize)]
@@ -81,14 +81,6 @@ struct PasskeyRegistrationChallenge {
 struct PasskeyAuthenticationChallenge {
     identifier: Option<String>,
     state: DiscoverableAuthentication,
-}
-
-fn registration_cache_key(flow_id: &str) -> String {
-    format!("external_auth:passkey:registration:{flow_id}")
-}
-
-fn login_cache_key(flow_id: &str) -> String {
-    format!("external_auth:passkey:login:{flow_id}")
 }
 
 fn new_flow_id() -> String {
@@ -310,26 +302,16 @@ async fn store_registration_challenge(
     flow_id: &str,
     challenge: &PasskeyRegistrationChallenge,
 ) {
-    state
-        .cache()
-        .set(
-            &registration_cache_key(flow_id),
-            challenge,
-            Some(PASSKEY_CHALLENGE_TTL_SECS),
-        )
-        .await;
+    cache::store_registration_challenge(state, flow_id, challenge).await;
 }
 
 async fn take_registration_challenge(
     state: &impl SharedRuntimeState,
     flow_id: &str,
 ) -> Result<PasskeyRegistrationChallenge> {
-    let key = registration_cache_key(flow_id);
-    let challenge =
-        state.cache().take(&key).await.ok_or_else(|| {
-            AsterError::auth_token_invalid("passkey registration challenge expired")
-        })?;
-    Ok(challenge)
+    cache::take_registration_challenge(state, flow_id)
+        .await
+        .ok_or_else(|| AsterError::auth_token_invalid("passkey registration challenge expired"))
 }
 
 async fn store_login_challenge(
@@ -337,27 +319,16 @@ async fn store_login_challenge(
     flow_id: &str,
     challenge: &PasskeyAuthenticationChallenge,
 ) {
-    state
-        .cache()
-        .set(
-            &login_cache_key(flow_id),
-            challenge,
-            Some(PASSKEY_CHALLENGE_TTL_SECS),
-        )
-        .await;
+    cache::store_login_challenge(state, flow_id, challenge).await;
 }
 
 async fn take_login_challenge(
     state: &impl SharedRuntimeState,
     flow_id: &str,
 ) -> Result<PasskeyAuthenticationChallenge> {
-    let key = login_cache_key(flow_id);
-    let challenge = state
-        .cache()
-        .take(&key)
+    cache::take_login_challenge(state, flow_id)
         .await
-        .ok_or_else(|| AsterError::auth_token_invalid("passkey login challenge expired"))?;
-    Ok(challenge)
+        .ok_or_else(|| AsterError::auth_token_invalid("passkey login challenge expired"))
 }
 
 fn serialize_registration_options(

--- a/src/services/passkey_service/cache.rs
+++ b/src/services/passkey_service/cache.rs
@@ -1,0 +1,139 @@
+//! Passkey/WebAuthn flow challenge 缓存。
+
+use crate::cache::CacheExt;
+use crate::runtime::SharedRuntimeState;
+
+use super::{PasskeyAuthenticationChallenge, PasskeyRegistrationChallenge};
+
+const PASSKEY_CHALLENGE_TTL_SECS: u64 = 300;
+
+fn registration_cache_key(flow_id: &str) -> String {
+    format!("external_auth:passkey:registration:{flow_id}")
+}
+
+fn login_cache_key(flow_id: &str) -> String {
+    format!("external_auth:passkey:login:{flow_id}")
+}
+
+pub(super) async fn store_registration_challenge(
+    state: &impl SharedRuntimeState,
+    flow_id: &str,
+    challenge: &PasskeyRegistrationChallenge,
+) {
+    state
+        .cache()
+        .set(
+            &registration_cache_key(flow_id),
+            challenge,
+            Some(PASSKEY_CHALLENGE_TTL_SECS),
+        )
+        .await;
+}
+
+pub(super) async fn take_registration_challenge(
+    state: &impl SharedRuntimeState,
+    flow_id: &str,
+) -> Option<PasskeyRegistrationChallenge> {
+    state.cache().take(&registration_cache_key(flow_id)).await
+}
+
+pub(super) async fn store_login_challenge(
+    state: &impl SharedRuntimeState,
+    flow_id: &str,
+    challenge: &PasskeyAuthenticationChallenge,
+) {
+    state
+        .cache()
+        .set(
+            &login_cache_key(flow_id),
+            challenge,
+            Some(PASSKEY_CHALLENGE_TTL_SECS),
+        )
+        .await;
+}
+
+pub(super) async fn take_login_challenge(
+    state: &impl SharedRuntimeState,
+    flow_id: &str,
+) -> Option<PasskeyAuthenticationChallenge> {
+    state.cache().take(&login_cache_key(flow_id)).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runtime::test_support::CacheOnlyState;
+    use webauthn_rs::prelude::{Uuid, Webauthn, WebauthnBuilder};
+
+    fn webauthn() -> Webauthn {
+        WebauthnBuilder::new(
+            "localhost",
+            &url::Url::parse("http://localhost").expect("test origin should parse"),
+        )
+        .expect("test webauthn builder should initialize")
+        .rp_name("AsterDrive Test")
+        .build()
+        .expect("test webauthn should build")
+    }
+
+    fn registration_challenge(user_id: i64) -> PasskeyRegistrationChallenge {
+        let user_handle = Uuid::parse_str("00000000-0000-0000-0000-000000000001").unwrap();
+        let (_, state) = webauthn()
+            .start_passkey_registration(user_handle, "alice", "Alice", None)
+            .expect("test registration challenge should start");
+        PasskeyRegistrationChallenge {
+            user_id,
+            user_handle,
+            default_name: format!("Passkey {user_id}"),
+            state,
+        }
+    }
+
+    fn login_challenge(identifier: Option<&str>) -> PasskeyAuthenticationChallenge {
+        let (_, state) = webauthn()
+            .start_discoverable_authentication()
+            .expect("test login challenge should start");
+        PasskeyAuthenticationChallenge {
+            identifier: identifier.map(str::to_string),
+            state,
+        }
+    }
+
+    #[tokio::test]
+    async fn registration_challenge_is_consumed_once() {
+        let state = CacheOnlyState::new().await;
+        let challenge = registration_challenge(42);
+
+        store_registration_challenge(&state, "flow", &challenge).await;
+
+        assert_eq!(
+            take_registration_challenge(&state, "flow")
+                .await
+                .map(|cached| cached.user_id),
+            Some(42)
+        );
+        assert!(take_registration_challenge(&state, "flow").await.is_none());
+    }
+
+    #[tokio::test]
+    async fn login_challenge_is_consumed_once_and_scoped_by_flow() {
+        let state = CacheOnlyState::new().await;
+
+        store_login_challenge(&state, "flow-a", &login_challenge(Some("alice"))).await;
+        store_login_challenge(&state, "flow-b", &login_challenge(None)).await;
+
+        assert_eq!(
+            take_login_challenge(&state, "flow-a")
+                .await
+                .and_then(|cached| cached.identifier),
+            Some("alice".to_string())
+        );
+        assert!(take_login_challenge(&state, "flow-a").await.is_none());
+        assert_eq!(
+            take_login_challenge(&state, "flow-b")
+                .await
+                .and_then(|cached| cached.identifier),
+            None
+        );
+    }
+}

--- a/src/services/preview_link_service.rs
+++ b/src/services/preview_link_service.rs
@@ -1,5 +1,7 @@
 //! 服务模块：`preview_link_service`。
 
+mod cache;
+
 use base64::Engine;
 use chrono::{DateTime, Duration, Utc};
 use serde::{Deserialize, Serialize};
@@ -19,7 +21,6 @@ use crate::services::{
 
 const PREVIEW_LINK_TTL_SECS: i64 = 5 * 60;
 const PREVIEW_LINK_MAX_USES: u32 = 5;
-const PREVIEW_LINK_CACHE_PREFIX: &str = "preview_link:";
 
 #[derive(Debug, Clone, Serialize)]
 #[cfg_attr(all(debug_assertions, feature = "openapi"), derive(ToSchema))]
@@ -48,7 +49,8 @@ struct PreviewTokenPayload {
 }
 
 struct ReservedUse {
-    cache_key: String,
+    token: String,
+    slot: u32,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -474,13 +476,11 @@ async fn reserve_usage(
     let ttl_secs = ttl_seconds(payload)?;
     let marker = Vec::new();
     for slot in 0..payload.max_uses {
-        let cache_key = preview_usage_slot_key(token, slot);
-        if state
-            .cache()
-            .set_bytes_if_absent(&cache_key, marker.clone(), Some(ttl_secs))
-            .await
-        {
-            return Ok(ReservedUse { cache_key });
+        if cache::reserve_usage_slot(state, token, slot, marker.clone(), ttl_secs).await {
+            return Ok(ReservedUse {
+                token: token.to_string(),
+                slot,
+            });
         }
     }
 
@@ -490,7 +490,7 @@ async fn reserve_usage(
 }
 
 async fn rollback_usage(state: &impl SharedRuntimeState, reserved: &ReservedUse) {
-    state.cache().delete(&reserved.cache_key).await;
+    cache::release_usage_slot(state, &reserved.token, reserved.slot).await;
 }
 
 fn ttl_seconds(payload: &PreviewTokenPayload) -> Result<u64> {
@@ -502,10 +502,6 @@ fn ttl_seconds(payload: &PreviewTokenPayload) -> Result<u64> {
         "preview link ttl conversion failed",
         AsterError::internal_error,
     )
-}
-
-fn preview_usage_slot_key(token: &str, slot: u32) -> String {
-    format!("{PREVIEW_LINK_CACHE_PREFIX}{token}:use:{slot}")
 }
 
 #[cfg(test)]

--- a/src/services/preview_link_service/cache.rs
+++ b/src/services/preview_link_service/cache.rs
@@ -1,0 +1,61 @@
+//! 预览链接使用次数缓存。
+
+use crate::runtime::SharedRuntimeState;
+
+const PREVIEW_LINK_CACHE_PREFIX: &str = "preview_link:";
+
+fn usage_slot_key(token: &str, slot: u32) -> String {
+    format!("{PREVIEW_LINK_CACHE_PREFIX}{token}:use:{slot}")
+}
+
+pub(super) async fn reserve_usage_slot(
+    state: &impl SharedRuntimeState,
+    token: &str,
+    slot: u32,
+    marker: Vec<u8>,
+    ttl_secs: u64,
+) -> bool {
+    state
+        .cache()
+        .set_bytes_if_absent(&usage_slot_key(token, slot), marker, Some(ttl_secs))
+        .await
+}
+
+pub(super) async fn release_usage_slot(state: &impl SharedRuntimeState, token: &str, slot: u32) {
+    state.cache().delete(&usage_slot_key(token, slot)).await;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runtime::test_support::CacheOnlyState;
+
+    #[tokio::test]
+    async fn usage_slot_reservation_is_single_use_per_slot() {
+        let state = CacheOnlyState::new().await;
+
+        assert!(reserve_usage_slot(&state, "token-a", 0, Vec::new(), 60).await);
+        assert!(!reserve_usage_slot(&state, "token-a", 0, Vec::new(), 60).await);
+        assert!(reserve_usage_slot(&state, "token-a", 1, Vec::new(), 60).await);
+        assert!(reserve_usage_slot(&state, "token-b", 0, Vec::new(), 60).await);
+    }
+
+    #[tokio::test]
+    async fn usage_slot_release_allows_reservation_again() {
+        let state = CacheOnlyState::new().await;
+
+        assert!(reserve_usage_slot(&state, "token-a", 0, Vec::new(), 60).await);
+        release_usage_slot(&state, "token-a", 0).await;
+
+        assert!(reserve_usage_slot(&state, "token-a", 0, Vec::new(), 60).await);
+    }
+
+    #[tokio::test]
+    async fn usage_slot_zero_ttl_expires_immediately() {
+        let state = CacheOnlyState::new().await;
+
+        assert!(reserve_usage_slot(&state, "token-a", 0, Vec::new(), 0).await);
+
+        assert!(reserve_usage_slot(&state, "token-a", 0, Vec::new(), 60).await);
+    }
+}

--- a/src/services/share_stream_service.rs
+++ b/src/services/share_stream_service.rs
@@ -1,15 +1,14 @@
 //! 服务模块：`share_stream_service`。
 
+mod cache;
+
 use base64::Engine;
 use chrono::{DateTime, Duration, Utc};
-use moka::future::Cache;
 use serde::{Deserialize, Serialize};
-use std::sync::LazyLock;
 use std::time::Duration as StdDuration;
 #[cfg(all(debug_assertions, feature = "openapi"))]
 use utoipa::ToSchema;
 
-use crate::cache::CacheExt;
 use crate::config::{operations, site_url};
 use crate::db::repository::{file_repo, share_repo};
 use crate::entities::{file, share};
@@ -19,16 +18,6 @@ use crate::services::{
     direct_link_service, file_service, file_service::ResolvedDownloadRange, share_service,
 };
 use crate::utils::numbers::u64_to_i64;
-
-const SHARE_STREAM_COUNTED_CACHE_PREFIX: &str = "share_stream_session_counted:";
-static FALLBACK_COUNTED_SESSIONS: LazyLock<Cache<String, CountMarkerState>> = LazyLock::new(|| {
-    Cache::builder()
-        .max_capacity(10_000)
-        .time_to_live(StdDuration::from_secs(
-            operations::MAX_SHARE_STREAM_SESSION_TTL_SECS,
-        ))
-        .build()
-});
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -430,10 +419,9 @@ async fn ensure_counted_once(
     session_token: &str,
     payload: &ShareStreamSessionPayload,
 ) -> Result<CountReservation> {
-    let key = counted_cache_key(session_token);
     let ttl_secs = ttl_seconds(payload)?;
     for _ in 0..20 {
-        match count_marker_state_by_key(state, &key).await {
+        match cache::load_count_marker(state, session_token).await {
             Some(CountMarkerState::Counted) => return Ok(CountReservation::AlreadyCounted),
             Some(CountMarkerState::Pending) => {
                 tokio::time::sleep(StdDuration::from_millis(25)).await;
@@ -443,14 +431,7 @@ async fn ensure_counted_once(
         }
 
         let pending = encode_marker_state(CountMarkerState::Pending)?;
-        if state
-            .cache()
-            .set_bytes_if_absent(&key, pending, Some(ttl_secs))
-            .await
-        {
-            FALLBACK_COUNTED_SESSIONS
-                .insert(key.clone(), CountMarkerState::Pending)
-                .await;
+        if cache::reserve_count_marker(state, session_token, pending, ttl_secs).await {
             return Ok(CountReservation::Reserved);
         }
 
@@ -467,14 +448,16 @@ async fn mark_counted(
     session_token: &str,
     payload: &ShareStreamSessionPayload,
 ) -> Result<()> {
-    let key = counted_cache_key(session_token);
     let ttl_secs = ttl_seconds(payload)?;
     let counted = CountMarkerState::Counted;
-    FALLBACK_COUNTED_SESSIONS.insert(key.clone(), counted).await;
-    state
-        .cache()
-        .set_bytes(&key, encode_marker_state(counted)?, Some(ttl_secs))
-        .await;
+    cache::store_count_marker(
+        state,
+        session_token,
+        counted,
+        encode_marker_state(counted)?,
+        ttl_secs,
+    )
+    .await;
     Ok(())
 }
 
@@ -482,31 +465,11 @@ async fn count_marker_state(
     state: &impl SharedRuntimeState,
     session_token: &str,
 ) -> Option<CountMarkerState> {
-    count_marker_state_by_key(state, &counted_cache_key(session_token)).await
-}
-
-async fn count_marker_state_by_key(
-    state: &impl SharedRuntimeState,
-    key: &str,
-) -> Option<CountMarkerState> {
-    let primary = state.cache().get::<CountMarkerState>(key).await;
-    let fallback = FALLBACK_COUNTED_SESSIONS.get(key).await;
-
-    match (primary, fallback) {
-        (Some(CountMarkerState::Counted), _) | (_, Some(CountMarkerState::Counted)) => {
-            Some(CountMarkerState::Counted)
-        }
-        (Some(CountMarkerState::Pending), _) | (_, Some(CountMarkerState::Pending)) => {
-            Some(CountMarkerState::Pending)
-        }
-        (None, None) => None,
-    }
+    cache::load_count_marker(state, session_token).await
 }
 
 async fn release_counted_marker(state: &impl SharedRuntimeState, session_token: &str) {
-    let key = counted_cache_key(session_token);
-    state.cache().delete(&key).await;
-    FALLBACK_COUNTED_SESSIONS.remove(&key).await;
+    cache::delete_count_marker(state, session_token).await;
 }
 
 fn ttl_seconds(payload: &ShareStreamSessionPayload) -> Result<u64> {
@@ -518,10 +481,6 @@ fn ttl_seconds(payload: &ShareStreamSessionPayload) -> Result<u64> {
         "share stream session ttl conversion failed",
         AsterError::internal_error,
     )
-}
-
-fn counted_cache_key(session_token: &str) -> String {
-    format!("{SHARE_STREAM_COUNTED_CACHE_PREFIX}{session_token}")
 }
 
 fn encode_marker_state(state: CountMarkerState) -> Result<Vec<u8>> {

--- a/src/services/share_stream_service.rs
+++ b/src/services/share_stream_service.rs
@@ -430,8 +430,7 @@ async fn ensure_counted_once(
             None => {}
         }
 
-        let pending = encode_marker_state(CountMarkerState::Pending)?;
-        if cache::reserve_count_marker(state, session_token, pending, ttl_secs).await {
+        if cache::reserve_count_marker(state, session_token, ttl_secs).await? {
             return Ok(CountReservation::Reserved);
         }
 
@@ -449,16 +448,7 @@ async fn mark_counted(
     payload: &ShareStreamSessionPayload,
 ) -> Result<()> {
     let ttl_secs = ttl_seconds(payload)?;
-    let counted = CountMarkerState::Counted;
-    cache::store_count_marker(
-        state,
-        session_token,
-        counted,
-        encode_marker_state(counted)?,
-        ttl_secs,
-    )
-    .await;
-    Ok(())
+    cache::store_count_marker(state, session_token, CountMarkerState::Counted, ttl_secs).await
 }
 
 async fn count_marker_state(
@@ -479,13 +469,6 @@ fn ttl_seconds(payload: &ShareStreamSessionPayload) -> Result<u64> {
     }
     u64::try_from(remaining).map_aster_err_ctx(
         "share stream session ttl conversion failed",
-        AsterError::internal_error,
-    )
-}
-
-fn encode_marker_state(state: CountMarkerState) -> Result<Vec<u8>> {
-    serde_json::to_vec(&state).map_aster_err_ctx(
-        "failed to encode share stream count marker",
         AsterError::internal_error,
     )
 }

--- a/src/services/share_stream_service/cache.rs
+++ b/src/services/share_stream_service/cache.rs
@@ -1,0 +1,157 @@
+//! 公开分享流式下载计数缓存。
+
+use std::sync::LazyLock;
+use std::time::Duration as StdDuration;
+
+use moka::future::Cache;
+
+use crate::cache::CacheExt;
+use crate::config::operations;
+use crate::runtime::SharedRuntimeState;
+
+use super::CountMarkerState;
+
+const SHARE_STREAM_COUNTED_CACHE_PREFIX: &str = "share_stream_session_counted:";
+
+static FALLBACK_COUNTED_SESSIONS: LazyLock<Cache<String, CountMarkerState>> = LazyLock::new(|| {
+    Cache::builder()
+        .max_capacity(10_000)
+        .time_to_live(StdDuration::from_secs(
+            operations::MAX_SHARE_STREAM_SESSION_TTL_SECS,
+        ))
+        .build()
+});
+
+fn counted_cache_key(session_token: &str) -> String {
+    format!("{SHARE_STREAM_COUNTED_CACHE_PREFIX}{session_token}")
+}
+
+pub(super) async fn load_count_marker(
+    state: &impl SharedRuntimeState,
+    session_token: &str,
+) -> Option<CountMarkerState> {
+    let key = counted_cache_key(session_token);
+    let primary = state.cache().get::<CountMarkerState>(&key).await;
+    let fallback = FALLBACK_COUNTED_SESSIONS.get(&key).await;
+
+    match (primary, fallback) {
+        (Some(CountMarkerState::Counted), _) | (_, Some(CountMarkerState::Counted)) => {
+            Some(CountMarkerState::Counted)
+        }
+        (Some(CountMarkerState::Pending), _) | (_, Some(CountMarkerState::Pending)) => {
+            Some(CountMarkerState::Pending)
+        }
+        (None, None) => None,
+    }
+}
+
+pub(super) async fn reserve_count_marker(
+    state: &impl SharedRuntimeState,
+    session_token: &str,
+    encoded_pending: Vec<u8>,
+    ttl_secs: u64,
+) -> bool {
+    let key = counted_cache_key(session_token);
+    if state
+        .cache()
+        .set_bytes_if_absent(&key, encoded_pending, Some(ttl_secs))
+        .await
+    {
+        FALLBACK_COUNTED_SESSIONS
+            .insert(key, CountMarkerState::Pending)
+            .await;
+        return true;
+    }
+    false
+}
+
+pub(super) async fn store_count_marker(
+    state: &impl SharedRuntimeState,
+    session_token: &str,
+    marker: CountMarkerState,
+    encoded_marker: Vec<u8>,
+    ttl_secs: u64,
+) {
+    let key = counted_cache_key(session_token);
+    FALLBACK_COUNTED_SESSIONS.insert(key.clone(), marker).await;
+    state
+        .cache()
+        .set_bytes(&key, encoded_marker, Some(ttl_secs))
+        .await;
+}
+
+pub(super) async fn delete_count_marker(state: &impl SharedRuntimeState, session_token: &str) {
+    let key = counted_cache_key(session_token);
+    state.cache().delete(&key).await;
+    FALLBACK_COUNTED_SESSIONS.remove(&key).await;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cache::CacheExt;
+    use crate::runtime::test_support::CacheOnlyState;
+
+    fn encoded(marker: CountMarkerState) -> Vec<u8> {
+        serde_json::to_vec(&marker).expect("marker should serialize")
+    }
+
+    #[tokio::test]
+    async fn count_marker_reservation_is_single_use_and_delete_clears_it() {
+        let state = CacheOnlyState::new().await;
+
+        assert!(
+            reserve_count_marker(&state, "session-a", encoded(CountMarkerState::Pending), 60).await
+        );
+        assert!(
+            !reserve_count_marker(&state, "session-a", encoded(CountMarkerState::Pending), 60)
+                .await
+        );
+        assert_eq!(
+            load_count_marker(&state, "session-a").await,
+            Some(CountMarkerState::Pending)
+        );
+
+        delete_count_marker(&state, "session-a").await;
+
+        assert!(load_count_marker(&state, "session-a").await.is_none());
+    }
+
+    #[tokio::test]
+    async fn counted_marker_has_priority_over_pending_marker() {
+        let state = CacheOnlyState::new().await;
+        let key = counted_cache_key("session-priority");
+
+        state
+            .cache()
+            .set(&key, &CountMarkerState::Pending, Some(60))
+            .await;
+        FALLBACK_COUNTED_SESSIONS
+            .insert(key, CountMarkerState::Counted)
+            .await;
+
+        assert_eq!(
+            load_count_marker(&state, "session-priority").await,
+            Some(CountMarkerState::Counted)
+        );
+    }
+
+    #[tokio::test]
+    async fn storing_counted_updates_primary_and_fallback() {
+        let state = CacheOnlyState::new().await;
+
+        store_count_marker(
+            &state,
+            "session-counted",
+            CountMarkerState::Counted,
+            encoded(CountMarkerState::Counted),
+            60,
+        )
+        .await;
+
+        assert_eq!(
+            load_count_marker(&state, "session-counted").await,
+            Some(CountMarkerState::Counted)
+        );
+    }
+}

--- a/src/services/share_stream_service/cache.rs
+++ b/src/services/share_stream_service/cache.rs
@@ -7,6 +7,7 @@ use moka::future::Cache;
 
 use crate::cache::CacheExt;
 use crate::config::operations;
+use crate::errors::{AsterError, MapAsterErr, Result};
 use crate::runtime::SharedRuntimeState;
 
 use super::CountMarkerState;
@@ -48,10 +49,10 @@ pub(super) async fn load_count_marker(
 pub(super) async fn reserve_count_marker(
     state: &impl SharedRuntimeState,
     session_token: &str,
-    encoded_pending: Vec<u8>,
     ttl_secs: u64,
-) -> bool {
+) -> Result<bool> {
     let key = counted_cache_key(session_token);
+    let encoded_pending = encode_marker_state(CountMarkerState::Pending)?;
     if state
         .cache()
         .set_bytes_if_absent(&key, encoded_pending, Some(ttl_secs))
@@ -60,24 +61,25 @@ pub(super) async fn reserve_count_marker(
         FALLBACK_COUNTED_SESSIONS
             .insert(key, CountMarkerState::Pending)
             .await;
-        return true;
+        return Ok(true);
     }
-    false
+    Ok(false)
 }
 
 pub(super) async fn store_count_marker(
     state: &impl SharedRuntimeState,
     session_token: &str,
     marker: CountMarkerState,
-    encoded_marker: Vec<u8>,
     ttl_secs: u64,
-) {
+) -> Result<()> {
     let key = counted_cache_key(session_token);
+    let encoded_marker = encode_marker_state(marker)?;
     FALLBACK_COUNTED_SESSIONS.insert(key.clone(), marker).await;
     state
         .cache()
         .set_bytes(&key, encoded_marker, Some(ttl_secs))
         .await;
+    Ok(())
 }
 
 pub(super) async fn delete_count_marker(state: &impl SharedRuntimeState, session_token: &str) {
@@ -86,27 +88,25 @@ pub(super) async fn delete_count_marker(state: &impl SharedRuntimeState, session
     FALLBACK_COUNTED_SESSIONS.remove(&key).await;
 }
 
+fn encode_marker_state(state: CountMarkerState) -> Result<Vec<u8>> {
+    serde_json::to_vec(&state).map_aster_err_ctx(
+        "failed to encode share stream count marker",
+        AsterError::internal_error,
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::cache::CacheExt;
     use crate::runtime::test_support::CacheOnlyState;
 
-    fn encoded(marker: CountMarkerState) -> Vec<u8> {
-        serde_json::to_vec(&marker).expect("marker should serialize")
-    }
-
     #[tokio::test]
     async fn count_marker_reservation_is_single_use_and_delete_clears_it() {
         let state = CacheOnlyState::new().await;
 
-        assert!(
-            reserve_count_marker(&state, "session-a", encoded(CountMarkerState::Pending), 60).await
-        );
-        assert!(
-            !reserve_count_marker(&state, "session-a", encoded(CountMarkerState::Pending), 60)
-                .await
-        );
+        assert!(reserve_count_marker(&state, "session-a", 60).await.unwrap());
+        assert!(!reserve_count_marker(&state, "session-a", 60).await.unwrap());
         assert_eq!(
             load_count_marker(&state, "session-a").await,
             Some(CountMarkerState::Pending)
@@ -139,15 +139,9 @@ mod tests {
     #[tokio::test]
     async fn storing_counted_updates_primary_and_fallback() {
         let state = CacheOnlyState::new().await;
-
-        store_count_marker(
-            &state,
-            "session-counted",
-            CountMarkerState::Counted,
-            encoded(CountMarkerState::Counted),
-            60,
-        )
-        .await;
+        store_count_marker(&state, "session-counted", CountMarkerState::Counted, 60)
+            .await
+            .unwrap();
 
         assert_eq!(
             load_count_marker(&state, "session-counted").await,

--- a/src/services/stream_ticket_service.rs
+++ b/src/services/stream_ticket_service.rs
@@ -1,14 +1,12 @@
 //! 服务模块：`stream_ticket_service`。
 
+mod cache;
+
 use chrono::{DateTime, Duration, Utc};
-use moka::future::Cache;
 use serde::{Deserialize, Serialize};
-use std::sync::LazyLock;
-use std::time::Duration as StdDuration;
 #[cfg(all(debug_assertions, feature = "openapi"))]
 use utoipa::ToSchema;
 
-use crate::cache::CacheExt;
 use crate::config::site_url;
 use crate::errors::{AsterError, MapAsterErr, Result};
 use crate::runtime::SharedRuntimeState;
@@ -18,16 +16,6 @@ use crate::services::{
 };
 
 const STREAM_TICKET_TTL_SECS: i64 = 5 * 60;
-const STREAM_TICKET_CACHE_PREFIX: &str = "stream_ticket:";
-static FALLBACK_STREAM_TICKETS: LazyLock<Cache<String, StreamTicketPayload>> =
-    LazyLock::new(|| {
-        Cache::builder()
-            .max_capacity(10_000)
-            .time_to_live(StdDuration::from_secs(
-                u64::try_from(STREAM_TICKET_TTL_SECS).unwrap_or(300),
-            ))
-            .build()
-    });
 
 #[derive(Debug, Clone, Serialize)]
 #[cfg_attr(all(debug_assertions, feature = "openapi"), derive(ToSchema))]
@@ -82,8 +70,7 @@ pub(crate) async fn create_archive_download_ticket_in_scope(
         },
     };
 
-    let cache_key = cache_key(&token);
-    store_ticket(state, &cache_key, &payload, ttl_secs_until(expires_at)?).await?;
+    cache::store_ticket(state, &token, &payload, ttl_secs_until(expires_at)?).await?;
 
     Ok(StreamTicketInfo {
         download_path: stream_download_path(state.runtime_config(), scope, &token),
@@ -113,8 +100,7 @@ pub(crate) async fn create_shared_archive_download_ticket(
         },
     };
 
-    let cache_key = cache_key(&token);
-    store_ticket(state, &cache_key, &payload, ttl_secs_until(expires_at)?).await?;
+    cache::store_ticket(state, &token, &payload, ttl_secs_until(expires_at)?).await?;
 
     Ok(StreamTicketInfo {
         download_path: shared_stream_download_path(state.runtime_config(), share_token, &token),
@@ -128,14 +114,13 @@ pub(crate) async fn resolve_archive_download_ticket_in_scope(
     scope: WorkspaceStorageScope,
     token: &str,
 ) -> Result<task_service::types::CreateArchiveTaskParams> {
-    let cache_key = cache_key(token);
-    let payload = load_ticket(state, &cache_key)
+    let payload = cache::load_ticket(state, token)
         .await
         .ok_or_else(|| AsterError::validation_error("stream ticket not found or expired"))?;
 
     let expires_at = decode_expiry(payload.exp)?;
     if expires_at < Utc::now() {
-        delete_ticket(state, &cache_key).await;
+        cache::delete_ticket(state, token).await;
         return Err(AsterError::validation_error("stream ticket expired"));
     }
 
@@ -163,14 +148,13 @@ pub(crate) async fn resolve_shared_archive_download_ticket(
     share_token: &str,
     token: &str,
 ) -> Result<task_service::types::CreateArchiveTaskParams> {
-    let cache_key = cache_key(token);
-    let payload = load_ticket(state, &cache_key)
+    let payload = cache::load_ticket(state, token)
         .await
         .ok_or_else(|| AsterError::validation_error("stream ticket not found or expired"))?;
 
     let expires_at = decode_expiry(payload.exp)?;
     if expires_at < Utc::now() {
-        delete_ticket(state, &cache_key).await;
+        cache::delete_ticket(state, token).await;
         return Err(AsterError::validation_error("stream ticket expired"));
     }
 
@@ -194,51 +178,6 @@ pub(crate) async fn resolve_shared_archive_download_ticket(
             "stream ticket belongs to a workspace archive download",
         )),
     }
-}
-
-fn cache_key(token: &str) -> String {
-    format!("{STREAM_TICKET_CACHE_PREFIX}{token}")
-}
-
-async fn store_ticket(
-    state: &impl SharedRuntimeState,
-    cache_key: &str,
-    payload: &StreamTicketPayload,
-    ttl_secs: u64,
-) -> Result<()> {
-    state.cache().set(cache_key, payload, Some(ttl_secs)).await;
-    if state
-        .cache()
-        .get::<StreamTicketPayload>(cache_key)
-        .await
-        .is_some()
-    {
-        return Ok(());
-    }
-
-    tracing::warn!(
-        "stream ticket cache backend did not persist entry; falling back to local cache"
-    );
-    FALLBACK_STREAM_TICKETS
-        .insert(cache_key.to_string(), payload.clone())
-        .await;
-    Ok(())
-}
-
-async fn load_ticket(
-    state: &impl SharedRuntimeState,
-    cache_key: &str,
-) -> Option<StreamTicketPayload> {
-    if let Some(payload) = state.cache().get::<StreamTicketPayload>(cache_key).await {
-        return Some(payload);
-    }
-
-    FALLBACK_STREAM_TICKETS.get(cache_key).await
-}
-
-async fn delete_ticket(state: &impl SharedRuntimeState, cache_key: &str) {
-    state.cache().delete(cache_key).await;
-    FALLBACK_STREAM_TICKETS.remove(cache_key).await;
 }
 
 fn ttl_secs_until(expires_at: DateTime<Utc>) -> Result<u64> {

--- a/src/services/stream_ticket_service/cache.rs
+++ b/src/services/stream_ticket_service/cache.rs
@@ -1,0 +1,144 @@
+//! 临时下载 ticket 缓存。
+
+use std::sync::LazyLock;
+use std::time::Duration as StdDuration;
+
+use moka::future::Cache;
+
+use crate::cache::CacheExt;
+use crate::errors::Result;
+use crate::runtime::SharedRuntimeState;
+
+use super::{STREAM_TICKET_TTL_SECS, StreamTicketPayload};
+
+const STREAM_TICKET_CACHE_PREFIX: &str = "stream_ticket:";
+
+static FALLBACK_STREAM_TICKETS: LazyLock<Cache<String, StreamTicketPayload>> =
+    LazyLock::new(|| {
+        Cache::builder()
+            .max_capacity(10_000)
+            .time_to_live(StdDuration::from_secs(
+                u64::try_from(STREAM_TICKET_TTL_SECS).unwrap_or(300),
+            ))
+            .build()
+    });
+
+fn ticket_cache_key(token: &str) -> String {
+    format!("{STREAM_TICKET_CACHE_PREFIX}{token}")
+}
+
+pub(super) async fn store_ticket(
+    state: &impl SharedRuntimeState,
+    token: &str,
+    payload: &StreamTicketPayload,
+    ttl_secs: u64,
+) -> Result<()> {
+    let cache_key = ticket_cache_key(token);
+    state.cache().set(&cache_key, payload, Some(ttl_secs)).await;
+    if state
+        .cache()
+        .get::<StreamTicketPayload>(&cache_key)
+        .await
+        .is_some()
+    {
+        return Ok(());
+    }
+
+    tracing::warn!(
+        "stream ticket cache backend did not persist entry; falling back to local cache"
+    );
+    FALLBACK_STREAM_TICKETS
+        .insert(cache_key, payload.clone())
+        .await;
+    Ok(())
+}
+
+pub(super) async fn load_ticket(
+    state: &impl SharedRuntimeState,
+    token: &str,
+) -> Option<StreamTicketPayload> {
+    let cache_key = ticket_cache_key(token);
+    if let Some(payload) = state.cache().get::<StreamTicketPayload>(&cache_key).await {
+        return Some(payload);
+    }
+
+    FALLBACK_STREAM_TICKETS.get(&cache_key).await
+}
+
+pub(super) async fn delete_ticket(state: &impl SharedRuntimeState, token: &str) {
+    let cache_key = ticket_cache_key(token);
+    state.cache().delete(&cache_key).await;
+    FALLBACK_STREAM_TICKETS.remove(&cache_key).await;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cache::CacheExt;
+    use crate::runtime::test_support::CacheOnlyState;
+
+    fn payload(exp: i64) -> StreamTicketPayload {
+        StreamTicketPayload {
+            actor_user_id: 42,
+            team_id: None,
+            exp,
+            kind: super::super::StreamTicketKind::ArchiveDownload {
+                file_ids: vec![1, 2],
+                folder_ids: vec![3],
+                archive_name: "archive.zip".to_string(),
+            },
+        }
+    }
+
+    #[tokio::test]
+    async fn ticket_roundtrips_through_primary_cache_and_delete_removes_it() {
+        let state = CacheOnlyState::new().await;
+
+        store_ticket(&state, "token-a", &payload(100), 60)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            load_ticket(&state, "token-a")
+                .await
+                .map(|cached| cached.actor_user_id),
+            Some(42)
+        );
+
+        delete_ticket(&state, "token-a").await;
+
+        assert!(load_ticket(&state, "token-a").await.is_none());
+    }
+
+    #[tokio::test]
+    async fn ticket_delete_removes_fallback_entry_even_if_primary_is_missing() {
+        let state = CacheOnlyState::new().await;
+        let key = ticket_cache_key("token-fallback");
+        FALLBACK_STREAM_TICKETS
+            .insert(key.clone(), payload(100))
+            .await;
+
+        assert!(load_ticket(&state, "token-fallback").await.is_some());
+
+        delete_ticket(&state, "token-fallback").await;
+
+        assert!(load_ticket(&state, "token-fallback").await.is_none());
+    }
+
+    #[tokio::test]
+    async fn ticket_primary_cache_wins_over_fallback() {
+        let state = CacheOnlyState::new().await;
+        let key = ticket_cache_key("token-priority");
+        FALLBACK_STREAM_TICKETS
+            .insert(key.clone(), payload(10))
+            .await;
+        state.cache().set(&key, &payload(20), Some(60)).await;
+
+        assert_eq!(
+            load_ticket(&state, "token-priority")
+                .await
+                .map(|cached| cached.exp),
+            Some(20)
+        );
+    }
+}

--- a/src/services/workspace_scope_service.rs
+++ b/src/services/workspace_scope_service.rs
@@ -4,17 +4,16 @@
 //! 这里负责把 scope 相关规则收口，避免每个上层 service 都自己拼一套
 //! `user_id` / `team_id` / `actor_user_id` 判断。
 
+mod cache;
+
 use crate::api::api_error_code::ApiErrorCode;
 use crate::db::repository::{file_repo, folder_repo, team_member_repo, team_repo, user_repo};
 use crate::entities::{file, folder};
 use crate::errors::{AsterError, Result, auth_forbidden_with_code};
 use crate::runtime::SharedRuntimeState;
-use crate::{cache::CacheExt, types::TeamMemberRole};
+use crate::types::TeamMemberRole;
 use sea_orm::ConnectionTrait;
 use serde::{Deserialize, Serialize};
-
-const TEAM_ACCESS_CACHE_TTL: u64 = 60;
-const ACTOR_USERNAME_CACHE_TTL: u64 = 60;
 
 /// scope 同时表达“资源属于哪个空间”和“是谁在操作”。
 ///
@@ -78,26 +77,11 @@ impl From<team_member_repo::ActiveTeamAccessSnapshot> for CachedTeamAccess {
     }
 }
 
-fn team_access_cache_prefix(team_id: i64) -> String {
-    format!("team_access:{team_id}:")
-}
-
-fn team_access_cache_key(team_id: i64, user_id: i64) -> String {
-    format!("{}{}", team_access_cache_prefix(team_id), user_id)
-}
-
-fn actor_username_cache_key(user_id: i64) -> String {
-    format!("actor_username:{user_id}")
-}
-
 pub(crate) async fn invalidate_team_access_cache_for_team(
     state: &impl SharedRuntimeState,
     team_id: i64,
 ) {
-    state
-        .cache()
-        .invalidate_prefix(&team_access_cache_prefix(team_id))
-        .await;
+    cache::invalidate_team_access_for_team(state, team_id).await;
 }
 
 pub(crate) async fn invalidate_team_access_cache_for_member(
@@ -105,10 +89,7 @@ pub(crate) async fn invalidate_team_access_cache_for_member(
     team_id: i64,
     user_id: i64,
 ) {
-    state
-        .cache()
-        .delete(&team_access_cache_key(team_id, user_id))
-        .await;
+    cache::invalidate_team_access_for_member(state, team_id, user_id).await;
 }
 
 impl WorkspaceStorageScope {
@@ -140,12 +121,11 @@ async fn load_team_access<C: ConnectionTrait>(
     team_id: i64,
     user_id: i64,
 ) -> Result<CachedTeamAccess> {
-    let cache_key = team_access_cache_key(team_id, user_id);
-    if let Some(cached) = state.cache().get::<CachedTeamAccess>(&cache_key).await {
+    if let Some(cached) = cache::load_team_access(state, team_id, user_id).await {
         let access = match load_team_access_from_database(db, team_id, user_id).await {
             Ok(access) => access,
             Err(error @ (AsterError::RecordNotFound(_) | AsterError::AuthForbidden(_))) => {
-                state.cache().delete(&cache_key).await;
+                cache::invalidate_team_access_for_member(state, team_id, user_id).await;
                 return Err(error);
             }
             Err(error) => return Err(error),
@@ -153,10 +133,7 @@ async fn load_team_access<C: ConnectionTrait>(
         if access == cached {
             tracing::debug!(team_id, user_id, "team access cache hit");
         } else {
-            state
-                .cache()
-                .set(&cache_key, &access, Some(TEAM_ACCESS_CACHE_TTL))
-                .await;
+            cache::store_team_access(state, team_id, user_id, &access).await;
             tracing::debug!(
                 team_id,
                 user_id,
@@ -167,10 +144,7 @@ async fn load_team_access<C: ConnectionTrait>(
     }
 
     let access = load_team_access_from_database(db, team_id, user_id).await?;
-    state
-        .cache()
-        .set(&cache_key, &access, Some(TEAM_ACCESS_CACHE_TTL))
-        .await;
+    cache::store_team_access(state, team_id, user_id, &access).await;
     tracing::debug!(team_id, user_id, "team access cache miss");
     Ok(access)
 }
@@ -230,17 +204,13 @@ pub(crate) async fn load_scope_actor_username_cached(
     scope: WorkspaceStorageScope,
 ) -> Result<String> {
     let user_id = scope.actor_user_id();
-    let cache_key = actor_username_cache_key(user_id);
-    if let Some(username) = state.cache().get::<String>(&cache_key).await {
+    if let Some(username) = cache::load_actor_username(state, user_id).await {
         tracing::debug!(user_id, "actor username cache hit");
         return Ok(username);
     }
 
     let username = load_scope_actor_username(state.reader_db(), scope).await?;
-    state
-        .cache()
-        .set(&cache_key, &username, Some(ACTOR_USERNAME_CACHE_TTL))
-        .await;
+    cache::store_actor_username(state, user_id, &username).await;
     tracing::debug!(user_id, "actor username cache miss");
     Ok(username)
 }

--- a/src/services/workspace_scope_service/cache.rs
+++ b/src/services/workspace_scope_service/cache.rs
@@ -1,0 +1,159 @@
+//! 工作空间 scope 权限缓存。
+
+use crate::cache::CacheExt;
+use crate::runtime::SharedRuntimeState;
+
+use super::CachedTeamAccess;
+
+const TEAM_ACCESS_CACHE_TTL: u64 = 60;
+const ACTOR_USERNAME_CACHE_TTL: u64 = 60;
+
+fn team_access_cache_prefix(team_id: i64) -> String {
+    format!("team_access:{team_id}:")
+}
+
+fn team_access_cache_key(team_id: i64, user_id: i64) -> String {
+    format!("{}{}", team_access_cache_prefix(team_id), user_id)
+}
+
+fn actor_username_cache_key(user_id: i64) -> String {
+    format!("actor_username:{user_id}")
+}
+
+pub(super) async fn load_team_access(
+    state: &impl SharedRuntimeState,
+    team_id: i64,
+    user_id: i64,
+) -> Option<CachedTeamAccess> {
+    state
+        .cache()
+        .get::<CachedTeamAccess>(&team_access_cache_key(team_id, user_id))
+        .await
+}
+
+pub(super) async fn store_team_access(
+    state: &impl SharedRuntimeState,
+    team_id: i64,
+    user_id: i64,
+    access: &CachedTeamAccess,
+) {
+    state
+        .cache()
+        .set(
+            &team_access_cache_key(team_id, user_id),
+            access,
+            Some(TEAM_ACCESS_CACHE_TTL),
+        )
+        .await;
+}
+
+pub(super) async fn invalidate_team_access_for_team(state: &impl SharedRuntimeState, team_id: i64) {
+    state
+        .cache()
+        .invalidate_prefix(&team_access_cache_prefix(team_id))
+        .await;
+}
+
+pub(super) async fn invalidate_team_access_for_member(
+    state: &impl SharedRuntimeState,
+    team_id: i64,
+    user_id: i64,
+) {
+    state
+        .cache()
+        .delete(&team_access_cache_key(team_id, user_id))
+        .await;
+}
+
+pub(super) async fn load_actor_username(
+    state: &impl SharedRuntimeState,
+    user_id: i64,
+) -> Option<String> {
+    state
+        .cache()
+        .get::<String>(&actor_username_cache_key(user_id))
+        .await
+}
+
+pub(super) async fn store_actor_username(
+    state: &impl SharedRuntimeState,
+    user_id: i64,
+    username: &str,
+) {
+    state
+        .cache()
+        .set(
+            &actor_username_cache_key(user_id),
+            &username,
+            Some(ACTOR_USERNAME_CACHE_TTL),
+        )
+        .await;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runtime::test_support::CacheOnlyState;
+    use crate::types::TeamMemberRole;
+
+    fn access(team_id: i64, role: TeamMemberRole) -> CachedTeamAccess {
+        CachedTeamAccess {
+            team_id,
+            policy_group_id: Some(team_id * 10),
+            role,
+        }
+    }
+
+    #[tokio::test]
+    async fn team_access_member_invalidation_does_not_drop_other_members() {
+        let state = CacheOnlyState::new().await;
+
+        store_team_access(&state, 7, 10, &access(7, TeamMemberRole::Member)).await;
+        store_team_access(&state, 7, 11, &access(7, TeamMemberRole::Admin)).await;
+
+        invalidate_team_access_for_member(&state, 7, 10).await;
+
+        assert!(load_team_access(&state, 7, 10).await.is_none());
+        assert_eq!(
+            load_team_access(&state, 7, 11)
+                .await
+                .map(|cached| cached.role),
+            Some(TeamMemberRole::Admin)
+        );
+    }
+
+    #[tokio::test]
+    async fn team_access_team_invalidation_is_prefix_scoped() {
+        let state = CacheOnlyState::new().await;
+
+        store_team_access(&state, 7, 10, &access(7, TeamMemberRole::Member)).await;
+        store_team_access(&state, 8, 10, &access(8, TeamMemberRole::Owner)).await;
+
+        invalidate_team_access_for_team(&state, 7).await;
+
+        assert!(load_team_access(&state, 7, 10).await.is_none());
+        assert_eq!(
+            load_team_access(&state, 8, 10)
+                .await
+                .map(|cached| cached.role),
+            Some(TeamMemberRole::Owner)
+        );
+    }
+
+    #[tokio::test]
+    async fn actor_username_is_scoped_by_user_id() {
+        let state = CacheOnlyState::new().await;
+
+        store_actor_username(&state, 10, "alice").await;
+        store_actor_username(&state, 11, "bob").await;
+
+        assert_eq!(
+            load_actor_username(&state, 10).await.as_deref(),
+            Some("alice")
+        );
+        assert_eq!(
+            load_actor_username(&state, 11).await.as_deref(),
+            Some("bob")
+        );
+    }
+}

--- a/src/webdav/auth.rs
+++ b/src/webdav/auth.rs
@@ -1,17 +1,17 @@
 //! WebDAV 子模块：`auth`。
 
+#[path = "auth/cache.rs"]
+mod cache;
+
 use base64::Engine;
 use serde::{Deserialize, Serialize};
 
 use crate::api::api_error_code::ApiErrorCode;
-use crate::cache::CacheExt;
 use crate::db::repository::{user_repo, webdav_account_repo};
 use crate::errors::{AsterError, MapAsterErr, auth_forbidden_with_code};
 use crate::runtime::SharedRuntimeState;
 use crate::services::workspace_storage_service::WorkspaceStorageScope;
 use crate::utils::hash;
-
-const WEBDAV_AUTH_CACHE_TTL: u64 = 60;
 
 /// WebDAV 认证结果
 #[derive(Debug)]
@@ -43,34 +43,11 @@ impl CachedWebdavAuth {
     }
 }
 
-fn username_cache_component(username: &str) -> String {
-    hash::sha256_hex(username.as_bytes())
-}
-
-fn password_cache_component(password: &str) -> String {
-    hash::sha256_hex(password.as_bytes())
-}
-
-fn webdav_auth_cache_prefix(username: &str) -> String {
-    format!("webdav_auth:{}:", username_cache_component(username))
-}
-
-fn webdav_auth_cache_key(username: &str, password: &str) -> String {
-    format!(
-        "{}{}",
-        webdav_auth_cache_prefix(username),
-        password_cache_component(password)
-    )
-}
-
 pub(crate) async fn invalidate_webdav_auth_for_username(
     state: &impl SharedRuntimeState,
     username: &str,
 ) {
-    state
-        .cache()
-        .invalidate_prefix(&webdav_auth_cache_prefix(username))
-        .await;
+    cache::invalidate_for_username(state, username).await;
 }
 
 pub(crate) async fn invalidate_webdav_auth_for_user(
@@ -120,10 +97,9 @@ async fn authenticate_basic(
         .split_once(':')
         .ok_or_else(|| AsterError::auth_invalid_credentials("invalid basic auth format"))?;
 
-    let cache_key = webdav_auth_cache_key(username, password);
-    if let Some(cached) = state.cache().get::<CachedWebdavAuth>(&cache_key).await {
+    if let Some(cached) = cache::load_auth(state, username, password).await {
         validate_cached_account(state, username, password, &cached).await?;
-        tracing::debug!(username_hash = %username_cache_component(username), "webdav auth cache hit");
+        tracing::debug!(username_hash = %cache::username_cache_component(username), "webdav auth cache hit");
         return Ok(WebdavAuthResult {
             scope: cached.scope(),
             root_folder_id: cached.root_folder_id,
@@ -173,20 +149,19 @@ async fn authenticate_basic(
         },
     };
 
-    state
-        .cache()
-        .set(
-            &cache_key,
-            &CachedWebdavAuth {
-                account_id: account.id,
-                user_id: account.user_id,
-                team_id: account.team_id,
-                root_folder_id: account.root_folder_id,
-            },
-            Some(WEBDAV_AUTH_CACHE_TTL),
-        )
-        .await;
-    tracing::debug!(username_hash = %username_cache_component(username), "webdav auth cache miss");
+    cache::store_auth(
+        state,
+        username,
+        password,
+        &CachedWebdavAuth {
+            account_id: account.id,
+            user_id: account.user_id,
+            team_id: account.team_id,
+            root_folder_id: account.root_folder_id,
+        },
+    )
+    .await;
+    tracing::debug!(username_hash = %cache::username_cache_component(username), "webdav auth cache miss");
     Ok(WebdavAuthResult {
         scope,
         root_folder_id: account.root_folder_id,

--- a/src/webdav/auth/cache.rs
+++ b/src/webdav/auth/cache.rs
@@ -1,0 +1,133 @@
+//! WebDAV 认证缓存。
+
+use crate::cache::CacheExt;
+use crate::runtime::SharedRuntimeState;
+use crate::utils::hash;
+
+use super::CachedWebdavAuth;
+
+const WEBDAV_AUTH_CACHE_TTL: u64 = 60;
+
+pub(super) fn username_cache_component(username: &str) -> String {
+    hash::sha256_hex(username.as_bytes())
+}
+
+fn password_cache_component(password: &str) -> String {
+    hash::sha256_hex(password.as_bytes())
+}
+
+fn auth_cache_prefix(username: &str) -> String {
+    format!("webdav_auth:{}:", username_cache_component(username))
+}
+
+fn auth_cache_key(username: &str, password: &str) -> String {
+    format!(
+        "{}{}",
+        auth_cache_prefix(username),
+        password_cache_component(password)
+    )
+}
+
+pub(super) async fn load_auth(
+    state: &impl SharedRuntimeState,
+    username: &str,
+    password: &str,
+) -> Option<CachedWebdavAuth> {
+    state
+        .cache()
+        .get::<CachedWebdavAuth>(&auth_cache_key(username, password))
+        .await
+}
+
+pub(super) async fn store_auth(
+    state: &impl SharedRuntimeState,
+    username: &str,
+    password: &str,
+    cached: &CachedWebdavAuth,
+) {
+    state
+        .cache()
+        .set(
+            &auth_cache_key(username, password),
+            cached,
+            Some(WEBDAV_AUTH_CACHE_TTL),
+        )
+        .await;
+}
+
+pub(super) async fn invalidate_for_username(state: &impl SharedRuntimeState, username: &str) {
+    state
+        .cache()
+        .invalidate_prefix(&auth_cache_prefix(username))
+        .await;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runtime::test_support::CacheOnlyState;
+
+    fn cached(account_id: i64) -> CachedWebdavAuth {
+        CachedWebdavAuth {
+            account_id,
+            user_id: 10,
+            team_id: None,
+            root_folder_id: Some(20),
+        }
+    }
+
+    #[tokio::test]
+    async fn auth_cache_key_hashes_username_and_password() {
+        let key = auth_cache_key("webdav-user", "secret-password");
+
+        assert!(key.starts_with("webdav_auth:"));
+        assert!(!key.contains("webdav-user"));
+        assert!(!key.contains("secret-password"));
+    }
+
+    #[tokio::test]
+    async fn auth_cache_is_scoped_by_username_and_password() {
+        let state = CacheOnlyState::new().await;
+
+        store_auth(&state, "alice", "password-a", &cached(1)).await;
+        store_auth(&state, "alice", "password-b", &cached(2)).await;
+        store_auth(&state, "bob", "password-a", &cached(3)).await;
+
+        assert_eq!(
+            load_auth(&state, "alice", "password-a")
+                .await
+                .map(|value| value.account_id),
+            Some(1)
+        );
+        assert_eq!(
+            load_auth(&state, "alice", "password-b")
+                .await
+                .map(|value| value.account_id),
+            Some(2)
+        );
+        assert_eq!(
+            load_auth(&state, "bob", "password-a")
+                .await
+                .map(|value| value.account_id),
+            Some(3)
+        );
+    }
+
+    #[tokio::test]
+    async fn username_invalidation_keeps_other_user_cache_entries() {
+        let state = CacheOnlyState::new().await;
+
+        store_auth(&state, "alice", "password-a", &cached(1)).await;
+        store_auth(&state, "bob", "password-a", &cached(2)).await;
+
+        invalidate_for_username(&state, "alice").await;
+
+        assert!(load_auth(&state, "alice", "password-a").await.is_none());
+        assert_eq!(
+            load_auth(&state, "bob", "password-a")
+                .await
+                .map(|value| value.account_id),
+            Some(2)
+        );
+    }
+}

--- a/src/webdav/path_resolver.rs
+++ b/src/webdav/path_resolver.rs
@@ -1,9 +1,10 @@
 //! WebDAV 子模块：`path_resolver`。
 
+mod cache;
+
 use sea_orm::{ConnectionTrait, DatabaseConnection};
 use serde::{Deserialize, Serialize};
 
-use crate::cache::CacheExt;
 use crate::db::repository::{file_repo, folder_repo};
 use crate::entities::{file, folder};
 use crate::errors::AsterError;
@@ -12,9 +13,7 @@ use crate::services::workspace_storage_service::WorkspaceStorageScope;
 use crate::utils::hash;
 use crate::webdav::dav::{DavPath, FsError};
 
-const WEBDAV_PATH_CACHE_TTL: u64 = 30;
-pub(crate) const WEBDAV_PATH_CACHE_PREFIX: &str = "webdav_path:";
-pub(crate) const WEBDAV_PARENT_CACHE_PREFIX: &str = "webdav_parent:";
+pub(crate) use cache::{WEBDAV_PARENT_CACHE_PREFIX, WEBDAV_PATH_CACHE_PREFIX};
 
 /// 路径解析结果
 #[derive(Debug, Clone)]
@@ -79,7 +78,7 @@ fn scope_cache_part(scope: WorkspaceStorageScope) -> String {
     }
 }
 
-fn resolve_path_cache_key(
+pub(super) fn resolve_path_cache_key(
     scope: WorkspaceStorageScope,
     path: &DavPath,
     root_folder_id: Option<i64>,
@@ -92,7 +91,7 @@ fn resolve_path_cache_key(
     )
 }
 
-fn resolve_parent_cache_key(
+pub(super) fn resolve_parent_cache_key(
     scope: WorkspaceStorageScope,
     path: &DavPath,
     root_folder_id: Option<i64>,
@@ -213,7 +212,7 @@ async fn load_cached_resolved_node(
             if segments.is_empty() {
                 Ok(Some(ResolvedNode::Root))
             } else {
-                state.cache().delete(cache_key).await;
+                cache::delete_by_key(state, cache_key).await;
                 Ok(None)
             }
         }
@@ -225,7 +224,7 @@ async fn load_cached_resolved_node(
             let folder = match folder_repo::find_by_id(state.writer_db(), id).await {
                 Ok(folder) => folder,
                 Err(error) if is_missing_entity(&error) => {
-                    state.cache().delete(cache_key).await;
+                    cache::delete_by_key(state, cache_key).await;
                     return Ok(None);
                 }
                 Err(_) => return Err(FsError::GeneralFailure),
@@ -234,18 +233,18 @@ async fn load_cached_resolved_node(
                 || crate::services::workspace_storage_service::ensure_folder_scope(&folder, scope)
                     .is_err()
             {
-                state.cache().delete(cache_key).await;
+                cache::delete_by_key(state, cache_key).await;
                 return Ok(None);
             }
             if segments.last().map(String::as_str) != Some(name.as_str())
                 || folder.name != name
                 || folder.parent_id != parent_id
             {
-                state.cache().delete(cache_key).await;
+                cache::delete_by_key(state, cache_key).await;
                 return Ok(None);
             }
             if !validate_cached_folder_path(state, scope, root_folder_id, id, &segments).await? {
-                state.cache().delete(cache_key).await;
+                cache::delete_by_key(state, cache_key).await;
                 return Ok(None);
             }
             Ok(Some(ResolvedNode::Folder(folder)))
@@ -258,7 +257,7 @@ async fn load_cached_resolved_node(
             let file = match file_repo::find_by_id(state.writer_db(), id).await {
                 Ok(file) => file,
                 Err(error) if is_missing_entity(&error) => {
-                    state.cache().delete(cache_key).await;
+                    cache::delete_by_key(state, cache_key).await;
                     return Ok(None);
                 }
                 Err(_) => return Err(FsError::GeneralFailure),
@@ -267,18 +266,18 @@ async fn load_cached_resolved_node(
                 || crate::services::workspace_storage_service::ensure_file_scope(&file, scope)
                     .is_err()
             {
-                state.cache().delete(cache_key).await;
+                cache::delete_by_key(state, cache_key).await;
                 return Ok(None);
             }
             if segments.last().map(String::as_str) != Some(name.as_str())
                 || file.name != name
                 || file.folder_id != folder_id
             {
-                state.cache().delete(cache_key).await;
+                cache::delete_by_key(state, cache_key).await;
                 return Ok(None);
             }
             let Some(parent_segments) = segments.get(..segments.len().saturating_sub(1)) else {
-                state.cache().delete(cache_key).await;
+                cache::delete_by_key(state, cache_key).await;
                 return Ok(None);
             };
             if !validate_cached_parent(
@@ -290,7 +289,7 @@ async fn load_cached_resolved_node(
             )
             .await?
             {
-                state.cache().delete(cache_key).await;
+                cache::delete_by_key(state, cache_key).await;
                 return Ok(None);
             }
             Ok(Some(ResolvedNode::File(file)))
@@ -419,7 +418,7 @@ pub(crate) async fn resolve_path_cached_in_scope(
     root_folder_id: Option<i64>,
 ) -> Result<ResolvedNode, FsError> {
     let cache_key = resolve_path_cache_key(scope, path, root_folder_id);
-    if let Some(cached) = state.cache().get::<CachedResolvedNode>(&cache_key).await
+    if let Some(cached) = cache::load_resolved_node_by_key(state, &cache_key).await
         && let Some(node) =
             load_cached_resolved_node(state, scope, path, root_folder_id, &cache_key, cached)
                 .await?
@@ -429,14 +428,7 @@ pub(crate) async fn resolve_path_cached_in_scope(
     }
 
     let node = resolve_path_in_scope(state.writer_db(), scope, path, root_folder_id).await?;
-    state
-        .cache()
-        .set(
-            &cache_key,
-            &cacheable_node(&node),
-            Some(WEBDAV_PATH_CACHE_TTL),
-        )
-        .await;
+    cache::store_resolved_node_by_key(state, &cache_key, &cacheable_node(&node)).await;
     tracing::debug!(?scope, root_folder_id, "webdav path cache miss");
     Ok(node)
 }
@@ -528,7 +520,7 @@ pub(crate) async fn resolve_parent_cached_in_scope(
 
     let parent_segments = &segments[..segments.len() - 1];
     let cache_key = resolve_parent_cache_key(scope, path, root_folder_id);
-    if let Some(cached) = state.cache().get::<CachedResolvedParent>(&cache_key).await {
+    if let Some(cached) = cache::load_resolved_parent_by_key(state, &cache_key).await {
         if validate_cached_parent(
             state,
             scope,
@@ -541,19 +533,12 @@ pub(crate) async fn resolve_parent_cached_in_scope(
             tracing::debug!(?scope, root_folder_id, "webdav parent path cache hit");
             return Ok((cached.parent_id, segments[segments.len() - 1].clone()));
         }
-        state.cache().delete(&cache_key).await;
+        cache::delete_by_key(state, &cache_key).await;
     }
 
     let (parent_id, name) =
         resolve_parent_in_scope(state.writer_db(), scope, path, root_folder_id).await?;
-    state
-        .cache()
-        .set(
-            &cache_key,
-            &CachedResolvedParent { parent_id },
-            Some(WEBDAV_PATH_CACHE_TTL),
-        )
-        .await;
+    cache::store_resolved_parent_by_key(state, &cache_key, parent_id).await;
     tracing::debug!(?scope, root_folder_id, "webdav parent path cache miss");
     Ok((parent_id, name))
 }

--- a/src/webdav/path_resolver/cache.rs
+++ b/src/webdav/path_resolver/cache.rs
@@ -1,0 +1,148 @@
+//! WebDAV 路径解析缓存。
+
+use crate::cache::CacheExt;
+use crate::runtime::SharedRuntimeState;
+
+use super::{CachedResolvedNode, CachedResolvedParent};
+
+const WEBDAV_PATH_CACHE_TTL: u64 = 30;
+pub(crate) const WEBDAV_PATH_CACHE_PREFIX: &str = "webdav_path:";
+pub(crate) const WEBDAV_PARENT_CACHE_PREFIX: &str = "webdav_parent:";
+
+pub(super) async fn load_resolved_node_by_key(
+    state: &impl SharedRuntimeState,
+    cache_key: &str,
+) -> Option<CachedResolvedNode> {
+    state.cache().get::<CachedResolvedNode>(cache_key).await
+}
+
+pub(super) async fn store_resolved_node_by_key(
+    state: &impl SharedRuntimeState,
+    cache_key: &str,
+    node: &CachedResolvedNode,
+) {
+    state
+        .cache()
+        .set(cache_key, node, Some(WEBDAV_PATH_CACHE_TTL))
+        .await;
+}
+
+pub(super) async fn load_resolved_parent_by_key(
+    state: &impl SharedRuntimeState,
+    cache_key: &str,
+) -> Option<CachedResolvedParent> {
+    state.cache().get::<CachedResolvedParent>(cache_key).await
+}
+
+pub(super) async fn store_resolved_parent_by_key(
+    state: &impl SharedRuntimeState,
+    cache_key: &str,
+    parent_id: Option<i64>,
+) {
+    state
+        .cache()
+        .set(
+            cache_key,
+            &CachedResolvedParent { parent_id },
+            Some(WEBDAV_PATH_CACHE_TTL),
+        )
+        .await;
+}
+
+pub(super) async fn delete_by_key(state: &impl SharedRuntimeState, cache_key: &str) {
+    state.cache().delete(cache_key).await;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runtime::test_support::CacheOnlyState;
+
+    #[tokio::test]
+    async fn resolved_node_cache_roundtrips_root_folder_and_file_variants() {
+        let state = CacheOnlyState::new().await;
+
+        let root_key = "webdav_path:test:root";
+        let folder_key = "webdav_path:test:folder";
+        let file_key = "webdav_path:test:file";
+
+        store_resolved_node_by_key(&state, root_key, &CachedResolvedNode::Root).await;
+        store_resolved_node_by_key(
+            &state,
+            folder_key,
+            &CachedResolvedNode::Folder {
+                id: 10,
+                parent_id: Some(1),
+                name: "docs".to_string(),
+            },
+        )
+        .await;
+        store_resolved_node_by_key(
+            &state,
+            file_key,
+            &CachedResolvedNode::File {
+                id: 20,
+                folder_id: Some(10),
+                name: "deck.pptx".to_string(),
+            },
+        )
+        .await;
+
+        assert!(matches!(
+            load_resolved_node_by_key(&state, root_key).await,
+            Some(CachedResolvedNode::Root)
+        ));
+        assert!(matches!(
+            load_resolved_node_by_key(&state, folder_key).await,
+            Some(CachedResolvedNode::Folder { id: 10, .. })
+        ));
+        assert!(matches!(
+            load_resolved_node_by_key(&state, file_key).await,
+            Some(CachedResolvedNode::File { id: 20, .. })
+        ));
+    }
+
+    #[tokio::test]
+    async fn resolved_parent_cache_roundtrips_none_and_some_parent_id() {
+        let state = CacheOnlyState::new().await;
+
+        store_resolved_parent_by_key(&state, "webdav_parent:test:none", None).await;
+        store_resolved_parent_by_key(&state, "webdav_parent:test:some", Some(42)).await;
+
+        assert_eq!(
+            load_resolved_parent_by_key(&state, "webdav_parent:test:none")
+                .await
+                .map(|cached| cached.parent_id),
+            Some(None)
+        );
+        assert_eq!(
+            load_resolved_parent_by_key(&state, "webdav_parent:test:some")
+                .await
+                .map(|cached| cached.parent_id),
+            Some(Some(42))
+        );
+    }
+
+    #[tokio::test]
+    async fn delete_by_key_removes_node_and_parent_entries() {
+        let state = CacheOnlyState::new().await;
+
+        store_resolved_node_by_key(&state, "webdav_path:test:delete", &CachedResolvedNode::Root)
+            .await;
+        store_resolved_parent_by_key(&state, "webdav_parent:test:delete", Some(42)).await;
+
+        delete_by_key(&state, "webdav_path:test:delete").await;
+        delete_by_key(&state, "webdav_parent:test:delete").await;
+
+        assert!(
+            load_resolved_node_by_key(&state, "webdav_path:test:delete")
+                .await
+                .is_none()
+        );
+        assert!(
+            load_resolved_parent_by_key(&state, "webdav_parent:test:delete")
+                .await
+                .is_none()
+        );
+    }
+}


### PR DESCRIPTION
…rehensive tests

Extract cache operations from service modules into dedicated cache submodules to improve separation of concerns and testability. Each cache module now encapsulates key generation, storage, retrieval, and invalidation logic for its domain.

**Changes:**
- Add `CacheOnlyState` test helper in `runtime::test_support` for cache-only testing
- Extract admin overview cache operations into `admin_service::cache` with scoping tests
- Extract auth snapshot cache operations into `auth_service::cache` with invalidation tests
- Extract folder path chain cache operations into `folder_service::cache` with scope tests
- Extract passkey challenge cache operations into `passkey_service::cache` with flow tests
- Extract preview link usage slot cache operations into `preview_link_service::cache` with reservation tests
- Extract share stream count marker cache operations into `share_stream_service::cache` with state machine tests
- Extract stream ticket cache operations into `stream_ticket_service::cache` with fallback tests
- Extract workspace scope cache operations into `workspace_scope_service::cache` with team access tests
- Extract WebDAV auth cache operations into `webdav::auth::cache` with username invalidation tests
- Extract WebDAV path resolver cache operations into `webdav::path_resolver::cache` with node variant tests
- Move cache-related constants and key generation functions into cache modules
- Add comprehensive test coverage for cache scoping, invalidation, and edge cases

closed #342 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **Refactor**
  * 统一并优化多处缓存的读取/写入/失效流程，按业务维度隔离缓存作用域与 TTL（如认证、管理概览、目录层级、预览名额、分享计数、下载票据、工作空间权限、WebDAV 认证与路径解析）。
  * 采用更可靠的“定向失效/消费式读取”策略，降低缓存互相影响与脏数据风险。

* **Tests**
  * 增强缓存相关单元测试覆盖，验证隔离性、一次性消费语义、释放/失效行为及往返正确性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->