### PR TITLE
feat(storage): support presigned inline preview with CORS-safe credential handling

### DIFF
--- a/docs/en/storage/s3-minio-r2.md
+++ b/docs/en/storage/s3-minio-r2.md
@@ -171,7 +171,7 @@ Then it is usually only suitable for `relay_stream`. To use `presigned`, browser
 | Upload mode | Use `relay_stream` for the first setup |
 | Download mode | Use `relay_stream` for the first setup |
 
-R2 custom domains, caching, and public access policies are configured separately on the Cloudflare side. AsterDrive only needs to operate private objects through the S3 API.
+R2 custom domains, caching, and public access policies are configured separately on the Cloudflare side. AsterDrive only needs to operate private objects through the S3 API. If you later switch upload or download to `presigned`, configure bucket CORS first.
 
 ### Common AWS S3 Configuration
 
@@ -332,31 +332,142 @@ Scenarios where it is not suitable:
 - CORS is hard to configure
 - You want all downloads to remain same-origin responses
 
-## 12. Configure CORS for `presigned` Uploads
+## 12. Configure CORS for `presigned`
 
-When using `presigned` uploads, the browser sends `PUT` requests directly to object storage. Object storage must allow AsterDrive's public origin.
+When using `presigned`, the browser accesses S3-compatible object storage directly. Object storage must allow cross-origin requests from the AsterDrive site, otherwise uploads, downloads, image previews, and PDF/video range requests may fail.
 
-Minimum requirements:
-
-- Allowed Origin: your `public site URL`
-- Allowed Method: `PUT`
-- Allowed Header: cover browser upload request headers
-- Expose Header: `ETag`
-
-Example:
+`AllowedOrigins` must contain the origin users use to open AsterDrive, for example:
 
 ```text
-AllowedOrigins:
-  - https://drive.example.com
-AllowedMethods:
-  - PUT
-AllowedHeaders:
-  - *
-ExposeHeaders:
-  - ETag
+https://drive.example.com
 ```
 
-Provider interfaces differ, but these are the core items.
+Do not include a path, and do not write `https://drive.example.com/` or `https://drive.example.com/api`.
+
+### Presigned Upload Only
+
+If you only enable `presigned` upload, use this configuration:
+
+```json
+[
+  {
+    "AllowedOrigins": [
+      "https://drive.example.com"
+    ],
+    "AllowedMethods": [
+      "PUT"
+    ],
+    "AllowedHeaders": [
+      "Content-Type",
+      "Content-Length",
+      "x-amz-content-sha256",
+      "x-amz-date",
+      "x-amz-security-token"
+    ],
+    "ExposeHeaders": [
+      "ETag"
+    ],
+    "MaxAgeSeconds": 3600
+  }
+]
+```
+
+If your browser or reverse proxy sends additional request headers, add those headers to `AllowedHeaders`. Provider interfaces differ, but the core items are origin, methods, request headers, and exposed response headers.
+
+### Presigned Download and Preview Only
+
+If you only enable `presigned` download or preview, use this configuration:
+
+```json
+[
+  {
+    "AllowedOrigins": [
+      "https://drive.example.com"
+    ],
+    "AllowedMethods": [
+      "GET",
+      "HEAD"
+    ],
+    "AllowedHeaders": [
+      "Range",
+      "If-None-Match"
+    ],
+    "ExposeHeaders": [
+      "Accept-Ranges",
+      "Content-Disposition",
+      "Content-Length",
+      "Content-Range",
+      "Content-Type",
+      "ETag",
+      "Range"
+    ],
+    "MaxAgeSeconds": 3600
+  }
+]
+```
+
+`Range`, `Content-Range`, and `Accept-Ranges` matter for video, audio, and PDF previews. Without them, small images may still open while seeking, segmented loading, or larger previews fail.
+
+### Presigned Upload and Download
+
+If the same bucket enables both `presigned` upload and download, use a combined rule:
+
+```json
+[
+  {
+    "AllowedOrigins": [
+      "https://drive.example.com"
+    ],
+    "AllowedMethods": [
+      "GET",
+      "HEAD",
+      "PUT"
+    ],
+    "AllowedHeaders": [
+      "Content-Length",
+      "Content-Type",
+      "If-None-Match",
+      "Range",
+      "x-amz-content-sha256",
+      "x-amz-date",
+      "x-amz-security-token"
+    ],
+    "ExposeHeaders": [
+      "Accept-Ranges",
+      "Content-Disposition",
+      "Content-Length",
+      "Content-Range",
+      "Content-Type",
+      "ETag",
+      "Range"
+    ],
+    "MaxAgeSeconds": 3600
+  }
+]
+```
+
+### Credentials During Preview
+
+R2 CORS supports `AllowedOrigins`, `AllowedMethods`, `AllowedHeaders`, `ExposeHeaders`, and `MaxAgeSeconds`; Cloudflare R2 documentation does not define an `AllowedCredentials` field. Other S3-compatible providers may also not return the headers required for credentialed CORS.
+
+For that reason, browser requests to object-storage presigned URLs should not include cookie credentials. AsterDrive preview first creates a short-lived `preview-link` through the authenticated API, then reads object content through that temporary link. The content request does not depend on cookies, so the browser does not require object storage to return:
+
+```http
+Access-Control-Allow-Credentials: true
+```
+
+If the browser console shows an error like:
+
+```text
+The value of the 'Access-Control-Allow-Credentials' header in the response is '' which must be 'true' when the request's credentials mode is 'include'.
+```
+
+Check:
+
+1. Whether the frontend is an old AsterDrive version.
+2. Whether preview still reads `/api/v1/files/{id}/download` through XHR and follows a 302 redirect to object storage.
+3. Whether the object storage response includes `Access-Control-Allow-Origin: https://your-site-origin`.
+4. Whether `AllowedOrigins` exactly matches the origin shown in the browser address bar.
 
 ::: tip How to tell whether it is a CORS issue
 If `relay_stream` succeeds, `presigned` fails, and the browser console shows a cross-origin error, object storage CORS is usually the place to check.

--- a/docs/storage/s3-minio-r2.md
+++ b/docs/storage/s3-minio-r2.md
@@ -171,7 +171,7 @@ http://minio:9000
 | 上传方式 | 初次建议 `relay_stream` |
 | 下载方式 | 初次建议 `relay_stream` |
 
-R2 的自定义域名、缓存和公开访问策略在 Cloudflare 侧单独配置。AsterDrive 只需要能通过 S3 API 操作私有对象。
+R2 的自定义域名、缓存和公开访问策略在 Cloudflare 侧单独配置。AsterDrive 只需要能通过 S3 API 操作私有对象。如果后续要把上传或下载切换到 `presigned`，需要先给 bucket 配好 CORS。
 
 ### AWS S3 常见写法
 
@@ -332,31 +332,142 @@ flowchart TD
 - CORS 不好配置
 - 希望所有下载都保持同源响应
 
-## 12. 给 `presigned` 上传配置 CORS
+## 12. 给 `presigned` 配置 CORS
 
-使用 `presigned` 上传时，浏览器会直接对对象存储发 `PUT` 请求。对象存储必须允许 AsterDrive 的公开来源。
+使用 `presigned` 时，浏览器会直接访问 S3-compatible 对象存储。对象存储必须允许 AsterDrive 站点的跨域请求，否则上传、下载、图片预览、PDF / 视频 Range 请求都可能失败。
 
-最少需要：
-
-- Allowed Origin：你的 `公开站点地址`
-- Allowed Method：`PUT`
-- Allowed Header：覆盖浏览器上传请求头
-- Expose Header：`ETag`
-
-示意：
+`AllowedOrigins` 必须填写浏览器访问 AsterDrive 的站点 origin，例如：
 
 ```text
-AllowedOrigins:
-  - https://drive.example.com
-AllowedMethods:
-  - PUT
-AllowedHeaders:
-  - *
-ExposeHeaders:
-  - ETag
+https://drive.example.com
 ```
 
-不同服务商界面不一样，但核心都是这几项。
+不要带路径，也不要写成 `https://drive.example.com/` 或 `https://drive.example.com/api`。
+
+### 只启用 Presigned 上传
+
+只启用 `presigned` 上传时，可以使用这份配置：
+
+```json
+[
+  {
+    "AllowedOrigins": [
+      "https://drive.example.com"
+    ],
+    "AllowedMethods": [
+      "PUT"
+    ],
+    "AllowedHeaders": [
+      "Content-Type",
+      "Content-Length",
+      "x-amz-content-sha256",
+      "x-amz-date",
+      "x-amz-security-token"
+    ],
+    "ExposeHeaders": [
+      "ETag"
+    ],
+    "MaxAgeSeconds": 3600
+  }
+]
+```
+
+如果浏览器或反向代理实际发送了额外请求头，需要把对应请求头加入 `AllowedHeaders`。不同 S3-compatible 服务商界面不一样，但核心都是 origin、method、request headers、exposed response headers 这几项。
+
+### 只启用 Presigned 下载和预览
+
+只启用 `presigned` 下载或预览时，可以使用这份配置：
+
+```json
+[
+  {
+    "AllowedOrigins": [
+      "https://drive.example.com"
+    ],
+    "AllowedMethods": [
+      "GET",
+      "HEAD"
+    ],
+    "AllowedHeaders": [
+      "Range",
+      "If-None-Match"
+    ],
+    "ExposeHeaders": [
+      "Accept-Ranges",
+      "Content-Disposition",
+      "Content-Length",
+      "Content-Range",
+      "Content-Type",
+      "ETag",
+      "Range"
+    ],
+    "MaxAgeSeconds": 3600
+  }
+]
+```
+
+`Range`、`Content-Range` 和 `Accept-Ranges` 对视频、音频、PDF 这类预览很重要。缺少这些配置时，小图片可能能打开，但视频 seek、PDF 分段加载或大文件预览会失败。
+
+### 上传和下载都启用 Presigned
+
+同一个 bucket 同时启用 `presigned` 上传和下载时，可以合并成一份配置：
+
+```json
+[
+  {
+    "AllowedOrigins": [
+      "https://drive.example.com"
+    ],
+    "AllowedMethods": [
+      "GET",
+      "HEAD",
+      "PUT"
+    ],
+    "AllowedHeaders": [
+      "Content-Length",
+      "Content-Type",
+      "If-None-Match",
+      "Range",
+      "x-amz-content-sha256",
+      "x-amz-date",
+      "x-amz-security-token"
+    ],
+    "ExposeHeaders": [
+      "Accept-Ranges",
+      "Content-Disposition",
+      "Content-Length",
+      "Content-Range",
+      "Content-Type",
+      "ETag",
+      "Range"
+    ],
+    "MaxAgeSeconds": 3600
+  }
+]
+```
+
+### 预览里的 credentials 问题
+
+R2 的 CORS 配置支持 `AllowedOrigins`、`AllowedMethods`、`AllowedHeaders`、`ExposeHeaders` 和 `MaxAgeSeconds`，Cloudflare R2 文档没有提供 `AllowedCredentials` 字段。其他 S3-compatible 服务商也不一定会返回 credentialed CORS 所需的响应头。
+
+因此，浏览器请求对象存储 presigned URL 时不应该带 cookie credentials。AsterDrive 的预览链路会先通过登录态 API 创建短时效 `preview-link`，再用这个临时链接读取对象内容。读取对象内容时不依赖 cookie，避免浏览器要求对象存储返回：
+
+```http
+Access-Control-Allow-Credentials: true
+```
+
+如果浏览器控制台出现类似错误：
+
+```text
+The value of the 'Access-Control-Allow-Credentials' header in the response is '' which must be 'true' when the request's credentials mode is 'include'.
+```
+
+优先检查：
+
+1. 前端是否在用旧版本 AsterDrive。
+2. 预览请求是否仍通过 XHR 直接读取 `/api/v1/files/{id}/download` 并追随 302 到对象存储。
+3. 对象存储响应是否至少包含 `Access-Control-Allow-Origin: https://你的站点域名`。
+4. `AllowedOrigins` 是否和浏览器地址栏里的 origin 完全一致。
 
 ::: tip 判断是不是 CORS 问题
 `relay_stream` 成功，`presigned` 失败，浏览器控制台又出现跨域错误时，基本就该看对象存储 CORS。

--- a/frontend-panel/src/components/files/UploadArea.test.tsx
+++ b/frontend-panel/src/components/files/UploadArea.test.tsx
@@ -20,6 +20,11 @@ const saveSession = vi.fn();
 const uploadChunk = vi.fn();
 const uploadPanelSpy = vi.fn();
 const apiClientPost = vi.fn();
+const mockAuthUser = {
+	preferences: {
+		storage_event_stream_enabled: true,
+	},
+};
 
 interface MockFileStoreState {
 	breadcrumb: Array<{ id: number | null; name: string }>;
@@ -30,6 +35,11 @@ interface MockFileStoreState {
 interface MockAuthStoreState {
 	refreshToken: () => Promise<void>;
 	refreshUser: (options?: { fields?: MeField[] }) => Promise<void>;
+	user: {
+		preferences?: {
+			storage_event_stream_enabled?: boolean;
+		};
+	} | null;
 }
 
 class MockApiError extends Error {
@@ -130,11 +140,13 @@ vi.mock("@/stores/authStore", () => ({
 			selector({
 				refreshToken,
 				refreshUser,
+				user: mockAuthUser,
 			}),
 		{
 			getState: () => ({
 				refreshToken,
 				refreshUser,
+				user: mockAuthUser,
 			}),
 		},
 	),
@@ -280,6 +292,7 @@ describe("UploadArea", () => {
 		refreshToken.mockResolvedValue(undefined);
 		refreshUser.mockReset();
 		refreshUser.mockResolvedValue(undefined);
+		mockAuthUser.preferences.storage_event_stream_enabled = true;
 		removeSession.mockReset();
 		saveSession.mockReset();
 		uploadChunk.mockReset();
@@ -382,8 +395,26 @@ describe("UploadArea", () => {
 
 		await waitFor(() => {
 			expect(refresh).toHaveBeenCalledTimes(1);
+		});
+		expect(refreshUser).not.toHaveBeenCalled();
+	});
+
+	it("refreshes quota locally after upload queue settles when storage events are disabled", async () => {
+		mockAuthUser.preferences.storage_event_stream_enabled = false;
+		const file = new File(["hello"], "hello.txt", { type: "text/plain" });
+
+		initUpload.mockResolvedValue({ mode: "direct" });
+		apiClientPost.mockResolvedValue({});
+
+		await renderUploadAreaWithFiles([file]);
+
+		await screen.findByText("hello.txt:Direct:files:upload_success");
+
+		await waitFor(() => {
+			expect(refresh).toHaveBeenCalledTimes(1);
 			expect(refreshUser).toHaveBeenCalledTimes(1);
 		});
+		expect(refreshUser).toHaveBeenCalledWith({ fields: ["quota"] });
 	});
 
 	it("keeps active uploads when the file browser route unmounts", async () => {
@@ -429,8 +460,8 @@ describe("UploadArea", () => {
 		await screen.findByText("route-switch.txt:Direct:files:upload_success");
 		await waitFor(() => {
 			expect(refresh).toHaveBeenCalledTimes(1);
-			expect(refreshUser).toHaveBeenCalledTimes(1);
 		});
+		expect(refreshUser).not.toHaveBeenCalled();
 	});
 
 	it("does not refresh after an all-failed upload queue", async () => {
@@ -525,8 +556,8 @@ describe("UploadArea", () => {
 		);
 		await waitFor(() => {
 			expect(refresh).toHaveBeenCalledTimes(1);
-			expect(refreshUser).toHaveBeenCalledTimes(1);
 		});
+		expect(refreshUser).not.toHaveBeenCalled();
 	});
 
 	it("restores recoverable sessions listed by the backend", async () => {

--- a/frontend-panel/src/components/files/UploadAreaHost.tsx
+++ b/frontend-panel/src/components/files/UploadAreaHost.tsx
@@ -20,6 +20,9 @@ export function UploadAreaHost({ workspace }: UploadAreaHostProps) {
 	const currentFolderId = useFileStore((state) => state.currentFolderId);
 	const breadcrumb = useFileStore((state) => state.breadcrumb);
 	const refreshUser = useAuthStore((state) => state.refreshUser);
+	const storageEventStreamEnabled = useAuthStore(
+		(state) => state.user?.preferences?.storage_event_stream_enabled !== false,
+	);
 	const setControls = useUploadAreaControlsStore((state) => state.setControls);
 	const setUploadPanelPresence = useUploadAreaControlsStore(
 		(state) => state.setUploadPanelPresence,
@@ -57,6 +60,7 @@ export function UploadAreaHost({ workspace }: UploadAreaHostProps) {
 		refresh,
 		refreshUser,
 		resumeFileInputRef,
+		storageEventStreamEnabled,
 		workspace,
 	});
 	const showUploadPanel = hasUploadActivity || uploadTasks.length > 0;

--- a/frontend-panel/src/components/files/preview/BlobImagePreview.test.tsx
+++ b/frontend-panel/src/components/files/preview/BlobImagePreview.test.tsx
@@ -58,6 +58,23 @@ describe("BlobImagePreview", () => {
 		expect(screen.getByText("loading_preview")).toBeInTheDocument();
 	});
 
+	it("renders loading without fetching while the image preview path is resolving", () => {
+		mockState.useBlobUrl.mockReturnValue({
+			blobUrl: null,
+			error: false,
+			loading: false,
+			retry: mockState.retry,
+		});
+
+		render(<BlobImagePreview file={file} path={null} />);
+
+		expect(mockState.useBlobUrl).toHaveBeenCalledWith(null, {
+			lane: "default",
+		});
+		expect(screen.getByText("loading_preview")).toBeInTheDocument();
+		expect(screen.queryByRole("img")).not.toBeInTheDocument();
+	});
+
 	it("renders the retry state when loading fails", () => {
 		mockState.useBlobUrl.mockReturnValue({
 			blobUrl: null,

--- a/frontend-panel/src/components/files/preview/BlobImagePreview.tsx
+++ b/frontend-panel/src/components/files/preview/BlobImagePreview.tsx
@@ -19,7 +19,7 @@ interface BlobImagePreviewProps {
 	imageStyle?: CSSProperties;
 	onImageLoad?: (source: ImagePreviewSource) => void;
 	onImageRenderError?: (source: ImagePreviewSource) => void;
-	path: string;
+	path: string | null;
 	source?: ImagePreviewSource;
 	showOriginalButtonPlacement?: "inline" | "none";
 	viewportClassName?: string;
@@ -84,6 +84,7 @@ export function BlobImagePreview({
 			: "original");
 	const isControlledSource = source != null;
 	const shouldLoadOriginal =
+		path != null &&
 		!isControlledSource &&
 		canShowOriginal &&
 		baseSource === "backend_preview" &&
@@ -99,11 +100,13 @@ export function BlobImagePreview({
 	const originalReady =
 		shouldLoadOriginal && originalBlobUrl && !originalLoading && !originalError;
 	const shouldFallbackOriginalRenderToPreview =
+		path != null &&
 		!isControlledSource &&
 		baseSource === "original" &&
 		originalRenderFailed &&
 		hasBackendPreview;
 	const shouldPromoteReadyOriginal =
+		path != null &&
 		!isControlledSource &&
 		baseSource === "backend_preview" &&
 		originalReady &&
@@ -115,7 +118,11 @@ export function BlobImagePreview({
 				? "original"
 				: baseSource;
 	const displayPath: string | null =
-		displaySource === "backend_preview" ? (fallbackPath ?? null) : path;
+		path == null
+			? null
+			: displaySource === "backend_preview"
+				? (fallbackPath ?? null)
+				: path;
 	const { blobUrl, error, loading, retry } = useBlobUrl(displayPath, {
 		lane: displaySource === "backend_preview" ? "preview" : "default",
 	});
@@ -125,6 +132,7 @@ export function BlobImagePreview({
 	const imageRenderKey = `${previewKey}\u0000${displaySource}`;
 	const imageRenderFailed = imageRenderFailedKey === imageRenderKey;
 	const canRequestOriginal =
+		path != null &&
 		!isControlledSource &&
 		canShowOriginal &&
 		baseSource === "backend_preview" &&

--- a/frontend-panel/src/components/files/preview/FilePreviewBody.test.tsx
+++ b/frontend-panel/src/components/files/preview/FilePreviewBody.test.tsx
@@ -1,0 +1,252 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { FilePreviewBody } from "@/components/files/preview/FilePreviewBody";
+import type { OpenWithOption } from "@/components/files/preview/types";
+
+const mockState = vi.hoisted(() => ({
+	blobImagePreview: vi.fn(),
+	musicPreview: vi.fn(),
+	videoPreview: vi.fn(),
+}));
+
+vi.mock("react-i18next", () => ({
+	useTranslation: () => ({
+		t: (key: string) => key,
+	}),
+}));
+
+vi.mock("@/components/files/preview/BlobImagePreview", () => ({
+	BlobImagePreview: (props: unknown) => {
+		mockState.blobImagePreview(props);
+		return <div data-testid="blob-image-preview" />;
+	},
+}));
+
+vi.mock("@/components/files/preview/MusicPreview", () => ({
+	MusicPreview: (props: unknown) => {
+		mockState.musicPreview(props);
+		return <div data-testid="music-preview" />;
+	},
+}));
+
+vi.mock("@/components/files/preview/VideoPreview", () => ({
+	VideoPreview: (props: unknown) => {
+		mockState.videoPreview(props);
+		return <div data-testid="video-preview" />;
+	},
+}));
+
+vi.mock("@/components/files/preview/UrlTemplatePreview", () => ({
+	UrlTemplatePreview: () => <div data-testid="url-template-preview" />,
+}));
+
+vi.mock("@/components/files/preview/WopiPreview", () => ({
+	WopiPreview: () => <div data-testid="wopi-preview" />,
+}));
+
+function option(mode: OpenWithOption["mode"]): OpenWithOption {
+	return {
+		icon: "File",
+		key: `builtin.${mode}`,
+		labelKey: `open_with_${mode}`,
+		mode,
+	};
+}
+
+function renderBody(overrides: Partial<Parameters<typeof FilePreviewBody>[0]>) {
+	return render(
+		<FilePreviewBody
+			file={{
+				id: 7,
+				name: "preview.bin",
+				mime_type: "application/octet-stream",
+			}}
+			activeOption={option("pdf")}
+			profile={{
+				category: "pdf",
+				defaultMode: "builtin.pdf",
+				isBlobPreview: true,
+				isEditableText: false,
+				isTextBased: false,
+				options: [option("pdf")],
+			}}
+			previewAppsLoaded
+			contentPreviewPath="/files/7/download"
+			downloadPath="/files/7/download"
+			getOptionLabel={(item) => item.labelKey}
+			onDirtyChange={vi.fn()}
+			editable
+			formattedCategory="json"
+			isExpanded={false}
+			{...overrides}
+		/>,
+	);
+}
+
+describe("FilePreviewBody", () => {
+	it("shows loading for pdf previews while the content preview path is resolving", () => {
+		renderBody({
+			activeOption: option("pdf"),
+			contentPreviewPath: null,
+		});
+
+		expect(screen.getByText("files:loading_preview")).toBeInTheDocument();
+	});
+
+	it("shows loading for markdown previews while the content preview path is resolving", () => {
+		renderBody({
+			activeOption: option("markdown"),
+			contentPreviewPath: null,
+			profile: {
+				category: "markdown",
+				defaultMode: "builtin.markdown",
+				isBlobPreview: true,
+				isEditableText: false,
+				isTextBased: true,
+				options: [option("markdown")],
+			},
+		});
+
+		expect(screen.getByText("files:loading_preview")).toBeInTheDocument();
+	});
+
+	it.each([
+		["table", "csv"],
+		["formatted", "json"],
+		["code", "text"],
+	] as const)("shows loading for %s previews while the content preview path is resolving", (mode, category) => {
+		renderBody({
+			activeOption: option(mode),
+			contentPreviewPath: null,
+			formattedCategory: category === "json" ? "json" : "xml",
+			profile: {
+				category,
+				defaultMode: `builtin.${mode}`,
+				isBlobPreview: true,
+				isEditableText: mode === "code",
+				isTextBased: true,
+				options: [option(mode)],
+			},
+		});
+
+		expect(screen.getByText("files:loading_preview")).toBeInTheDocument();
+	});
+
+	it("passes a nullable content path through image previews", () => {
+		renderBody({
+			activeOption: option("image"),
+			contentPreviewPath: null,
+			imagePreviewPath: "/files/7/image-preview",
+			isExpanded: true,
+			profile: {
+				category: "image",
+				defaultMode: "builtin.image",
+				isBlobPreview: true,
+				isEditableText: false,
+				isTextBased: false,
+				options: [option("image")],
+			},
+		});
+
+		expect(screen.getByTestId("blob-image-preview")).toBeInTheDocument();
+		expect(mockState.blobImagePreview).toHaveBeenCalledWith(
+			expect.objectContaining({
+				fallbackPath: "/files/7/image-preview",
+				fillContainer: true,
+				path: null,
+			}),
+		);
+	});
+
+	it("passes a nullable content path through audio previews", () => {
+		const loadMusicBackendMetadata = vi.fn();
+		const mediaStreamLinkFactory = vi.fn();
+
+		renderBody({
+			activeOption: option("audio"),
+			contentPreviewPath: null,
+			loadMusicBackendMetadata,
+			mediaStreamLinkFactory,
+			thumbnailPath: "/files/7/thumbnail",
+			profile: {
+				category: "audio",
+				defaultMode: "builtin.audio",
+				isBlobPreview: true,
+				isEditableText: false,
+				isTextBased: false,
+				options: [option("audio")],
+			},
+		});
+
+		expect(screen.getByTestId("music-preview")).toBeInTheDocument();
+		expect(mockState.musicPreview).toHaveBeenCalledWith(
+			expect.objectContaining({
+				loadBackendMetadata: loadMusicBackendMetadata,
+				mediaStreamLinkFactory,
+				path: null,
+				thumbnailPath: "/files/7/thumbnail",
+			}),
+		);
+	});
+
+	it("passes a nullable content path through video previews", () => {
+		const mediaStreamLinkFactory = vi.fn();
+
+		renderBody({
+			activeOption: option("video"),
+			contentPreviewPath: null,
+			mediaStreamLinkFactory,
+			profile: {
+				category: "video",
+				defaultMode: "builtin.video",
+				isBlobPreview: true,
+				isEditableText: false,
+				isTextBased: false,
+				options: [option("video")],
+			},
+		});
+
+		expect(screen.getByTestId("video-preview")).toBeInTheDocument();
+		expect(mockState.videoPreview).toHaveBeenCalledWith(
+			expect.objectContaining({
+				mediaStreamLinkFactory,
+				path: null,
+			}),
+		);
+	});
+
+	it("renders url template previews without requiring a resolved content path", () => {
+		renderBody({
+			activeOption: option("url_template"),
+			contentPreviewPath: null,
+			profile: {
+				category: "document",
+				defaultMode: "builtin.url_template",
+				isBlobPreview: false,
+				isEditableText: false,
+				isTextBased: false,
+				options: [option("url_template")],
+			},
+		});
+
+		expect(screen.getByTestId("url-template-preview")).toBeInTheDocument();
+	});
+
+	it("shows unavailable for WOPI previews without a session resource", () => {
+		renderBody({
+			activeOption: option("wopi"),
+			contentPreviewPath: null,
+			profile: {
+				category: "document",
+				defaultMode: "builtin.wopi",
+				isBlobPreview: false,
+				isEditableText: false,
+				isTextBased: false,
+				options: [option("wopi")],
+			},
+			wopiSessionResource: null,
+		});
+
+		expect(screen.getByText("preview_not_available")).toBeInTheDocument();
+	});
+});

--- a/frontend-panel/src/components/files/preview/FilePreviewBody.tsx
+++ b/frontend-panel/src/components/files/preview/FilePreviewBody.tsx
@@ -63,6 +63,7 @@ interface FilePreviewBodyProps {
 	activeOption: OpenWithOption | null;
 	profile: PreviewProfile | null;
 	previewAppsLoaded: boolean;
+	contentPreviewPath: string | null;
 	downloadPath: string;
 	imagePreviewPath?: string;
 	thumbnailPath?: string;
@@ -87,6 +88,7 @@ export function FilePreviewBody({
 	activeOption,
 	profile,
 	previewAppsLoaded,
+	contentPreviewPath,
 	downloadPath,
 	imagePreviewPath,
 	thumbnailPath,
@@ -118,9 +120,10 @@ export function FilePreviewBody({
 	}
 
 	if (activeOption.mode === "pdf") {
+		if (!contentPreviewPath) return previewLoadingState;
 		return (
 			<Suspense fallback={previewLoadingState}>
-				<PdfPreview path={downloadPath} fileName={file.name} />
+				<PdfPreview path={contentPreviewPath} fileName={file.name} />
 			</Suspense>
 		);
 	}
@@ -130,7 +133,7 @@ export function FilePreviewBody({
 			<BlobImagePreview
 				file={file}
 				fillContainer={isExpanded}
-				path={downloadPath}
+				path={contentPreviewPath}
 				fallbackPath={imagePreviewPath}
 			/>
 		);
@@ -141,7 +144,7 @@ export function FilePreviewBody({
 			<MusicPreview
 				file={file}
 				loadBackendMetadata={loadMusicBackendMetadata}
-				path={downloadPath}
+				path={contentPreviewPath}
 				thumbnailPath={thumbnailPath}
 				mediaStreamLinkFactory={mediaStreamLinkFactory}
 			/>
@@ -152,7 +155,7 @@ export function FilePreviewBody({
 		return (
 			<VideoPreview
 				file={file}
-				path={downloadPath}
+				path={contentPreviewPath}
 				mediaStreamLinkFactory={mediaStreamLinkFactory}
 			/>
 		);
@@ -185,48 +188,52 @@ export function FilePreviewBody({
 	}
 
 	if (activeOption.mode === "markdown") {
+		if (!contentPreviewPath) return previewLoadingState;
 		return (
 			<Suspense fallback={previewLoadingState}>
-				<MarkdownPreview path={downloadPath} />
+				<MarkdownPreview path={contentPreviewPath} />
 			</Suspense>
 		);
 	}
 
 	if (activeOption.mode === "table") {
+		if (!contentPreviewPath) return previewLoadingState;
 		const delimiter = normalizeTablePreviewDelimiter(
 			activeOption.config?.delimiter,
 		);
 
 		return (
 			<Suspense fallback={previewLoadingState}>
-				<CsvTablePreview path={downloadPath} delimiter={delimiter} />
+				<CsvTablePreview path={contentPreviewPath} delimiter={delimiter} />
 			</Suspense>
 		);
 	}
 
 	if (activeOption.mode === "formatted") {
+		if (!contentPreviewPath) return previewLoadingState;
 		if (formattedCategory === "xml") {
 			return (
 				<Suspense fallback={previewLoadingState}>
-					<XmlPreview path={downloadPath} mode="formatted" />
+					<XmlPreview path={contentPreviewPath} mode="formatted" />
 				</Suspense>
 			);
 		}
 
 		return (
 			<Suspense fallback={previewLoadingState}>
-				<JsonPreview path={downloadPath} />
+				<JsonPreview path={contentPreviewPath} />
 			</Suspense>
 		);
 	}
 
 	if (activeOption.mode === "code") {
+		if (!contentPreviewPath) return previewLoadingState;
 		return (
 			<Suspense fallback={previewLoadingState}>
 				<TextCodePreview
 					file={file}
 					modeLabel={getOptionLabel(activeOption)}
-					path={downloadPath}
+					path={contentPreviewPath}
 					onFileUpdated={onFileUpdated}
 					onDirtyChange={onDirtyChange}
 					editable={editable}

--- a/frontend-panel/src/components/files/preview/FilePreviewDialog.test.tsx
+++ b/frontend-panel/src/components/files/preview/FilePreviewDialog.test.tsx
@@ -963,10 +963,9 @@ describe("FilePreviewDialog", () => {
 		expect(
 			await screen.findByRole("img", { name: "r2-image.png" }),
 		).toHaveAttribute("data-preview-path", "");
-		expect(screen.getByRole("img", { name: "r2-image.png" })).not.toHaveAttribute(
-			"data-preview-path",
-			"/files/7/download",
-		);
+		expect(
+			screen.getByRole("img", { name: "r2-image.png" }),
+		).not.toHaveAttribute("data-preview-path", "/files/7/download");
 		expect(previewLinkFactory).toHaveBeenCalledTimes(1);
 
 		resolvePreviewLink({

--- a/frontend-panel/src/components/files/preview/FilePreviewDialog.test.tsx
+++ b/frontend-panel/src/components/files/preview/FilePreviewDialog.test.tsx
@@ -225,13 +225,14 @@ vi.mock("@/components/files/preview/BlobImagePreview", () => ({
 		file: { name: string };
 		fallbackPath?: string;
 		fillContainer?: boolean;
-		path: string;
+		path: string | null;
 	}) => (
 		<img
 			alt={file.name}
 			data-fallback-path={fallbackPath ?? ""}
 			data-fill-container={String(Boolean(fillContainer))}
-			src={`blob:${path}`}
+			data-preview-path={path ?? ""}
+			src={path ? `blob:${path}` : "blob:loading"}
 		/>
 	),
 }));
@@ -915,6 +916,72 @@ describe("FilePreviewDialog", () => {
 		expect(screen.getByTestId("dialog-overlay").className).toContain(
 			"bg-zinc-950/88",
 		);
+	});
+
+	it("waits for preview-link before loading image preview content", async () => {
+		mockState.profile = {
+			category: "image",
+			defaultMode: "builtin.image",
+			isBlobPreview: true,
+			isEditableText: false,
+			isTextBased: false,
+			options: [
+				{
+					icon: "Eye",
+					key: "builtin.image",
+					labelKey: "open_with_image",
+					mode: "image",
+				},
+			],
+		};
+		let resolvePreviewLink!: (value: {
+			expires_at: string;
+			max_uses: number;
+			path: string;
+		}) => void;
+		const previewLinkFactory = vi.fn(
+			() =>
+				new Promise<{
+					expires_at: string;
+					max_uses: number;
+					path: string;
+				}>((resolve) => {
+					resolvePreviewLink = resolve;
+				}),
+		);
+
+		renderDialog({
+			file: {
+				id: 7,
+				mime_type: "image/png",
+				name: "r2-image.png",
+				size: 2048,
+			} as never,
+			previewLinkFactory,
+		});
+
+		expect(
+			await screen.findByRole("img", { name: "r2-image.png" }),
+		).toHaveAttribute("data-preview-path", "");
+		expect(screen.getByRole("img", { name: "r2-image.png" })).not.toHaveAttribute(
+			"data-preview-path",
+			"/files/7/download",
+		);
+		expect(previewLinkFactory).toHaveBeenCalledTimes(1);
+
+		resolvePreviewLink({
+			expires_at: "2026-06-21T22:30:00Z",
+			max_uses: 5,
+			path: "/pv/token/r2-image.png",
+		});
+
+		await waitFor(() => {
+			expect(screen.getByRole("img", { name: "r2-image.png" })).toHaveAttribute(
+				"data-preview-path",
+				"/pv/token/r2-image.png",
+			);
+		});
+		expect(previewLinkFactory).toHaveBeenCalledTimes(1);
 	});
 
 	it("keeps image previews fullscreen without a windowed restore control", async () => {

--- a/frontend-panel/src/components/files/preview/FilePreviewDialog.tsx
+++ b/frontend-panel/src/components/files/preview/FilePreviewDialog.tsx
@@ -91,7 +91,7 @@ export function FilePreviewDialog({
 						<ImagePreviewPanel
 							file={file}
 							allOptionsCount={model.allOptions.length}
-							downloadPath={model.resolvedDownloadPath}
+							downloadPath={model.resolvedContentPreviewPath}
 							imagePreviewPath={model.resolvedImagePreviewPath}
 							onChooseOpenMethod={model.handleOpenMethodPickerOpen}
 							onClose={model.closeWithGuard}
@@ -118,6 +118,7 @@ export function FilePreviewDialog({
 									activeOption={model.activeOption}
 									profile={model.profile}
 									previewAppsLoaded={model.previewAppsLoaded}
+									contentPreviewPath={model.resolvedContentPreviewPath}
 									downloadPath={model.resolvedDownloadPath}
 									imagePreviewPath={model.resolvedImagePreviewPath}
 									thumbnailPath={model.resolvedThumbnailPath}

--- a/frontend-panel/src/components/files/preview/ImagePreviewPanel.tsx
+++ b/frontend-panel/src/components/files/preview/ImagePreviewPanel.tsx
@@ -90,7 +90,7 @@ function isImagePreviewInteractiveTarget(target: EventTarget | null) {
 interface ImagePreviewPanelProps {
 	file: FileInfo | FileListItem;
 	allOptionsCount: number;
-	downloadPath: string;
+	downloadPath: string | null;
 	imagePreviewPath?: string;
 	nextImageFile?: FileInfo | FileListItem;
 	onChooseOpenMethod: () => void;
@@ -398,7 +398,7 @@ function ImagePreviewTransformLayer({
 	onImageLoad,
 	onImageRenderError,
 }: {
-	downloadPath: string;
+	downloadPath: string | null;
 	effectiveShowOriginalState: ShowOriginalState;
 	effectiveSource: ImagePreviewSource;
 	file: FileInfo | FileListItem;

--- a/frontend-panel/src/components/files/preview/MusicPreview.test.tsx
+++ b/frontend-panel/src/components/files/preview/MusicPreview.test.tsx
@@ -89,6 +89,21 @@ describe("MusicPreview", () => {
 		).toBeInTheDocument();
 	});
 
+	it("renders loading while the audio preview path is resolving", () => {
+		render(
+			<MusicPreview
+				file={{ name: "track.mp3", mime_type: "audio/mpeg" }}
+				path={null}
+			/>,
+		);
+
+		expect(screen.getByText("loading_preview")).toBeInTheDocument();
+		expect(
+			screen.queryByRole("button", { name: "music_preview_play" }),
+		).not.toBeInTheDocument();
+		expect(mockState.prepareAuthenticatedResource).not.toHaveBeenCalled();
+	});
+
 	it("starts direct music playback through the global player store", async () => {
 		render(
 			<MusicPreview

--- a/frontend-panel/src/components/files/preview/MusicPreview.tsx
+++ b/frontend-panel/src/components/files/preview/MusicPreview.tsx
@@ -11,6 +11,7 @@ import {
 } from "@/stores/musicPlayerStore";
 import type { ShareStreamSessionInfo } from "@/types/api";
 import { PreviewError } from "./PreviewError";
+import { PreviewLoadingState } from "./PreviewLoadingState";
 import {
 	PreviewSurface,
 	PreviewSurfaceContent,
@@ -22,7 +23,7 @@ interface MusicPreviewProps {
 	file: PreviewableFileLike;
 	loadBackendMetadata?: MusicPlayerTrack["loadBackendMetadata"];
 	mediaStreamLinkFactory?: () => Promise<ShareStreamSessionInfo>;
-	path: string;
+	path: string | null;
 	thumbnailPath?: string;
 }
 
@@ -74,6 +75,7 @@ export function MusicPreview({
 	}, []);
 
 	const startPlayback = useCallback(() => {
+		if (!path) return;
 		const requestId = startRequestIdRef.current + 1;
 		startRequestIdRef.current = requestId;
 		startAbortControllerRef.current?.abort();
@@ -160,6 +162,16 @@ export function MusicPreview({
 		thumbnailPath,
 		trackId,
 	]);
+
+	if (!path) {
+		return (
+			<PreviewSurface className="min-h-[50vh]">
+				<PreviewSurfaceContent>
+					<PreviewLoadingState text={t("loading_preview")} className="h-full" />
+				</PreviewSurfaceContent>
+			</PreviewSurface>
+		);
+	}
 
 	if (streamLinkFailed) {
 		return <PreviewError />;

--- a/frontend-panel/src/components/files/preview/VideoPreview.test.tsx
+++ b/frontend-panel/src/components/files/preview/VideoPreview.test.tsx
@@ -63,6 +63,19 @@ describe("VideoPreview", () => {
 		HTMLMediaElement.prototype.load = vi.fn();
 	});
 
+	it("renders loading while the video preview path is resolving", () => {
+		render(
+			<VideoPreview
+				file={{ name: "clip.mp4", mime_type: "video/mp4" }}
+				path={null}
+			/>,
+		);
+
+		expect(screen.getByText("loading_preview")).toBeInTheDocument();
+		expect(mockState.prepareAuthenticatedResource).not.toHaveBeenCalled();
+		expect(mockState.artplayerInstances).toHaveLength(0);
+	});
+
 	it("prepares and passes the HTTP download URL to Artplayer", async () => {
 		render(
 			<VideoPreview

--- a/frontend-panel/src/components/files/preview/VideoPreview.tsx
+++ b/frontend-panel/src/components/files/preview/VideoPreview.tsx
@@ -18,7 +18,7 @@ const VIDEO_CONTENT_CLASS = "flex items-center justify-center bg-zinc-950";
 interface VideoPreviewProps {
 	file: PreviewableFileLike;
 	mediaStreamLinkFactory?: () => Promise<ShareStreamSessionInfo>;
-	path: string;
+	path: string | null;
 }
 
 interface VideoStatus {
@@ -103,6 +103,11 @@ export function VideoPreview({
 	);
 
 	useEffect(() => {
+		if (!path) {
+			setResolvedResource(null);
+			return;
+		}
+
 		let cancelled = false;
 
 		const resolveDirectPath = async () => {

--- a/frontend-panel/src/components/files/preview/useFilePreviewDialogModel.test.tsx
+++ b/frontend-panel/src/components/files/preview/useFilePreviewDialogModel.test.tsx
@@ -273,9 +273,7 @@ describe("useFilePreviewDialogModel", () => {
 		const { result } = renderModel({ file: audioFile, openMode: "direct" });
 
 		expect(result.current.resolvedDownloadPath).toBe("/files/7/download");
-		expect(result.current.resolvedContentPreviewPath).toBe(
-			"/files/7/download",
-		);
+		expect(result.current.resolvedContentPreviewPath).toBe("/files/7/download");
 		expect(result.current.resolvedImagePreviewPath).toBe(
 			"/files/7/image-preview",
 		);

--- a/frontend-panel/src/components/files/preview/useFilePreviewDialogModel.test.tsx
+++ b/frontend-panel/src/components/files/preview/useFilePreviewDialogModel.test.tsx
@@ -273,6 +273,9 @@ describe("useFilePreviewDialogModel", () => {
 		const { result } = renderModel({ file: audioFile, openMode: "direct" });
 
 		expect(result.current.resolvedDownloadPath).toBe("/files/7/download");
+		expect(result.current.resolvedContentPreviewPath).toBe(
+			"/files/7/download",
+		);
 		expect(result.current.resolvedImagePreviewPath).toBe(
 			"/files/7/image-preview",
 		);
@@ -289,6 +292,195 @@ describe("useFilePreviewDialogModel", () => {
 			signal: expect.any(AbortSignal),
 		});
 		expect(metadata).toEqual({ title: "Backend Song" });
+	});
+
+	it("uses preview-link paths for read-only content previews", async () => {
+		const previewLinkFactory = vi.fn(async () => ({
+			expires_at: "2026-06-21T22:30:00Z",
+			max_uses: 5,
+			path: "/pv/token/manual.pdf",
+		}));
+		mockState.detectFilePreviewProfile.mockReturnValue(
+			profile({
+				category: "pdf",
+				defaultMode: "builtin.pdf",
+				isBlobPreview: true,
+				isEditableText: false,
+				isTextBased: false,
+				options: [pdfOption],
+			}),
+		);
+
+		const { result } = renderModel({
+			file: file({
+				extension: "pdf",
+				file_category: "document",
+				mime_type: "application/pdf",
+				name: "manual.pdf",
+			}),
+			openMode: "direct",
+			previewLinkFactory,
+		});
+
+		expect(result.current.resolvedContentPreviewPath).toBeNull();
+		await waitFor(() => {
+			expect(result.current.resolvedContentPreviewPath).toBe(
+				"/pv/token/manual.pdf",
+			);
+		});
+		expect(result.current.resolvedDownloadPath).toBe("/files/7/download");
+		expect(previewLinkFactory).toHaveBeenCalledTimes(1);
+	});
+
+	it("reuses the in-flight preview-link request when parent callbacks change", async () => {
+		let resolvePreviewLink!: (value: {
+			expires_at: string;
+			max_uses: number;
+			path: string;
+		}) => void;
+		const previewLinkPromise = new Promise<{
+			expires_at: string;
+			max_uses: number;
+			path: string;
+		}>((resolve) => {
+			resolvePreviewLink = resolve;
+		});
+		const firstPreviewLinkFactory = vi.fn(() => previewLinkPromise);
+		const secondPreviewLinkFactory = vi.fn(() => previewLinkPromise);
+
+		const { rerender, result } = renderModel({
+			openMode: "direct",
+			previewLinkFactory: firstPreviewLinkFactory,
+		});
+
+		rerender({
+			open: true,
+			file: file(),
+			onClose: vi.fn(),
+			openMode: "direct",
+			previewLinkFactory: secondPreviewLinkFactory,
+			translateFileLabel: (key: string) => `files:${key}`,
+		});
+
+		expect(result.current.resolvedContentPreviewPath).toBeNull();
+		expect(firstPreviewLinkFactory).toHaveBeenCalledTimes(1);
+		expect(secondPreviewLinkFactory).not.toHaveBeenCalled();
+
+		resolvePreviewLink({
+			expires_at: "2026-06-21T22:30:00Z",
+			max_uses: 5,
+			path: "/pv/token/notes.md",
+		});
+
+		await waitFor(() => {
+			expect(result.current.resolvedContentPreviewPath).toBe(
+				"/pv/token/notes.md",
+			);
+		});
+		expect(firstPreviewLinkFactory).toHaveBeenCalledTimes(1);
+		expect(secondPreviewLinkFactory).not.toHaveBeenCalled();
+	});
+
+	it("clears content preview paths while the kept-mounted dialog is closing", async () => {
+		const previewLinkFactory = vi.fn(async () => ({
+			expires_at: "2026-06-21T22:30:00Z",
+			max_uses: 5,
+			path: "/pv/token/notes.md",
+		}));
+		const { rerender, result } = renderModel({
+			openMode: "direct",
+			previewLinkFactory,
+		});
+
+		await waitFor(() => {
+			expect(result.current.resolvedContentPreviewPath).toBe(
+				"/pv/token/notes.md",
+			);
+		});
+
+		rerender({
+			open: false,
+			file: file(),
+			onClose: vi.fn(),
+			openMode: "direct",
+			previewLinkFactory,
+			translateFileLabel: (key: string) => `files:${key}`,
+		});
+
+		expect(result.current.resolvedContentPreviewPath).toBeNull();
+		expect(result.current.resolvedDownloadPath).toBe("/files/7/download");
+		expect(previewLinkFactory).toHaveBeenCalledTimes(1);
+	});
+
+	it("falls back to authenticated download paths when preview-link creation fails", async () => {
+		const previewLinkFactory = vi.fn(async () => {
+			throw new Error("preview link failed");
+		});
+
+		const { result } = renderModel({
+			openMode: "direct",
+			previewLinkFactory,
+		});
+
+		await waitFor(() => {
+			expect(previewLinkFactory).toHaveBeenCalledTimes(1);
+			expect(result.current.resolvedContentPreviewPath).toBe(
+				"/files/7/download",
+			);
+		});
+	});
+
+	it("ignores stale preview-link results after file changes", async () => {
+		let resolveFirst!: (value: {
+			expires_at: string;
+			max_uses: number;
+			path: string;
+		}) => void;
+		const firstPromise = new Promise<{
+			expires_at: string;
+			max_uses: number;
+			path: string;
+		}>((resolve) => {
+			resolveFirst = resolve;
+		});
+		const previewLinkFactory = vi
+			.fn()
+			.mockReturnValueOnce(firstPromise)
+			.mockResolvedValueOnce({
+				expires_at: "2026-06-21T22:31:00Z",
+				max_uses: 5,
+				path: "/pv/token-2/next.pdf",
+			});
+
+		const { rerender, result } = renderModel({
+			file: file({ id: 7, name: "manual.pdf" }),
+			openMode: "direct",
+			previewLinkFactory,
+		});
+
+		rerender({
+			open: true,
+			file: file({ id: 8, name: "next.pdf" }),
+			onClose: vi.fn(),
+			openMode: "direct",
+			previewLinkFactory,
+			translateFileLabel: (key: string) => `files:${key}`,
+		});
+
+		resolveFirst({
+			expires_at: "2026-06-21T22:30:00Z",
+			max_uses: 5,
+			path: "/pv/token-1/manual.pdf",
+		});
+
+		await waitFor(() => {
+			expect(result.current.resolvedContentPreviewPath).toBe(
+				"/pv/token-2/next.pdf",
+			);
+		});
+		expect(result.current.resolvedContentPreviewPath).not.toBe(
+			"/pv/token-1/manual.pdf",
+		);
 	});
 
 	it("prefers explicit metadata loaders over generated audio metadata loaders", async () => {

--- a/frontend-panel/src/components/files/preview/useFilePreviewDialogModel.test.tsx
+++ b/frontend-panel/src/components/files/preview/useFilePreviewDialogModel.test.tsx
@@ -428,6 +428,68 @@ describe("useFilePreviewDialogModel", () => {
 		});
 	});
 
+	it("does not retry preview-link creation after a failed request while the file stays open", async () => {
+		const previewLinkFactory = vi.fn(async () => {
+			throw new Error("preview link failed");
+		});
+
+		const { rerender, result } = renderModel({
+			openMode: "direct",
+			previewLinkFactory,
+		});
+
+		await waitFor(() => {
+			expect(result.current.resolvedContentPreviewPath).toBe(
+				"/files/7/download",
+			);
+		});
+
+		rerender({
+			open: true,
+			file: file(),
+			onClose: vi.fn(),
+			openMode: "direct",
+			previewLinkFactory,
+			translateFileLabel: (key: string) => `files:${key}`,
+		});
+
+		expect(result.current.resolvedContentPreviewPath).toBe("/files/7/download");
+		expect(previewLinkFactory).toHaveBeenCalledTimes(1);
+	});
+
+	it("does not retry preview-link creation after a ready link while the file stays open", async () => {
+		const previewLinkFactory = vi.fn(async () => ({
+			expires_at: "2026-06-21T22:30:00Z",
+			max_uses: 5,
+			path: "/pv/token/manual.pdf",
+		}));
+
+		const { rerender, result } = renderModel({
+			openMode: "direct",
+			previewLinkFactory,
+		});
+
+		await waitFor(() => {
+			expect(result.current.resolvedContentPreviewPath).toBe(
+				"/pv/token/manual.pdf",
+			);
+		});
+
+		rerender({
+			open: true,
+			file: file(),
+			onClose: vi.fn(),
+			openMode: "direct",
+			previewLinkFactory,
+			translateFileLabel: (key: string) => `files:${key}`,
+		});
+
+		expect(result.current.resolvedContentPreviewPath).toBe(
+			"/pv/token/manual.pdf",
+		);
+		expect(previewLinkFactory).toHaveBeenCalledTimes(1);
+	});
+
 	it("ignores stale preview-link results after file changes", async () => {
 		let resolveFirst!: (value: {
 			expires_at: string;

--- a/frontend-panel/src/components/files/preview/useFilePreviewDialogModel.ts
+++ b/frontend-panel/src/components/files/preview/useFilePreviewDialogModel.ts
@@ -36,6 +36,19 @@ const PREVIEW_DIALOG_OPEN_ANIMATION_MS = 120;
 // Matches Tailwind's md breakpoint boundary.
 const MOBILE_PREVIEW_MEDIA_QUERY = "(max-width: 767px)";
 
+type PreviewLinkState = {
+	fileId: number;
+	path: string | null;
+	status: "idle" | "loading" | "ready" | "failed";
+};
+
+type ContentPreviewResourceInput = {
+	downloadPath: string;
+	fileId: number;
+	open: boolean;
+	previewLinkFactory?: FilePreviewDialogProps["previewLinkFactory"];
+};
+
 export interface FilePreviewDialogProps {
 	open: boolean;
 	file: FileInfo | FileListItem;
@@ -220,6 +233,108 @@ function useMediaQuery(query: string) {
 	return matches;
 }
 
+function useContentPreviewResourcePath({
+	downloadPath,
+	fileId,
+	open,
+	previewLinkFactory,
+}: ContentPreviewResourceInput) {
+	const previewLinkFactoryRef = useRef(previewLinkFactory);
+	const hasPreviewLinkFactory = Boolean(previewLinkFactory);
+	const [previewLinkState, setPreviewLinkState] = useState<PreviewLinkState>(
+		() => ({
+			fileId,
+			path: null,
+			status: "idle",
+		}),
+	);
+	const previewLinkRequestRef = useRef<{
+		fileId: number;
+		promise: Promise<PreviewLinkInfo>;
+	} | null>(null);
+
+	useEffect(() => {
+		previewLinkFactoryRef.current = previewLinkFactory;
+	}, [previewLinkFactory]);
+
+	useEffect(() => {
+		if (!open || !hasPreviewLinkFactory) {
+			previewLinkRequestRef.current = null;
+			setPreviewLinkState((current) =>
+				current.fileId === fileId &&
+				current.status === "idle" &&
+				current.path === null
+					? current
+					: {
+							fileId,
+							path: null,
+							status: "idle",
+						},
+			);
+			return;
+		}
+
+		let cancelled = false;
+		const factory = previewLinkFactoryRef.current;
+		if (!factory) return;
+
+		setPreviewLinkState((current) => {
+			if (
+				current.fileId === fileId &&
+				(current.status === "ready" || current.status === "failed")
+			) {
+				return current;
+			}
+			if (current.fileId === fileId && current.status === "loading") {
+				return current;
+			}
+			return {
+				fileId,
+				path: null,
+				status: "loading",
+			};
+		});
+
+		let request = previewLinkRequestRef.current;
+		if (!request || request.fileId !== fileId) {
+			request = {
+				fileId,
+				promise: factory(),
+			};
+			previewLinkRequestRef.current = request;
+		}
+
+		request.promise
+			.then((previewLink) => {
+				if (cancelled || previewLinkRequestRef.current !== request) return;
+				setPreviewLinkState({
+					fileId,
+					path: previewLink.path,
+					status: "ready",
+				});
+			})
+			.catch(() => {
+				if (cancelled || previewLinkRequestRef.current !== request) return;
+				setPreviewLinkState({
+					fileId,
+					path: null,
+					status: "failed",
+				});
+			});
+
+		return () => {
+			cancelled = true;
+		};
+	}, [fileId, hasPreviewLinkFactory, open]);
+
+	if (!open) return null;
+	if (!hasPreviewLinkFactory) return downloadPath;
+	if (previewLinkState.fileId !== fileId) return null;
+	if (previewLinkState.status === "ready") return previewLinkState.path;
+	if (previewLinkState.status === "failed") return downloadPath;
+	return null;
+}
+
 export function useFilePreviewDialogModel({
 	open,
 	file,
@@ -272,6 +387,12 @@ export function useFilePreviewDialogModel({
 								),
 					)
 			: undefined);
+	const resolvedContentPreviewPath = useContentPreviewResourcePath({
+		downloadPath: resolvedDownloadPath,
+		fileId: file.id,
+		open,
+		previewLinkFactory,
+	});
 
 	useEffect(() => {
 		if (!mediaDataSupportLoaded) {
@@ -605,6 +726,7 @@ export function useFilePreviewDialogModel({
 		isImagePreview,
 		previewAppsLoaded,
 		profile,
+		resolvedContentPreviewPath,
 		resolvedDownloadPath,
 		resolvedImagePreviewPath,
 		resolvedLoadMusicBackendMetadata,

--- a/frontend-panel/src/components/files/useUploadAreaManager.ts
+++ b/frontend-panel/src/components/files/useUploadAreaManager.ts
@@ -51,6 +51,7 @@ interface UseUploadAreaManagerOptions {
 	refresh: () => Promise<void>;
 	refreshUser: (options?: { fields?: MeField[] }) => Promise<void>;
 	resumeFileInputRef: RefObject<HTMLInputElement | null>;
+	storageEventStreamEnabled: boolean;
 	workspace: Workspace;
 }
 
@@ -60,6 +61,7 @@ export function useUploadAreaManager({
 	refresh,
 	refreshUser,
 	resumeFileInputRef,
+	storageEventStreamEnabled,
 	workspace,
 }: UseUploadAreaManagerOptions) {
 	const { t } = useTranslation(["core", "files"]);
@@ -218,13 +220,13 @@ export function useUploadAreaManager({
 			pendingRefreshFolderIds.has(currentFolderIdRef.current);
 		pendingRefreshFolderIdsRef.current = new Set();
 
-		if (pendingRefreshFolderIds.size > 0) {
+		if (pendingRefreshFolderIds.size > 0 && !storageEventStreamEnabled) {
 			void refreshUser({ fields: ["quota"] });
 		}
 		if (shouldRefreshCurrentFolder) {
 			void refresh();
 		}
-	}, [refresh, refreshUser, tasks]);
+	}, [refresh, refreshUser, storageEventStreamEnabled, tasks]);
 
 	const clearCompletedTasks = useCallback(() => {
 		setTasks((prev) => prev.filter((task) => task.status !== "completed"));

--- a/frontend-panel/src/hooks/useBlobUrl.test.tsx
+++ b/frontend-panel/src/hooks/useBlobUrl.test.tsx
@@ -268,6 +268,44 @@ describe("useBlobUrl", () => {
 		clearBlobUrlCache();
 	});
 
+	it("omits credentials for preview-link and external blob resources", async () => {
+		mockState.get.mockResolvedValue({
+			status: 200,
+			data: new Blob(["preview"]),
+			headers: { etag: '"etag-pv"' },
+		});
+		const { clearBlobUrlCache, useBlobUrl } = await loadHookModule();
+
+		const preview = renderHook(() => useBlobUrl("/pv/token/image.webp"));
+		await waitFor(() => {
+			expect(preview.result.current.blobUrl).toBe("blob:1");
+		});
+		expect(mockState.get).toHaveBeenLastCalledWith("/pv/token/image.webp", {
+			headers: {},
+			responseType: "blob",
+			withCredentials: false,
+			validateStatus: expect.any(Function),
+		});
+
+		mockState.get.mockClear();
+		const external = renderHook(() =>
+			useBlobUrl("https://objects.example.test/image.webp"),
+		);
+		await waitFor(() => {
+			expect(external.result.current.blobUrl).toBe("blob:2");
+		});
+		expect(mockState.get).toHaveBeenLastCalledWith(
+			"https://objects.example.test/image.webp",
+			{
+				headers: {},
+				responseType: "blob",
+				withCredentials: false,
+				validateStatus: expect.any(Function),
+			},
+		);
+		clearBlobUrlCache();
+	});
+
 	it("revalidates cached blobs with etags and keeps the same object url on 304", async () => {
 		const imageBlob = new Blob(["image"]);
 		mockState.get
@@ -298,6 +336,7 @@ describe("useBlobUrl", () => {
 		expect(mockState.get).toHaveBeenNthCalledWith(2, "/thumb", {
 			headers: { "If-None-Match": '"etag-4"' },
 			responseType: "blob",
+			withCredentials: true,
 			validateStatus: expect.any(Function),
 		});
 		expect(URL.createObjectURL).toHaveBeenCalledTimes(1);
@@ -372,6 +411,7 @@ describe("useBlobUrl", () => {
 		expect(mockState.get).toHaveBeenNthCalledWith(2, "/thumb", {
 			headers: { "If-None-Match": '"etag-persisted"' },
 			responseType: "blob",
+			withCredentials: true,
 			validateStatus: expect.any(Function),
 		});
 
@@ -563,6 +603,7 @@ describe("useBlobUrl", () => {
 		expect(mockState.get).toHaveBeenNthCalledWith(1, "/thumb-1", {
 			headers: {},
 			responseType: "blob",
+			withCredentials: true,
 			validateStatus: expect.any(Function),
 		});
 
@@ -581,6 +622,7 @@ describe("useBlobUrl", () => {
 		expect(mockState.get).toHaveBeenNthCalledWith(2, "/thumb-2", {
 			headers: {},
 			responseType: "blob",
+			withCredentials: true,
 			validateStatus: expect.any(Function),
 		});
 
@@ -639,11 +681,13 @@ describe("useBlobUrl", () => {
 		expect(mockState.get).toHaveBeenCalledWith("/thumb-1", {
 			headers: {},
 			responseType: "blob",
+			withCredentials: true,
 			validateStatus: expect.any(Function),
 		});
 		expect(mockState.get).toHaveBeenCalledWith("/image-preview", {
 			headers: {},
 			responseType: "blob",
+			withCredentials: true,
 			validateStatus: expect.any(Function),
 		});
 		expect(mockState.get).not.toHaveBeenCalledWith(
@@ -674,6 +718,7 @@ describe("useBlobUrl", () => {
 		expect(mockState.get).toHaveBeenNthCalledWith(3, "/thumb-2", {
 			headers: {},
 			responseType: "blob",
+			withCredentials: true,
 			validateStatus: expect.any(Function),
 		});
 

--- a/frontend-panel/src/hooks/useBlobUrl.ts
+++ b/frontend-panel/src/hooks/useBlobUrl.ts
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { config } from "@/config/app";
+import { shouldSendResourceCredentials } from "@/lib/apiUrl";
 import { logger } from "@/lib/logger";
 import { api } from "@/services/http";
 
@@ -311,6 +312,7 @@ async function fetchBlobUrlFromNetwork({
 			api.client.get(path, {
 				headers,
 				responseType: "blob",
+				withCredentials: shouldSendResourceCredentials(path),
 				validateStatus: (status) =>
 					status === 200 ||
 					status === 304 ||

--- a/frontend-panel/src/hooks/useTextContent.test.tsx
+++ b/frontend-panel/src/hooks/useTextContent.test.tsx
@@ -13,6 +13,13 @@ vi.mock("@/services/http", () => ({
 	},
 }));
 
+vi.mock("@/lib/apiUrl", async () => {
+	const actual = await vi.importActual<typeof import("@/lib/apiUrl")>(
+		"@/lib/apiUrl",
+	);
+	return actual;
+});
+
 async function loadHookModule() {
 	vi.resetModules();
 	return await import("@/hooks/useTextContent");
@@ -80,6 +87,7 @@ describe("useTextContent", () => {
 		expect(mockState.get).toHaveBeenNthCalledWith(2, "/files/1/content", {
 			headers: { "If-None-Match": '"etag-2"' },
 			responseType: "text",
+			withCredentials: true,
 			validateStatus: expect.any(Function),
 		});
 		expect(second.result.current.etag).toBe('"etag-2"');
@@ -129,6 +137,7 @@ describe("useTextContent", () => {
 		expect(mockState.get).toHaveBeenNthCalledWith(2, "/files/1/content", {
 			headers: {},
 			responseType: "text",
+			withCredentials: true,
 			validateStatus: expect.any(Function),
 		});
 		clearTextContentCache();
@@ -159,8 +168,47 @@ describe("useTextContent", () => {
 		expect(mockState.get).toHaveBeenNthCalledWith(2, "/files/1/content", {
 			headers: { "If-None-Match": '"etag-3"' },
 			responseType: "text",
+			withCredentials: true,
 			validateStatus: expect.any(Function),
 		});
+		clearTextContentCache();
+	});
+
+	it("omits credentials for preview-link and external text resources", async () => {
+		mockState.get.mockResolvedValue({
+			status: 200,
+			data: "preview",
+			headers: { etag: '"etag-pv"' },
+		});
+		const { clearTextContentCache, useTextContent } = await loadHookModule();
+
+		const preview = renderHook(() => useTextContent("/pv/token/file.txt"));
+		await waitFor(() => {
+			expect(preview.result.current.content).toBe("preview");
+		});
+		expect(mockState.get).toHaveBeenLastCalledWith("/pv/token/file.txt", {
+			headers: {},
+			responseType: "text",
+			withCredentials: false,
+			validateStatus: expect.any(Function),
+		});
+
+		mockState.get.mockClear();
+		const external = renderHook(() =>
+			useTextContent("https://objects.example.test/file.txt"),
+		);
+		await waitFor(() => {
+			expect(external.result.current.content).toBe("preview");
+		});
+		expect(mockState.get).toHaveBeenLastCalledWith(
+			"https://objects.example.test/file.txt",
+			{
+				headers: {},
+				responseType: "text",
+				withCredentials: false,
+				validateStatus: expect.any(Function),
+			},
+		);
 		clearTextContentCache();
 	});
 

--- a/frontend-panel/src/hooks/useTextContent.test.tsx
+++ b/frontend-panel/src/hooks/useTextContent.test.tsx
@@ -14,9 +14,8 @@ vi.mock("@/services/http", () => ({
 }));
 
 vi.mock("@/lib/apiUrl", async () => {
-	const actual = await vi.importActual<typeof import("@/lib/apiUrl")>(
-		"@/lib/apiUrl",
-	);
+	const actual =
+		await vi.importActual<typeof import("@/lib/apiUrl")>("@/lib/apiUrl");
 	return actual;
 });
 

--- a/frontend-panel/src/hooks/useTextContent.ts
+++ b/frontend-panel/src/hooks/useTextContent.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
+import { shouldSendResourceCredentials } from "@/lib/apiUrl";
 import { api } from "@/services/http";
 
 interface TextCacheValue {
@@ -67,6 +68,7 @@ async function fetchTextContent(
 		.get(path, {
 			headers,
 			responseType: "text",
+			withCredentials: shouldSendResourceCredentials(path),
 			validateStatus: (status) => status === 200 || status === 304,
 		})
 		.then((response) => {

--- a/frontend-panel/src/lib/apiUrl.test.ts
+++ b/frontend-panel/src/lib/apiUrl.test.ts
@@ -98,7 +98,10 @@ describe("resolveApiResourceUrl", () => {
 	});
 
 	it("treats absolute resource URLs as external with a relative API base outside the browser", () => {
-		const originalWindow = globalThis.window;
+		const originalWindowDescriptor = Object.getOwnPropertyDescriptor(
+			globalThis,
+			"window",
+		);
 		vi.spyOn(appConfig.config, "apiBaseUrl", "get").mockReturnValue("/api/v1");
 		Reflect.deleteProperty(globalThis, "window");
 
@@ -107,11 +110,9 @@ describe("resolveApiResourceUrl", () => {
 				isExternalResourceUrl("https://api.example.com/api/v1/files/7"),
 			).toBe(true);
 		} finally {
-			Object.defineProperty(globalThis, "window", {
-				configurable: true,
-				value: originalWindow,
-				writable: true,
-			});
+			if (originalWindowDescriptor) {
+				Object.defineProperty(globalThis, "window", originalWindowDescriptor);
+			}
 		}
 	});
 

--- a/frontend-panel/src/lib/apiUrl.test.ts
+++ b/frontend-panel/src/lib/apiUrl.test.ts
@@ -5,6 +5,7 @@ import {
 	isPublicResourcePath,
 	normalizeApiResourcePath,
 	resolveApiResourceUrl,
+	shouldSendResourceCredentials,
 } from "@/lib/apiUrl";
 
 const appConfig = await import("@/config/app");
@@ -69,6 +70,17 @@ describe("resolveApiResourceUrl", () => {
 		expect(isPublicResourcePath("/api/v1/s/token/download")).toBe(true);
 		expect(isPublicResourcePath("/s/token/download")).toBe(true);
 		expect(isPublicResourcePath("/files/7/download")).toBe(false);
+		expect(shouldSendResourceCredentials("/files/7/download")).toBe(true);
+		expect(shouldSendResourceCredentials("/api/v1/files/7/download")).toBe(
+			true,
+		);
+		expect(shouldSendResourceCredentials("/pv/token/file.pdf")).toBe(false);
+		expect(shouldSendResourceCredentials("/api/v1/s/token/download")).toBe(
+			false,
+		);
+		expect(
+			shouldSendResourceCredentials("https://cdn.example.com/file.pdf"),
+		).toBe(false);
 
 		expect(isBrowserAddressableResourcePath("/api/v1/files/7/download")).toBe(
 			true,

--- a/frontend-panel/src/lib/apiUrl.test.ts
+++ b/frontend-panel/src/lib/apiUrl.test.ts
@@ -53,6 +53,24 @@ describe("resolveApiResourceUrl", () => {
 		);
 	});
 
+	it("keeps credentials for absolute resource URLs under the configured API base", () => {
+		vi.spyOn(appConfig.config, "apiBaseUrl", "get").mockReturnValue(
+			"https://api.example.com/api/v1",
+		);
+
+		expect(
+			isExternalResourceUrl("https://api.example.com/api/v1/files/7/download"),
+		).toBe(false);
+		expect(
+			shouldSendResourceCredentials(
+				"https://api.example.com/api/v1/files/7/download",
+			),
+		).toBe(true);
+		expect(
+			shouldSendResourceCredentials("https://cdn.example.com/files/7/download"),
+		).toBe(false);
+	});
+
 	it("classifies resource paths consistently for auth probing", () => {
 		expect(isExternalResourceUrl("https://cdn.example.com/file.pdf")).toBe(
 			true,

--- a/frontend-panel/src/lib/apiUrl.test.ts
+++ b/frontend-panel/src/lib/apiUrl.test.ts
@@ -71,6 +71,50 @@ describe("resolveApiResourceUrl", () => {
 		).toBe(false);
 	});
 
+	it("keeps credentials for absolute resource URLs under a relative API base", () => {
+		vi.spyOn(appConfig.config, "apiBaseUrl", "get").mockReturnValue("/api/v1");
+
+		expect(
+			isExternalResourceUrl(
+				`${window.location.origin}/api/v1/files/7/download`,
+			),
+		).toBe(false);
+		expect(
+			shouldSendResourceCredentials(
+				`${window.location.origin}/api/v1/files/7/download`,
+			),
+		).toBe(true);
+	});
+
+	it("treats absolute resource URLs as external when the configured API base cannot be parsed", () => {
+		vi.spyOn(appConfig.config, "apiBaseUrl", "get").mockReturnValue(
+			"https://[invalid",
+		);
+
+		expect(isExternalResourceUrl("https://api.example.com/files/7")).toBe(true);
+		expect(
+			shouldSendResourceCredentials("https://api.example.com/files/7"),
+		).toBe(false);
+	});
+
+	it("treats absolute resource URLs as external with a relative API base outside the browser", () => {
+		const originalWindow = globalThis.window;
+		vi.spyOn(appConfig.config, "apiBaseUrl", "get").mockReturnValue("/api/v1");
+		Reflect.deleteProperty(globalThis, "window");
+
+		try {
+			expect(
+				isExternalResourceUrl("https://api.example.com/api/v1/files/7"),
+			).toBe(true);
+		} finally {
+			Object.defineProperty(globalThis, "window", {
+				configurable: true,
+				value: originalWindow,
+				writable: true,
+			});
+		}
+	});
+
 	it("classifies resource paths consistently for auth probing", () => {
 		expect(isExternalResourceUrl("https://cdn.example.com/file.pdf")).toBe(
 			true,

--- a/frontend-panel/src/lib/apiUrl.ts
+++ b/frontend-panel/src/lib/apiUrl.ts
@@ -7,8 +7,6 @@ export function joinApiUrl(base: string, path: string) {
 }
 
 function isConfiguredApiUrl(path: string) {
-	if (!/^https?:\/\//i.test(path)) return false;
-
 	try {
 		const resourceUrl = new URL(path);
 		const baseUrl = /^https?:\/\//i.test(config.apiBaseUrl)

--- a/frontend-panel/src/lib/apiUrl.ts
+++ b/frontend-panel/src/lib/apiUrl.ts
@@ -6,8 +6,32 @@ export function joinApiUrl(base: string, path: string) {
 	return `${normalizedBase}${normalizedPath}`;
 }
 
+function isConfiguredApiUrl(path: string) {
+	if (!/^https?:\/\//i.test(path)) return false;
+
+	try {
+		const resourceUrl = new URL(path);
+		const baseUrl = /^https?:\/\//i.test(config.apiBaseUrl)
+			? new URL(config.apiBaseUrl)
+			: typeof window !== "undefined"
+				? new URL(config.apiBaseUrl, window.location.origin)
+				: null;
+		if (!baseUrl || resourceUrl.origin !== baseUrl.origin) return false;
+
+		const basePath = baseUrl.pathname.replace(/\/+$/, "") || "/";
+		return (
+			basePath === "/" ||
+			resourceUrl.pathname === basePath ||
+			resourceUrl.pathname.startsWith(`${basePath}/`)
+		);
+	} catch {
+		return false;
+	}
+}
+
 export function isExternalResourceUrl(path: string) {
-	return /^(?:https?:\/\/|blob:)/i.test(path);
+	if (/^blob:/i.test(path)) return true;
+	return /^https?:\/\//i.test(path) && !isConfiguredApiUrl(path);
 }
 
 export function normalizeApiResourcePath(path: string) {

--- a/frontend-panel/src/lib/apiUrl.ts
+++ b/frontend-panel/src/lib/apiUrl.ts
@@ -24,6 +24,10 @@ export function isPublicResourcePath(path: string) {
 	);
 }
 
+export function shouldSendResourceCredentials(path: string) {
+	return !isExternalResourceUrl(path) && !isPublicResourcePath(path);
+}
+
 export function isBrowserAddressableResourcePath(path: string) {
 	return (
 		isExternalResourceUrl(path) ||

--- a/frontend-panel/src/lib/authenticatedResource.ts
+++ b/frontend-panel/src/lib/authenticatedResource.ts
@@ -1,8 +1,4 @@
-import {
-	isExternalResourceUrl,
-	isPublicResourcePath,
-	resolveApiResourceUrl,
-} from "@/lib/apiUrl";
+import { resolveApiResourceUrl, shouldSendResourceCredentials } from "@/lib/apiUrl";
 import { isSessionAuthFailure } from "@/lib/authErrors";
 import { logger } from "@/lib/logger";
 import { useAuthStore } from "@/stores/authStore";
@@ -21,7 +17,7 @@ type PrepareAuthenticatedResourceOptions = {
 const probeCache = new Map<string, ProbeCacheEntry>();
 
 function shouldProbeAuthenticatedResource(path: string) {
-	return !isExternalResourceUrl(path) && !isPublicResourcePath(path);
+	return shouldSendResourceCredentials(path);
 }
 
 function probeCacheKey(path: string) {

--- a/frontend-panel/src/lib/authenticatedResource.ts
+++ b/frontend-panel/src/lib/authenticatedResource.ts
@@ -1,4 +1,7 @@
-import { resolveApiResourceUrl, shouldSendResourceCredentials } from "@/lib/apiUrl";
+import {
+	resolveApiResourceUrl,
+	shouldSendResourceCredentials,
+} from "@/lib/apiUrl";
 import { isSessionAuthFailure } from "@/lib/authErrors";
 import { logger } from "@/lib/logger";
 import { useAuthStore } from "@/stores/authStore";

--- a/src/services/file_service/download/build.rs
+++ b/src/services/file_service/download/build.rs
@@ -141,13 +141,15 @@ pub(crate) async fn build_download_outcome_with_disposition_and_range(
     }
 
     let policy = state.policy_snapshot().get_policy_or_err(blob.policy_id)?;
-    let should_presign = disposition == DownloadDisposition::Attachment
-        && crate::storage::connectors::presigned_download_enabled(&policy)?;
+    let requires_sandbox =
+        disposition == DownloadDisposition::Inline && requires_inline_sandbox(&file.mime_type);
+    let should_presign =
+        !requires_sandbox && crate::storage::connectors::presigned_download_enabled(&policy)?;
 
     if should_presign {
-        // 只有"附件下载 + 存储驱动支持 + 策略允许"才走 presigned redirect。
-        // inline 预览仍由服务端统一加 CSP 和缓存头，避免把浏览器安全策略交给外部存储。
-        return build_presigned_redirect_outcome(state, &policy, file, blob).await;
+        // Inline previews may redirect to presigned storage only for types that do
+        // not require same-origin CSP sandboxing.
+        return build_presigned_redirect_outcome(state, &policy, file, blob, disposition).await;
     }
 
     build_stream_outcome_with_disposition_and_range(state, file, blob, disposition, None, range)
@@ -159,6 +161,7 @@ async fn build_presigned_redirect_outcome(
     policy: &crate::entities::storage_policy::Model,
     file: &file::Model,
     blob: &file_blob::Model,
+    disposition: DownloadDisposition,
 ) -> Result<DownloadOutcome> {
     let driver = state.driver_registry().get_driver(policy)?;
     let presigned = driver.as_presigned().ok_or_else(|| {
@@ -171,9 +174,7 @@ async fn build_presigned_redirect_outcome(
             Duration::from_secs(PRESIGNED_DOWNLOAD_TTL_SECS),
             PresignedDownloadOptions {
                 response_cache_control: Some("private, max-age=0, must-revalidate".to_string()),
-                response_content_disposition: Some(
-                    DownloadDisposition::Attachment.header_value(&file.name),
-                ),
+                response_content_disposition: Some(disposition.header_value(&file.name)),
                 response_content_type: Some(file.mime_type.clone()),
             },
         )

--- a/src/services/file_service/download/tests.rs
+++ b/src/services/file_service/download/tests.rs
@@ -2,6 +2,7 @@ use std::sync::{
     Arc,
     atomic::{AtomicUsize, Ordering},
 };
+use std::time::Duration;
 
 use actix_web::body;
 use async_trait::async_trait;
@@ -18,12 +19,17 @@ use crate::runtime::PrimaryAppState;
 use crate::services::file_service::DownloadDisposition;
 use crate::services::{mail_service, policy_service};
 use crate::storage::BlobMetadata;
+use crate::storage::traits::driver::PresignedDownloadOptions;
+use crate::storage::traits::extensions::PresignedStorageDriver;
 use crate::storage::{DriverRegistry, PolicySnapshot, StorageDriver};
-use crate::types::{DriverType, StoredStoragePolicyAllowedTypes, UserRole, UserStatus};
+use crate::types::{
+    DriverType, StoredStoragePolicyAllowedTypes, StoredStoragePolicyOptions, UserRole, UserStatus,
+};
 
-use super::build::build_stream_outcome_with_disposition;
+use super::build::build_download_outcome_with_disposition_and_range;
 use super::response::outcome_to_response;
 use super::streaming::AbortAwareStream;
+use super::types::DownloadOutcome;
 
 #[tokio::test]
 async fn abort_aware_stream_disarms_hook_on_clean_eof() {
@@ -139,15 +145,115 @@ impl StorageDriver for CountingStreamDriver {
     }
 }
 
+impl CountingStreamDriver {
+    fn with_presigned(self) -> PresignedCountingStreamDriver {
+        PresignedCountingStreamDriver(self)
+    }
+}
+
+#[derive(Clone)]
+struct PresignedCountingStreamDriver(CountingStreamDriver);
+
+#[async_trait]
+impl StorageDriver for PresignedCountingStreamDriver {
+    async fn put(&self, path: &str, data: &[u8]) -> crate::errors::Result<String> {
+        self.0.put(path, data).await
+    }
+
+    async fn get(&self, path: &str) -> crate::errors::Result<Vec<u8>> {
+        self.0.get(path).await
+    }
+
+    async fn get_stream(
+        &self,
+        path: &str,
+    ) -> crate::errors::Result<Box<dyn AsyncRead + Unpin + Send>> {
+        self.0.get_stream(path).await
+    }
+
+    async fn delete(&self, path: &str) -> crate::errors::Result<()> {
+        self.0.delete(path).await
+    }
+
+    async fn exists(&self, path: &str) -> crate::errors::Result<bool> {
+        self.0.exists(path).await
+    }
+
+    async fn metadata(&self, path: &str) -> crate::errors::Result<BlobMetadata> {
+        self.0.metadata(path).await
+    }
+
+    fn as_presigned(&self) -> Option<&dyn PresignedStorageDriver> {
+        Some(self)
+    }
+}
+
+#[async_trait]
+impl PresignedStorageDriver for PresignedCountingStreamDriver {
+    async fn presigned_url(
+        &self,
+        path: &str,
+        _expires: Duration,
+        options: PresignedDownloadOptions,
+    ) -> crate::errors::Result<Option<String>> {
+        let mut url = reqwest::Url::parse("https://objects.example.test/download")
+            .expect("mock presigned base URL should parse");
+        {
+            let mut query = url.query_pairs_mut();
+            query.append_pair("path", path);
+            if let Some(value) = options.response_cache_control {
+                query.append_pair("response-cache-control", &value);
+            }
+            if let Some(value) = options.response_content_disposition {
+                query.append_pair("response-content-disposition", &value);
+            }
+            if let Some(value) = options.response_content_type {
+                query.append_pair("response-content-type", &value);
+            }
+        }
+        Ok(Some(url.to_string()))
+    }
+
+    async fn presigned_put_url(
+        &self,
+        path: &str,
+        _expires: Duration,
+    ) -> crate::errors::Result<Option<String>> {
+        Ok(Some(format!(
+            "https://objects.example.test/upload?path={path}"
+        )))
+    }
+}
+
 async fn build_download_test_state(
-    driver: CountingStreamDriver,
+    driver: impl StorageDriver + Clone + 'static,
     payload_size: i64,
 ) -> (
     PrimaryAppState,
     file::Model,
     file_blob::Model,
-    CountingStreamDriver,
+    impl StorageDriver + Clone + 'static,
 ) {
+    build_download_test_state_with_policy(
+        driver,
+        payload_size,
+        DriverType::Local,
+        StoredStoragePolicyOptions::empty(),
+        "text/plain",
+    )
+    .await
+}
+
+async fn build_download_test_state_with_policy<D>(
+    driver: D,
+    payload_size: i64,
+    driver_type: DriverType,
+    options: StoredStoragePolicyOptions,
+    mime_type: &str,
+) -> (PrimaryAppState, file::Model, file_blob::Model, D)
+where
+    D: StorageDriver + Clone + 'static,
+{
     let temp_root = std::env::temp_dir().join(format!(
         "asterdrive-download-stream-test-{}",
         uuid::Uuid::new_v4()
@@ -171,7 +277,7 @@ async fn build_download_test_state(
     let now = Utc::now();
     let policy = storage_policy::ActiveModel {
         name: Set("Download Stream Policy".to_string()),
-        driver_type: Set(DriverType::Local),
+        driver_type: Set(driver_type),
         endpoint: Set(String::new()),
         bucket: Set(String::new()),
         access_key: Set(String::new()),
@@ -179,7 +285,7 @@ async fn build_download_test_state(
         base_path: Set(temp_root.to_string_lossy().into_owned()),
         max_file_size: Set(0),
         allowed_types: Set(StoredStoragePolicyAllowedTypes::empty()),
-        options: Set(crate::types::StoredStoragePolicyOptions::empty()),
+        options: Set(options),
         is_default: Set(true),
         chunk_size: Set(5_242_880),
         created_at: Set(now),
@@ -286,7 +392,7 @@ async fn build_download_test_state(
             owner_user_id: Set(Some(user.id)),
             created_by_user_id: Set(Some(user.id)),
             created_by_username: Set(user.username.clone()),
-            mime_type: Set("text/plain".to_string()),
+            mime_type: Set(mime_type.to_string()),
             created_at: Set(now),
             updated_at: Set(now),
             deleted_at: Set(None),
@@ -308,11 +414,12 @@ async fn build_stream_response_uses_get_stream_instead_of_get() {
     let get_stream_calls = driver.get_stream_calls.clone();
     let (state, file, blob, _) = build_download_test_state(driver, payload.len() as i64).await;
 
-    let outcome = build_stream_outcome_with_disposition(
+    let outcome = build_download_outcome_with_disposition_and_range(
         &state,
         &file,
         &blob,
         DownloadDisposition::Attachment,
+        None,
         None,
     )
     .await
@@ -332,5 +439,151 @@ async fn build_stream_response_uses_get_stream_instead_of_get() {
         get_stream_calls.load(Ordering::SeqCst),
         1,
         "download response should open exactly one streaming reader"
+    );
+}
+
+fn presigned_download_options() -> StoredStoragePolicyOptions {
+    StoredStoragePolicyOptions::from(
+        r#"{"object_storage_download_strategy":"presigned"}"#.to_string(),
+    )
+}
+
+#[actix_web::test]
+async fn attachment_download_redirects_to_presigned_url_with_attachment_disposition() {
+    let payload = b"presigned attachment".to_vec();
+    let base_driver = CountingStreamDriver::new(payload.clone());
+    let get_stream_calls = base_driver.get_stream_calls.clone();
+    let (state, file, blob, _) = build_download_test_state_with_policy(
+        base_driver.with_presigned(),
+        payload.len() as i64,
+        DriverType::S3,
+        presigned_download_options(),
+        "text/plain",
+    )
+    .await;
+
+    let outcome = build_download_outcome_with_disposition_and_range(
+        &state,
+        &file,
+        &blob,
+        DownloadDisposition::Attachment,
+        None,
+        None,
+    )
+    .await
+    .expect("attachment presigned outcome should build");
+
+    let DownloadOutcome::PresignedRedirect { url } = outcome else {
+        panic!("attachment downloads should redirect to presigned storage URL");
+    };
+    let parsed = reqwest::Url::parse(&url).expect("presigned URL should parse");
+    let query = parsed
+        .query_pairs()
+        .into_owned()
+        .collect::<std::collections::HashMap<_, _>>();
+    assert_eq!(
+        query
+            .get("response-content-disposition")
+            .map(String::as_str),
+        Some("attachment; filename*=UTF-8''download.txt")
+    );
+    assert_eq!(
+        query.get("response-content-type").map(String::as_str),
+        Some("text/plain")
+    );
+    assert_eq!(
+        get_stream_calls.load(Ordering::SeqCst),
+        0,
+        "presigned redirect must not open a backend stream"
+    );
+}
+
+#[actix_web::test]
+async fn safe_inline_preview_redirects_to_presigned_url_with_inline_disposition() {
+    let payload = b"presigned inline".to_vec();
+    let base_driver = CountingStreamDriver::new(payload.clone());
+    let get_stream_calls = base_driver.get_stream_calls.clone();
+    let (state, file, blob, _) = build_download_test_state_with_policy(
+        base_driver.with_presigned(),
+        payload.len() as i64,
+        DriverType::S3,
+        presigned_download_options(),
+        "image/webp",
+    )
+    .await;
+
+    let outcome = build_download_outcome_with_disposition_and_range(
+        &state,
+        &file,
+        &blob,
+        DownloadDisposition::Inline,
+        None,
+        None,
+    )
+    .await
+    .expect("safe inline presigned outcome should build");
+
+    let DownloadOutcome::PresignedRedirect { url } = outcome else {
+        panic!("safe inline previews should redirect to presigned storage URL");
+    };
+    let parsed = reqwest::Url::parse(&url).expect("presigned URL should parse");
+    let query = parsed
+        .query_pairs()
+        .into_owned()
+        .collect::<std::collections::HashMap<_, _>>();
+    assert_eq!(
+        query
+            .get("response-content-disposition")
+            .map(String::as_str),
+        Some("inline; filename*=UTF-8''download.txt")
+    );
+    assert_eq!(
+        query.get("response-content-type").map(String::as_str),
+        Some("image/webp")
+    );
+    assert_eq!(
+        get_stream_calls.load(Ordering::SeqCst),
+        0,
+        "presigned inline redirect must not open a backend stream"
+    );
+}
+
+#[actix_web::test]
+async fn sandboxed_inline_preview_does_not_redirect_to_presigned_storage() {
+    let payload = b"<script>alert(1)</script>".to_vec();
+    let base_driver = CountingStreamDriver::new(payload.clone());
+    let get_stream_calls = base_driver.get_stream_calls.clone();
+    let (state, file, blob, _) = build_download_test_state_with_policy(
+        base_driver.with_presigned(),
+        payload.len() as i64,
+        DriverType::S3,
+        presigned_download_options(),
+        "text/html",
+    )
+    .await;
+
+    let outcome = build_download_outcome_with_disposition_and_range(
+        &state,
+        &file,
+        &blob,
+        DownloadDisposition::Inline,
+        None,
+        None,
+    )
+    .await
+    .expect("sandboxed inline outcome should build");
+
+    let response = outcome_to_response(outcome);
+    assert_eq!(response.status(), actix_web::http::StatusCode::OK);
+    assert_eq!(
+        response.headers().get("Content-Security-Policy"),
+        Some(&actix_web::http::header::HeaderValue::from_static(
+            "sandbox"
+        ))
+    );
+    assert_eq!(
+        get_stream_calls.load(Ordering::SeqCst),
+        1,
+        "sandboxed inline preview should stream through backend to apply CSP"
     );
 }

--- a/src/services/file_service/download/tests.rs
+++ b/src/services/file_service/download/tests.rs
@@ -25,11 +25,16 @@ use crate::storage::{DriverRegistry, PolicySnapshot, StorageDriver};
 use crate::types::{
     DriverType, StoredStoragePolicyAllowedTypes, StoredStoragePolicyOptions, UserRole, UserStatus,
 };
+use crate::utils::numbers::usize_to_i64;
 
 use super::build::build_download_outcome_with_disposition_and_range;
 use super::response::outcome_to_response;
 use super::streaming::AbortAwareStream;
 use super::types::DownloadOutcome;
+
+fn payload_len_i64(payload: &[u8]) -> i64 {
+    usize_to_i64(payload.len(), "payload_len").expect("test payload length should fit in i64")
+}
 
 #[tokio::test]
 async fn abort_aware_stream_disarms_hook_on_clean_eof() {
@@ -412,7 +417,7 @@ async fn build_stream_response_uses_get_stream_instead_of_get() {
     let driver = CountingStreamDriver::new(payload.clone());
     let get_calls = driver.get_calls.clone();
     let get_stream_calls = driver.get_stream_calls.clone();
-    let (state, file, blob, _) = build_download_test_state(driver, payload.len() as i64).await;
+    let (state, file, blob, _) = build_download_test_state(driver, payload_len_i64(&payload)).await;
 
     let outcome = build_download_outcome_with_disposition_and_range(
         &state,
@@ -455,7 +460,7 @@ async fn attachment_download_redirects_to_presigned_url_with_attachment_disposit
     let get_stream_calls = base_driver.get_stream_calls.clone();
     let (state, file, blob, _) = build_download_test_state_with_policy(
         base_driver.with_presigned(),
-        payload.len() as i64,
+        payload_len_i64(&payload),
         DriverType::S3,
         presigned_download_options(),
         "text/plain",
@@ -505,7 +510,7 @@ async fn safe_inline_preview_redirects_to_presigned_url_with_inline_disposition(
     let get_stream_calls = base_driver.get_stream_calls.clone();
     let (state, file, blob, _) = build_download_test_state_with_policy(
         base_driver.with_presigned(),
-        payload.len() as i64,
+        payload_len_i64(&payload),
         DriverType::S3,
         presigned_download_options(),
         "image/webp",
@@ -555,7 +560,7 @@ async fn sandboxed_inline_preview_does_not_redirect_to_presigned_storage() {
     let get_stream_calls = base_driver.get_stream_calls.clone();
     let (state, file, blob, _) = build_download_test_state_with_policy(
         base_driver.with_presigned(),
-        payload.len() as i64,
+        payload_len_i64(&payload),
         DriverType::S3,
         presigned_download_options(),
         "text/html",

--- a/src/services/preview_link_service.rs
+++ b/src/services/preview_link_service.rs
@@ -152,7 +152,7 @@ pub(crate) async fn download_file(
     if let Some(if_none_match) = if_none_match
         && file_service::if_none_match_matches(if_none_match, &blob.hash)
     {
-        return file_service::build_stream_outcome_with_disposition_and_range(
+        return file_service::build_download_outcome_with_disposition_and_range(
             state,
             file,
             &blob,
@@ -164,7 +164,7 @@ pub(crate) async fn download_file(
     }
 
     let reserved = reserve_usage(state, token, payload).await?;
-    match file_service::build_stream_outcome_with_disposition_and_range(
+    match file_service::build_download_outcome_with_disposition_and_range(
         state,
         file,
         &blob,


### PR DESCRIPTION
Extend presigned download strategy to support inline previews for safe MIME types (images, audio, video, PDF) while preserving same-origin CSP sandboxing for executable content (HTML, SVG, XML).

**Backend changes:**
- Allow presigned redirects for inline disposition when content does not require CSP sandbox
- Pass disposition to presigned URL generator to set correct `Content-Disposition` response header
- Add integration tests verifying attachment downloads, safe inline previews, and sandboxed inline previews

**Frontend changes:**
- Introduce preview-link resource paths that omit credentials when accessing presigned or external storage URLs
- Add `useContentPreviewResourcePath` hook to request short-lived preview links and fall back to authenticated download paths
- Thread `contentPreviewPath` through preview components (image, video, music, PDF, text-based previews)
- Update `useBlobUrl` and `useTextContent` to conditionally send credentials based on resource origin
- Refresh user quota locally after upload queue settles only when storage event stream is disabled

**Documentation updates:**
- Expand CORS configuration section with separate examples for presigned upload, download, and combined scenarios
- Document required `Range`, `Content-Range`, `Accept-Ranges`, and `Content-Type` headers for video, audio, and PDF preview
- Explain credential-free preview link flow and troubleshooting steps for `Access-Control-Allow-Credentials` errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * 更新 S3/MinIO/R2 存储指南：补充 R2 自定义域名/缓存/公开策略需在 Cloudflare 配置；重写预签名上传/下载/预览的 CORS 指引与示例，并新增预览期间凭据与排查要点。
* **New Features**
  * 支持更精细的“内容预览路径”解析与就绪后切换，提升预览加载体验。
* **Bug Fixes**
  * 优化预览/外部资源的凭据发送策略；改进空预览路径与分支加载时的显示稳定性；调整预签名下载/内联预览的响应头与沙箱行为。
* **Chores**
  * 关闭存储事件流时，上传完成后更准确刷新本地配额；同时收紧相关测试断言。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->