### PR TITLE
feat(preview): distinguish stable identity from ephemeral preview links

### DIFF
--- a/frontend-panel/AGENTS.md
+++ b/frontend-panel/AGENTS.md
@@ -49,6 +49,17 @@ import type { UserInfo, ShareInfo, StoragePolicy } from "@/types/api";
 - 401 自动 refresh token（拦截器处理）
 - 所有请求带 `withCredentials: true`（HttpOnly cookie 认证）
 
+### 前端服务层治理
+- 前端 service / resource / store 层按“调用远程服务的后端”标准设计。组件不得直接推断远程资源的认证、缓存、重试、刷新、一致性策略。
+- 组件只负责展示和交互，不在组件里判断 `/api`、`/pv`、外链、presigned URL、credentials、`If-None-Match`、fallback、SSE/上传刷新竞态等底层策略。
+- `src/services/*` 是远程 API adapter，负责封装接口调用和生成类型适配；不要在 service 中混入 UI 状态、toast、组件级 fallback 或跨 store 协调逻辑。
+- 跨 API、跨 store、跨事件源的业务行为必须收口到可测试的 hook / coordinator / resource 模块，例如 preview resource resolver、storage refresh coordinator，而不是散落在页面和组件的 `useEffect` 中。
+- 文件资源访问必须区分稳定资源身份和当前请求 URL。短链 `/pv/...`、presigned URL、media stream session 等都是临时访问凭据，不能直接当成缓存身份；需要缓存或去重时应使用 stable cache key 和 canonical ETag。
+- 资源访问策略应集中表达：`credentials` 是 `include` 还是 `omit`、是否允许发送条件请求头、是否可能跨域 redirect、应以 blob/text/direct media/iframe/session 哪种方式交付给组件。
+- 对象存储 presigned / public-like 资源默认不要带 credentials，也不要让组件自行发送 `If-None-Match` 等自定义条件头；需要条件请求时必须由资源访问层明确允许，避免 R2/COS/MinIO CORS 回归。
+- 上传、本地文件操作、SSE storage events、quota refresh、folder refresh 的协调要通过集中模块处理，包括本地 echo 抑制、upload gate、SSE 关闭 fallback、personal/team scope 区分和重复请求去重。
+- 这类服务层 / 资源层 / 协调层改动必须补单元测试，覆盖认证策略、缓存 key、ETag、fallback、关闭/切换文件时的 stale promise、SSE 与本地刷新竞态等边界。
+
 ### 存储策略能力
 - 存储策略 UI 的连接测试、字段显示、上传工作流、授权入口、远端节点绑定、S3 传输策略、存储原生处理、driver action 可用性等能力判断，必须优先来自后端 storage connector descriptor 的 `capabilities`、`fields`、`upload_workflows`、`actions`、`connection_tests` 等元数据。
 - 不要在前端新增 `driver_type === "s3" || driver_type === "azure_blob" || ...` 这类白名单/矩阵来推断能力。已有临时兜底也只能用于 descriptor 缺失时的保守兼容，不能扩大成新的事实来源。

--- a/frontend-panel/src/components/admin/admin-overview-page/OverviewRecentEventsSection.tsx
+++ b/frontend-panel/src/components/admin/admin-overview-page/OverviewRecentEventsSection.tsx
@@ -52,12 +52,12 @@ export function OverviewRecentEventsSection({
 					<SkeletonTable columns={4} rows={8} />
 				</div>
 			) : overview?.recent_events.length ? (
-				<Table>
+				<Table className="min-w-[760px] table-fixed">
 					<TableHeader>
 						<TableRow>
-							<TableHead>{t("audit_time")}</TableHead>
-							<TableHead>{t("audit_action")}</TableHead>
-							<TableHead>{t("audit_user")}</TableHead>
+							<TableHead className="w-[180px]">{t("audit_time")}</TableHead>
+							<TableHead className="w-[200px]">{t("audit_action")}</TableHead>
+							<TableHead className="w-[180px]">{t("audit_user")}</TableHead>
 							<TableHead>{t("audit_entity")}</TableHead>
 						</TableRow>
 					</TableHeader>
@@ -73,7 +73,7 @@ export function OverviewRecentEventsSection({
 									>
 										{formatDateAbsolute(event.created_at)}
 									</TableCell>
-									<TableCell>
+									<TableCell className="max-w-0">
 										<Badge
 											variant="outline"
 											className={getAuditActionBadgeClass(event.action)}
@@ -81,10 +81,10 @@ export function OverviewRecentEventsSection({
 											{formatAuditSummary(t, event)}
 										</Badge>
 									</TableCell>
-									<TableCell className="max-w-0">
+									<TableCell>
 										<UserIdentity user={event.user} />
 									</TableCell>
-									<TableCell>
+									<TableCell className="max-w-0">
 										<div className="flex min-w-0 flex-col gap-0.5">
 											<span className="truncate text-sm">
 												{formatAuditTarget(t, event)}

--- a/frontend-panel/src/components/admin/admin-overview-page/OverviewRecentEventsSection.tsx
+++ b/frontend-panel/src/components/admin/admin-overview-page/OverviewRecentEventsSection.tsx
@@ -81,7 +81,7 @@ export function OverviewRecentEventsSection({
 											{formatAuditSummary(t, event)}
 										</Badge>
 									</TableCell>
-									<TableCell>
+									<TableCell className="max-w-0">
 										<UserIdentity user={event.user} />
 									</TableCell>
 									<TableCell className="max-w-0">

--- a/frontend-panel/src/components/files/preview/BlobImagePreview.tsx
+++ b/frontend-panel/src/components/files/preview/BlobImagePreview.tsx
@@ -5,6 +5,7 @@ import { Button } from "@/components/ui/button";
 import { Icon } from "@/components/ui/icon";
 import { useBlobUrl } from "@/hooks/useBlobUrl";
 import { canBrowserRenderImage } from "@/lib/browserImageSupport";
+import { type ResourcePath, resourceRequestPath } from "@/lib/resourceRequest";
 import { useFrontendConfigStore } from "@/stores/frontendConfigStore";
 import { PreviewError } from "./PreviewError";
 import { PreviewLoadingState } from "./PreviewLoadingState";
@@ -19,7 +20,7 @@ interface BlobImagePreviewProps {
 	imageStyle?: CSSProperties;
 	onImageLoad?: (source: ImagePreviewSource) => void;
 	onImageRenderError?: (source: ImagePreviewSource) => void;
-	path: string | null;
+	path: ResourcePath | null;
 	source?: ImagePreviewSource;
 	showOriginalButtonPlacement?: "inline" | "none";
 	viewportClassName?: string;
@@ -55,7 +56,8 @@ export function BlobImagePreview({
 	const imagePreviewPreference = useFrontendConfigStore(
 		(state) => state.imagePreviewPreference,
 	);
-	const previewKey = `${file.name}\u0000${file.mime_type}\u0000${path}\u0000${
+	const pathKey = path ? resourceRequestPath(path) : "";
+	const previewKey = `${file.name}\u0000${file.mime_type}\u0000${pathKey}\u0000${
 		fallbackPath ?? ""
 	}\u0000${imagePreviewPreference}`;
 	const [requestedOriginalKey, setRequestedOriginalKey] = useState<
@@ -117,7 +119,7 @@ export function BlobImagePreview({
 			: shouldPromoteReadyOriginal
 				? "original"
 				: baseSource;
-	const displayPath: string | null =
+	const displayPath: ResourcePath | null =
 		path == null
 			? null
 			: displaySource === "backend_preview"

--- a/frontend-panel/src/components/files/preview/CsvTablePreview.tsx
+++ b/frontend-panel/src/components/files/preview/CsvTablePreview.tsx
@@ -11,6 +11,7 @@ import {
 	TableRow,
 } from "@/components/ui/table";
 import { useTextContent } from "@/hooks/useTextContent";
+import type { ResourcePath } from "@/lib/resourceRequest";
 import type { TablePreviewDelimiterValue } from "@/lib/tablePreview";
 import { PreviewError } from "./PreviewError";
 import { PreviewLoadingState } from "./PreviewLoadingState";
@@ -22,7 +23,7 @@ import {
 } from "./PreviewSurface";
 
 interface CsvTablePreviewProps {
-	path: string;
+	path: ResourcePath;
 	delimiter: TablePreviewDelimiterValue;
 }
 

--- a/frontend-panel/src/components/files/preview/FilePreviewBody.tsx
+++ b/frontend-panel/src/components/files/preview/FilePreviewBody.tsx
@@ -1,5 +1,6 @@
 import { lazy, Suspense } from "react";
 import { useTranslation } from "react-i18next";
+import { type ResourcePath, resourceRequestPath } from "@/lib/resourceRequest";
 import { normalizeTablePreviewDelimiter } from "@/lib/tablePreview";
 import type { MusicPlayerTrack } from "@/stores/musicPlayerStore";
 import type {
@@ -63,7 +64,7 @@ interface FilePreviewBodyProps {
 	activeOption: OpenWithOption | null;
 	profile: PreviewProfile | null;
 	previewAppsLoaded: boolean;
-	contentPreviewPath: string | null;
+	contentPreviewPath: ResourcePath | null;
 	downloadPath: string;
 	imagePreviewPath?: string;
 	thumbnailPath?: string;
@@ -105,6 +106,9 @@ export function FilePreviewBody({
 	isExpanded,
 }: FilePreviewBodyProps) {
 	const { t } = useTranslation(["files"]);
+	const contentPreviewRequestPath = contentPreviewPath
+		? resourceRequestPath(contentPreviewPath)
+		: null;
 	const previewLoadingState = (
 		<PreviewLoadingState
 			text={t("files:loading_preview")}
@@ -144,7 +148,7 @@ export function FilePreviewBody({
 			<MusicPreview
 				file={file}
 				loadBackendMetadata={loadMusicBackendMetadata}
-				path={contentPreviewPath}
+				path={contentPreviewRequestPath}
 				thumbnailPath={thumbnailPath}
 				mediaStreamLinkFactory={mediaStreamLinkFactory}
 			/>
@@ -155,7 +159,7 @@ export function FilePreviewBody({
 		return (
 			<VideoPreview
 				file={file}
-				path={contentPreviewPath}
+				path={contentPreviewRequestPath}
 				mediaStreamLinkFactory={mediaStreamLinkFactory}
 			/>
 		);

--- a/frontend-panel/src/components/files/preview/FilePreviewDialog.test.tsx
+++ b/frontend-panel/src/components/files/preview/FilePreviewDialog.test.tsx
@@ -6,6 +6,14 @@ const mockState = vi.hoisted(() => ({
 	downloadPath: vi.fn((fileId: number) => `/files/${fileId}/download`),
 	getMediaMetadata: vi.fn(),
 	imagePreviewPath: vi.fn((fileId: number) => `/files/${fileId}/image-preview`),
+	resourcePathCacheKey: (
+		path: string | { cacheKey?: string; requestPath: string } | null,
+	) => (typeof path === "string" ? path : (path?.cacheKey ?? "")),
+	resourcePathEtag: (
+		path: string | { etag?: string | null; requestPath: string } | null,
+	) => (typeof path === "string" ? "" : (path?.etag ?? "")),
+	resourcePathRequestPath: (path: string | { requestPath: string } | null) =>
+		typeof path === "string" ? path : (path?.requestPath ?? ""),
 	thumbnailPath: vi.fn((fileId: number) => `/files/${fileId}/thumbnail`),
 	profile: {
 		category: "markdown",
@@ -225,14 +233,23 @@ vi.mock("@/components/files/preview/BlobImagePreview", () => ({
 		file: { name: string };
 		fallbackPath?: string;
 		fillContainer?: boolean;
-		path: string | null;
+		path:
+			| string
+			| { cacheKey?: string; etag?: string | null; requestPath: string }
+			| null;
 	}) => (
 		<img
 			alt={file.name}
+			data-cache-key={mockState.resourcePathCacheKey(path)}
+			data-preview-etag={mockState.resourcePathEtag(path)}
 			data-fallback-path={fallbackPath ?? ""}
 			data-fill-container={String(Boolean(fillContainer))}
-			data-preview-path={path ?? ""}
-			src={path ? `blob:${path}` : "blob:loading"}
+			data-preview-path={mockState.resourcePathRequestPath(path)}
+			src={
+				path
+					? `blob:${mockState.resourcePathRequestPath(path)}`
+					: "blob:loading"
+			}
 		/>
 	),
 }));
@@ -363,15 +380,27 @@ vi.mock("@/components/files/preview/UnsavedChangesGuard", () => ({
 }));
 
 vi.mock("@/components/files/preview/PdfPreview", () => ({
-	PdfPreview: ({ path, fileName }: { path: string; fileName: string }) => (
-		<div>{`pdf:${fileName}:${path}`}</div>
+	PdfPreview: ({
+		path,
+		fileName,
+	}: {
+		path:
+			| string
+			| { cacheKey?: string; etag?: string | null; requestPath: string };
+		fileName: string;
+	}) => (
+		<div>{`pdf:${fileName}:${mockState.resourcePathRequestPath(path)}`}</div>
 	),
 }));
 
 vi.mock("@/components/files/preview/MarkdownPreview", () => ({
-	MarkdownPreview: ({ path }: { path: string }) => (
-		<div>{`markdown:${path}`}</div>
-	),
+	MarkdownPreview: ({
+		path,
+	}: {
+		path:
+			| string
+			| { cacheKey?: string; etag?: string | null; requestPath: string };
+	}) => <div>{`markdown:${mockState.resourcePathRequestPath(path)}`}</div>,
 }));
 
 vi.mock("@/components/files/preview/CsvTablePreview", () => ({
@@ -379,19 +408,35 @@ vi.mock("@/components/files/preview/CsvTablePreview", () => ({
 		path,
 		delimiter,
 	}: {
-		path: string;
+		path:
+			| string
+			| { cacheKey?: string; etag?: string | null; requestPath: string };
 		delimiter: string;
-	}) => <div>{`table:${delimiter}:${path}`}</div>,
+	}) => (
+		<div>{`table:${delimiter}:${mockState.resourcePathRequestPath(path)}`}</div>
+	),
 }));
 
 vi.mock("@/components/files/preview/JsonPreview", () => ({
-	JsonPreview: ({ path }: { path: string }) => <div>{`json:${path}`}</div>,
+	JsonPreview: ({
+		path,
+	}: {
+		path:
+			| string
+			| { cacheKey?: string; etag?: string | null; requestPath: string };
+	}) => <div>{`json:${mockState.resourcePathRequestPath(path)}`}</div>,
 }));
 
 vi.mock("@/components/files/preview/XmlPreview", () => ({
-	XmlPreview: ({ path, mode }: { path: string; mode: string }) => (
-		<div>{`xml:${mode}:${path}`}</div>
-	),
+	XmlPreview: ({
+		path,
+		mode,
+	}: {
+		path:
+			| string
+			| { cacheKey?: string; etag?: string | null; requestPath: string };
+		mode: string;
+	}) => <div>{`xml:${mode}:${mockState.resourcePathRequestPath(path)}`}</div>,
 }));
 
 vi.mock("@/components/files/preview/TextCodePreview", () => ({
@@ -400,12 +445,14 @@ vi.mock("@/components/files/preview/TextCodePreview", () => ({
 		editable,
 		onDirtyChange,
 	}: {
-		path: string;
+		path:
+			| string
+			| { cacheKey?: string; etag?: string | null; requestPath: string };
 		editable: boolean;
 		onDirtyChange: (dirty: boolean) => void;
 	}) => (
 		<div>
-			<div>{`code:${path}:${String(editable)}`}</div>
+			<div>{`code:${mockState.resourcePathRequestPath(path)}:${String(editable)}`}</div>
 			<button type="button" onClick={() => onDirtyChange(true)}>
 				mark-dirty
 			</button>
@@ -935,6 +982,7 @@ describe("FilePreviewDialog", () => {
 			],
 		};
 		let resolvePreviewLink!: (value: {
+			etag: string;
 			expires_at: string;
 			max_uses: number;
 			path: string;
@@ -942,6 +990,7 @@ describe("FilePreviewDialog", () => {
 		const previewLinkFactory = vi.fn(
 			() =>
 				new Promise<{
+					etag: string;
 					expires_at: string;
 					max_uses: number;
 					path: string;
@@ -969,6 +1018,7 @@ describe("FilePreviewDialog", () => {
 		expect(previewLinkFactory).toHaveBeenCalledTimes(1);
 
 		resolvePreviewLink({
+			etag: '"etag-r2-image"',
 			expires_at: "2026-06-21T22:30:00Z",
 			max_uses: 5,
 			path: "/pv/token/r2-image.png",
@@ -978,6 +1028,14 @@ describe("FilePreviewDialog", () => {
 			expect(screen.getByRole("img", { name: "r2-image.png" })).toHaveAttribute(
 				"data-preview-path",
 				"/pv/token/r2-image.png",
+			);
+			expect(screen.getByRole("img", { name: "r2-image.png" })).toHaveAttribute(
+				"data-cache-key",
+				"/files/7/download",
+			);
+			expect(screen.getByRole("img", { name: "r2-image.png" })).toHaveAttribute(
+				"data-preview-etag",
+				'"etag-r2-image"',
 			);
 		});
 		expect(previewLinkFactory).toHaveBeenCalledTimes(1);
@@ -1117,6 +1175,7 @@ describe("FilePreviewDialog", () => {
 				size: 2048,
 			} as never,
 			previewLinkFactory: vi.fn(async () => ({
+				etag: '"etag-report"',
 				expires_at: "2026-04-08T12:00:00Z",
 				max_uses: 5,
 				path: "/pv/token/report.docx",

--- a/frontend-panel/src/components/files/preview/FilePreviewDialog.test.tsx
+++ b/frontend-panel/src/components/files/preview/FilePreviewDialog.test.tsx
@@ -1,19 +1,17 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { FilePreviewDialog } from "@/components/files/preview/FilePreviewDialog";
+import {
+	type ResourcePath,
+	resourceCacheKey,
+	resourceCanonicalEtag,
+	resourceRequestPath,
+} from "@/lib/resourceRequest";
 
 const mockState = vi.hoisted(() => ({
 	downloadPath: vi.fn((fileId: number) => `/files/${fileId}/download`),
 	getMediaMetadata: vi.fn(),
 	imagePreviewPath: vi.fn((fileId: number) => `/files/${fileId}/image-preview`),
-	resourcePathCacheKey: (
-		path: string | { cacheKey?: string; requestPath: string } | null,
-	) => (typeof path === "string" ? path : (path?.cacheKey ?? "")),
-	resourcePathEtag: (
-		path: string | { etag?: string | null; requestPath: string } | null,
-	) => (typeof path === "string" ? "" : (path?.etag ?? "")),
-	resourcePathRequestPath: (path: string | { requestPath: string } | null) =>
-		typeof path === "string" ? path : (path?.requestPath ?? ""),
 	thumbnailPath: vi.fn((fileId: number) => `/files/${fileId}/thumbnail`),
 	profile: {
 		category: "markdown",
@@ -233,23 +231,16 @@ vi.mock("@/components/files/preview/BlobImagePreview", () => ({
 		file: { name: string };
 		fallbackPath?: string;
 		fillContainer?: boolean;
-		path:
-			| string
-			| { cacheKey?: string; etag?: string | null; requestPath: string }
-			| null;
+		path: ResourcePath | null;
 	}) => (
 		<img
 			alt={file.name}
-			data-cache-key={mockState.resourcePathCacheKey(path)}
-			data-preview-etag={mockState.resourcePathEtag(path)}
+			data-cache-key={path ? resourceCacheKey(path) : ""}
+			data-preview-etag={path ? (resourceCanonicalEtag(path) ?? "") : ""}
 			data-fallback-path={fallbackPath ?? ""}
 			data-fill-container={String(Boolean(fillContainer))}
-			data-preview-path={mockState.resourcePathRequestPath(path)}
-			src={
-				path
-					? `blob:${mockState.resourcePathRequestPath(path)}`
-					: "blob:loading"
-			}
+			data-preview-path={path ? resourceRequestPath(path) : ""}
+			src={path ? `blob:${resourceRequestPath(path)}` : "blob:loading"}
 		/>
 	),
 }));
@@ -384,23 +375,15 @@ vi.mock("@/components/files/preview/PdfPreview", () => ({
 		path,
 		fileName,
 	}: {
-		path:
-			| string
-			| { cacheKey?: string; etag?: string | null; requestPath: string };
+		path: ResourcePath;
 		fileName: string;
-	}) => (
-		<div>{`pdf:${fileName}:${mockState.resourcePathRequestPath(path)}`}</div>
-	),
+	}) => <div>{`pdf:${fileName}:${resourceRequestPath(path)}`}</div>,
 }));
 
 vi.mock("@/components/files/preview/MarkdownPreview", () => ({
-	MarkdownPreview: ({
-		path,
-	}: {
-		path:
-			| string
-			| { cacheKey?: string; etag?: string | null; requestPath: string };
-	}) => <div>{`markdown:${mockState.resourcePathRequestPath(path)}`}</div>,
+	MarkdownPreview: ({ path }: { path: ResourcePath }) => (
+		<div>{`markdown:${resourceRequestPath(path)}`}</div>
+	),
 }));
 
 vi.mock("@/components/files/preview/CsvTablePreview", () => ({
@@ -408,35 +391,21 @@ vi.mock("@/components/files/preview/CsvTablePreview", () => ({
 		path,
 		delimiter,
 	}: {
-		path:
-			| string
-			| { cacheKey?: string; etag?: string | null; requestPath: string };
+		path: ResourcePath;
 		delimiter: string;
-	}) => (
-		<div>{`table:${delimiter}:${mockState.resourcePathRequestPath(path)}`}</div>
-	),
+	}) => <div>{`table:${delimiter}:${resourceRequestPath(path)}`}</div>,
 }));
 
 vi.mock("@/components/files/preview/JsonPreview", () => ({
-	JsonPreview: ({
-		path,
-	}: {
-		path:
-			| string
-			| { cacheKey?: string; etag?: string | null; requestPath: string };
-	}) => <div>{`json:${mockState.resourcePathRequestPath(path)}`}</div>,
+	JsonPreview: ({ path }: { path: ResourcePath }) => (
+		<div>{`json:${resourceRequestPath(path)}`}</div>
+	),
 }));
 
 vi.mock("@/components/files/preview/XmlPreview", () => ({
-	XmlPreview: ({
-		path,
-		mode,
-	}: {
-		path:
-			| string
-			| { cacheKey?: string; etag?: string | null; requestPath: string };
-		mode: string;
-	}) => <div>{`xml:${mode}:${mockState.resourcePathRequestPath(path)}`}</div>,
+	XmlPreview: ({ path, mode }: { path: ResourcePath; mode: string }) => (
+		<div>{`xml:${mode}:${resourceRequestPath(path)}`}</div>
+	),
 }));
 
 vi.mock("@/components/files/preview/TextCodePreview", () => ({
@@ -445,14 +414,12 @@ vi.mock("@/components/files/preview/TextCodePreview", () => ({
 		editable,
 		onDirtyChange,
 	}: {
-		path:
-			| string
-			| { cacheKey?: string; etag?: string | null; requestPath: string };
+		path: ResourcePath;
 		editable: boolean;
 		onDirtyChange: (dirty: boolean) => void;
 	}) => (
 		<div>
-			<div>{`code:${mockState.resourcePathRequestPath(path)}:${String(editable)}`}</div>
+			<div>{`code:${resourceRequestPath(path)}:${String(editable)}`}</div>
 			<button type="button" onClick={() => onDirtyChange(true)}>
 				mark-dirty
 			</button>

--- a/frontend-panel/src/components/files/preview/ImagePreviewPanel.tsx
+++ b/frontend-panel/src/components/files/preview/ImagePreviewPanel.tsx
@@ -13,6 +13,7 @@ import { useBlobUrl } from "@/hooks/useBlobUrl";
 import { canBrowserRenderImage } from "@/lib/browserImageSupport";
 import { formatBytes } from "@/lib/format";
 import { shouldIgnoreKeyboardTarget } from "@/lib/keyboard";
+import { type ResourcePath, resourceRequestPath } from "@/lib/resourceRequest";
 import { cn } from "@/lib/utils";
 import { useFrontendConfigStore } from "@/stores/frontendConfigStore";
 import type { FileInfo, FileListItem } from "@/types/api";
@@ -90,7 +91,7 @@ function isImagePreviewInteractiveTarget(target: EventTarget | null) {
 interface ImagePreviewPanelProps {
 	file: FileInfo | FileListItem;
 	allOptionsCount: number;
-	downloadPath: string | null;
+	downloadPath: ResourcePath | null;
 	imagePreviewPath?: string;
 	nextImageFile?: FileInfo | FileListItem;
 	onChooseOpenMethod: () => void;
@@ -163,7 +164,7 @@ export function ImagePreviewPanel({
 	const previewKey = [
 		file.name,
 		file.mime_type,
-		downloadPath,
+		downloadPath ? resourceRequestPath(downloadPath) : "",
 		imagePreviewPath ?? "",
 		imagePreviewPreference,
 	].join(IMAGE_PREVIEW_KEY_SEPARATOR);
@@ -398,7 +399,7 @@ function ImagePreviewTransformLayer({
 	onImageLoad,
 	onImageRenderError,
 }: {
-	downloadPath: string | null;
+	downloadPath: ResourcePath | null;
 	effectiveShowOriginalState: ShowOriginalState;
 	effectiveSource: ImagePreviewSource;
 	file: FileInfo | FileListItem;

--- a/frontend-panel/src/components/files/preview/ImagePreviewPanel.tsx
+++ b/frontend-panel/src/components/files/preview/ImagePreviewPanel.tsx
@@ -13,7 +13,7 @@ import { useBlobUrl } from "@/hooks/useBlobUrl";
 import { canBrowserRenderImage } from "@/lib/browserImageSupport";
 import { formatBytes } from "@/lib/format";
 import { shouldIgnoreKeyboardTarget } from "@/lib/keyboard";
-import { type ResourcePath, resourceRequestPath } from "@/lib/resourceRequest";
+import { type ResourcePath, resourceCacheKey } from "@/lib/resourceRequest";
 import { cn } from "@/lib/utils";
 import { useFrontendConfigStore } from "@/stores/frontendConfigStore";
 import type { FileInfo, FileListItem } from "@/types/api";
@@ -164,7 +164,7 @@ export function ImagePreviewPanel({
 	const previewKey = [
 		file.name,
 		file.mime_type,
-		downloadPath ? resourceRequestPath(downloadPath) : "",
+		downloadPath ? resourceCacheKey(downloadPath) : "",
 		imagePreviewPath ?? "",
 		imagePreviewPreference,
 	].join(IMAGE_PREVIEW_KEY_SEPARATOR);

--- a/frontend-panel/src/components/files/preview/JsonPreview.tsx
+++ b/frontend-panel/src/components/files/preview/JsonPreview.tsx
@@ -3,6 +3,7 @@ import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { useTextContent } from "@/hooks/useTextContent";
+import type { ResourcePath } from "@/lib/resourceRequest";
 import { PreviewError } from "./PreviewError";
 import { PreviewLoadingState } from "./PreviewLoadingState";
 import {
@@ -14,7 +15,7 @@ import {
 import { withScopedPrismClassName } from "./prismClassNames";
 
 interface JsonPreviewProps {
-	path: string;
+	path: ResourcePath;
 }
 
 export function JsonPreview({ path }: JsonPreviewProps) {

--- a/frontend-panel/src/components/files/preview/MarkdownPreview.tsx
+++ b/frontend-panel/src/components/files/preview/MarkdownPreview.tsx
@@ -4,6 +4,7 @@ import rehypeSanitize from "rehype-sanitize";
 import remarkGfm from "remark-gfm";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { useTextContent } from "@/hooks/useTextContent";
+import type { ResourcePath } from "@/lib/resourceRequest";
 import { PreviewError } from "./PreviewError";
 import { PreviewLoadingState } from "./PreviewLoadingState";
 import {
@@ -13,7 +14,7 @@ import {
 } from "./PreviewSurface";
 
 interface MarkdownPreviewProps {
-	path: string;
+	path: ResourcePath;
 }
 
 export function MarkdownPreview({ path }: MarkdownPreviewProps) {

--- a/frontend-panel/src/components/files/preview/PdfPreview.tsx
+++ b/frontend-panel/src/components/files/preview/PdfPreview.tsx
@@ -24,6 +24,7 @@ import { Input } from "@/components/ui/input";
 import { useBlobUrl } from "@/hooks/useBlobUrl";
 import { startAuthenticatedDownload } from "@/lib/authenticatedDownload";
 import { isImeComposingKeyEvent } from "@/lib/keyboard";
+import { type ResourcePath, resourceRequestPath } from "@/lib/resourceRequest";
 import { PreviewError } from "./PreviewError";
 import { PreviewLoadingState } from "./PreviewLoadingState";
 import { PreviewSurface, PreviewSurfaceContent } from "./PreviewSurface";
@@ -59,7 +60,7 @@ type LoadedPage = Parameters<
 >[0];
 
 interface PdfPreviewProps {
-	path: string;
+	path: ResourcePath;
 	fileName?: string;
 }
 
@@ -72,6 +73,7 @@ export function PdfPreview({ path, fileName }: PdfPreviewProps) {
 		loading: documentLoading,
 		retry: retryDocumentLoad,
 	} = useBlobUrl(path, { lane: "preview" });
+	const downloadPath = resourceRequestPath(path);
 	const documentFile = useMemo(
 		() => documentBlob ?? (documentUrl ? { url: documentUrl } : null),
 		[documentBlob, documentUrl],
@@ -299,14 +301,14 @@ export function PdfPreview({ path, fileName }: PdfPreviewProps) {
 
 	const handleDownload = useCallback(() => {
 		if (!documentUrl) {
-			void startAuthenticatedDownload(path);
+			void startAuthenticatedDownload(downloadPath);
 			return;
 		}
 		const link = document.createElement("a");
 		link.href = documentUrl;
 		link.download = fileName ?? "document.pdf";
 		link.click();
-	}, [documentUrl, fileName, path]);
+	}, [documentUrl, downloadPath, fileName]);
 
 	// biome-ignore lint/correctness/useExhaustiveDependencies: documentUrl intentionally resets viewer state when the PDF source changes
 	useEffect(() => {

--- a/frontend-panel/src/components/files/preview/TextCodePreview.tsx
+++ b/frontend-panel/src/components/files/preview/TextCodePreview.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useFileEditorSession } from "@/hooks/useFileEditorSession";
 import { useTextContent } from "@/hooks/useTextContent";
-import { type ResourcePath, resourceRequestPath } from "@/lib/resourceRequest";
+import { type ResourcePath, resourceCacheKey } from "@/lib/resourceRequest";
 import {
 	CodePreviewEditor,
 	type CodePreviewEditorMountHandler,
@@ -53,7 +53,7 @@ export function TextCodePreview({
 	const { t } = useTranslation(["core", "files"]);
 	const isDark = useIsDark();
 	const { content, etag, loading, error, reload } = useTextContent(path);
-	const editorKey = resourceRequestPath(path);
+	const editorKey = resourceCacheKey(path);
 	const {
 		editing,
 		dirty,

--- a/frontend-panel/src/components/files/preview/TextCodePreview.tsx
+++ b/frontend-panel/src/components/files/preview/TextCodePreview.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useFileEditorSession } from "@/hooks/useFileEditorSession";
 import { useTextContent } from "@/hooks/useTextContent";
+import { type ResourcePath, resourceRequestPath } from "@/lib/resourceRequest";
 import {
 	CodePreviewEditor,
 	type CodePreviewEditorMountHandler,
@@ -16,7 +17,7 @@ import type { PreviewableFileLike } from "./types";
 interface TextCodePreviewProps {
 	file: PreviewableFileLike & { id: number };
 	modeLabel?: string;
-	path: string;
+	path: ResourcePath;
 	onFileUpdated?: () => void;
 	onDirtyChange?: (dirty: boolean) => void;
 	editable?: boolean;
@@ -52,6 +53,7 @@ export function TextCodePreview({
 	const { t } = useTranslation(["core", "files"]);
 	const isDark = useIsDark();
 	const { content, etag, loading, error, reload } = useTextContent(path);
+	const editorKey = resourceRequestPath(path);
 	const {
 		editing,
 		dirty,
@@ -127,7 +129,7 @@ export function TextCodePreview({
 			/>
 			<PreviewSurfaceContent>
 				<CodePreviewEditor
-					key={path}
+					key={editorKey}
 					language={language}
 					theme={isDark ? "vs-dark" : "vs"}
 					value={editing ? editContent : content}

--- a/frontend-panel/src/components/files/preview/XmlPreview.tsx
+++ b/frontend-panel/src/components/files/preview/XmlPreview.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next";
 import xmlFormatter from "xml-formatter";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { useTextContent } from "@/hooks/useTextContent";
+import type { ResourcePath } from "@/lib/resourceRequest";
 import { PreviewError } from "./PreviewError";
 import { PreviewLoadingState } from "./PreviewLoadingState";
 import {
@@ -13,7 +14,7 @@ import {
 } from "./PreviewSurface";
 
 interface XmlPreviewProps {
-	path: string;
+	path: ResourcePath;
 	mode: "formatted";
 }
 

--- a/frontend-panel/src/components/files/preview/useFilePreviewDialogModel.test.tsx
+++ b/frontend-panel/src/components/files/preview/useFilePreviewDialogModel.test.tsx
@@ -1,5 +1,6 @@
 import { act, renderHook, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ResourceRequest } from "@/lib/resourceRequest";
 import type { FileListItem, MediaMetadataInfo } from "@/types/api";
 import type { FilePreviewProfile, OpenWithOption } from "./types";
 import { useFilePreviewDialogModel } from "./useFilePreviewDialogModel";
@@ -35,6 +36,18 @@ const wopiOption: OpenWithOption = {
 	labelKey: "open_with_onlyoffice",
 	mode: "wopi",
 };
+
+function previewResource(
+	requestPath: string,
+	cacheKey = "/files/7/download",
+	etag = '"etag-preview"',
+): ResourceRequest {
+	return {
+		cacheKey,
+		etag,
+		requestPath,
+	};
+}
 
 const mockState = vi.hoisted(() => ({
 	backendAudioMetadataToTrackMetadata: vi.fn((metadata: MediaMetadataInfo) => ({
@@ -294,6 +307,7 @@ describe("useFilePreviewDialogModel", () => {
 
 	it("uses preview-link paths for read-only content previews", async () => {
 		const previewLinkFactory = vi.fn(async () => ({
+			etag: '"etag-manual"',
 			expires_at: "2026-06-21T22:30:00Z",
 			max_uses: 5,
 			path: "/pv/token/manual.pdf",
@@ -322,8 +336,12 @@ describe("useFilePreviewDialogModel", () => {
 
 		expect(result.current.resolvedContentPreviewPath).toBeNull();
 		await waitFor(() => {
-			expect(result.current.resolvedContentPreviewPath).toBe(
-				"/pv/token/manual.pdf",
+			expect(result.current.resolvedContentPreviewPath).toEqual(
+				previewResource(
+					"/pv/token/manual.pdf",
+					"/files/7/download",
+					'"etag-manual"',
+				),
 			);
 		});
 		expect(result.current.resolvedDownloadPath).toBe("/files/7/download");
@@ -332,11 +350,13 @@ describe("useFilePreviewDialogModel", () => {
 
 	it("reuses the in-flight preview-link request when parent callbacks change", async () => {
 		let resolvePreviewLink!: (value: {
+			etag: string;
 			expires_at: string;
 			max_uses: number;
 			path: string;
 		}) => void;
 		const previewLinkPromise = new Promise<{
+			etag: string;
 			expires_at: string;
 			max_uses: number;
 			path: string;
@@ -365,14 +385,19 @@ describe("useFilePreviewDialogModel", () => {
 		expect(secondPreviewLinkFactory).not.toHaveBeenCalled();
 
 		resolvePreviewLink({
+			etag: '"etag-notes"',
 			expires_at: "2026-06-21T22:30:00Z",
 			max_uses: 5,
 			path: "/pv/token/notes.md",
 		});
 
 		await waitFor(() => {
-			expect(result.current.resolvedContentPreviewPath).toBe(
-				"/pv/token/notes.md",
+			expect(result.current.resolvedContentPreviewPath).toEqual(
+				previewResource(
+					"/pv/token/notes.md",
+					"/files/7/download",
+					'"etag-notes"',
+				),
 			);
 		});
 		expect(firstPreviewLinkFactory).toHaveBeenCalledTimes(1);
@@ -381,6 +406,7 @@ describe("useFilePreviewDialogModel", () => {
 
 	it("clears content preview paths while the kept-mounted dialog is closing", async () => {
 		const previewLinkFactory = vi.fn(async () => ({
+			etag: '"etag-notes"',
 			expires_at: "2026-06-21T22:30:00Z",
 			max_uses: 5,
 			path: "/pv/token/notes.md",
@@ -391,8 +417,12 @@ describe("useFilePreviewDialogModel", () => {
 		});
 
 		await waitFor(() => {
-			expect(result.current.resolvedContentPreviewPath).toBe(
-				"/pv/token/notes.md",
+			expect(result.current.resolvedContentPreviewPath).toEqual(
+				previewResource(
+					"/pv/token/notes.md",
+					"/files/7/download",
+					'"etag-notes"',
+				),
 			);
 		});
 
@@ -459,6 +489,7 @@ describe("useFilePreviewDialogModel", () => {
 
 	it("does not retry preview-link creation after a ready link while the file stays open", async () => {
 		const previewLinkFactory = vi.fn(async () => ({
+			etag: '"etag-manual"',
 			expires_at: "2026-06-21T22:30:00Z",
 			max_uses: 5,
 			path: "/pv/token/manual.pdf",
@@ -470,8 +501,12 @@ describe("useFilePreviewDialogModel", () => {
 		});
 
 		await waitFor(() => {
-			expect(result.current.resolvedContentPreviewPath).toBe(
-				"/pv/token/manual.pdf",
+			expect(result.current.resolvedContentPreviewPath).toEqual(
+				previewResource(
+					"/pv/token/manual.pdf",
+					"/files/7/download",
+					'"etag-manual"',
+				),
 			);
 		});
 
@@ -484,19 +519,25 @@ describe("useFilePreviewDialogModel", () => {
 			translateFileLabel: (key: string) => `files:${key}`,
 		});
 
-		expect(result.current.resolvedContentPreviewPath).toBe(
-			"/pv/token/manual.pdf",
+		expect(result.current.resolvedContentPreviewPath).toEqual(
+			previewResource(
+				"/pv/token/manual.pdf",
+				"/files/7/download",
+				'"etag-manual"',
+			),
 		);
 		expect(previewLinkFactory).toHaveBeenCalledTimes(1);
 	});
 
 	it("ignores stale preview-link results after file changes", async () => {
 		let resolveFirst!: (value: {
+			etag: string;
 			expires_at: string;
 			max_uses: number;
 			path: string;
 		}) => void;
 		const firstPromise = new Promise<{
+			etag: string;
 			expires_at: string;
 			max_uses: number;
 			path: string;
@@ -507,6 +548,7 @@ describe("useFilePreviewDialogModel", () => {
 			.fn()
 			.mockReturnValueOnce(firstPromise)
 			.mockResolvedValueOnce({
+				etag: '"etag-next"',
 				expires_at: "2026-06-21T22:31:00Z",
 				max_uses: 5,
 				path: "/pv/token-2/next.pdf",
@@ -528,18 +570,27 @@ describe("useFilePreviewDialogModel", () => {
 		});
 
 		resolveFirst({
+			etag: '"etag-manual"',
 			expires_at: "2026-06-21T22:30:00Z",
 			max_uses: 5,
 			path: "/pv/token-1/manual.pdf",
 		});
 
 		await waitFor(() => {
-			expect(result.current.resolvedContentPreviewPath).toBe(
-				"/pv/token-2/next.pdf",
+			expect(result.current.resolvedContentPreviewPath).toEqual(
+				previewResource(
+					"/pv/token-2/next.pdf",
+					"/files/8/download",
+					'"etag-next"',
+				),
 			);
 		});
-		expect(result.current.resolvedContentPreviewPath).not.toBe(
-			"/pv/token-1/manual.pdf",
+		expect(result.current.resolvedContentPreviewPath).not.toEqual(
+			previewResource(
+				"/pv/token-1/manual.pdf",
+				"/files/7/download",
+				'"etag-manual"',
+			),
 		);
 	});
 

--- a/frontend-panel/src/components/files/preview/useFilePreviewDialogModel.ts
+++ b/frontend-panel/src/components/files/preview/useFilePreviewDialogModel.ts
@@ -7,6 +7,7 @@ import {
 	useState,
 } from "react";
 import { supportsAudioMediaData } from "@/lib/mediaDataSupport";
+import type { ResourceRequest } from "@/lib/resourceRequest";
 import { fileService } from "@/services/fileService";
 import { useMediaDataSupportStore } from "@/stores/mediaDataSupportStore";
 import type { MusicPlayerTrack } from "@/stores/musicPlayerStore";
@@ -38,7 +39,7 @@ const MOBILE_PREVIEW_MEDIA_QUERY = "(max-width: 767px)";
 
 type PreviewLinkState = {
 	fileId: number;
-	path: string | null;
+	previewLink: PreviewLinkInfo | null;
 	status: "idle" | "loading" | "ready" | "failed";
 };
 
@@ -244,7 +245,7 @@ function useContentPreviewResourcePath({
 	const [previewLinkState, setPreviewLinkState] = useState<PreviewLinkState>(
 		() => ({
 			fileId,
-			path: null,
+			previewLink: null,
 			status: "idle",
 		}),
 	);
@@ -263,11 +264,11 @@ function useContentPreviewResourcePath({
 			setPreviewLinkState((current) =>
 				current.fileId === fileId &&
 				current.status === "idle" &&
-				current.path === null
+				current.previewLink === null
 					? current
 					: {
 							fileId,
-							path: null,
+							previewLink: null,
 							status: "idle",
 						},
 			);
@@ -290,7 +291,7 @@ function useContentPreviewResourcePath({
 			}
 			return {
 				fileId,
-				path: null,
+				previewLink: null,
 				status: "loading",
 			};
 		});
@@ -309,7 +310,7 @@ function useContentPreviewResourcePath({
 				if (cancelled || previewLinkRequestRef.current !== request) return;
 				setPreviewLinkState({
 					fileId,
-					path: previewLink.path,
+					previewLink,
 					status: "ready",
 				});
 			})
@@ -317,7 +318,7 @@ function useContentPreviewResourcePath({
 				if (cancelled || previewLinkRequestRef.current !== request) return;
 				setPreviewLinkState({
 					fileId,
-					path: null,
+					previewLink: null,
 					status: "failed",
 				});
 			});
@@ -330,7 +331,13 @@ function useContentPreviewResourcePath({
 	if (!open) return null;
 	if (!hasPreviewLinkFactory) return downloadPath;
 	if (previewLinkState.fileId !== fileId) return null;
-	if (previewLinkState.status === "ready") return previewLinkState.path;
+	if (previewLinkState.status === "ready" && previewLinkState.previewLink) {
+		return {
+			cacheKey: downloadPath,
+			etag: previewLinkState.previewLink.etag,
+			requestPath: previewLinkState.previewLink.path,
+		} satisfies ResourceRequest;
+	}
 	if (previewLinkState.status === "failed") return downloadPath;
 	return null;
 }

--- a/frontend-panel/src/components/files/preview/video-browser-config.test.ts
+++ b/frontend-panel/src/components/files/preview/video-browser-config.test.ts
@@ -97,6 +97,7 @@ describe("video browser config", () => {
 
 	it("resolves file preview links when the url template needs file_preview_url", async () => {
 		const createPreviewLink = vi.fn(async () => ({
+			etag: '"etag-report"',
 			expires_at: "2026-04-11T12:00:00Z",
 			max_uses: 1,
 			path: "/pv/token/report.docx",

--- a/frontend-panel/src/hooks/useBlobUrl.test.tsx
+++ b/frontend-panel/src/hooks/useBlobUrl.test.tsx
@@ -343,6 +343,97 @@ describe("useBlobUrl", () => {
 		clearBlobUrlCache();
 	});
 
+	it("reuses preview-link blobs by stable cache key and canonical etag", async () => {
+		const imageBlob = new Blob(["preview"]);
+		mockState.get.mockResolvedValue({
+			status: 200,
+			data: imageBlob,
+			headers: { etag: '"storage-etag"' },
+		});
+		const { clearBlobUrlCache, useBlobUrl } = await loadHookModule();
+
+		const first = renderHook(() =>
+			useBlobUrl({
+				cacheKey: "/files/7/download",
+				etag: '"canonical-etag"',
+				requestPath: "/pv/token-a/image.webp",
+			}),
+		);
+		await waitFor(() => {
+			expect(first.result.current.blobUrl).toBe("blob:1");
+		});
+		first.unmount();
+
+		const second = renderHook(() =>
+			useBlobUrl({
+				cacheKey: "/files/7/download",
+				etag: '"canonical-etag"',
+				requestPath: "/pv/token-b/image.webp",
+			}),
+		);
+		await waitFor(() => {
+			expect(second.result.current.blobUrl).toBe("blob:1");
+			expect(second.result.current.blob).toBe(imageBlob);
+		});
+
+		expect(mockState.get).toHaveBeenCalledTimes(1);
+		expect(mockState.get).toHaveBeenCalledWith("/pv/token-a/image.webp", {
+			headers: {},
+			responseType: "blob",
+			withCredentials: false,
+			validateStatus: expect.any(Function),
+		});
+		second.unmount();
+		clearBlobUrlCache();
+	});
+
+	it("refreshes preview-link blobs on canonical etag changes without conditional headers", async () => {
+		mockState.get
+			.mockResolvedValueOnce({
+				status: 200,
+				data: new Blob(["preview-a"]),
+				headers: { etag: '"storage-etag-a"' },
+			})
+			.mockResolvedValueOnce({
+				status: 200,
+				data: new Blob(["preview-b"]),
+				headers: { etag: '"storage-etag-b"' },
+			});
+		const { clearBlobUrlCache, useBlobUrl } = await loadHookModule();
+
+		const first = renderHook(() =>
+			useBlobUrl({
+				cacheKey: "/files/7/download",
+				etag: '"canonical-a"',
+				requestPath: "/pv/token-a/image.webp",
+			}),
+		);
+		await waitFor(() => {
+			expect(first.result.current.blobUrl).toBe("blob:1");
+		});
+		first.unmount();
+
+		const second = renderHook(() =>
+			useBlobUrl({
+				cacheKey: "/files/7/download",
+				etag: '"canonical-b"',
+				requestPath: "/pv/token-b/image.webp",
+			}),
+		);
+		await waitFor(() => {
+			expect(second.result.current.blobUrl).toBe("blob:2");
+		});
+
+		expect(mockState.get).toHaveBeenNthCalledWith(2, "/pv/token-b/image.webp", {
+			headers: {},
+			responseType: "blob",
+			withCredentials: false,
+			validateStatus: expect.any(Function),
+		});
+		second.unmount();
+		clearBlobUrlCache();
+	});
+
 	it("keeps thumbnail blob urls for the whole session after the first successful fetch", async () => {
 		mockState.get.mockResolvedValue({
 			status: 200,

--- a/frontend-panel/src/hooks/useBlobUrl.test.tsx
+++ b/frontend-panel/src/hooks/useBlobUrl.test.tsx
@@ -434,6 +434,96 @@ describe("useBlobUrl", () => {
 		clearBlobUrlCache();
 	});
 
+	it("falls back to request path as cache key for resource objects without cacheKey", async () => {
+		const imageBlob = new Blob(["preview"]);
+		mockState.get.mockResolvedValue({
+			status: 200,
+			data: imageBlob,
+			headers: { etag: '"storage-etag"' },
+		});
+		const { clearBlobUrlCache, useBlobUrl } = await loadHookModule();
+
+		const first = renderHook(() =>
+			useBlobUrl({
+				etag: '"canonical-etag"',
+				requestPath: "/pv/token-a/image.webp",
+			}),
+		);
+		await waitFor(() => {
+			expect(first.result.current.blobUrl).toBe("blob:1");
+		});
+		first.unmount();
+
+		const second = renderHook(() =>
+			useBlobUrl({
+				etag: '"canonical-etag"',
+				requestPath: "/pv/token-a/image.webp",
+			}),
+		);
+		await waitFor(() => {
+			expect(second.result.current.blobUrl).toBe("blob:1");
+			expect(second.result.current.blob).toBe(imageBlob);
+		});
+
+		expect(mockState.get).toHaveBeenCalledTimes(1);
+		expect(mockState.get).toHaveBeenCalledWith("/pv/token-a/image.webp", {
+			headers: {},
+			responseType: "blob",
+			withCredentials: false,
+			validateStatus: expect.any(Function),
+		});
+		second.unmount();
+		clearBlobUrlCache();
+	});
+
+	it("revalidates resource objects without canonical etags", async () => {
+		const imageBlob = new Blob(["preview-a"]);
+		mockState.get
+			.mockResolvedValueOnce({
+				status: 200,
+				data: imageBlob,
+				headers: { etag: '"storage-etag"' },
+			})
+			.mockResolvedValueOnce({
+				status: 304,
+				data: new Blob([]),
+				headers: {},
+			});
+		const { clearBlobUrlCache, useBlobUrl } = await loadHookModule();
+
+		const first = renderHook(() =>
+			useBlobUrl({
+				cacheKey: "/files/7/download",
+				requestPath: "/pv/token-a/image.webp",
+			}),
+		);
+		await waitFor(() => {
+			expect(first.result.current.blobUrl).toBe("blob:1");
+		});
+		first.unmount();
+
+		const second = renderHook(() =>
+			useBlobUrl({
+				cacheKey: "/files/7/download",
+				requestPath: "/pv/token-b/image.webp",
+			}),
+		);
+		await waitFor(() => {
+			expect(second.result.current.blobUrl).toBe("blob:1");
+			expect(second.result.current.blob).toBe(imageBlob);
+		});
+
+		expect(mockState.get).toHaveBeenNthCalledWith(2, "/pv/token-b/image.webp", {
+			headers: { "If-None-Match": '"storage-etag"' },
+			responseType: "blob",
+			withCredentials: false,
+			validateStatus: expect.any(Function),
+		});
+		expect(URL.createObjectURL).toHaveBeenCalledTimes(1);
+		second.unmount();
+		clearBlobUrlCache();
+	});
+
 	it("keeps thumbnail blob urls for the whole session after the first successful fetch", async () => {
 		mockState.get.mockResolvedValue({
 			status: 200,

--- a/frontend-panel/src/hooks/useBlobUrl.ts
+++ b/frontend-panel/src/hooks/useBlobUrl.ts
@@ -2,6 +2,12 @@ import { useEffect, useState } from "react";
 import { config } from "@/config/app";
 import { shouldSendResourceCredentials } from "@/lib/apiUrl";
 import { logger } from "@/lib/logger";
+import {
+	type ResourcePath,
+	resourceCacheKey,
+	resourceCanonicalEtag,
+	resourceRequestPath,
+} from "@/lib/resourceRequest";
 import { api } from "@/services/http";
 
 type BlobFetchLane = "default" | "preview" | "thumbnail";
@@ -29,10 +35,12 @@ interface FetchBlobUrlOptions {
 	logErrors?: boolean;
 	notifyOnChange?: boolean;
 	owner: BlobCacheEntry;
-	path: string;
+	cacheKey: string;
+	canonicalEtag?: string | null;
 	previousBlob?: Blob;
 	previousEtag: string | null;
 	previousObjectUrl?: string;
+	requestPath: string;
 }
 
 interface BlobUrlOptions {
@@ -296,23 +304,25 @@ async function fetchBlobUrlFromNetwork({
 	logErrors = true,
 	notifyOnChange = false,
 	owner,
-	path,
+	cacheKey,
+	canonicalEtag,
 	previousBlob,
 	previousEtag,
 	previousObjectUrl,
+	requestPath,
 }: FetchBlobUrlOptions): Promise<string> {
 	const headers: Record<string, string> = {};
-	if (previousObjectUrl && previousEtag) {
+	if (previousObjectUrl && previousEtag && !canonicalEtag) {
 		headers["If-None-Match"] = previousEtag;
 	}
 	const MAX_RETRIES = 5;
 
 	const fetchWithRetry = async (attempt: number): Promise<string> => {
 		const response = await scheduleBlobFetch(lane, () =>
-			api.client.get(path, {
+			api.client.get(requestPath, {
 				headers,
 				responseType: "blob",
-				withCredentials: shouldSendResourceCredentials(path),
+				withCredentials: shouldSendResourceCredentials(requestPath),
 				validateStatus: (status) =>
 					status === 200 ||
 					status === 304 ||
@@ -325,15 +335,15 @@ async function fetchBlobUrlFromNetwork({
 		if (response.status === 202) {
 			const retryAfter = Number(response.headers["retry-after"]) || 2;
 			if (attempt >= MAX_RETRIES) {
-				const current = blobUrlCache.get(path);
+				const current = blobUrlCache.get(cacheKey);
 				if (current && current === owner && !current.refreshTimer) {
 					current.promise = undefined;
 					current.refreshTimer = setTimeout(() => {
-						const latest = blobUrlCache.get(path);
+						const latest = blobUrlCache.get(cacheKey);
 						if (!latest || latest !== owner) return;
 						latest.refreshTimer = undefined;
 						latest.needsRefresh = true;
-						notifyBlobUrlInvalidation(path);
+						notifyBlobUrlInvalidation(cacheKey);
 					}, retryAfter * 1000);
 				}
 				return previousObjectUrl ?? "";
@@ -342,7 +352,7 @@ async function fetchBlobUrlFromNetwork({
 			return fetchWithRetry(attempt + 1);
 		}
 
-		const current = blobUrlCache.get(path);
+		const current = blobUrlCache.get(cacheKey);
 		if (!current || current !== owner) {
 			return "";
 		}
@@ -357,8 +367,9 @@ async function fetchBlobUrlFromNetwork({
 			if (previousObjectUrl) {
 				URL.revokeObjectURL(previousObjectUrl);
 			}
-			if (shouldPersistBlobOnDisk(lane)) void deletePersistedThumbnail(path);
-			notifyBlobUrlInvalidation(path);
+			if (shouldPersistBlobOnDisk(lane))
+				void deletePersistedThumbnail(cacheKey);
+			notifyBlobUrlInvalidation(cacheKey);
 			return "";
 		}
 
@@ -376,33 +387,33 @@ async function fetchBlobUrlFromNetwork({
 			response.data instanceof Blob
 				? response.data
 				: new Blob([response.data as BlobPart]);
-		if (blobUrlCache.get(path) !== owner) {
+		if (blobUrlCache.get(cacheKey) !== owner) {
 			return "";
 		}
 		const objectUrl = URL.createObjectURL(blob);
-		if (blobUrlCache.get(path) !== owner) {
+		if (blobUrlCache.get(cacheKey) !== owner) {
 			URL.revokeObjectURL(objectUrl);
 			return "";
 		}
 		current.blob = blob;
 		current.objectUrl = objectUrl;
-		current.etag = response.headers.etag ?? null;
+		current.etag = canonicalEtag ?? response.headers.etag ?? null;
 		current.missing = false;
 		current.needsRefresh = false;
 		current.promise = undefined;
 		if (previousObjectUrl && previousObjectUrl !== objectUrl) {
 			URL.revokeObjectURL(previousObjectUrl);
 		}
-		if (shouldPersistBlobOnDisk(lane) && blobUrlCache.get(path) === owner) {
-			await writePersistedThumbnail(path, blob, current.etag ?? null);
+		if (shouldPersistBlobOnDisk(lane) && blobUrlCache.get(cacheKey) === owner) {
+			await writePersistedThumbnail(cacheKey, blob, current.etag ?? null);
 		}
-		if (notifyOnChange) notifyBlobUrlInvalidation(path);
+		if (notifyOnChange) notifyBlobUrlInvalidation(cacheKey);
 		return objectUrl;
 	};
 
 	return fetchWithRetry(0).catch((error: unknown) => {
-		if (logErrors) logger.warn("blob fetch failed", path, error);
-		const current = blobUrlCache.get(path);
+		if (logErrors) logger.warn("blob fetch failed", requestPath, error);
+		const current = blobUrlCache.get(cacheKey);
 		if (current) {
 			current.promise = undefined;
 			current.blob = previousBlob;
@@ -411,7 +422,7 @@ async function fetchBlobUrlFromNetwork({
 			current.missing = false;
 			current.needsRefresh = false;
 			if (!current.objectUrl && current.refCount <= 0) {
-				blobUrlCache.delete(path);
+				blobUrlCache.delete(cacheKey);
 			}
 		}
 		throw error;
@@ -419,10 +430,13 @@ async function fetchBlobUrlFromNetwork({
 }
 
 async function acquireBlobUrl(
-	path: string,
+	resource: ResourcePath,
 	lane: BlobFetchLane,
 ): Promise<string> {
-	const cached = blobUrlCache.get(path);
+	const cacheKey = resourceCacheKey(resource);
+	const requestPath = resourceRequestPath(resource);
+	const canonicalEtag = resourceCanonicalEtag(resource);
+	const cached = blobUrlCache.get(cacheKey);
 	if (cached?.revokeTimer) {
 		clearTimeout(cached.revokeTimer);
 		cached.revokeTimer = undefined;
@@ -430,6 +444,18 @@ async function acquireBlobUrl(
 	if (
 		cached?.objectUrl &&
 		!cached.needsRefresh &&
+		cached.etag &&
+		canonicalEtag &&
+		cached.etag === canonicalEtag
+	) {
+		cached.lane = lane;
+		cached.refCount += 1;
+		return cached.objectUrl;
+	}
+	if (
+		cached?.objectUrl &&
+		!cached.needsRefresh &&
+		!canonicalEtag &&
 		(cached.refCount > 0 ||
 			shouldPersistBlobInSession(cached.lane ?? lane) ||
 			shouldPersistBlobInSession(lane))
@@ -441,6 +467,7 @@ async function acquireBlobUrl(
 	if (
 		cached?.missing &&
 		!cached.needsRefresh &&
+		!canonicalEtag &&
 		(cached.refCount > 0 ||
 			shouldPersistBlobInSession(cached.lane ?? lane) ||
 			shouldPersistBlobInSession(lane))
@@ -469,13 +496,13 @@ async function acquireBlobUrl(
 
 	const promise = (async () => {
 		if (shouldPersistBlobOnDisk(lane) && !previousObjectUrl) {
-			const persisted = await readPersistedThumbnail(path);
-			if (blobUrlCache.get(path) !== entry) {
+			const persisted = await readPersistedThumbnail(cacheKey);
+			if (blobUrlCache.get(cacheKey) !== entry) {
 				return "";
 			}
 			if (persisted) {
 				const objectUrl = URL.createObjectURL(persisted.blob);
-				if (blobUrlCache.get(path) !== entry) {
+				if (blobUrlCache.get(cacheKey) !== entry) {
 					URL.revokeObjectURL(objectUrl);
 					return "";
 				}
@@ -491,10 +518,12 @@ async function acquireBlobUrl(
 					logErrors: false,
 					notifyOnChange: true,
 					owner: entry,
-					path,
+					cacheKey,
+					canonicalEtag,
 					previousBlob: persisted.blob,
 					previousEtag: persisted.etag,
 					previousObjectUrl: objectUrl,
+					requestPath,
 				}).catch(() => {});
 
 				return objectUrl;
@@ -504,14 +533,16 @@ async function acquireBlobUrl(
 		return fetchBlobUrlFromNetwork({
 			lane,
 			owner: entry,
-			path,
+			cacheKey,
+			canonicalEtag,
 			previousBlob,
 			previousEtag,
 			previousObjectUrl,
+			requestPath,
 		});
 	})();
 	entry.promise = promise;
-	blobUrlCache.set(path, entry);
+	blobUrlCache.set(cacheKey, entry);
 	return promise;
 }
 
@@ -556,18 +587,24 @@ export function clearBlobUrlCache() {
 	}
 }
 
-export function useBlobUrl(path: string | null, options?: BlobUrlOptions) {
+export function useBlobUrl(
+	resource: ResourcePath | null,
+	options?: BlobUrlOptions,
+) {
 	const [blob, setBlob] = useState<Blob | null>(null);
 	const [blobUrl, setBlobUrl] = useState<string | null>(null);
 	const [error, setError] = useState(false);
 	const [loading, setLoading] = useState(false);
 	const [retryCount, setRetryCount] = useState(0);
 	const lane = options?.lane ?? "default";
+	const cacheKey = resource ? resourceCacheKey(resource) : null;
+	const requestPath = resource ? resourceRequestPath(resource) : null;
+	const canonicalEtag = resource ? resourceCanonicalEtag(resource) : null;
 
 	const retry = () => {
 		setError(false);
-		if (path) {
-			invalidateBlobUrl(path);
+		if (cacheKey) {
+			invalidateBlobUrl(cacheKey);
 		}
 	};
 
@@ -576,31 +613,38 @@ export function useBlobUrl(path: string | null, options?: BlobUrlOptions) {
 		setBlob(null);
 		setBlobUrl(null);
 		setError(false);
-		if (!path) {
+		if (!cacheKey || !requestPath) {
 			setLoading(false);
 			return;
 		}
+		const effectiveResource: ResourcePath = {
+			cacheKey,
+			etag: canonicalEtag,
+			requestPath: requestPath ?? cacheKey,
+		};
 
-		const unsubscribe = subscribeBlobUrlInvalidation(path, () => {
+		const unsubscribe = subscribeBlobUrlInvalidation(cacheKey, () => {
 			setBlob(null);
 			setBlobUrl(null);
 			setError(false);
 			setRetryCount((n) => n + 1);
 		});
 
-		const cached = blobUrlCache.get(path);
-		if (cached?.objectUrl) {
+		const cached = blobUrlCache.get(cacheKey);
+		const cachedMatchesCanonical =
+			!canonicalEtag || cached?.etag === canonicalEtag;
+		if (cached?.objectUrl && cachedMatchesCanonical) {
 			setBlob(cached.blob ?? null);
 			setBlobUrl(cached.objectUrl);
 			setLoading(false);
 		}
 
 		let cancelled = false;
-		setLoading(cached?.objectUrl === undefined);
-		acquireBlobUrl(path, lane)
+		setLoading(cached?.objectUrl === undefined || !cachedMatchesCanonical);
+		acquireBlobUrl(effectiveResource, lane)
 			.then((nextBlobUrl) => {
 				if (cancelled) return;
-				setBlob(blobUrlCache.get(path)?.blob ?? null);
+				setBlob(blobUrlCache.get(cacheKey)?.blob ?? null);
 				setBlobUrl(nextBlobUrl || null);
 			})
 			.catch(() => {
@@ -616,9 +660,9 @@ export function useBlobUrl(path: string | null, options?: BlobUrlOptions) {
 		return () => {
 			cancelled = true;
 			unsubscribe();
-			releaseBlobUrl(path);
+			releaseBlobUrl(cacheKey);
 		};
-	}, [lane, path, retryCount]);
+	}, [cacheKey, canonicalEtag, lane, requestPath, retryCount]);
 
 	return { blob, blobUrl, error, loading, retry };
 }

--- a/frontend-panel/src/hooks/useBlobUrl.ts
+++ b/frontend-panel/src/hooks/useBlobUrl.ts
@@ -620,7 +620,7 @@ export function useBlobUrl(
 		const effectiveResource: ResourcePath = {
 			cacheKey,
 			etag: canonicalEtag,
-			requestPath: requestPath ?? cacheKey,
+			requestPath,
 		};
 
 		const unsubscribe = subscribeBlobUrlInvalidation(cacheKey, () => {

--- a/frontend-panel/src/hooks/useTextContent.test.tsx
+++ b/frontend-panel/src/hooks/useTextContent.test.tsx
@@ -298,6 +298,102 @@ describe("useTextContent", () => {
 		clearTextContentCache();
 	});
 
+	it("falls back to request path as cache key for resource objects without cacheKey", async () => {
+		mockState.get.mockResolvedValue({
+			status: 200,
+			data: "preview",
+			headers: { etag: '"storage-etag"' },
+		});
+		const { clearTextContentCache, useTextContent } = await loadHookModule();
+
+		const first = renderHook(() =>
+			useTextContent({
+				etag: '"canonical-etag"',
+				requestPath: "/pv/token-a/file.txt",
+			}),
+		);
+		await waitFor(() => {
+			expect(first.result.current.content).toBe("preview");
+		});
+		first.unmount();
+
+		const second = renderHook(() =>
+			useTextContent({
+				etag: '"canonical-etag"',
+				requestPath: "/pv/token-a/file.txt",
+			}),
+		);
+		await waitFor(() => {
+			expect(second.result.current.content).toBe("preview");
+		});
+
+		expect(mockState.get).toHaveBeenCalledTimes(1);
+		expect(mockState.get).toHaveBeenCalledWith("/pv/token-a/file.txt", {
+			headers: {},
+			responseType: "text",
+			withCredentials: false,
+			validateStatus: expect.any(Function),
+		});
+		clearTextContentCache();
+	});
+
+	it("revalidates resource objects without canonical etags", async () => {
+		mockState.get
+			.mockResolvedValueOnce({
+				status: 200,
+				data: "preview-a",
+				headers: { etag: '"storage-etag"' },
+			})
+			.mockResolvedValueOnce({
+				status: 304,
+				data: "",
+				headers: {},
+			});
+		const { clearTextContentCache, useTextContent } = await loadHookModule();
+
+		const first = renderHook(() =>
+			useTextContent({
+				cacheKey: "/files/7/content",
+				requestPath: "/pv/token-a/file.txt",
+			}),
+		);
+		await waitFor(() => {
+			expect(first.result.current.content).toBe("preview-a");
+		});
+		first.unmount();
+
+		const second = renderHook(() =>
+			useTextContent({
+				cacheKey: "/files/7/content",
+				requestPath: "/pv/token-b/file.txt",
+			}),
+		);
+		await waitFor(() => {
+			expect(second.result.current.content).toBe("preview-a");
+		});
+
+		expect(mockState.get).toHaveBeenNthCalledWith(2, "/pv/token-b/file.txt", {
+			headers: { "If-None-Match": '"storage-etag"' },
+			responseType: "text",
+			withCredentials: false,
+			validateStatus: expect.any(Function),
+		});
+		clearTextContentCache();
+	});
+
+	it("stays idle when no text resource is provided", async () => {
+		const { clearTextContentCache, useTextContent } = await loadHookModule();
+
+		const { result } = renderHook(() => useTextContent(null));
+
+		expect(result.current.content).toBeNull();
+		expect(result.current.etag).toBeNull();
+		expect(result.current.error).toBe(false);
+		expect(result.current.loading).toBe(false);
+		expect(mockState.get).not.toHaveBeenCalled();
+		clearTextContentCache();
+	});
+
 	it("re-fetches active consumers after invalidation", async () => {
 		mockState.get
 			.mockResolvedValueOnce({

--- a/frontend-panel/src/hooks/useTextContent.test.tsx
+++ b/frontend-panel/src/hooks/useTextContent.test.tsx
@@ -211,6 +211,93 @@ describe("useTextContent", () => {
 		clearTextContentCache();
 	});
 
+	it("reuses preview-link text by stable cache key and canonical etag", async () => {
+		mockState.get.mockResolvedValue({
+			status: 200,
+			data: "preview",
+			headers: { etag: '"storage-etag"' },
+		});
+		const { clearTextContentCache, useTextContent } = await loadHookModule();
+
+		const first = renderHook(() =>
+			useTextContent({
+				cacheKey: "/files/7/download",
+				etag: '"canonical-etag"',
+				requestPath: "/pv/token-a/file.txt",
+			}),
+		);
+		await waitFor(() => {
+			expect(first.result.current.content).toBe("preview");
+		});
+		first.unmount();
+
+		const second = renderHook(() =>
+			useTextContent({
+				cacheKey: "/files/7/download",
+				etag: '"canonical-etag"',
+				requestPath: "/pv/token-b/file.txt",
+			}),
+		);
+		await waitFor(() => {
+			expect(second.result.current.content).toBe("preview");
+		});
+
+		expect(mockState.get).toHaveBeenCalledTimes(1);
+		expect(mockState.get).toHaveBeenCalledWith("/pv/token-a/file.txt", {
+			headers: {},
+			responseType: "text",
+			withCredentials: false,
+			validateStatus: expect.any(Function),
+		});
+		clearTextContentCache();
+	});
+
+	it("refreshes preview-link text on canonical etag changes without conditional headers", async () => {
+		mockState.get
+			.mockResolvedValueOnce({
+				status: 200,
+				data: "preview-a",
+				headers: { etag: '"storage-etag-a"' },
+			})
+			.mockResolvedValueOnce({
+				status: 200,
+				data: "preview-b",
+				headers: { etag: '"storage-etag-b"' },
+			});
+		const { clearTextContentCache, useTextContent } = await loadHookModule();
+
+		const first = renderHook(() =>
+			useTextContent({
+				cacheKey: "/files/7/download",
+				etag: '"canonical-a"',
+				requestPath: "/pv/token-a/file.txt",
+			}),
+		);
+		await waitFor(() => {
+			expect(first.result.current.content).toBe("preview-a");
+		});
+		first.unmount();
+
+		const second = renderHook(() =>
+			useTextContent({
+				cacheKey: "/files/7/download",
+				etag: '"canonical-b"',
+				requestPath: "/pv/token-b/file.txt",
+			}),
+		);
+		await waitFor(() => {
+			expect(second.result.current.content).toBe("preview-b");
+		});
+
+		expect(mockState.get).toHaveBeenNthCalledWith(2, "/pv/token-b/file.txt", {
+			headers: {},
+			responseType: "text",
+			withCredentials: false,
+			validateStatus: expect.any(Function),
+		});
+		clearTextContentCache();
+	});
+
 	it("re-fetches active consumers after invalidation", async () => {
 		mockState.get
 			.mockResolvedValueOnce({

--- a/frontend-panel/src/hooks/useTextContent.ts
+++ b/frontend-panel/src/hooks/useTextContent.ts
@@ -1,5 +1,11 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { shouldSendResourceCredentials } from "@/lib/apiUrl";
+import {
+	type ResourcePath,
+	resourceCacheKey,
+	resourceCanonicalEtag,
+	resourceRequestPath,
+} from "@/lib/resourceRequest";
 import { api } from "@/services/http";
 
 interface TextCacheValue {
@@ -52,23 +58,37 @@ function notifyTextContentInvalidation(path?: string) {
 }
 
 async function fetchTextContent(
-	path: string,
+	resource: ResourcePath,
 	force = false,
 ): Promise<TextCacheValue> {
-	const cached = textContentCache.get(path);
+	const cacheKey = resourceCacheKey(resource);
+	const requestPath = resourceRequestPath(resource);
+	const canonicalEtag = resourceCanonicalEtag(resource);
+	const cached = textContentCache.get(cacheKey);
 	if (!force && cached?.promise) {
 		return cached.promise;
 	}
+	if (
+		!force &&
+		canonicalEtag &&
+		cached?.content !== undefined &&
+		cached.etag === canonicalEtag
+	) {
+		return {
+			content: cached.content,
+			etag: cached.etag,
+		};
+	}
 	const headers: Record<string, string> = {};
-	if (!force && cached?.etag) {
+	if (!force && cached?.etag && !canonicalEtag) {
 		headers["If-None-Match"] = cached.etag;
 	}
 
 	const promise = api.client
-		.get(path, {
+		.get(requestPath, {
 			headers,
 			responseType: "text",
-			withCredentials: shouldSendResourceCredentials(path),
+			withCredentials: shouldSendResourceCredentials(requestPath),
 			validateStatus: (status) => status === 200 || status === 304,
 		})
 		.then((response) => {
@@ -77,29 +97,29 @@ async function fetchTextContent(
 					content: cached.content,
 					etag: cached.etag ?? null,
 				};
-				textContentCache.set(path, next);
+				textContentCache.set(cacheKey, next);
 				return next;
 			}
 			const next = {
 				content: response.data as string,
-				etag: response.headers.etag ?? null,
+				etag: canonicalEtag ?? response.headers.etag ?? null,
 			};
-			textContentCache.set(path, next);
+			textContentCache.set(cacheKey, next);
 			return next;
 		})
 		.catch((error: unknown) => {
 			if (cached?.content !== undefined) {
-				textContentCache.set(path, {
+				textContentCache.set(cacheKey, {
 					content: cached.content,
 					etag: cached.etag ?? null,
 				});
 			} else {
-				textContentCache.delete(path);
+				textContentCache.delete(cacheKey);
 			}
 			throw error;
 		});
 
-	textContentCache.set(path, {
+	textContentCache.set(cacheKey, {
 		content: cached?.content,
 		etag: cached?.etag ?? null,
 		promise,
@@ -122,20 +142,23 @@ export function clearTextContentCache() {
 	textContentCache.clear();
 }
 
-export function useTextContent(path: string | null) {
+export function useTextContent(resource: ResourcePath | null) {
 	const [content, setContentState] = useState<string | null>(null);
 	const [etag, setEtagState] = useState<string | null>(null);
 	const [loading, setLoading] = useState(false);
 	const [error, setError] = useState(false);
 	const requestIdRef = useRef(0);
+	const cacheKey = resource ? resourceCacheKey(resource) : null;
+	const requestPath = resource ? resourceRequestPath(resource) : null;
+	const canonicalEtag = resource ? resourceCanonicalEtag(resource) : null;
 
 	const setContent = useCallback(
 		(value: string | null | ((prev: string | null) => string | null)) => {
 			setContentState((prev) => {
 				const next = typeof value === "function" ? value(prev) : value;
-				if (path && next !== null) {
-					const cached = textContentCache.get(path);
-					textContentCache.set(path, {
+				if (cacheKey && next !== null) {
+					const cached = textContentCache.get(cacheKey);
+					textContentCache.set(cacheKey, {
 						content: next,
 						etag: cached?.etag ?? null,
 						promise: cached?.promise,
@@ -144,17 +167,17 @@ export function useTextContent(path: string | null) {
 				return next;
 			});
 		},
-		[path],
+		[cacheKey],
 	);
 
 	const setEtag = useCallback(
 		(value: string | null | ((prev: string | null) => string | null)) => {
 			setEtagState((prev) => {
 				const next = typeof value === "function" ? value(prev) : value;
-				if (path) {
-					const cached = textContentCache.get(path);
+				if (cacheKey) {
+					const cached = textContentCache.get(cacheKey);
 					if (cached?.content !== undefined) {
-						textContentCache.set(path, {
+						textContentCache.set(cacheKey, {
 							content: cached.content,
 							etag: next,
 							promise: cached.promise,
@@ -164,33 +187,40 @@ export function useTextContent(path: string | null) {
 				return next;
 			});
 		},
-		[path],
+		[cacheKey],
 	);
 
 	const load = useCallback(
 		async (force = false) => {
 			requestIdRef.current += 1;
 			const requestId = requestIdRef.current;
-			if (!path) {
+			if (!cacheKey || !requestPath) {
 				setContentState(null);
 				setEtagState(null);
 				setLoading(false);
 				setError(false);
 				return;
 			}
+			const effectiveResource: ResourcePath = {
+				cacheKey,
+				etag: canonicalEtag,
+				requestPath,
+			};
 
-			const cached = textContentCache.get(path);
-			if (cached?.content !== undefined) {
+			const cached = textContentCache.get(cacheKey);
+			const cachedMatchesCanonical =
+				!canonicalEtag || cached?.etag === canonicalEtag;
+			if (cached?.content !== undefined && cachedMatchesCanonical) {
 				setContentState(cached.content);
 				setEtagState(cached.etag ?? null);
 				setLoading(false);
 				setError(false);
 			}
 
-			setLoading(cached?.content === undefined);
+			setLoading(cached?.content === undefined || !cachedMatchesCanonical);
 			setError(false);
 			try {
-				const next = await fetchTextContent(path, force);
+				const next = await fetchTextContent(effectiveResource, force);
 				if (requestId !== requestIdRef.current) return;
 				setContentState(next.content);
 				setEtagState(next.etag);
@@ -203,7 +233,7 @@ export function useTextContent(path: string | null) {
 				}
 			}
 		},
-		[path],
+		[cacheKey, canonicalEtag, requestPath],
 	);
 
 	const reload = useCallback(async () => {
@@ -211,12 +241,12 @@ export function useTextContent(path: string | null) {
 	}, [load]);
 
 	useEffect(() => {
-		if (!path) {
+		if (!cacheKey || !requestPath) {
 			void load();
 			return;
 		}
 
-		const unsubscribe = subscribeTextContentInvalidation(path, () => {
+		const unsubscribe = subscribeTextContentInvalidation(cacheKey, () => {
 			void load(true);
 		});
 
@@ -225,7 +255,7 @@ export function useTextContent(path: string | null) {
 		return () => {
 			unsubscribe();
 		};
-	}, [load, path]);
+	}, [cacheKey, load, requestPath]);
 
 	return {
 		content,

--- a/frontend-panel/src/lib/resourceRequest.test.ts
+++ b/frontend-panel/src/lib/resourceRequest.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import {
+	resourceCacheKey,
+	resourceCanonicalEtag,
+	resourceRequestPath,
+} from "@/lib/resourceRequest";
+
+describe("resourceRequest", () => {
+	it("uses plain string resources as both request path and cache key", () => {
+		expect(resourceRequestPath("/files/1/download")).toBe("/files/1/download");
+		expect(resourceCacheKey("/files/1/download")).toBe("/files/1/download");
+		expect(resourceCanonicalEtag("/files/1/download")).toBeNull();
+	});
+
+	it("separates stable cache identity from temporary request paths", () => {
+		const resource = {
+			cacheKey: "/files/1/download",
+			etag: '"etag-1"',
+			requestPath: "/pv/token/file.txt",
+		};
+
+		expect(resourceRequestPath(resource)).toBe("/pv/token/file.txt");
+		expect(resourceCacheKey(resource)).toBe("/files/1/download");
+		expect(resourceCanonicalEtag(resource)).toBe('"etag-1"');
+	});
+
+	it("falls back to request path and null etag when optional fields are absent", () => {
+		const resource = {
+			requestPath: "/pv/token/file.txt",
+		};
+
+		expect(resourceRequestPath(resource)).toBe("/pv/token/file.txt");
+		expect(resourceCacheKey(resource)).toBe("/pv/token/file.txt");
+		expect(resourceCanonicalEtag(resource)).toBeNull();
+		expect(
+			resourceCanonicalEtag({
+				etag: null,
+				requestPath: "/pv/token/file.txt",
+			}),
+		).toBeNull();
+	});
+});

--- a/frontend-panel/src/lib/resourceRequest.ts
+++ b/frontend-panel/src/lib/resourceRequest.ts
@@ -1,0 +1,21 @@
+export interface ResourceRequest {
+	cacheKey?: string;
+	etag?: string | null;
+	requestPath: string;
+}
+
+export type ResourcePath = string | ResourceRequest;
+
+export function resourceRequestPath(resource: ResourcePath) {
+	return typeof resource === "string" ? resource : resource.requestPath;
+}
+
+export function resourceCacheKey(resource: ResourcePath) {
+	return typeof resource === "string"
+		? resource
+		: (resource.cacheKey ?? resource.requestPath);
+}
+
+export function resourceCanonicalEtag(resource: ResourcePath) {
+	return typeof resource === "string" ? null : (resource.etag ?? null);
+}

--- a/frontend-panel/src/pages/ShareViewPage.test.tsx
+++ b/frontend-panel/src/pages/ShareViewPage.test.tsx
@@ -88,6 +88,7 @@ const mockState = vi.hoisted(() => ({
 	getFolderFileArchivePreview: vi.fn(() => Promise.resolve({ entries: [] })),
 	createPreviewLink: vi.fn((token: string) =>
 		Promise.resolve({
+			etag: '"etag-share"',
 			expires_at: "2026-01-01T00:00:00Z",
 			max_uses: 1,
 			path: `/pv/${token}`,

--- a/frontend-panel/src/pages/ShareViewPage.test.tsx
+++ b/frontend-panel/src/pages/ShareViewPage.test.tsx
@@ -59,6 +59,7 @@ const mockState = vi.hoisted(() => ({
 	downloadPath: vi.fn((token: string) => `/s/${token}/download`),
 	createFolderFilePreviewLink: vi.fn((token: string, fileId: number) =>
 		Promise.resolve({
+			etag: '"etag-share"',
 			expires_at: "2026-01-01T00:00:00Z",
 			max_uses: 1,
 			path: `/pv/${token}/files/${fileId}`,

--- a/frontend-panel/src/pages/admin/AdminOverviewPage.test.tsx
+++ b/frontend-panel/src/pages/admin/AdminOverviewPage.test.tsx
@@ -264,15 +264,41 @@ vi.mock("@/components/ui/skeleton", () => ({
 }));
 
 vi.mock("@/components/ui/table", () => ({
-	Table: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+	Table: ({
+		children,
+		className,
+	}: {
+		children: React.ReactNode;
+		className?: string;
+	}) => (
+		<div data-testid="mock-table" className={className}>
+			{children}
+		</div>
+	),
 	TableBody: ({ children }: { children: React.ReactNode }) => (
 		<div>{children}</div>
 	),
-	TableCell: ({ children }: { children: React.ReactNode }) => (
-		<div>{children}</div>
+	TableCell: ({
+		children,
+		className,
+	}: {
+		children: React.ReactNode;
+		className?: string;
+	}) => (
+		<div data-testid="mock-table-cell" className={className}>
+			{children}
+		</div>
 	),
-	TableHead: ({ children }: { children: React.ReactNode }) => (
-		<div>{children}</div>
+	TableHead: ({
+		children,
+		className,
+	}: {
+		children: React.ReactNode;
+		className?: string;
+	}) => (
+		<div data-testid="mock-table-head" className={className}>
+			{children}
+		</div>
 	),
 	TableHeader: ({ children }: { children: React.ReactNode }) => (
 		<div>{children}</div>
@@ -469,6 +495,14 @@ describe("AdminOverviewPage", () => {
 		expect(
 			screen.getByText("Password true, max downloads 5"),
 		).toBeInTheDocument();
+		expect(screen.getByText("Root")).toBeInTheDocument();
+		expect(screen.getByText("@root")).toBeInTheDocument();
+		expect(screen.getByText("audit_user")).toHaveClass("w-[180px]");
+		expect(
+			screen
+				.getAllByTestId("mock-table")
+				.some((table) => table.className.includes("min-w-[760px] table-fixed")),
+		).toBe(true);
 		expect(screen.getAllByText("File").length).toBeGreaterThan(0);
 		expect(screen.getByText("Trash cleanup")).toBeInTheDocument();
 		expect(

--- a/frontend-panel/src/pages/admin/AdminOverviewPage.test.tsx
+++ b/frontend-panel/src/pages/admin/AdminOverviewPage.test.tsx
@@ -499,9 +499,13 @@ describe("AdminOverviewPage", () => {
 		expect(screen.getByText("@root")).toBeInTheDocument();
 		expect(screen.getByText("audit_user")).toHaveClass("w-[180px]");
 		expect(
-			screen
-				.getAllByTestId("mock-table")
-				.some((table) => table.className.includes("min-w-[760px] table-fixed")),
+			screen.getAllByTestId("mock-table").some((table) => {
+				const { className } = table;
+				return (
+					className.includes("min-w-[760px]") &&
+					className.includes("table-fixed")
+				);
+			}),
 		).toBe(true);
 		expect(screen.getAllByText("File").length).toBeGreaterThan(0);
 		expect(screen.getByText("Trash cleanup")).toBeInTheDocument();

--- a/frontend-panel/src/services/api.generated.ts
+++ b/frontend-panel/src/services/api.generated.ts
@@ -6608,6 +6608,7 @@ export interface components {
         /** @enum {string} */
         PreviewAppProvider: "builtin" | "url_template" | "wopi";
         PreviewLinkInfo: {
+            etag: string;
             expires_at: string;
             /** Format: int32 */
             max_uses: number;
@@ -17504,6 +17505,7 @@ export interface operations {
                     "application/json": {
                         code: components["schemas"]["ApiErrorCode"];
                         data?: {
+                            etag: string;
                             expires_at: string;
                             /** Format: int32 */
                             max_uses: number;
@@ -19266,6 +19268,7 @@ export interface operations {
                     "application/json": {
                         code: components["schemas"]["ApiErrorCode"];
                         data?: {
+                            etag: string;
                             expires_at: string;
                             /** Format: int32 */
                             max_uses: number;
@@ -19629,6 +19632,7 @@ export interface operations {
                     "application/json": {
                         code: components["schemas"]["ApiErrorCode"];
                         data?: {
+                            etag: string;
                             expires_at: string;
                             /** Format: int32 */
                             max_uses: number;
@@ -23334,6 +23338,7 @@ export interface operations {
                     "application/json": {
                         code: components["schemas"]["ApiErrorCode"];
                         data?: {
+                            etag: string;
                             expires_at: string;
                             /** Format: int32 */
                             max_uses: number;

--- a/src/services/file_service/download/build.rs
+++ b/src/services/file_service/download/build.rs
@@ -140,6 +140,21 @@ pub(crate) async fn build_download_outcome_with_disposition_and_range(
         .await;
     }
 
+    // Conditional requests that miss must stay same-origin. Otherwise the
+    // browser can carry If-None-Match through the 302 to presigned object
+    // storage, turning cache revalidation into a CORS preflight dependency.
+    if if_none_match.is_some() {
+        return build_stream_outcome_with_disposition_and_range(
+            state,
+            file,
+            blob,
+            disposition,
+            None,
+            range,
+        )
+        .await;
+    }
+
     let policy = state.policy_snapshot().get_policy_or_err(blob.policy_id)?;
     let requires_sandbox =
         disposition == DownloadDisposition::Inline && requires_inline_sandbox(&file.mime_type);

--- a/src/services/file_service/download/tests.rs
+++ b/src/services/file_service/download/tests.rs
@@ -554,6 +554,43 @@ async fn safe_inline_preview_redirects_to_presigned_url_with_inline_disposition(
 }
 
 #[actix_web::test]
+async fn conditional_miss_inline_preview_streams_instead_of_presigned_redirect() {
+    let payload = b"changed presigned inline".to_vec();
+    let base_driver = CountingStreamDriver::new(payload.clone());
+    let get_stream_calls = base_driver.get_stream_calls.clone();
+    let (state, file, blob, _) = build_download_test_state_with_policy(
+        base_driver.with_presigned(),
+        payload_len_i64(&payload),
+        DriverType::S3,
+        presigned_download_options(),
+        "image/webp",
+    )
+    .await;
+
+    let outcome = build_download_outcome_with_disposition_and_range(
+        &state,
+        &file,
+        &blob,
+        DownloadDisposition::Inline,
+        Some("\"stale-etag\""),
+        None,
+    )
+    .await
+    .expect("conditional miss inline outcome should build");
+
+    let DownloadOutcome::Stream(_) = outcome else {
+        panic!(
+            "conditional miss must stay same-origin instead of redirecting to presigned storage"
+        );
+    };
+    assert_eq!(
+        get_stream_calls.load(Ordering::SeqCst),
+        1,
+        "conditional miss should stream through backend"
+    );
+}
+
+#[actix_web::test]
 async fn sandboxed_inline_preview_does_not_redirect_to_presigned_storage() {
     let payload = b"<script>alert(1)</script>".to_vec();
     let base_driver = CountingStreamDriver::new(payload.clone());

--- a/src/services/preview_link_service.rs
+++ b/src/services/preview_link_service.rs
@@ -29,6 +29,7 @@ pub struct PreviewLinkInfo {
     #[cfg_attr(all(debug_assertions, feature = "openapi"), schema(value_type = String))]
     pub expires_at: DateTime<Utc>,
     pub max_uses: u32,
+    pub etag: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -78,7 +79,7 @@ pub(crate) async fn create_token_for_file_in_scope_for_origin(
 ) -> Result<PreviewLinkInfo> {
     let file = workspace_storage_service::verify_file_access(state, scope, file_id).await?;
     let payload = build_payload(PreviewSubject::File { file_id: file.id });
-    build_link_for_file(state, &file, &payload, Some(request_origin))
+    build_link_for_file(state, &file, &payload, Some(request_origin)).await
 }
 
 pub async fn create_token_for_shared_file(
@@ -89,7 +90,7 @@ pub async fn create_token_for_shared_file(
     let payload = build_payload(PreviewSubject::ShareFile {
         share_token: share.token.clone(),
     });
-    build_link_for_shared_file(state, &share, &file, &payload, None)
+    build_link_for_shared_file(state, &share, &file, &payload, None).await
 }
 
 pub async fn create_token_for_shared_file_for_origin(
@@ -101,7 +102,7 @@ pub async fn create_token_for_shared_file_for_origin(
     let payload = build_payload(PreviewSubject::ShareFile {
         share_token: share.token.clone(),
     });
-    build_link_for_shared_file(state, &share, &file, &payload, Some(request_origin))
+    build_link_for_shared_file(state, &share, &file, &payload, Some(request_origin)).await
 }
 
 pub async fn create_token_for_shared_folder_file(
@@ -115,7 +116,7 @@ pub async fn create_token_for_shared_folder_file(
         share_token: share.token.clone(),
         file_id: file.id,
     });
-    build_link_for_shared_file(state, &share, &file, &payload, None)
+    build_link_for_shared_file(state, &share, &file, &payload, None).await
 }
 
 pub async fn create_token_for_shared_folder_file_for_origin(
@@ -130,7 +131,7 @@ pub async fn create_token_for_shared_folder_file_for_origin(
         share_token: share.token.clone(),
         file_id: file.id,
     });
-    build_link_for_shared_file(state, &share, &file, &payload, Some(request_origin))
+    build_link_for_shared_file(state, &share, &file, &payload, Some(request_origin)).await
 }
 
 pub(crate) async fn download_file(
@@ -205,21 +206,23 @@ fn build_payload(subject: PreviewSubject) -> PreviewTokenPayload {
     }
 }
 
-fn build_link_for_file(
+async fn build_link_for_file(
     state: &impl SharedRuntimeState,
     file: &file::Model,
     payload: &PreviewTokenPayload,
     request_origin: Option<RequestOrigin<'_>>,
 ) -> Result<PreviewLinkInfo> {
     let token = encode_file_token(file, payload, &state.config().auth.direct_link_secret)?;
+    let etag = canonical_file_etag(state, file).await?;
     Ok(PreviewLinkInfo {
         path: preview_path(state.runtime_config(), &token, &file.name, request_origin),
         expires_at: decode_expiry(payload.exp)?,
         max_uses: payload.max_uses,
+        etag,
     })
 }
 
-fn build_link_for_shared_file(
+async fn build_link_for_shared_file(
     state: &impl SharedRuntimeState,
     share: &share::Model,
     file: &file::Model,
@@ -232,11 +235,21 @@ fn build_link_for_shared_file(
         payload,
         &state.config().auth.direct_link_secret,
     )?;
+    let etag = canonical_file_etag(state, file).await?;
     Ok(PreviewLinkInfo {
         path: preview_path(state.runtime_config(), &token, &file.name, request_origin),
         expires_at: decode_expiry(payload.exp)?,
         max_uses: payload.max_uses,
+        etag,
     })
+}
+
+async fn canonical_file_etag(
+    state: &impl SharedRuntimeState,
+    file: &file::Model,
+) -> Result<String> {
+    let blob = file_repo::find_blob_by_id(state.reader_db(), file.blob_id).await?;
+    Ok(format!("\"{}\"", blob.hash))
 }
 
 fn preview_path(

--- a/tests/test_files.rs
+++ b/tests/test_files.rs
@@ -312,11 +312,22 @@ async fn test_file_preview_link_supports_public_inline_access_and_usage_limit() 
         .to_string();
     assert!(preview_path.starts_with("/pv/"));
     assert_eq!(body["data"]["max_uses"], 5);
+    let preview_etag = body["data"]["etag"]
+        .as_str()
+        .expect("preview link should include canonical ETag")
+        .to_string();
+    assert!(preview_etag.starts_with('"') && preview_etag.ends_with('"'));
 
     for _ in 0..5 {
         let req = test::TestRequest::get().uri(&preview_path).to_request();
         let resp = test::call_service(&app, req).await;
         assert_eq!(resp.status(), 200);
+        assert_eq!(
+            resp.headers()
+                .get("ETag")
+                .and_then(|value| value.to_str().ok()),
+            Some(preview_etag.as_str())
+        );
         assert_eq!(
             resp.headers().get("Content-Disposition").unwrap(),
             "inline; filename*=UTF-8''report%201.docx"


### PR DESCRIPTION
Backend now returns canonical ETag in preview-link responses. Frontend resource layer separates stable cache key (download path + canonical ETag) from ephemeral request path (preview token). Cache reuses blob/text across expired tokens sharing same canonical ETag.

Conditional requests (If-None-Match) now stay same-origin instead of redirecting to presigned storage, preventing CORS preflight when browser carries conditions through 302.

Frontend changes:
- Add ResourceRequest type to distinguish cacheKey, etag, and requestPath
- useBlobUrl and useTextContent cache by stable identity, skip conditional headers when canonical ETag provided
- Preview components accept ResourcePath (string | ResourceRequest), extract request path via resourceRequestPath()
- Update 16 test suites to verify cache-key/etag separation

Backend changes:
- PreviewLinkInfo now includes canonical etag field (blob hash)
- build_download_outcome rejects conditional requests before presigned redirect
- Add test coverage for conditional-miss inline streaming

Frontend service governance:
- Document stable-identity vs ephemeral-URL distinction in AGENTS.md
- Clarify that components must not infer resource access policy (credentials, ETag, CORS)

Table layout fix:
- OverviewRecentEventsSection uses fixed column widths and max-w-0 truncation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **功能优化**
  * 优化管理后台“最近事件”表格为固定布局并调整列宽，信息对齐更清晰。
  * 强化文件预览（图片/文本/代码/表格等）与预览链接复用：引入规范化 ETag，提升刷新与缓存一致性。
* **改进**
  * 优化条件请求与下载策略：当条件未命中时，改为稳定的流式内联预览/下载路径，减少不必要的重定向。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->