### PR TITLE
feat(admin): add managed ingress driver descriptor discovery

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -140,6 +140,40 @@ bun run test:e2e
 - 数据库事务失败不用手写多余 `rollback()`；SeaORM transaction drop 会自动回滚。
 - 不要把下载、上传完成、配额扣减、版本写入、审计写入拆成互相看不见的散逻辑；跨表一致性要在 service/repo 边界清楚表达。
 
+### Service 边界约束
+
+AI 很容易把能跑的代码堆到一个 service 里，后面就没人敢改。改后端 service 前必须先判断本次逻辑属于哪一层，并按层放置：
+
+- `src/api/routes/*`：只做协议适配、鉴权/权限 guard、参数提取、调用 service、响应映射；不要做业务规则、driver 分支、复杂 DTO 拼装。
+- `src/services/*`：只做 use case 编排，例如加载上下文、调用领域校验/解析器、调用 repo、触发必要 side effects；不要把 normalize、capability 判断、descriptor 拼装、协议转发、driver 构造全塞在一个函数里。
+- `src/services/<domain>/*` 内部模块：承载可测试的领域规则，例如 normalization、target selection、capability resolver、descriptor builder、finalization contract；能写成纯函数就不要依赖 `AppState`。
+- `src/db/repository/*`：只做数据访问和原子 SQL，不写 transport、driver、UI descriptor、产品流程判断。
+- `src/storage/remote_protocol/*`：只处理 wire protocol、签名、path encoding、HTTP/tunnel transport、capability wire model 和 response parsing；不要决定 UI 展示、policy target 选择、default target 这类产品语义。
+- `src/storage/connectors/*` / `src/storage/traits/*`：表达存储能力、driver/connector descriptor 和对象内容能力；业务层不要绕过这些抽象直接分支到具体 SDK。
+
+触发以下信号时先拆模块，不要继续往当前函数里堆：
+
+- 一个 service 函数同时出现 `AppState`、repo 写入、remote protocol client、driver 构造、descriptor 拼装、audit/registry reload。
+- 大量 `match driver_type` 出现在业务 service 中，而不是 driver/connector/target registry 或 capability resolver 中。
+- 同一个函数既做输入 normalize，又做远端能力判断，又做 DB side effect。
+- 为了 UI 表单展示在 service use case 里拼字段矩阵。
+- 函数超过约 80-120 行且没有清晰的“编排步骤”，需要说明为什么不拆。
+
+推荐的 service 函数形状：
+
+```rust
+pub async fn create_xxx(state, input) -> Result<Output> {
+    let input = normalize(input)?;
+    let context = load_context(state, &input).await?;
+    validate(&context, &input)?;
+    let result = repo::create(...).await?;
+    run_required_side_effects(state, &result).await?;
+    Ok(present(result))
+}
+```
+
+如果新功能需要跨 route/service/domain/repo/storage/protocol 多层，先在实现说明里列出每层各改什么。边界说不清就停下问 1547，别硬写。
+
 ## 数据库和类型约定
 
 - 运行态通过 `DbHandles` 保存 writer 和 reader。写入、事务、读后写、配额权威判断、登录签发 session、refresh token rotation、上传 init/chunk/complete/cancel 继续走 writer。

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,9 +33,9 @@ dependencies = [
 
 [[package]]
 name = "actix-http"
-version = "3.13.0"
+version = "3.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7e804b8fe4e585f6fba0df09a8ae62fb7edc5ff31c177a3d82693740c475d04"
+checksum = "48e2faa3e7418ed780cca54829d32782a4008a077230f67457caa063415e99c2"
 dependencies = [
  "actix-codec",
  "actix-rt",
@@ -1731,9 +1731,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chacha20"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
@@ -3617,9 +3617,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.102"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03d04c30968dffe80775bd4d7fb676131cd04a1fb46d2686dbffbaec2d9dfd31"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -4880,9 +4880,9 @@ dependencies = [
 
 [[package]]
 name = "quinn"
-version = "0.11.9"
+version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
 dependencies = [
  "bytes",
  "cfg_aliases",
@@ -4900,9 +4900,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "aws-lc-rs",
  "bytes",
@@ -4936,9 +4936,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
 ]
@@ -5410,9 +5410,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.40"
+version = "0.23.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -6458,9 +6458,9 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.39.3"
+version = "0.39.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21d0d938c10fcda3e897e28aaddf4ab462375d411f4378cd63b1c945f69aba96"
+checksum = "2c8bd2130a9b60bee2581bf82cfe89ee836424d1f37dcfa4ce21509611684673"
 dependencies = [
  "libc",
  "memchr",
@@ -6643,9 +6643,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.49"
+version = "0.3.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "711a53c2d47bbd818258c498c8dbfe186a2526c631495cfe7e078567f86b8469"
+checksum = "85c17d80feb7334b40c484e45ed1a5273dfd8bfda537c3be2e74a06a6686f327"
 dependencies = [
  "deranged",
  "num-conv",
@@ -6663,9 +6663,9 @@ checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.29"
+version = "0.2.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71c652a3727a9cbb9a02f707f530b618ce00d0ccd762009c8c23bd191df3c17d"
+checksum = "dcef1a61bdb119096e153208ec5cbec23944ce8bca13be5c7f60c634f7403935"
 dependencies = [
  "num-conv",
  "time-core",
@@ -7285,9 +7285,9 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "1.23.3"
+version = "1.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "144d6b123cef80b301b8f72a9e2ca4370ddec21950d0a103dd22c437006d2db7"
+checksum = "bf80a72845275afea99e7f2b434723d3bc7e38470fcd1c7ed39a599c73319a53"
 dependencies = [
  "getrandom 0.4.3",
  "js-sys",
@@ -7385,9 +7385,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.125"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ddb3f79143bced6de84270411622a2699cee572fc0875aeaf1e7867cf9fca1a"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -7399,9 +7399,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.75"
+version = "0.4.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "503b14d284f2c8dac03b819967e155ea753f573586193b2b2c95990cb5d69280"
+checksum = "c62df1340f32221cb9c54d6a27b030e3dba64361d4a95bed55f9aacb44da291d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -7409,9 +7409,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.125"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e21a184b13fb19e157296e2c46056aec9092264fab83e4ba59e68c61b323c3d"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -7419,9 +7419,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.125"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fecefd9c35bd935a20fc3fc344b5f29138961e4f47fb03297d88f2587afb5ebd"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -7432,9 +7432,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.125"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23939e44bb9a5d7576fa2b563dc2e136628f1224e88a8deed09e04858b77871f"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
 ]
@@ -7454,9 +7454,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.102"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6430a72df5eb332242960fe84b3002a241163998241eb596d4f739b9757061d"
+checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -8158,9 +8158,9 @@ dependencies = [
 
 [[package]]
 name = "zlib-rs"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be3d40e40a133f9c916ee3f9f4fa2d9d63435b5fbe1bfc6d9dae0aa0ada1513"
+checksum = "977347db8caa080403f6b6b7c1cda9479a8e869316f7e13a59b19076a40f94e3"
 
 [[package]]
 name = "zmij"

--- a/frontend-panel/src/components/admin/admin-remote-nodes-page/RemoteNodeDialog.tsx
+++ b/frontend-panel/src/components/admin/admin-remote-nodes-page/RemoteNodeDialog.tsx
@@ -11,6 +11,7 @@ import {
 } from "@/components/ui/dialog";
 import { ADMIN_CONTROL_HEIGHT_CLASS } from "@/lib/constants";
 import type {
+	ManagedIngressDriverDescriptor,
 	RemoteCreateIngressProfileRequest,
 	RemoteIngressProfileInfo,
 	RemoteNodeInfo,
@@ -33,12 +34,17 @@ import {
 } from "./shared";
 
 const EMPTY_MANAGED_INGRESS_PROFILES: RemoteIngressProfileInfo[] = [];
+const EMPTY_MANAGED_INGRESS_DRIVER_DESCRIPTORS: ManagedIngressDriverDescriptor[] =
+	[];
 
 interface RemoteNodeDialogProps {
 	createStep: number;
 	createStepTouched: boolean;
 	editingNode: RemoteNodeInfo | null;
 	form: RemoteNodeFormData;
+	managedIngressDriverDescriptors?: ManagedIngressDriverDescriptor[];
+	managedIngressDriverDescriptorsError?: string | null;
+	managedIngressDriverDescriptorsLoading?: boolean;
 	managedIngressProfiles?: RemoteIngressProfileInfo[];
 	managedIngressProfilesEnabled?: boolean;
 	managedIngressProfilesError?: string | null;
@@ -73,6 +79,9 @@ export function RemoteNodeDialog({
 	createStepTouched,
 	editingNode,
 	form,
+	managedIngressDriverDescriptors = EMPTY_MANAGED_INGRESS_DRIVER_DESCRIPTORS,
+	managedIngressDriverDescriptorsError = null,
+	managedIngressDriverDescriptorsLoading = false,
 	managedIngressProfiles = EMPTY_MANAGED_INGRESS_PROFILES,
 	managedIngressProfilesEnabled = false,
 	managedIngressProfilesError = null,
@@ -264,6 +273,15 @@ export function RemoteNodeDialog({
 								enabledToneClass={enabledToneClass}
 								form={form}
 								managedIngressProfiles={managedIngressProfiles}
+								managedIngressDriverDescriptors={
+									managedIngressDriverDescriptors
+								}
+								managedIngressDriverDescriptorsError={
+									managedIngressDriverDescriptorsError
+								}
+								managedIngressDriverDescriptorsLoading={
+									managedIngressDriverDescriptorsLoading
+								}
 								managedIngressProfilesEnabled={managedIngressProfilesEnabled}
 								managedIngressProfilesError={managedIngressProfilesError}
 								managedIngressProfilesLoading={managedIngressProfilesLoading}

--- a/frontend-panel/src/components/admin/admin-remote-nodes-page/RemoteNodeEditForm.tsx
+++ b/frontend-panel/src/components/admin/admin-remote-nodes-page/RemoteNodeEditForm.tsx
@@ -5,6 +5,7 @@ import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
 import { ADMIN_CONTROL_HEIGHT_CLASS } from "@/lib/constants";
 import type {
+	ManagedIngressDriverDescriptor,
 	RemoteCreateIngressProfileRequest,
 	RemoteIngressProfileInfo,
 	RemoteNodeInfo,
@@ -30,6 +31,9 @@ interface RemoteNodeEditFormProps {
 	editingNode: RemoteNodeInfo | null;
 	enabledToneClass: string;
 	form: RemoteNodeFormData;
+	managedIngressDriverDescriptors: ManagedIngressDriverDescriptor[];
+	managedIngressDriverDescriptorsError: string | null;
+	managedIngressDriverDescriptorsLoading: boolean;
 	managedIngressProfiles: RemoteIngressProfileInfo[];
 	managedIngressProfilesEnabled: boolean;
 	managedIngressProfilesError: string | null;
@@ -55,6 +59,9 @@ export function RemoteNodeEditForm({
 	editingNode,
 	enabledToneClass,
 	form,
+	managedIngressDriverDescriptors,
+	managedIngressDriverDescriptorsError,
+	managedIngressDriverDescriptorsLoading,
 	managedIngressProfiles,
 	managedIngressProfilesEnabled,
 	managedIngressProfilesError,
@@ -144,8 +151,15 @@ export function RemoteNodeEditForm({
 				onDeleteManagedIngressProfile ? (
 					<RemoteNodeManagedIngressSection
 						profiles={managedIngressProfiles}
-						loading={managedIngressProfilesLoading}
-						errorMessage={managedIngressProfilesError}
+						driverDescriptors={managedIngressDriverDescriptors}
+						loading={
+							managedIngressProfilesLoading ||
+							managedIngressDriverDescriptorsLoading
+						}
+						errorMessage={
+							managedIngressProfilesError ??
+							managedIngressDriverDescriptorsError
+						}
 						onCreateProfile={onCreateManagedIngressProfile}
 						onUpdateProfile={onUpdateManagedIngressProfile}
 						onDeleteProfile={onDeleteManagedIngressProfile}

--- a/frontend-panel/src/components/admin/admin-remote-nodes-page/RemoteNodeManagedIngressForm.tsx
+++ b/frontend-panel/src/components/admin/admin-remote-nodes-page/RemoteNodeManagedIngressForm.tsx
@@ -1,5 +1,8 @@
 import { useTranslation } from "react-i18next";
-import type { ManagedIngressProfileFormData } from "@/components/admin/managedIngressProfileDialogShared";
+import {
+	isManagedIngressDriverType,
+	type ManagedIngressProfileFormData,
+} from "@/components/admin/managedIngressProfileDialogShared";
 import { Button } from "@/components/ui/button";
 import { Icon } from "@/components/ui/icon";
 import { Input } from "@/components/ui/input";
@@ -13,7 +16,11 @@ import {
 } from "@/components/ui/select";
 import { Switch } from "@/components/ui/switch";
 import { ADMIN_CONTROL_HEIGHT_CLASS } from "@/lib/constants";
-import type { RemoteIngressProfileInfo } from "@/types/api";
+import type {
+	ManagedIngressDriverDescriptor,
+	ManagedIngressDriverFieldDescriptor,
+	RemoteIngressProfileInfo,
+} from "@/types/api";
 import type {
 	RemoteNodeManagedIngressDraftMode,
 	RemoteNodeManagedIngressFieldChangeHandler,
@@ -23,6 +30,8 @@ interface RemoteNodeManagedIngressFormProps {
 	accessKeyError: string | null;
 	bucketError: string | null;
 	defaultToggleLocked: boolean;
+	driverDescriptors: ManagedIngressDriverDescriptor[];
+	driverTypeError: string | null;
 	draftMode: RemoteNodeManagedIngressDraftMode;
 	editingProfile: RemoteIngressProfileInfo | null;
 	endpointError: string | null;
@@ -42,6 +51,8 @@ export function RemoteNodeManagedIngressForm({
 	accessKeyError,
 	bucketError,
 	defaultToggleLocked,
+	driverDescriptors,
+	driverTypeError,
 	draftMode,
 	editingProfile,
 	endpointError,
@@ -57,16 +68,31 @@ export function RemoteNodeManagedIngressForm({
 	submitting,
 }: RemoteNodeManagedIngressFormProps) {
 	const { t } = useTranslation("admin");
-	const driverTypeOptions = [
-		{
-			label: t("remote_node_ingress_profile_driver_local"),
-			value: "local",
-		},
-		{
-			label: t("remote_node_ingress_profile_driver_s3"),
-			value: "s3",
-		},
-	] as const;
+	const driverTypeOptions = driverDescriptors.map((descriptor) => ({
+		label: t(descriptor.label_key),
+		value: descriptor.driver_type,
+	}));
+	const activeDriverDescriptor =
+		driverDescriptors.find(
+			(descriptor) => descriptor.driver_type === form.driver_type,
+		) ?? null;
+	const fieldByName = new Map(
+		activeDriverDescriptor?.fields.map((field) => [field.name, field]) ?? [],
+	);
+	const field = (name: string) => fieldByName.get(name);
+	const fieldHelp = (
+		descriptor: ManagedIngressDriverFieldDescriptor | undefined,
+	) => (descriptor?.help_key ? t(descriptor.help_key) : null);
+	const fieldPlaceholder = (
+		descriptor: ManagedIngressDriverFieldDescriptor | undefined,
+	) => descriptor?.placeholder ?? undefined;
+	const basePathField = field("base_path");
+	const maxFileSizeField = field("max_file_size");
+	const endpointField = field("endpoint");
+	const bucketField = field("bucket");
+	const accessKeyField = field("access_key");
+	const secretKeyField = field("secret_key");
+	const isDefaultField = field("is_default");
 
 	return (
 		<div className="mt-4 rounded-2xl border border-border/70 bg-muted/10 p-4">
@@ -114,7 +140,7 @@ export function RemoteNodeManagedIngressForm({
 						items={driverTypeOptions}
 						value={form.driver_type}
 						onValueChange={(value) => {
-							if (value === "local" || value === "s3") {
+							if (isManagedIngressDriverType(value)) {
 								onFieldChange("driver_type", value);
 							}
 						}}
@@ -133,163 +159,186 @@ export function RemoteNodeManagedIngressForm({
 							))}
 						</SelectContent>
 					</Select>
-				</div>
-
-				<div className="space-y-2">
-					<Label htmlFor="managed-ingress-base-path">{t("base_path")}</Label>
-					<Input
-						id="managed-ingress-base-path"
-						value={form.base_path}
-						onChange={(event) => onFieldChange("base_path", event.target.value)}
-						className={ADMIN_CONTROL_HEIGHT_CLASS}
-						aria-invalid={localPathError ? true : undefined}
-						placeholder={
-							form.driver_type === "local" ? "tenant-a/incoming" : "prefix"
-						}
-					/>
-					<p className="text-xs text-muted-foreground">
-						{form.driver_type === "local"
-							? t("remote_node_ingress_profile_local_path_hint")
-							: t("remote_node_ingress_profile_s3_path_hint")}
-					</p>
-					{localPathError ? (
-						<p className="text-xs text-destructive">{localPathError}</p>
+					{driverTypeError ? (
+						<p className="text-xs text-destructive">{driverTypeError}</p>
 					) : null}
 				</div>
 
-				<div className="space-y-2">
-					<Label htmlFor="managed-ingress-max-file-size">
-						{t("max_file_size")} (bytes)
-					</Label>
-					<Input
-						id="managed-ingress-max-file-size"
-						type="number"
-						min="0"
-						step="1"
-						value={form.max_file_size}
-						onChange={(event) =>
-							onFieldChange("max_file_size", event.target.value)
-						}
-						className={ADMIN_CONTROL_HEIGHT_CLASS}
-						aria-invalid={maxFileSizeError ? true : undefined}
-						placeholder="0"
-					/>
-					<p className="text-xs text-muted-foreground">
-						{t("remote_node_ingress_profile_max_file_size_hint")}
-					</p>
-					{maxFileSizeError ? (
-						<p className="text-xs text-destructive">{maxFileSizeError}</p>
-					) : null}
-				</div>
-
-				{form.driver_type === "s3" ? (
-					<>
-						<div className="space-y-2">
-							<Label htmlFor="managed-ingress-endpoint">{t("endpoint")}</Label>
-							<Input
-								id="managed-ingress-endpoint"
-								value={form.endpoint}
-								onChange={(event) =>
-									onFieldChange("endpoint", event.target.value)
-								}
-								className={ADMIN_CONTROL_HEIGHT_CLASS}
-								aria-invalid={endpointError ? true : undefined}
-								placeholder="https://s3.example.com"
-							/>
-							{endpointError ? (
-								<p className="text-xs text-destructive">{endpointError}</p>
-							) : null}
-						</div>
-
-						<div className="space-y-2">
-							<Label htmlFor="managed-ingress-bucket">{t("bucket")}</Label>
-							<Input
-								id="managed-ingress-bucket"
-								value={form.bucket}
-								onChange={(event) =>
-									onFieldChange("bucket", event.target.value)
-								}
-								className={ADMIN_CONTROL_HEIGHT_CLASS}
-								aria-invalid={bucketError ? true : undefined}
-							/>
-							{bucketError ? (
-								<p className="text-xs text-destructive">{bucketError}</p>
-							) : null}
-						</div>
-
-						<div className="space-y-2">
-							<Label htmlFor="managed-ingress-access-key">
-								{t("access_key")}
-							</Label>
-							<Input
-								id="managed-ingress-access-key"
-								value={form.access_key}
-								onChange={(event) =>
-									onFieldChange("access_key", event.target.value)
-								}
-								className={ADMIN_CONTROL_HEIGHT_CLASS}
-								aria-invalid={accessKeyError ? true : undefined}
-							/>
-							{accessKeyError ? (
-								<p className="text-xs text-destructive">{accessKeyError}</p>
-							) : null}
-						</div>
-
-						<div className="space-y-2">
-							<Label htmlFor="managed-ingress-secret-key">
-								{t("secret_key")}
-							</Label>
-							<Input
-								id="managed-ingress-secret-key"
-								type="password"
-								value={form.secret_key}
-								onChange={(event) =>
-									onFieldChange("secret_key", event.target.value)
-								}
-								className={ADMIN_CONTROL_HEIGHT_CLASS}
-								aria-invalid={secretKeyError ? true : undefined}
-								placeholder={
-									draftMode === "edit" && editingProfile?.driver_type === "s3"
-										? "••••••••"
-										: undefined
-								}
-							/>
+				{basePathField ? (
+					<div className="space-y-2">
+						<Label htmlFor="managed-ingress-base-path">{t("base_path")}</Label>
+						<Input
+							id="managed-ingress-base-path"
+							value={form.base_path}
+							onChange={(event) =>
+								onFieldChange("base_path", event.target.value)
+							}
+							className={ADMIN_CONTROL_HEIGHT_CLASS}
+							aria-invalid={localPathError ? true : undefined}
+							placeholder={fieldPlaceholder(basePathField)}
+						/>
+						{fieldHelp(basePathField) ? (
 							<p className="text-xs text-muted-foreground">
-								{draftMode === "edit" && editingProfile?.driver_type === "s3"
-									? t("remote_node_ingress_profile_credentials_optional_hint")
-									: t("remote_node_ingress_profile_credentials_hint")}
+								{fieldHelp(basePathField)}
 							</p>
-							{secretKeyError ? (
-								<p className="text-xs text-destructive">{secretKeyError}</p>
-							) : null}
-						</div>
+						) : null}
+						{localPathError ? (
+							<p className="text-xs text-destructive">{localPathError}</p>
+						) : null}
+					</div>
+				) : null}
+
+				{maxFileSizeField ? (
+					<div className="space-y-2">
+						<Label htmlFor="managed-ingress-max-file-size">
+							{t("max_file_size")} (bytes)
+						</Label>
+						<Input
+							id="managed-ingress-max-file-size"
+							type="number"
+							min="0"
+							step="1"
+							value={form.max_file_size}
+							onChange={(event) =>
+								onFieldChange("max_file_size", event.target.value)
+							}
+							className={ADMIN_CONTROL_HEIGHT_CLASS}
+							aria-invalid={maxFileSizeError ? true : undefined}
+							placeholder={fieldPlaceholder(maxFileSizeField)}
+						/>
+						{fieldHelp(maxFileSizeField) ? (
+							<p className="text-xs text-muted-foreground">
+								{fieldHelp(maxFileSizeField)}
+							</p>
+						) : null}
+						{maxFileSizeError ? (
+							<p className="text-xs text-destructive">{maxFileSizeError}</p>
+						) : null}
+					</div>
+				) : null}
+
+				{endpointField || bucketField || accessKeyField || secretKeyField ? (
+					<>
+						{endpointField ? (
+							<div className="space-y-2">
+								<Label htmlFor="managed-ingress-endpoint">
+									{t("endpoint")}
+								</Label>
+								<Input
+									id="managed-ingress-endpoint"
+									value={form.endpoint}
+									onChange={(event) =>
+										onFieldChange("endpoint", event.target.value)
+									}
+									className={ADMIN_CONTROL_HEIGHT_CLASS}
+									aria-invalid={endpointError ? true : undefined}
+									placeholder={fieldPlaceholder(endpointField)}
+								/>
+								{endpointError ? (
+									<p className="text-xs text-destructive">{endpointError}</p>
+								) : null}
+							</div>
+						) : null}
+
+						{bucketField ? (
+							<div className="space-y-2">
+								<Label htmlFor="managed-ingress-bucket">{t("bucket")}</Label>
+								<Input
+									id="managed-ingress-bucket"
+									value={form.bucket}
+									onChange={(event) =>
+										onFieldChange("bucket", event.target.value)
+									}
+									className={ADMIN_CONTROL_HEIGHT_CLASS}
+									aria-invalid={bucketError ? true : undefined}
+								/>
+								{bucketError ? (
+									<p className="text-xs text-destructive">{bucketError}</p>
+								) : null}
+							</div>
+						) : null}
+
+						{accessKeyField ? (
+							<div className="space-y-2">
+								<Label htmlFor="managed-ingress-access-key">
+									{t("access_key")}
+								</Label>
+								<Input
+									id="managed-ingress-access-key"
+									value={form.access_key}
+									onChange={(event) =>
+										onFieldChange("access_key", event.target.value)
+									}
+									className={ADMIN_CONTROL_HEIGHT_CLASS}
+									aria-invalid={accessKeyError ? true : undefined}
+								/>
+								{accessKeyError ? (
+									<p className="text-xs text-destructive">{accessKeyError}</p>
+								) : null}
+							</div>
+						) : null}
+
+						{secretKeyField ? (
+							<div className="space-y-2">
+								<Label htmlFor="managed-ingress-secret-key">
+									{t("secret_key")}
+								</Label>
+								<Input
+									id="managed-ingress-secret-key"
+									type="password"
+									value={form.secret_key}
+									onChange={(event) =>
+										onFieldChange("secret_key", event.target.value)
+									}
+									className={ADMIN_CONTROL_HEIGHT_CLASS}
+									aria-invalid={secretKeyError ? true : undefined}
+									placeholder={
+										draftMode === "edit" && editingProfile?.driver_type === "s3"
+											? "••••••••"
+											: undefined
+									}
+								/>
+								<p className="text-xs text-muted-foreground">
+									{draftMode === "edit" && editingProfile?.driver_type === "s3"
+										? t("remote_node_ingress_profile_credentials_optional_hint")
+										: t("remote_node_ingress_profile_credentials_hint")}
+								</p>
+								{secretKeyError ? (
+									<p className="text-xs text-destructive">{secretKeyError}</p>
+								) : null}
+							</div>
+						) : null}
 					</>
-				) : (
+				) : activeDriverDescriptor ? (
 					<div className="rounded-2xl border border-dashed border-border/70 bg-background/70 p-4 md:col-span-2">
 						<p className="text-sm leading-6 text-muted-foreground">
-							{t("remote_node_ingress_profile_local_scope_hint")}
+							{activeDriverDescriptor.description_key
+								? t(activeDriverDescriptor.description_key)
+								: t(activeDriverDescriptor.label_key)}
 						</p>
 					</div>
-				)}
+				) : null}
 
-				<div className="space-y-2 md:col-span-2">
-					<div className="flex items-center gap-2">
-						<Switch
-							id="managed-ingress-default"
-							checked={form.is_default}
-							onCheckedChange={(value) => onFieldChange("is_default", value)}
-							disabled={defaultToggleLocked}
-						/>
-						<Label htmlFor="managed-ingress-default">
-							{t("remote_node_ingress_profile_default_toggle")}
-						</Label>
+				{isDefaultField ? (
+					<div className="space-y-2 md:col-span-2">
+						<div className="flex items-center gap-2">
+							<Switch
+								id="managed-ingress-default"
+								checked={form.is_default}
+								onCheckedChange={(value) => onFieldChange("is_default", value)}
+								disabled={defaultToggleLocked}
+							/>
+							<Label htmlFor="managed-ingress-default">
+								{t("remote_node_ingress_profile_default_toggle")}
+							</Label>
+						</div>
+						<p className="text-xs text-muted-foreground">
+							{defaultToggleLocked
+								? t("remote_node_ingress_profile_default_locked_hint")
+								: t("remote_node_ingress_profile_default_hint")}
+						</p>
 					</div>
-					<p className="text-xs text-muted-foreground">
-						{defaultToggleLocked
-							? t("remote_node_ingress_profile_default_locked_hint")
-							: t("remote_node_ingress_profile_default_hint")}
-					</p>
-				</div>
+				) : null}
 			</div>
 
 			<div className="mt-4 flex justify-end gap-2">

--- a/frontend-panel/src/components/admin/admin-remote-nodes-page/RemoteNodeManagedIngressSection.test.tsx
+++ b/frontend-panel/src/components/admin/admin-remote-nodes-page/RemoteNodeManagedIngressSection.test.tsx
@@ -8,7 +8,10 @@ import {
 import type { ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { RemoteNodeManagedIngressSection } from "@/components/admin/admin-remote-nodes-page/RemoteNodeManagedIngressSection";
-import type { RemoteIngressProfileInfo } from "@/types/api";
+import type {
+	ManagedIngressDriverDescriptor,
+	RemoteIngressProfileInfo,
+} from "@/types/api";
 
 vi.mock("react-i18next", () => ({
 	useTranslation: () => ({
@@ -164,7 +167,116 @@ const profile = (
 	...overrides,
 });
 
+const localDriverDescriptor: ManagedIngressDriverDescriptor = {
+	description_key: "remote_node_ingress_profile_local_scope_hint",
+	driver_type: "local",
+	fields: [
+		{
+			help_key: "remote_node_ingress_profile_local_path_hint",
+			kind: "text",
+			label_key: "base_path",
+			name: "base_path",
+			placeholder: "tenant-a/incoming",
+			required: true,
+			secret: false,
+		},
+		{
+			help_key: "remote_node_ingress_profile_max_file_size_hint",
+			kind: "number",
+			label_key: "max_file_size",
+			name: "max_file_size",
+			placeholder: "0",
+			required: false,
+			secret: false,
+		},
+		{
+			help_key: "remote_node_ingress_profile_default_hint",
+			kind: "boolean",
+			label_key: "remote_node_ingress_profile_default_toggle",
+			name: "is_default",
+			placeholder: null,
+			required: false,
+			secret: false,
+		},
+	],
+	label_key: "remote_node_ingress_profile_driver_local",
+};
+
+const s3DriverDescriptor: ManagedIngressDriverDescriptor = {
+	description_key: "remote_node_ingress_profile_s3_path_hint",
+	driver_type: "s3",
+	fields: [
+		{
+			help_key: null,
+			kind: "text",
+			label_key: "endpoint",
+			name: "endpoint",
+			placeholder: "https://s3.example.com",
+			required: true,
+			secret: false,
+		},
+		{
+			help_key: null,
+			kind: "text",
+			label_key: "bucket",
+			name: "bucket",
+			placeholder: null,
+			required: true,
+			secret: false,
+		},
+		{
+			help_key: null,
+			kind: "text",
+			label_key: "access_key",
+			name: "access_key",
+			placeholder: null,
+			required: true,
+			secret: false,
+		},
+		{
+			help_key: null,
+			kind: "secret",
+			label_key: "secret_key",
+			name: "secret_key",
+			placeholder: null,
+			required: true,
+			secret: true,
+		},
+		{
+			help_key: "remote_node_ingress_profile_s3_path_hint",
+			kind: "text",
+			label_key: "base_path",
+			name: "base_path",
+			placeholder: "prefix",
+			required: false,
+			secret: false,
+		},
+		{
+			help_key: "remote_node_ingress_profile_max_file_size_hint",
+			kind: "number",
+			label_key: "max_file_size",
+			name: "max_file_size",
+			placeholder: "0",
+			required: false,
+			secret: false,
+		},
+		{
+			help_key: "remote_node_ingress_profile_default_hint",
+			kind: "boolean",
+			label_key: "remote_node_ingress_profile_default_toggle",
+			name: "is_default",
+			placeholder: null,
+			required: false,
+			secret: false,
+		},
+	],
+	label_key: "remote_node_ingress_profile_driver_s3",
+};
+
+const defaultDriverDescriptors = [localDriverDescriptor, s3DriverDescriptor];
+
 function renderSection({
+	driverDescriptors = defaultDriverDescriptors,
 	errorMessage = null,
 	loading = false,
 	onCreateProfile = vi.fn().mockResolvedValue(undefined),
@@ -174,6 +286,7 @@ function renderSection({
 } = {}) {
 	render(
 		<RemoteNodeManagedIngressSection
+			driverDescriptors={driverDescriptors}
 			errorMessage={errorMessage}
 			loading={loading}
 			onCreateProfile={onCreateProfile}
@@ -197,6 +310,7 @@ describe("RemoteNodeManagedIngressSection", () => {
 	it("shows loading, empty and error states", () => {
 		const { rerender } = render(
 			<RemoteNodeManagedIngressSection
+				driverDescriptors={defaultDriverDescriptors}
 				errorMessage={null}
 				loading
 				onCreateProfile={vi.fn()}
@@ -210,6 +324,7 @@ describe("RemoteNodeManagedIngressSection", () => {
 
 		rerender(
 			<RemoteNodeManagedIngressSection
+				driverDescriptors={defaultDriverDescriptors}
 				errorMessage={null}
 				loading={false}
 				onCreateProfile={vi.fn()}
@@ -225,6 +340,7 @@ describe("RemoteNodeManagedIngressSection", () => {
 
 		rerender(
 			<RemoteNodeManagedIngressSection
+				driverDescriptors={defaultDriverDescriptors}
 				errorMessage="cannot reach node"
 				loading={false}
 				onCreateProfile={vi.fn()}
@@ -280,6 +396,16 @@ describe("RemoteNodeManagedIngressSection", () => {
 		expect(
 			screen.queryByText("remote_node_ingress_profile_form_create_title"),
 		).not.toBeInTheDocument();
+	});
+
+	it("does not create profiles when no supported driver descriptor is returned", () => {
+		renderSection({ driverDescriptors: [] });
+
+		expect(
+			screen.getByRole("button", {
+				name: /remote_node_ingress_profiles_create/,
+			}),
+		).toBeDisabled();
 	});
 
 	it("validates S3 credentials on create and submits normalized fields", async () => {
@@ -378,6 +504,7 @@ describe("RemoteNodeManagedIngressSection", () => {
 		const onDeleteProfile = vi.fn().mockResolvedValue(undefined);
 		const { rerender } = render(
 			<RemoteNodeManagedIngressSection
+				driverDescriptors={defaultDriverDescriptors}
 				errorMessage={null}
 				loading={false}
 				onCreateProfile={vi.fn()}
@@ -394,6 +521,7 @@ describe("RemoteNodeManagedIngressSection", () => {
 
 		rerender(
 			<RemoteNodeManagedIngressSection
+				driverDescriptors={defaultDriverDescriptors}
 				errorMessage={null}
 				loading={false}
 				onCreateProfile={vi.fn()}
@@ -409,6 +537,7 @@ describe("RemoteNodeManagedIngressSection", () => {
 
 		rerender(
 			<RemoteNodeManagedIngressSection
+				driverDescriptors={defaultDriverDescriptors}
 				errorMessage={null}
 				loading={false}
 				onCreateProfile={vi.fn()}

--- a/frontend-panel/src/components/admin/admin-remote-nodes-page/RemoteNodeManagedIngressSection.tsx
+++ b/frontend-panel/src/components/admin/admin-remote-nodes-page/RemoteNodeManagedIngressSection.tsx
@@ -5,12 +5,15 @@ import {
 	buildUpdateManagedIngressProfilePayload,
 	emptyManagedIngressProfileForm,
 	getManagedIngressProfileForm,
+	isManagedIngressDriverType,
+	type ManagedIngressDriverType,
 	type ManagedIngressProfileFormData,
 } from "@/components/admin/managedIngressProfileDialogShared";
 import { Button } from "@/components/ui/button";
 import { Icon } from "@/components/ui/icon";
 import { ADMIN_CONTROL_HEIGHT_CLASS } from "@/lib/constants";
 import type {
+	ManagedIngressDriverDescriptor,
 	RemoteCreateIngressProfileRequest,
 	RemoteIngressProfileInfo,
 	RemoteUpdateIngressProfileRequest,
@@ -18,7 +21,13 @@ import type {
 import { RemoteNodeManagedIngressForm } from "./RemoteNodeManagedIngressForm";
 import { RemoteNodeManagedIngressProfilesList } from "./RemoteNodeManagedIngressProfilesList";
 
+type SupportedManagedIngressDriverDescriptor =
+	ManagedIngressDriverDescriptor & {
+		driver_type: ManagedIngressDriverType;
+	};
+
 interface RemoteNodeManagedIngressSectionProps {
+	driverDescriptors: ManagedIngressDriverDescriptor[];
 	errorMessage: string | null;
 	loading: boolean;
 	onCreateProfile: (
@@ -33,6 +42,7 @@ interface RemoteNodeManagedIngressSectionProps {
 }
 
 export function RemoteNodeManagedIngressSection({
+	driverDescriptors,
 	errorMessage,
 	loading,
 	onCreateProfile,
@@ -60,6 +70,28 @@ export function RemoteNodeManagedIngressSection({
 			: null;
 	const activeDraftMode =
 		draftMode === "edit" && editingProfile == null ? null : draftMode;
+	const supportedDriverDescriptors = driverDescriptors.flatMap(
+		(descriptor): SupportedManagedIngressDriverDescriptor[] =>
+			isManagedIngressDriverType(descriptor.driver_type)
+				? [{ ...descriptor, driver_type: descriptor.driver_type }]
+				: [],
+	);
+	const activeDriverDescriptor =
+		supportedDriverDescriptors.find(
+			(descriptor) => descriptor.driver_type === form.driver_type,
+		) ?? null;
+	const firstSupportedDriverType =
+		supportedDriverDescriptors[0]?.driver_type ?? null;
+	const supportedDriverTypes = new Set(
+		supportedDriverDescriptors.map((descriptor) => descriptor.driver_type),
+	);
+	const driverTypeError =
+		activeDraftMode != null && !supportedDriverTypes.has(form.driver_type)
+			? t("remote_node_ingress_profile_driver_unsupported")
+			: null;
+	const activeFieldNames = new Set(
+		activeDriverDescriptor?.fields.map((field) => field.name) ?? [],
+	);
 	const activePendingDeleteProfileKey = profiles.some(
 		(profile) => profile.profile_key === pendingDeleteProfileKey,
 	)
@@ -67,10 +99,14 @@ export function RemoteNodeManagedIngressSection({
 		: null;
 
 	const startCreate = () => {
+		if (!firstSupportedDriverType) {
+			return;
+		}
 		setDraftMode("create");
 		setEditingProfileKey(null);
 		setForm({
 			...emptyManagedIngressProfileForm,
+			driver_type: firstSupportedDriverType,
 			is_default: profiles.length === 0,
 		});
 	};
@@ -104,7 +140,7 @@ export function RemoteNodeManagedIngressSection({
 			: t("remote_node_ingress_profile_max_file_size_invalid");
 	const localPathCandidate = form.base_path.trim().replaceAll("\\", "/");
 	const localPathError =
-		form.driver_type === "local"
+		activeFieldNames.has("base_path") && form.driver_type === "local"
 			? !form.base_path.trim()
 				? t("remote_node_ingress_profile_base_path_required")
 				: localPathCandidate.startsWith("/") ||
@@ -114,15 +150,15 @@ export function RemoteNodeManagedIngressSection({
 					: null
 			: null;
 	const endpointError =
-		form.driver_type === "s3" && !form.endpoint.trim()
+		activeFieldNames.has("endpoint") && !form.endpoint.trim()
 			? t("remote_node_ingress_profile_endpoint_required")
 			: null;
 	const bucketError =
-		form.driver_type === "s3" && !form.bucket.trim()
+		activeFieldNames.has("bucket") && !form.bucket.trim()
 			? t("remote_node_ingress_profile_bucket_required")
 			: null;
 	const requiresS3Credentials =
-		form.driver_type === "s3" &&
+		activeFieldNames.has("access_key") &&
 		(activeDraftMode === "create" || editingProfile?.driver_type !== "s3");
 	const accessKeyError =
 		requiresS3Credentials && !form.access_key.trim()
@@ -140,6 +176,7 @@ export function RemoteNodeManagedIngressSection({
 		Boolean(
 			nameError ||
 				maxFileSizeError ||
+				driverTypeError ||
 				localPathError ||
 				endpointError ||
 				bucketError ||
@@ -193,7 +230,11 @@ export function RemoteNodeManagedIngressSection({
 						size="sm"
 						className={ADMIN_CONTROL_HEIGHT_CLASS}
 						onClick={startCreate}
-						disabled={loading || Boolean(errorMessage)}
+						disabled={
+							loading ||
+							Boolean(errorMessage) ||
+							firstSupportedDriverType == null
+						}
 					>
 						<Icon name="Plus" className="mr-1 size-4" />
 						{t("remote_node_ingress_profiles_create")}
@@ -212,6 +253,8 @@ export function RemoteNodeManagedIngressSection({
 					accessKeyError={accessKeyError}
 					bucketError={bucketError}
 					defaultToggleLocked={Boolean(defaultToggleLocked)}
+					driverDescriptors={supportedDriverDescriptors}
+					driverTypeError={driverTypeError}
 					draftMode={activeDraftMode}
 					editingProfile={editingProfile}
 					endpointError={endpointError}

--- a/frontend-panel/src/components/admin/managedIngressProfileDialogShared.ts
+++ b/frontend-panel/src/components/admin/managedIngressProfileDialogShared.ts
@@ -7,6 +7,12 @@ import type {
 
 export type ManagedIngressDriverType = "local" | "s3";
 
+export function isManagedIngressDriverType(
+	driverType: unknown,
+): driverType is ManagedIngressDriverType {
+	return driverType === "local" || driverType === "s3";
+}
+
 export interface ManagedIngressProfileFormData {
 	name: string;
 	driver_type: ManagedIngressDriverType;

--- a/frontend-panel/src/i18n/locales/en/admin/remote-nodes.json
+++ b/frontend-panel/src/i18n/locales/en/admin/remote-nodes.json
@@ -142,6 +142,7 @@
 	"remote_node_ingress_profile_local_scope_hint": "This profile writes into follower-local storage. The base path above is always resolved relative to `server.follower.managed_ingress_local_root`, never as an arbitrary host path.",
 	"remote_node_ingress_profile_driver_local": "Local",
 	"remote_node_ingress_profile_driver_s3": "S3",
+	"remote_node_ingress_profile_driver_unsupported": "This follower does not declare support for the selected ingress driver.",
 	"remote_node_ingress_profile_default_toggle": "Use as the default ingress profile",
 	"remote_node_ingress_profile_default_hint": "Managed follower ingress always lands on the default profile.",
 	"remote_node_ingress_profile_default_locked_hint": "This profile is already default. To change it, set another profile as default first.",

--- a/frontend-panel/src/i18n/locales/zh/admin/remote-nodes.json
+++ b/frontend-panel/src/i18n/locales/zh/admin/remote-nodes.json
@@ -142,6 +142,7 @@
 	"remote_node_ingress_profile_local_scope_hint": "这个配置会写入 follower 本地存储。上面的基础路径永远只会相对于 `server.follower.managed_ingress_local_root` 解析，不会接受任意宿主机绝对路径。",
 	"remote_node_ingress_profile_driver_local": "本地",
 	"remote_node_ingress_profile_driver_s3": "S3",
+	"remote_node_ingress_profile_driver_unsupported": "这台 follower 没有声明支持当前接收驱动。",
 	"remote_node_ingress_profile_default_toggle": "设为默认接收落点",
 	"remote_node_ingress_profile_default_hint": "主控写入这台 follower 的对象默认会落到这里。",
 	"remote_node_ingress_profile_default_locked_hint": "这条落点已经是默认值。要切换默认，请先把另一条设为默认。",

--- a/frontend-panel/src/pages/admin/AdminRemoteNodesPage.test.tsx
+++ b/frontend-panel/src/pages/admin/AdminRemoteNodesPage.test.tsx
@@ -26,6 +26,7 @@ const adminRemoteNodeServiceMocks = vi.hoisted(() => ({
 	deleteIngressProfile: vi.fn(),
 	get: vi.fn(),
 	list: vi.fn(),
+	listIngressProfileDrivers: vi.fn(),
 	listIngressProfiles: vi.fn(),
 	testConnection: vi.fn(),
 	update: vi.fn(),
@@ -460,6 +461,24 @@ describe("AdminRemoteNodesPage", () => {
 			items: [],
 			total: 0,
 		});
+		adminRemoteNodeServiceMocks.listIngressProfileDrivers.mockResolvedValue([
+			{
+				description_key: "remote_node_ingress_profile_local_scope_hint",
+				driver_type: "local",
+				fields: [
+					{
+						help_key: "remote_node_ingress_profile_local_path_hint",
+						kind: "text",
+						label_key: "base_path",
+						name: "base_path",
+						placeholder: "tenant-a/incoming",
+						required: true,
+						secret: false,
+					},
+				],
+				label_key: "remote_node_ingress_profile_driver_local",
+			},
+		]);
 		adminRemoteNodeServiceMocks.listIngressProfiles.mockResolvedValue([
 			{
 				applied_revision: 1,
@@ -596,6 +615,9 @@ describe("AdminRemoteNodesPage", () => {
 				adminRemoteNodeServiceMocks.listIngressProfiles,
 			).toHaveBeenCalledWith(7);
 		});
+		expect(
+			adminRemoteNodeServiceMocks.listIngressProfileDrivers,
+		).toHaveBeenCalledWith(7);
 		expect(screen.getByTestId("remote-node-dialog")).toHaveTextContent("edit");
 		expect(screen.getByTestId("managed-ingress-enabled")).toHaveTextContent(
 			"true",
@@ -667,6 +689,9 @@ describe("AdminRemoteNodesPage", () => {
 		expect(
 			adminRemoteNodeServiceMocks.listIngressProfiles,
 		).not.toHaveBeenCalled();
+		expect(
+			adminRemoteNodeServiceMocks.listIngressProfileDrivers,
+		).not.toHaveBeenCalled();
 	});
 
 	it("loads managed ingress profiles for reverse tunnel nodes without base_url", async () => {
@@ -701,6 +726,9 @@ describe("AdminRemoteNodesPage", () => {
 				adminRemoteNodeServiceMocks.listIngressProfiles,
 			).toHaveBeenCalledWith(7);
 		});
+		expect(
+			adminRemoteNodeServiceMocks.listIngressProfileDrivers,
+		).toHaveBeenCalledWith(7);
 		expect(screen.getByTestId("managed-ingress-enabled")).toHaveTextContent(
 			"true",
 		);
@@ -739,6 +767,9 @@ describe("AdminRemoteNodesPage", () => {
 				adminRemoteNodeServiceMocks.listIngressProfiles,
 			).toHaveBeenCalledWith(7);
 		});
+		expect(
+			adminRemoteNodeServiceMocks.listIngressProfileDrivers,
+		).toHaveBeenCalledWith(7);
 		expect(screen.getByTestId("managed-ingress-enabled")).toHaveTextContent(
 			"true",
 		);

--- a/frontend-panel/src/pages/admin/AdminRemoteNodesPage.test.tsx
+++ b/frontend-panel/src/pages/admin/AdminRemoteNodesPage.test.tsx
@@ -65,6 +65,8 @@ vi.mock("@/components/admin/admin-remote-nodes-page/RemoteNodeDialog", () => ({
 	RemoteNodeDialog: ({
 		editingNode,
 		form,
+		managedIngressDriverDescriptors,
+		managedIngressDriverDescriptorsError,
 		managedIngressProfilesEnabled,
 		managedIngressProfilesError,
 		mode,
@@ -82,6 +84,8 @@ vi.mock("@/components/admin/admin-remote-nodes-page/RemoteNodeDialog", () => ({
 	}: {
 		editingNode: { id: number; name: string } | null;
 		form: { base_url: string; is_enabled: boolean; name: string };
+		managedIngressDriverDescriptors: unknown[];
+		managedIngressDriverDescriptorsError: string | null;
 		managedIngressProfilesEnabled: boolean;
 		managedIngressProfilesError: string | null;
 		mode: "create" | "edit";
@@ -115,6 +119,12 @@ vi.mock("@/components/admin/admin-remote-nodes-page/RemoteNodeDialog", () => ({
 				</div>
 				<div data-testid="managed-ingress-error">
 					{managedIngressProfilesError ?? ""}
+				</div>
+				<div data-testid="managed-ingress-driver-count">
+					{managedIngressDriverDescriptors.length}
+				</div>
+				<div data-testid="managed-ingress-driver-error">
+					{managedIngressDriverDescriptorsError ?? ""}
 				</div>
 				<div data-testid="editing-node-name">{editingNode?.name ?? ""}</div>
 				<button
@@ -805,6 +815,50 @@ describe("AdminRemoteNodesPage", () => {
 				"Error: profile failed",
 			);
 		});
+		expect(mockState.handleApiError).toHaveBeenCalledWith(expect.any(Error));
+	});
+
+	it("surfaces managed ingress driver descriptor errors without canceling profile loading", async () => {
+		adminRemoteNodeServiceMocks.listIngressProfileDrivers.mockRejectedValueOnce(
+			new Error("descriptor failed"),
+		);
+		mockState.useApiList.mockReturnValue({
+			items: [
+				{
+					base_url: "https://edge.example.com",
+					enrollment_status: "completed",
+					id: 7,
+					name: "Edge Alpha",
+				},
+			],
+			loading: false,
+			reload: mockState.reload,
+			setItems: mockState.setItems,
+			setTotal: mockState.setTotal,
+			total: 1,
+		});
+
+		renderPage();
+
+		fireEvent.click(screen.getByRole("button", { name: "edit:7" }));
+
+		await waitFor(() => {
+			expect(
+				adminRemoteNodeServiceMocks.listIngressProfiles,
+			).toHaveBeenCalledWith(7);
+			expect(
+				adminRemoteNodeServiceMocks.listIngressProfileDrivers,
+			).toHaveBeenCalledWith(7);
+		});
+		await waitFor(() => {
+			expect(
+				screen.getByTestId("managed-ingress-driver-error"),
+			).toHaveTextContent("Error: descriptor failed");
+		});
+		expect(
+			screen.getByTestId("managed-ingress-driver-count"),
+		).toHaveTextContent("0");
+		expect(screen.getByTestId("managed-ingress-error")).toBeEmptyDOMElement();
 		expect(mockState.handleApiError).toHaveBeenCalledWith(expect.any(Error));
 	});
 

--- a/frontend-panel/src/pages/admin/AdminRemoteNodesPage.tsx
+++ b/frontend-panel/src/pages/admin/AdminRemoteNodesPage.tsx
@@ -46,6 +46,9 @@ export default function AdminRemoteNodesPage() {
 		handleVerifyEnrollmentConnection,
 		loading,
 		managedIngressProfiles,
+		managedIngressDriverDescriptors,
+		managedIngressDriverDescriptorsError,
+		managedIngressDriverDescriptorsLoading,
 		managedIngressProfilesError,
 		managedIngressProfilesLoading,
 		nextPageDisabled,
@@ -153,6 +156,13 @@ export default function AdminRemoteNodesPage() {
 						hasCompletedRemoteNodeEnrollment(editingNode)
 					}
 					managedIngressProfiles={managedIngressProfiles}
+					managedIngressDriverDescriptors={managedIngressDriverDescriptors}
+					managedIngressDriverDescriptorsError={
+						managedIngressDriverDescriptorsError
+					}
+					managedIngressDriverDescriptorsLoading={
+						managedIngressDriverDescriptorsLoading
+					}
 					managedIngressProfilesLoading={managedIngressProfilesLoading}
 					managedIngressProfilesError={managedIngressProfilesError}
 					onFieldChange={setField}

--- a/frontend-panel/src/pages/admin/useAdminRemoteNodesPageController.ts
+++ b/frontend-panel/src/pages/admin/useAdminRemoteNodesPageController.ts
@@ -32,6 +32,7 @@ import { adminRemoteNodeService } from "@/services/adminService";
 import { useFrontendConfigStore } from "@/stores/frontendConfigStore";
 import type { AdminRemoteNodeSortBy } from "@/types/adminSort";
 import type {
+	ManagedIngressDriverDescriptor,
 	RemoteCreateIngressProfileRequest,
 	RemoteEnrollmentCommandInfo,
 	RemoteIngressProfileInfo,
@@ -130,6 +131,16 @@ export function useAdminRemoteNodesPageController() {
 		useState(false);
 	const [managedIngressProfilesError, setManagedIngressProfilesError] =
 		useState<string | null>(null);
+	const [managedIngressDriverDescriptors, setManagedIngressDriverDescriptors] =
+		useState<ManagedIngressDriverDescriptor[]>([]);
+	const [
+		managedIngressDriverDescriptorsLoading,
+		setManagedIngressDriverDescriptorsLoading,
+	] = useState(false);
+	const [
+		managedIngressDriverDescriptorsError,
+		setManagedIngressDriverDescriptorsError,
+	] = useState<string | null>(null);
 	const {
 		pendingId: deletingRemoteNodeId,
 		runWithPending: runWithDeletingRemoteNode,
@@ -193,6 +204,41 @@ export function useAdminRemoteNodesPageController() {
 		setManagedIngressProfiles([]);
 		setManagedIngressProfilesLoading(false);
 		setManagedIngressProfilesError(null);
+		setManagedIngressDriverDescriptors([]);
+		setManagedIngressDriverDescriptorsLoading(false);
+		setManagedIngressDriverDescriptorsError(null);
+	};
+
+	const loadManagedIngressDriverDescriptors = async (
+		remoteNodeId: number,
+		{ showErrorToast = true }: { showErrorToast?: boolean } = {},
+	) => {
+		const requestId = managedIngressRequestIdRef.current;
+		setManagedIngressDriverDescriptorsLoading(true);
+		setManagedIngressDriverDescriptorsError(null);
+
+		try {
+			const descriptors =
+				await adminRemoteNodeService.listIngressProfileDrivers(remoteNodeId);
+			if (managedIngressRequestIdRef.current !== requestId) {
+				return;
+			}
+			setManagedIngressDriverDescriptors(descriptors);
+			setManagedIngressDriverDescriptorsError(null);
+		} catch (error) {
+			if (managedIngressRequestIdRef.current !== requestId) {
+				return;
+			}
+			setManagedIngressDriverDescriptors([]);
+			setManagedIngressDriverDescriptorsError(getApiErrorMessage(error));
+			if (showErrorToast) {
+				handleApiError(error);
+			}
+		} finally {
+			if (managedIngressRequestIdRef.current === requestId) {
+				setManagedIngressDriverDescriptorsLoading(false);
+			}
+		}
 	};
 
 	const loadManagedIngressProfiles = async (
@@ -255,8 +301,10 @@ export function useAdminRemoteNodesPageController() {
 			);
 		} else if (hasCompletedRemoteNodeEnrollment(node)) {
 			void loadManagedIngressProfiles(node.id);
+			void loadManagedIngressDriverDescriptors(node.id);
 		} else {
 			setManagedIngressProfilesError(null);
+			setManagedIngressDriverDescriptorsError(null);
 		}
 		setDialogOpen(true);
 	};
@@ -613,6 +661,9 @@ export function useAdminRemoteNodesPageController() {
 		handleVerifyEnrollmentConnection,
 		loading,
 		managedIngressProfiles,
+		managedIngressDriverDescriptors,
+		managedIngressDriverDescriptorsError,
+		managedIngressDriverDescriptorsLoading,
 		managedIngressProfilesError,
 		managedIngressProfilesLoading,
 		nextPageDisabled,

--- a/frontend-panel/src/pages/admin/useAdminRemoteNodesPageController.ts
+++ b/frontend-panel/src/pages/admin/useAdminRemoteNodesPageController.ts
@@ -146,6 +146,7 @@ export function useAdminRemoteNodesPageController() {
 		runWithPending: runWithDeletingRemoteNode,
 	} = usePendingId<number>();
 	const managedIngressRequestIdRef = useRef(0);
+	const managedIngressDriverDescriptorsRequestIdRef = useRef(0);
 	const totalPages = Math.max(1, Math.ceil(total / pageSize));
 	const currentPage = Math.floor(offset / pageSize) + 1;
 	const prevPageDisabled = offset === 0;
@@ -201,6 +202,7 @@ export function useAdminRemoteNodesPageController() {
 
 	const resetManagedIngressState = () => {
 		managedIngressRequestIdRef.current += 1;
+		managedIngressDriverDescriptorsRequestIdRef.current += 1;
 		setManagedIngressProfiles([]);
 		setManagedIngressProfilesLoading(false);
 		setManagedIngressProfilesError(null);
@@ -213,20 +215,21 @@ export function useAdminRemoteNodesPageController() {
 		remoteNodeId: number,
 		{ showErrorToast = true }: { showErrorToast?: boolean } = {},
 	) => {
-		const requestId = managedIngressRequestIdRef.current;
+		const requestId = managedIngressDriverDescriptorsRequestIdRef.current + 1;
+		managedIngressDriverDescriptorsRequestIdRef.current = requestId;
 		setManagedIngressDriverDescriptorsLoading(true);
 		setManagedIngressDriverDescriptorsError(null);
 
 		try {
 			const descriptors =
 				await adminRemoteNodeService.listIngressProfileDrivers(remoteNodeId);
-			if (managedIngressRequestIdRef.current !== requestId) {
+			if (managedIngressDriverDescriptorsRequestIdRef.current !== requestId) {
 				return;
 			}
 			setManagedIngressDriverDescriptors(descriptors);
 			setManagedIngressDriverDescriptorsError(null);
 		} catch (error) {
-			if (managedIngressRequestIdRef.current !== requestId) {
+			if (managedIngressDriverDescriptorsRequestIdRef.current !== requestId) {
 				return;
 			}
 			setManagedIngressDriverDescriptors([]);
@@ -235,7 +238,7 @@ export function useAdminRemoteNodesPageController() {
 				handleApiError(error);
 			}
 		} finally {
-			if (managedIngressRequestIdRef.current === requestId) {
+			if (managedIngressDriverDescriptorsRequestIdRef.current === requestId) {
 				setManagedIngressDriverDescriptorsLoading(false);
 			}
 		}

--- a/frontend-panel/src/services/adminService.test.ts
+++ b/frontend-panel/src/services/adminService.test.ts
@@ -605,6 +605,7 @@ describe("adminService", () => {
 	});
 
 	it("uses the expected managed ingress profile endpoints", () => {
+		adminRemoteNodeService.listIngressProfileDrivers(6);
 		adminRemoteNodeService.listIngressProfiles(6);
 		adminRemoteNodeService.createIngressProfile(6, {
 			name: "Ingress A",
@@ -623,6 +624,9 @@ describe("adminService", () => {
 		});
 		adminRemoteNodeService.deleteIngressProfile(6, "igp_demo");
 
+		expect(mockState.get).toHaveBeenCalledWith(
+			"/admin/remote-nodes/6/ingress-profile-drivers",
+		);
 		expect(mockState.get).toHaveBeenCalledWith(
 			"/admin/remote-nodes/6/ingress-profiles",
 		);

--- a/frontend-panel/src/services/adminService.ts
+++ b/frontend-panel/src/services/adminService.ts
@@ -55,6 +55,7 @@ import type {
 	ExternalAuthProviderTestResult,
 	FolderInfo,
 	LockPage,
+	ManagedIngressDriverDescriptor,
 	MigratePolicyGroupAssignmentsRequest,
 	PolicyGroupAssignmentMigrationResult,
 	PromoteS3CompatiblePolicyDriverRequest,
@@ -430,6 +431,11 @@ export const adminRemoteNodeService = {
 	listIngressProfiles: (id: number) =>
 		api.get<RemoteIngressProfileInfo[]>(
 			`/admin/remote-nodes/${id}/ingress-profiles`,
+		),
+
+	listIngressProfileDrivers: (id: number) =>
+		api.get<ManagedIngressDriverDescriptor[]>(
+			`/admin/remote-nodes/${id}/ingress-profile-drivers`,
 		),
 
 	createIngressProfile: (id: number, data: RemoteCreateIngressProfileRequest) =>

--- a/frontend-panel/src/services/api.generated.ts
+++ b/frontend-panel/src/services/api.generated.ts
@@ -644,6 +644,22 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/admin/remote-nodes/{id}/ingress-profile-drivers": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["list_remote_node_ingress_profile_drivers"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/admin/remote-nodes/{id}/ingress-profiles": {
         parameters: {
             query?: never;
@@ -5747,6 +5763,17 @@ export interface components {
             /** @enum {string} */
             status: "mfa_required";
         };
+        ManagedIngressDriverFieldDescriptor: {
+            help_key?: string | null;
+            kind: components["schemas"]["ManagedIngressDriverFieldKind"];
+            label_key: string;
+            name: string;
+            placeholder?: string | null;
+            required: boolean;
+            secret: boolean;
+        };
+        /** @enum {string} */
+        ManagedIngressDriverFieldKind: "text" | "secret" | "boolean" | "number";
         /**
          * @description Partial `/auth/me` response. The always-needed account identity is kept
          *     stable, while heavier or narrow-use groups are serialized only when selected.
@@ -6871,6 +6898,11 @@ export interface components {
             profile_key: string;
             updated_at: string;
         };
+        RemoteManagedIngressCapabilities: {
+            driver_types?: components["schemas"]["RemoteManagedIngressDriverType"][];
+            enabled: boolean;
+        };
+        RemoteManagedIngressDriverType: string;
         /** @enum {string} */
         RemoteNodeEnrollmentStatus: "not_started" | "pending" | "redeemed" | "completed" | "expired";
         RemoteNodeInfo: {
@@ -6902,6 +6934,7 @@ export interface components {
             browser_cors?: components["schemas"]["RemoteStorageBrowserCorsContract"];
             features?: components["schemas"]["RemoteStorageFeatureFlags"];
             limits?: components["schemas"]["RemoteStorageProtocolLimits"];
+            managed_ingress?: null | components["schemas"]["RemoteManagedIngressCapabilities"];
             min_supported_protocol_version?: string;
             protocol_version?: string;
             server_version?: string | null;
@@ -11363,6 +11396,7 @@ export interface operations {
                             browser_cors?: components["schemas"]["RemoteStorageBrowserCorsContract"];
                             features?: components["schemas"]["RemoteStorageFeatureFlags"];
                             limits?: components["schemas"]["RemoteStorageProtocolLimits"];
+                            managed_ingress?: null | components["schemas"]["RemoteManagedIngressCapabilities"];
                             min_supported_protocol_version?: string;
                             protocol_version?: string;
                             server_version?: string | null;
@@ -11592,6 +11626,60 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["ApiResponse_RemoteEnrollmentCommandInfo"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Remote node not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    list_remote_node_ingress_profile_drivers: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Remote node ID */
+                id: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description List remote node ingress profile driver descriptors */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        code: components["schemas"]["ApiErrorCode"];
+                        data?: {
+                            description_key: string;
+                            driver_type: components["schemas"]["DriverType"];
+                            fields: components["schemas"]["ManagedIngressDriverFieldDescriptor"][];
+                            label_key: string;
+                        }[];
+                        error?: null | components["schemas"]["ApiErrorInfo"];
+                        msg: string;
+                    };
                 };
             };
             /** @description Unauthorized */

--- a/frontend-panel/src/types/api.ts
+++ b/frontend-panel/src/types/api.ts
@@ -327,6 +327,10 @@ export type RemoteEnrollmentCommandInfo =
 	components["schemas"]["RemoteEnrollmentCommandInfo"];
 export type RemoteIngressProfileInfo =
 	components["schemas"]["RemoteIngressProfileInfo"];
+export type ManagedIngressDriverFieldDescriptor =
+	components["schemas"]["ManagedIngressDriverFieldDescriptor"];
+export type ManagedIngressDriverDescriptor =
+	OperationData<"list_remote_node_ingress_profile_drivers">[number];
 export type RemoteNodeEnrollmentStatus =
 	components["schemas"]["RemoteNodeEnrollmentStatus"];
 export type RemoteNodeInfo = components["schemas"]["RemoteNodeInfo"];

--- a/src/api/openapi.rs
+++ b/src/api/openapi.rs
@@ -309,6 +309,7 @@ use utoipa::{Modify, OpenApi};
         crate::api::routes::admin::remote_nodes::test_remote_node_params,
         crate::api::routes::admin::remote_nodes::create_remote_node_enrollment_token,
         crate::api::routes::admin::remote_nodes::list_remote_node_ingress_profiles,
+        crate::api::routes::admin::remote_nodes::list_remote_node_ingress_profile_drivers,
         crate::api::routes::admin::remote_nodes::create_remote_node_ingress_profile,
         crate::api::routes::admin::remote_nodes::update_remote_node_ingress_profile,
         crate::api::routes::admin::remote_nodes::delete_remote_node_ingress_profile,

--- a/src/api/routes/admin/mod.rs
+++ b/src/api/routes/admin/mod.rs
@@ -66,8 +66,9 @@ pub use policies::{
 pub use remote_nodes::{
     create_remote_node, create_remote_node_enrollment_token, create_remote_node_ingress_profile,
     delete_remote_node, delete_remote_node_ingress_profile, get_remote_node,
-    list_remote_node_ingress_profiles, list_remote_nodes, test_remote_node,
-    test_remote_node_params, update_remote_node, update_remote_node_ingress_profile,
+    list_remote_node_ingress_profile_drivers, list_remote_node_ingress_profiles, list_remote_nodes,
+    test_remote_node, test_remote_node_params, update_remote_node,
+    update_remote_node_ingress_profile,
 };
 pub use shares::{admin_delete_share, list_all_shares};
 pub use storage_migrations::{
@@ -165,6 +166,10 @@ pub fn routes(
                     .route(
                         "/remote-nodes/{id}/ingress-profiles",
                         web::get().to(list_remote_node_ingress_profiles),
+                    )
+                    .route(
+                        "/remote-nodes/{id}/ingress-profile-drivers",
+                        web::get().to(list_remote_node_ingress_profile_drivers),
                     )
                     .route(
                         "/remote-nodes/{id}/ingress-profiles",

--- a/src/api/routes/admin/policies.rs
+++ b/src/api/routes/admin/policies.rs
@@ -16,7 +16,7 @@ use crate::errors::Result;
 use crate::runtime::{PrimaryAppState, SharedRuntimeState};
 use crate::services::storage_credential_service;
 use crate::services::{audit_service, auth_service::Claims, policy_service};
-use crate::types::{DriverType, StorageCredentialProvider};
+use crate::types::DriverType;
 use actix_web::{HttpRequest, HttpResponse, http::header, web};
 
 // ── Conversion helpers (must stay here because they use policy_service types) ──────────
@@ -629,7 +629,7 @@ pub async fn validate_storage_policy_credential(
     path: web::Path<(i64, String)>,
 ) -> Result<HttpResponse> {
     let (policy_id, provider) = path.into_inner();
-    let provider = StorageCredentialProvider::parse(&provider).ok_or_else(|| {
+    let provider = provider.parse().map_err(|()| {
         crate::errors::AsterError::validation_error("unsupported storage credential provider")
     })?;
     let result = storage_credential_service::validate_policy_credential(

--- a/src/api/routes/admin/remote_nodes.rs
+++ b/src/api/routes/admin/remote_nodes.rs
@@ -17,19 +17,7 @@ use crate::services::{
 use crate::storage::remote_protocol::{
     RemoteCreateIngressProfileRequest, RemoteUpdateIngressProfileRequest,
 };
-use crate::types::DriverType;
 use actix_web::{HttpRequest, HttpResponse, web};
-
-fn driver_type_audit_name(driver_type: DriverType) -> &'static str {
-    match driver_type {
-        DriverType::Local => "local",
-        DriverType::S3 => "s3",
-        DriverType::AzureBlob => "azure_blob",
-        DriverType::TencentCos => "tencent_cos",
-        DriverType::Remote => "remote",
-        DriverType::OneDrive => "onedrive",
-    }
-}
 
 fn enrollment_status_audit_name(
     status: managed_follower_service::RemoteNodeEnrollmentStatus,
@@ -397,6 +385,30 @@ pub async fn list_remote_node_ingress_profiles(
 }
 
 #[api_docs_macros::path(
+    get,
+    path = "/api/v1/admin/remote-nodes/{id}/ingress-profile-drivers",
+    tag = "admin",
+    operation_id = "list_remote_node_ingress_profile_drivers",
+    params(("id" = i64, Path, description = "Remote node ID")),
+    responses(
+        (status = 200, description = "List remote node ingress profile driver descriptors", body = inline(ApiResponse<Vec<crate::services::managed_ingress_profile_service::ManagedIngressDriverDescriptor>>)),
+        (status = 401, description = crate::api::constants::OPENAPI_UNAUTHORIZED),
+        (status = 403, description = "Forbidden"),
+        (status = 404, description = "Remote node not found"),
+    ),
+    security(("bearer" = [])),
+)]
+pub async fn list_remote_node_ingress_profile_drivers(
+    state: web::Data<PrimaryAppState>,
+    path: web::Path<i64>,
+) -> Result<HttpResponse> {
+    let descriptors =
+        managed_ingress_profile_service::list_remote_driver_descriptors(state.get_ref(), *path)
+            .await?;
+    Ok(HttpResponse::Ok().json(ApiResponse::ok(descriptors)))
+}
+
+#[api_docs_macros::path(
     post,
     path = "/api/v1/admin/remote-nodes/{id}/ingress-profiles",
     tag = "admin",
@@ -433,7 +445,7 @@ pub async fn create_remote_node_ingress_profile(
         || {
             audit_service::details(audit_service::RemoteIngressProfileAuditDetails {
                 profile_key: &profile.profile_key,
-                driver_type: driver_type_audit_name(profile.driver_type),
+                driver_type: profile.driver_type.as_str(),
                 is_default: profile.is_default,
             })
         },
@@ -487,7 +499,7 @@ pub async fn update_remote_node_ingress_profile(
         || {
             audit_service::details(audit_service::RemoteIngressProfileAuditDetails {
                 profile_key: &profile.profile_key,
-                driver_type: driver_type_audit_name(profile.driver_type),
+                driver_type: profile.driver_type.as_str(),
                 is_default: profile.is_default,
             })
         },

--- a/src/api/routes/auth/external_auth.rs
+++ b/src/api/routes/auth/external_auth.rs
@@ -21,7 +21,7 @@ use actix_web::http::header;
 use actix_web::{HttpRequest, HttpResponse, web};
 
 fn parse_provider_kind(value: &str) -> Result<ExternalAuthProviderKind> {
-    ExternalAuthProviderKind::parse(value).ok_or_else(|| {
+    value.parse().map_err(|()| {
         AsterError::record_not_found(format!("external auth provider kind '{value}'"))
     })
 }

--- a/src/api/routes/internal_storage.rs
+++ b/src/api/routes/internal_storage.rs
@@ -303,7 +303,10 @@ async fn get_capabilities(
         binding_id = binding.id,
         "follower internal storage capabilities requested"
     );
-    Ok(HttpResponse::Ok().json(ApiResponse::ok(RemoteStorageCapabilities::current())))
+    let capabilities = RemoteStorageCapabilities::current().with_managed_ingress_driver_types(
+        managed_ingress_profile_service::registered_managed_ingress_driver_types(),
+    );
+    Ok(HttpResponse::Ok().json(ApiResponse::ok(capabilities)))
 }
 
 async fn get_capacity(

--- a/src/services/managed_ingress_profile_service/driver.rs
+++ b/src/services/managed_ingress_profile_service/driver.rs
@@ -1,14 +1,411 @@
 use std::path::Path;
 use std::sync::Arc;
 
+use crate::api::api_error_code::ApiErrorCode;
 use crate::entities::{managed_ingress_profile, storage_policy};
-use crate::errors::{AsterError, MapAsterErr, Result};
+use crate::errors::{AsterError, MapAsterErr, Result, validation_error_with_code};
 use crate::runtime::FollowerRuntimeState;
 use crate::storage::StorageDriver;
+use crate::storage::drivers::s3_config::normalize_s3_endpoint_and_bucket;
 use crate::storage::drivers::{local::LocalDriver, s3::S3Driver};
 use crate::types::{DriverType, StoredStoragePolicyAllowedTypes, StoredStoragePolicyOptions};
+use serde::{Deserialize, Serialize};
+#[cfg(all(debug_assertions, feature = "openapi"))]
+use utoipa::ToSchema;
 
-use super::paths::resolve_managed_local_path;
+use super::paths::{normalize_relative_local_path, resolve_managed_local_path};
+
+pub(in crate::services::managed_ingress_profile_service) struct ManagedIngressDriverFields {
+    pub driver_type: DriverType,
+    pub endpoint: String,
+    pub bucket: String,
+    pub access_key: String,
+    pub secret_key: String,
+    pub base_path: String,
+}
+
+pub(in crate::services::managed_ingress_profile_service) struct NormalizedManagedIngressDriverFields
+{
+    pub driver_type: DriverType,
+    pub endpoint: String,
+    pub bucket: String,
+    pub access_key: String,
+    pub secret_key: String,
+    pub base_path: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[cfg_attr(all(debug_assertions, feature = "openapi"), derive(ToSchema))]
+pub enum ManagedIngressDriverFieldKind {
+    Text,
+    Secret,
+    Boolean,
+    Number,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(all(debug_assertions, feature = "openapi"), derive(ToSchema))]
+pub struct ManagedIngressDriverFieldDescriptor {
+    pub name: String,
+    pub kind: ManagedIngressDriverFieldKind,
+    pub required: bool,
+    pub secret: bool,
+    pub label_key: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub placeholder: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub help_key: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(all(debug_assertions, feature = "openapi"), derive(ToSchema))]
+pub struct ManagedIngressDriverDescriptor {
+    pub driver_type: DriverType,
+    pub label_key: String,
+    pub description_key: String,
+    pub fields: Vec<ManagedIngressDriverFieldDescriptor>,
+}
+
+fn managed_ingress_text_field(
+    name: &str,
+    label_key: &str,
+    placeholder: Option<&str>,
+    help_key: Option<&str>,
+    required: bool,
+    secret: bool,
+) -> ManagedIngressDriverFieldDescriptor {
+    ManagedIngressDriverFieldDescriptor {
+        name: name.to_string(),
+        kind: if secret {
+            ManagedIngressDriverFieldKind::Secret
+        } else {
+            ManagedIngressDriverFieldKind::Text
+        },
+        required,
+        secret,
+        label_key: label_key.to_string(),
+        placeholder: placeholder.map(str::to_string),
+        help_key: help_key.map(str::to_string),
+    }
+}
+
+fn managed_ingress_number_field(
+    name: &str,
+    label_key: &str,
+    placeholder: Option<&str>,
+    help_key: Option<&str>,
+    required: bool,
+) -> ManagedIngressDriverFieldDescriptor {
+    ManagedIngressDriverFieldDescriptor {
+        name: name.to_string(),
+        kind: ManagedIngressDriverFieldKind::Number,
+        required,
+        secret: false,
+        label_key: label_key.to_string(),
+        placeholder: placeholder.map(str::to_string),
+        help_key: help_key.map(str::to_string),
+    }
+}
+
+fn managed_ingress_boolean_field(
+    name: &str,
+    label_key: &str,
+    help_key: Option<&str>,
+    required: bool,
+) -> ManagedIngressDriverFieldDescriptor {
+    ManagedIngressDriverFieldDescriptor {
+        name: name.to_string(),
+        kind: ManagedIngressDriverFieldKind::Boolean,
+        required,
+        secret: false,
+        label_key: label_key.to_string(),
+        placeholder: None,
+        help_key: help_key.map(str::to_string),
+    }
+}
+
+trait ManagedIngressDriverConnector {
+    fn driver_type() -> DriverType;
+
+    fn descriptor() -> ManagedIngressDriverDescriptor;
+
+    fn normalize_fields(
+        fields: ManagedIngressDriverFields,
+    ) -> Result<NormalizedManagedIngressDriverFields>;
+
+    fn policy_base_path<S: FollowerRuntimeState>(
+        state: &S,
+        profile: &managed_ingress_profile::Model,
+    ) -> Result<String>;
+
+    fn validate_policy(policy: &storage_policy::Model) -> Result<()>;
+
+    fn build_driver(policy: &storage_policy::Model) -> Result<Arc<dyn StorageDriver>>;
+}
+
+struct LocalManagedIngressDriverConnector;
+
+impl ManagedIngressDriverConnector for LocalManagedIngressDriverConnector {
+    fn driver_type() -> DriverType {
+        DriverType::Local
+    }
+
+    fn descriptor() -> ManagedIngressDriverDescriptor {
+        ManagedIngressDriverDescriptor {
+            driver_type: Self::driver_type(),
+            label_key: "remote_node_ingress_profile_driver_local".to_string(),
+            description_key: "remote_node_ingress_profile_local_scope_hint".to_string(),
+            fields: vec![
+                managed_ingress_text_field(
+                    "base_path",
+                    "base_path",
+                    Some("tenant-a/incoming"),
+                    Some("remote_node_ingress_profile_local_path_hint"),
+                    true,
+                    false,
+                ),
+                managed_ingress_number_field(
+                    "max_file_size",
+                    "max_file_size",
+                    Some("0"),
+                    Some("remote_node_ingress_profile_max_file_size_hint"),
+                    false,
+                ),
+                managed_ingress_boolean_field(
+                    "is_default",
+                    "remote_node_ingress_profile_default_toggle",
+                    Some("remote_node_ingress_profile_default_hint"),
+                    false,
+                ),
+            ],
+        }
+    }
+
+    fn normalize_fields(
+        fields: ManagedIngressDriverFields,
+    ) -> Result<NormalizedManagedIngressDriverFields> {
+        Ok(NormalizedManagedIngressDriverFields {
+            driver_type: Self::driver_type(),
+            endpoint: String::new(),
+            bucket: String::new(),
+            access_key: String::new(),
+            secret_key: String::new(),
+            base_path: normalize_relative_local_path(&fields.base_path)?,
+        })
+    }
+
+    fn policy_base_path<S: FollowerRuntimeState>(
+        state: &S,
+        profile: &managed_ingress_profile::Model,
+    ) -> Result<String> {
+        Ok(resolve_managed_local_path(
+            &state.config().server.follower.managed_ingress_local_root,
+            &profile.base_path,
+        )?
+        .to_string_lossy()
+        .into_owned())
+    }
+
+    fn validate_policy(policy: &storage_policy::Model) -> Result<()> {
+        let base_path = Path::new(&policy.base_path);
+        std::fs::create_dir_all(base_path).map_aster_err_ctx(
+            &format!(
+                "create managed ingress local path '{}'",
+                base_path.display()
+            ),
+            AsterError::storage_driver_error,
+        )
+    }
+
+    fn build_driver(policy: &storage_policy::Model) -> Result<Arc<dyn StorageDriver>> {
+        Self::validate_policy(policy)?;
+        Ok(Arc::new(LocalDriver::new(policy)?))
+    }
+}
+
+struct S3ManagedIngressDriverConnector;
+
+impl ManagedIngressDriverConnector for S3ManagedIngressDriverConnector {
+    fn driver_type() -> DriverType {
+        DriverType::S3
+    }
+
+    fn descriptor() -> ManagedIngressDriverDescriptor {
+        ManagedIngressDriverDescriptor {
+            driver_type: Self::driver_type(),
+            label_key: "remote_node_ingress_profile_driver_s3".to_string(),
+            description_key: "remote_node_ingress_profile_s3_path_hint".to_string(),
+            fields: vec![
+                managed_ingress_text_field(
+                    "endpoint",
+                    "endpoint",
+                    Some("https://s3.example.com"),
+                    None,
+                    true,
+                    false,
+                ),
+                managed_ingress_text_field("bucket", "bucket", None, None, true, false),
+                managed_ingress_text_field("access_key", "access_key", None, None, true, false),
+                managed_ingress_text_field("secret_key", "secret_key", None, None, true, true),
+                managed_ingress_text_field(
+                    "base_path",
+                    "base_path",
+                    Some("prefix"),
+                    Some("remote_node_ingress_profile_s3_path_hint"),
+                    false,
+                    false,
+                ),
+                managed_ingress_number_field(
+                    "max_file_size",
+                    "max_file_size",
+                    Some("0"),
+                    Some("remote_node_ingress_profile_max_file_size_hint"),
+                    false,
+                ),
+                managed_ingress_boolean_field(
+                    "is_default",
+                    "remote_node_ingress_profile_default_toggle",
+                    Some("remote_node_ingress_profile_default_hint"),
+                    false,
+                ),
+            ],
+        }
+    }
+
+    fn normalize_fields(
+        fields: ManagedIngressDriverFields,
+    ) -> Result<NormalizedManagedIngressDriverFields> {
+        let normalized = normalize_s3_endpoint_and_bucket(&fields.endpoint, &fields.bucket)
+            .map_err(|error| error.into_aster_error())?;
+        Ok(NormalizedManagedIngressDriverFields {
+            driver_type: Self::driver_type(),
+            endpoint: normalized.endpoint,
+            bucket: normalized.bucket,
+            access_key: normalize_non_blank("access_key", &fields.access_key)?,
+            secret_key: normalize_non_blank("secret_key", &fields.secret_key)?,
+            base_path: fields.base_path.trim().trim_matches('/').to_string(),
+        })
+    }
+
+    fn policy_base_path<S: FollowerRuntimeState>(
+        _state: &S,
+        profile: &managed_ingress_profile::Model,
+    ) -> Result<String> {
+        Ok(profile.base_path.clone())
+    }
+
+    fn validate_policy(policy: &storage_policy::Model) -> Result<()> {
+        S3Driver::validate_policy(policy)
+    }
+
+    fn build_driver(policy: &storage_policy::Model) -> Result<Arc<dyn StorageDriver>> {
+        Ok(Arc::new(S3Driver::new(policy)?))
+    }
+}
+
+struct ManagedIngressDriverRegistration {
+    driver_type: DriverType,
+    connector: BuiltinManagedIngressDriverConnector,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum BuiltinManagedIngressDriverConnector {
+    Local,
+    S3,
+}
+
+impl BuiltinManagedIngressDriverConnector {
+    fn descriptor(self) -> ManagedIngressDriverDescriptor {
+        match self {
+            Self::Local => LocalManagedIngressDriverConnector::descriptor(),
+            Self::S3 => S3ManagedIngressDriverConnector::descriptor(),
+        }
+    }
+
+    fn normalize_fields(
+        self,
+        fields: ManagedIngressDriverFields,
+    ) -> Result<NormalizedManagedIngressDriverFields> {
+        match self {
+            Self::Local => LocalManagedIngressDriverConnector::normalize_fields(fields),
+            Self::S3 => S3ManagedIngressDriverConnector::normalize_fields(fields),
+        }
+    }
+
+    fn policy_base_path<S: FollowerRuntimeState>(
+        self,
+        state: &S,
+        profile: &managed_ingress_profile::Model,
+    ) -> Result<String> {
+        match self {
+            Self::Local => LocalManagedIngressDriverConnector::policy_base_path(state, profile),
+            Self::S3 => S3ManagedIngressDriverConnector::policy_base_path(state, profile),
+        }
+    }
+
+    fn validate_policy(self, policy: &storage_policy::Model) -> Result<()> {
+        match self {
+            Self::Local => LocalManagedIngressDriverConnector::validate_policy(policy),
+            Self::S3 => S3ManagedIngressDriverConnector::validate_policy(policy),
+        }
+    }
+
+    fn build_driver(self, policy: &storage_policy::Model) -> Result<Arc<dyn StorageDriver>> {
+        match self {
+            Self::Local => LocalManagedIngressDriverConnector::build_driver(policy),
+            Self::S3 => S3ManagedIngressDriverConnector::build_driver(policy),
+        }
+    }
+}
+
+static MANAGED_INGRESS_DRIVER_REGISTRATIONS: &[ManagedIngressDriverRegistration] = &[
+    ManagedIngressDriverRegistration {
+        driver_type: DriverType::Local,
+        connector: BuiltinManagedIngressDriverConnector::Local,
+    },
+    ManagedIngressDriverRegistration {
+        driver_type: DriverType::S3,
+        connector: BuiltinManagedIngressDriverConnector::S3,
+    },
+];
+
+fn registration_for(driver_type: DriverType) -> Result<&'static ManagedIngressDriverRegistration> {
+    MANAGED_INGRESS_DRIVER_REGISTRATIONS
+        .iter()
+        .find(|registration| registration.driver_type == driver_type)
+        .ok_or_else(|| managed_ingress_unsupported_driver_error(driver_type))
+}
+
+pub(crate) fn registered_managed_ingress_driver_types() -> Vec<DriverType> {
+    MANAGED_INGRESS_DRIVER_REGISTRATIONS
+        .iter()
+        .map(|registration| registration.driver_type)
+        .collect()
+}
+
+#[cfg(test)]
+pub(crate) fn list_registered_managed_ingress_driver_descriptors()
+-> Vec<ManagedIngressDriverDescriptor> {
+    MANAGED_INGRESS_DRIVER_REGISTRATIONS
+        .iter()
+        .map(|registration| registration.connector.descriptor())
+        .collect()
+}
+
+pub fn managed_ingress_driver_descriptor(
+    driver_type: DriverType,
+) -> Result<ManagedIngressDriverDescriptor> {
+    Ok(registration_for(driver_type)?.connector.descriptor())
+}
+
+pub(in crate::services::managed_ingress_profile_service) fn normalize_driver_fields(
+    fields: ManagedIngressDriverFields,
+) -> Result<NormalizedManagedIngressDriverFields> {
+    registration_for(fields.driver_type)?
+        .connector
+        .normalize_fields(fields)
+}
 
 pub(in crate::services::managed_ingress_profile_service) fn validate_driver_from_profile<
     S: FollowerRuntimeState,
@@ -16,24 +413,9 @@ pub(in crate::services::managed_ingress_profile_service) fn validate_driver_from
     state: &S,
     profile: &managed_ingress_profile::Model,
 ) -> Result<()> {
-    let policy = build_policy_model(state, profile)?;
-    match policy.driver_type {
-        DriverType::Local => {
-            let base_path = Path::new(&policy.base_path);
-            std::fs::create_dir_all(base_path).map_aster_err_ctx(
-                &format!(
-                    "create managed ingress local path '{}'",
-                    base_path.display()
-                ),
-                AsterError::storage_driver_error,
-            )
-        }
-        DriverType::S3 => S3Driver::validate_policy(&policy),
-        DriverType::AzureBlob
-        | DriverType::TencentCos
-        | DriverType::Remote
-        | DriverType::OneDrive => Err(managed_ingress_unsupported_driver_error(policy.driver_type)),
-    }
+    let registration = registration_for(profile.driver_type)?;
+    let policy = build_policy_model(state, profile, registration)?;
+    registration.connector.validate_policy(&policy)
 }
 
 pub(in crate::services::managed_ingress_profile_service) fn build_driver_from_profile<
@@ -42,57 +424,27 @@ pub(in crate::services::managed_ingress_profile_service) fn build_driver_from_pr
     state: &S,
     profile: &managed_ingress_profile::Model,
 ) -> Result<Arc<dyn StorageDriver>> {
-    let policy = build_policy_model(state, profile)?;
-    match policy.driver_type {
-        DriverType::Local => {
-            let base_path = Path::new(&policy.base_path);
-            std::fs::create_dir_all(base_path).map_aster_err_ctx(
-                &format!(
-                    "create managed ingress local path '{}'",
-                    base_path.display()
-                ),
-                AsterError::storage_driver_error,
-            )?;
-            Ok(Arc::new(LocalDriver::new(&policy)?))
-        }
-        DriverType::S3 => Ok(Arc::new(S3Driver::new(&policy)?)),
-        DriverType::AzureBlob
-        | DriverType::TencentCos
-        | DriverType::Remote
-        | DriverType::OneDrive => Err(managed_ingress_unsupported_driver_error(policy.driver_type)),
-    }
+    let registration = registration_for(profile.driver_type)?;
+    let policy = build_policy_model(state, profile, registration)?;
+    registration.connector.build_driver(&policy)
 }
 
 fn managed_ingress_unsupported_driver_error(driver_type: DriverType) -> AsterError {
-    AsterError::validation_error(format!(
-        "managed ingress profiles do not support the {} driver",
-        match driver_type {
-            DriverType::TencentCos => "tencent_cos",
-            DriverType::AzureBlob => "azure_blob",
-            DriverType::Remote => "remote",
-            DriverType::OneDrive => "onedrive",
-            other => other.as_str(),
-        }
-    ))
+    validation_error_with_code(
+        ApiErrorCode::ManagedIngressDriverUnsupported,
+        format!(
+            "managed ingress profiles do not support the {} driver",
+            driver_type.as_str()
+        ),
+    )
 }
 
 fn build_policy_model<S: FollowerRuntimeState>(
     state: &S,
     profile: &managed_ingress_profile::Model,
+    registration: &ManagedIngressDriverRegistration,
 ) -> Result<storage_policy::Model> {
-    let base_path = match profile.driver_type {
-        DriverType::Local => resolve_managed_local_path(
-            &state.config().server.follower.managed_ingress_local_root,
-            &profile.base_path,
-        )?
-        .to_string_lossy()
-        .into_owned(),
-        DriverType::S3 => profile.base_path.clone(),
-        DriverType::AzureBlob
-        | DriverType::TencentCos
-        | DriverType::Remote
-        | DriverType::OneDrive => String::new(),
-    };
+    let base_path = registration.connector.policy_base_path(state, profile)?;
 
     Ok(storage_policy::Model {
         id: profile.id,
@@ -112,4 +464,14 @@ fn build_policy_model<S: FollowerRuntimeState>(
         created_at: profile.created_at,
         updated_at: profile.updated_at,
     })
+}
+
+fn normalize_non_blank(field: &str, value: &str) -> Result<String> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return Err(AsterError::validation_error(format!(
+            "{field} cannot be blank"
+        )));
+    }
+    Ok(trimmed.to_string())
 }

--- a/src/services/managed_ingress_profile_service/mod.rs
+++ b/src/services/managed_ingress_profile_service/mod.rs
@@ -9,6 +9,10 @@ mod remote;
 #[cfg(test)]
 mod tests;
 
+pub(crate) use driver::registered_managed_ingress_driver_types;
+pub use driver::{ManagedIngressDriverDescriptor, ManagedIngressDriverFieldDescriptor};
 pub use local_profiles::{create, delete, list, resolve_effective_target, update};
 pub use models::ResolvedIngressTarget;
-pub use remote::{create_remote, delete_remote, list_remote, update_remote};
+pub use remote::{
+    create_remote, delete_remote, list_remote, list_remote_driver_descriptors, update_remote,
+};

--- a/src/services/managed_ingress_profile_service/mod.rs
+++ b/src/services/managed_ingress_profile_service/mod.rs
@@ -10,7 +10,10 @@ mod remote;
 mod tests;
 
 pub(crate) use driver::registered_managed_ingress_driver_types;
-pub use driver::{ManagedIngressDriverDescriptor, ManagedIngressDriverFieldDescriptor};
+pub use driver::{
+    ManagedIngressDriverDescriptor, ManagedIngressDriverFieldDescriptor,
+    ManagedIngressDriverFieldKind,
+};
 pub use local_profiles::{create, delete, list, resolve_effective_target, update};
 pub use models::ResolvedIngressTarget;
 pub use remote::{

--- a/src/services/managed_ingress_profile_service/normalization.rs
+++ b/src/services/managed_ingress_profile_service/normalization.rs
@@ -1,14 +1,12 @@
-use crate::api::api_error_code::ApiErrorCode;
 use crate::entities::managed_ingress_profile;
-use crate::errors::{AsterError, Result, validation_error_with_code};
-use crate::storage::drivers::s3_config::normalize_s3_endpoint_and_bucket;
+use crate::errors::{AsterError, Result};
 use crate::storage::remote_protocol::{
     RemoteCreateIngressProfileRequest, RemoteCreateLocalIngressProfileRequest,
     RemoteCreateS3IngressProfileRequest, RemoteUpdateIngressProfileRequest,
 };
 use crate::types::DriverType;
 
-use super::paths::normalize_relative_local_path;
+use super::driver::{ManagedIngressDriverFields, normalize_driver_fields};
 
 pub(in crate::services::managed_ingress_profile_service) struct NormalizedIngressProfileInput {
     pub name: String,
@@ -154,43 +152,26 @@ fn normalize_profile_fields(fields: IngressProfileFields) -> Result<NormalizedIn
         ));
     }
 
-    match driver_type {
-        DriverType::AzureBlob
-        | DriverType::TencentCos
-        | DriverType::Remote
-        | DriverType::OneDrive => Err(validation_error_with_code(
-            ApiErrorCode::ManagedIngressDriverUnsupported,
-            "managed ingress profiles only support local and s3 drivers",
-        )),
-        DriverType::Local => Ok(NormalizedIngressProfileInput {
-            name,
-            driver_type,
-            endpoint: String::new(),
-            bucket: String::new(),
-            access_key: String::new(),
-            secret_key: String::new(),
-            base_path: normalize_relative_local_path(&base_path)?,
-            max_file_size,
-            is_default,
-        }),
-        DriverType::S3 => {
-            let normalized = normalize_s3_endpoint_and_bucket(&endpoint, &bucket)
-                .map_err(|error| error.into_aster_error())?;
-            let access_key = normalize_non_blank("access_key", &access_key)?;
-            let secret_key = normalize_non_blank("secret_key", &secret_key)?;
-            Ok(NormalizedIngressProfileInput {
-                name,
-                driver_type,
-                endpoint: normalized.endpoint,
-                bucket: normalized.bucket,
-                access_key,
-                secret_key,
-                base_path: base_path.trim().trim_matches('/').to_string(),
-                max_file_size,
-                is_default,
-            })
-        }
-    }
+    let normalized = normalize_driver_fields(ManagedIngressDriverFields {
+        driver_type,
+        endpoint,
+        bucket,
+        access_key,
+        secret_key,
+        base_path,
+    })?;
+
+    Ok(NormalizedIngressProfileInput {
+        name,
+        driver_type: normalized.driver_type,
+        endpoint: normalized.endpoint,
+        bucket: normalized.bucket,
+        access_key: normalized.access_key,
+        secret_key: normalized.secret_key,
+        base_path: normalized.base_path,
+        max_file_size,
+        is_default,
+    })
 }
 
 fn normalize_non_blank(field: &str, value: &str) -> Result<String> {

--- a/src/services/managed_ingress_profile_service/remote.rs
+++ b/src/services/managed_ingress_profile_service/remote.rs
@@ -1,9 +1,14 @@
-use crate::errors::Result;
+use crate::api::api_error_code::ApiErrorCode;
+use crate::entities::managed_follower;
+use crate::errors::{Result, validation_error_with_code};
 use crate::runtime::RemoteProtocolRuntimeState;
 use crate::services::managed_follower_service;
 use crate::storage::remote_protocol::{
     RemoteCreateIngressProfileRequest, RemoteIngressProfileInfo, RemoteUpdateIngressProfileRequest,
 };
+use crate::types::DriverType;
+
+use super::driver::{ManagedIngressDriverDescriptor, managed_ingress_driver_descriptor};
 
 pub async fn list_remote<S: RemoteProtocolRuntimeState>(
     state: &S,
@@ -15,13 +20,32 @@ pub async fn list_remote<S: RemoteProtocolRuntimeState>(
         .await
 }
 
+pub async fn list_remote_driver_descriptors<S: RemoteProtocolRuntimeState>(
+    state: &S,
+    remote_node_id: i64,
+) -> Result<Vec<ManagedIngressDriverDescriptor>> {
+    let node = remote_node_for_ingress_write(state, remote_node_id).await?;
+    let capabilities = managed_follower_service::parse_capabilities(&node.last_capabilities);
+    let managed_ingress = capabilities.effective_managed_ingress();
+    let descriptors = managed_ingress
+        .driver_types
+        .iter()
+        .filter_map(|driver_type| driver_type.as_known_driver_type())
+        .filter(|driver_type| managed_ingress.supports_known_driver(*driver_type))
+        .filter_map(|driver_type| managed_ingress_driver_descriptor(driver_type).ok())
+        .collect();
+
+    Ok(descriptors)
+}
+
 pub async fn create_remote<S: RemoteProtocolRuntimeState>(
     state: &S,
     remote_node_id: i64,
     input: RemoteCreateIngressProfileRequest,
 ) -> Result<RemoteIngressProfileInfo> {
-    remote_client_for_node(state, remote_node_id)
-        .await?
+    let node = remote_node_for_ingress_write(state, remote_node_id).await?;
+    ensure_remote_ingress_driver_supported(&node, input.driver_type())?;
+    managed_follower_service::remote_storage_client_for_node(state, &node)?
         .create_ingress_profile(&input)
         .await
 }
@@ -32,8 +56,11 @@ pub async fn update_remote<S: RemoteProtocolRuntimeState>(
     profile_key: &str,
     input: RemoteUpdateIngressProfileRequest,
 ) -> Result<RemoteIngressProfileInfo> {
-    remote_client_for_node(state, remote_node_id)
-        .await?
+    let node = remote_node_for_ingress_write(state, remote_node_id).await?;
+    if let Some(driver_type) = input.driver_type {
+        ensure_remote_ingress_driver_supported(&node, driver_type)?;
+    }
+    managed_follower_service::remote_storage_client_for_node(state, &node)?
         .update_ingress_profile(profile_key, &input)
         .await
 }
@@ -64,7 +91,35 @@ async fn remote_client_for_node<S: RemoteProtocolRuntimeState>(
     state: &S,
     remote_node_id: i64,
 ) -> Result<crate::storage::remote_protocol::RemoteStorageClient> {
-    let node =
-        managed_follower_service::require_completed_enrollment(state, remote_node_id).await?;
+    let node = remote_node_for_ingress_write(state, remote_node_id).await?;
     managed_follower_service::remote_storage_client_for_node(state, &node)
+}
+
+async fn remote_node_for_ingress_write<S: RemoteProtocolRuntimeState>(
+    state: &S,
+    remote_node_id: i64,
+) -> Result<managed_follower::Model> {
+    managed_follower_service::require_completed_enrollment(state, remote_node_id).await
+}
+
+fn ensure_remote_ingress_driver_supported(
+    node: &managed_follower::Model,
+    driver_type: DriverType,
+) -> Result<()> {
+    let capabilities = managed_follower_service::parse_capabilities(&node.last_capabilities);
+    if capabilities
+        .effective_managed_ingress()
+        .supports_known_driver(driver_type)
+    {
+        return Ok(());
+    }
+
+    Err(validation_error_with_code(
+        ApiErrorCode::ManagedIngressDriverUnsupported,
+        format!(
+            "remote node #{} does not declare managed ingress support for the {} driver",
+            node.id,
+            driver_type.as_str()
+        ),
+    ))
 }

--- a/src/services/managed_ingress_profile_service/tests.rs
+++ b/src/services/managed_ingress_profile_service/tests.rs
@@ -1,6 +1,9 @@
 use super::{
     create, delete,
-    driver::{build_driver_from_profile, validate_driver_from_profile},
+    driver::{
+        build_driver_from_profile, list_registered_managed_ingress_driver_descriptors,
+        registered_managed_ingress_driver_types, validate_driver_from_profile,
+    },
     list,
     normalization::{normalize_create_input, normalize_update_input},
     paths::{normalize_relative_local_path, resolve_managed_local_path},
@@ -386,18 +389,78 @@ fn normalize_update_input_resets_driver_specific_fields_when_driver_changes() {
     assert_eq!(normalized.base_path, "local/profile");
 }
 
+#[test]
+fn managed_ingress_driver_registry_contains_supported_builtin_drivers() {
+    assert_eq!(
+        registered_managed_ingress_driver_types(),
+        vec![DriverType::Local, DriverType::S3]
+    );
+}
+
+#[test]
+fn managed_ingress_driver_descriptors_cover_builtin_profile_fields() {
+    let descriptors = list_registered_managed_ingress_driver_descriptors();
+    assert_eq!(descriptors.len(), 2);
+
+    let local = descriptors
+        .iter()
+        .find(|descriptor| descriptor.driver_type == DriverType::Local)
+        .expect("local managed ingress descriptor should be registered");
+    assert_eq!(
+        local
+            .fields
+            .iter()
+            .map(|field| field.name.as_str())
+            .collect::<Vec<_>>(),
+        vec!["base_path", "max_file_size", "is_default"]
+    );
+
+    let s3 = descriptors
+        .iter()
+        .find(|descriptor| descriptor.driver_type == DriverType::S3)
+        .expect("s3 managed ingress descriptor should be registered");
+    assert_eq!(
+        s3.fields
+            .iter()
+            .map(|field| field.name.as_str())
+            .collect::<Vec<_>>(),
+        vec![
+            "endpoint",
+            "bucket",
+            "access_key",
+            "secret_key",
+            "base_path",
+            "max_file_size",
+            "is_default"
+        ]
+    );
+    assert!(
+        s3.fields
+            .iter()
+            .any(|field| field.name == "secret_key" && field.secret)
+    );
+}
+
 #[tokio::test]
 async fn driver_builder_rejects_remote_managed_ingress_profiles() {
     let state = setup_state().await;
     let profile = model_with_driver(DriverType::Remote);
 
     let validate_error = validate_driver_from_profile(&state, &profile).unwrap_err();
+    assert_eq!(
+        validate_error.api_error_code_override(),
+        Some(ApiErrorCode::ManagedIngressDriverUnsupported)
+    );
     assert!(
         validate_error
             .message()
             .contains("do not support the remote driver")
     );
     let build_error = expect_aster_err(build_driver_from_profile(&state, &profile));
+    assert_eq!(
+        build_error.api_error_code_override(),
+        Some(ApiErrorCode::ManagedIngressDriverUnsupported)
+    );
     assert!(
         build_error
             .message()
@@ -411,12 +474,20 @@ async fn driver_builder_rejects_tencent_cos_managed_ingress_profiles() {
     let profile = model_with_driver(DriverType::TencentCos);
 
     let validate_error = validate_driver_from_profile(&state, &profile).unwrap_err();
+    assert_eq!(
+        validate_error.api_error_code_override(),
+        Some(ApiErrorCode::ManagedIngressDriverUnsupported)
+    );
     assert!(
         validate_error
             .message()
             .contains("do not support the tencent_cos driver")
     );
     let build_error = expect_aster_err(build_driver_from_profile(&state, &profile));
+    assert_eq!(
+        build_error.api_error_code_override(),
+        Some(ApiErrorCode::ManagedIngressDriverUnsupported)
+    );
     assert!(
         build_error
             .message()

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -35,7 +35,6 @@ pub mod preview_app_service;
 pub mod preview_link_service;
 pub mod profile_service;
 pub mod property_service;
-pub mod readiness_service;
 pub mod search_service;
 pub mod share_service;
 pub mod share_stream_service;

--- a/src/services/readiness_service.rs
+++ b/src/services/readiness_service.rs
@@ -1,7 +1,0 @@
-//! 服务模块：`readiness_service`。
-//!
-//! 保留旧模块名，实际实现集中在 `health_service`。
-
-pub use crate::services::health_service::{
-    check_follower_ready, check_primary_ready, ping_database,
-};

--- a/src/services/share_service/management.rs
+++ b/src/services/share_service/management.rs
@@ -85,7 +85,7 @@ pub(crate) async fn create_share_in_scope(
 
     let now = Utc::now();
     let model = share::ActiveModel {
-        token: Set(id::new_share_token()),
+        token: Set(id::new_short_token()),
         user_id: Set(scope.actor_user_id()),
         team_id: Set(scope.team_id()),
         file_id: Set(file_id),

--- a/src/storage/connectors/mod.rs
+++ b/src/storage/connectors/mod.rs
@@ -765,7 +765,7 @@ pub fn storage_authorization_provider(
     Ok(storage_driver_descriptor(driver_type)?
         .authorization_provider
         .as_deref()
-        .and_then(StorageCredentialProvider::parse))
+        .and_then(|provider| provider.parse().ok()))
 }
 
 pub fn ensure_storage_authorization_supported(
@@ -780,7 +780,7 @@ pub fn ensure_storage_authorization_supported(
     let supported_provider = descriptor
         .authorization_provider
         .as_deref()
-        .and_then(StorageCredentialProvider::parse);
+        .and_then(|provider| provider.parse().ok());
     if starts_authorization && supported_provider == Some(provider) {
         return Ok(StorageCredentialKind::OauthDelegated);
     }
@@ -805,7 +805,7 @@ pub fn ensure_storage_credential_validation_supported(
     let supported_provider = descriptor
         .authorization_provider
         .as_deref()
-        .and_then(StorageCredentialProvider::parse);
+        .and_then(|provider| provider.parse().ok());
     if validates_credential && supported_provider == Some(provider) {
         return Ok(StorageCredentialKind::OauthDelegated);
     }

--- a/src/storage/drivers/remote/tests.rs
+++ b/src/storage/drivers/remote/tests.rs
@@ -409,7 +409,7 @@ async fn v4_remote_driver_rejects_v2_node_without_capacity_support() {
         Some(StorageErrorKind::Misconfigured)
     );
     assert!(
-        error.message().contains("local supports v4-v4"),
+        error.message().contains("local supports v4-v5"),
         "unexpected error message: {}",
         error.message()
     );

--- a/src/storage/remote_protocol/models.rs
+++ b/src/storage/remote_protocol/models.rs
@@ -10,10 +10,11 @@ use std::fmt;
 #[cfg(all(debug_assertions, feature = "openapi"))]
 use utoipa::ToSchema;
 
-pub const INTERNAL_STORAGE_PROTOCOL_VERSION: u16 = 4;
+pub const INTERNAL_STORAGE_PROTOCOL_VERSION: u16 = 5;
 pub const INTERNAL_STORAGE_MIN_SUPPORTED_PROTOCOL_VERSION: u16 = 4;
-pub const INTERNAL_STORAGE_PROTOCOL_VERSION_LABEL: &str = "v4";
+pub const INTERNAL_STORAGE_PROTOCOL_VERSION_LABEL: &str = "v5";
 pub const INTERNAL_STORAGE_MIN_SUPPORTED_PROTOCOL_VERSION_LABEL: &str = "v4";
+const LEGACY_MANAGED_INGRESS_IMPLICIT_PROTOCOL_VERSION: u16 = 4;
 pub const REMOTE_BROWSER_PRESIGNED_CORS_ALLOWED_HEADERS: &str = "content-type, range";
 pub const REMOTE_BROWSER_PRESIGNED_CORS_GET_EXPOSE_HEADERS: &str = "Accept-Ranges, Cache-Control, Content-Disposition, Content-Length, Content-Range, Content-Type, ETag";
 pub const REMOTE_BROWSER_PRESIGNED_CORS_PUT_EXPOSE_HEADERS: &str = "ETag";
@@ -33,6 +34,8 @@ pub struct RemoteStorageCapabilities {
     pub browser_cors: RemoteStorageBrowserCorsContract,
     #[serde(default)]
     pub limits: RemoteStorageProtocolLimits,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub managed_ingress: Option<RemoteManagedIngressCapabilities>,
     #[serde(default)]
     pub supports_list: bool,
     #[serde(default)]
@@ -59,6 +62,7 @@ impl RemoteStorageCapabilities {
             features: RemoteStorageFeatureFlags::current(),
             browser_cors: RemoteStorageBrowserCorsContract::current(),
             limits: RemoteStorageProtocolLimits::default(),
+            managed_ingress: Some(RemoteManagedIngressCapabilities::default()),
             supports_list: true,
             supports_range_read: true,
             supports_stream_upload: true,
@@ -74,11 +78,33 @@ impl RemoteStorageCapabilities {
             features: RemoteStorageFeatureFlags::default(),
             browser_cors: RemoteStorageBrowserCorsContract::default(),
             limits: RemoteStorageProtocolLimits::default(),
+            managed_ingress: None,
             supports_list: false,
             supports_range_read: false,
             supports_stream_upload: false,
             supports_capacity: false,
         }
+    }
+
+    pub fn with_managed_ingress_driver_types(mut self, driver_types: Vec<DriverType>) -> Self {
+        self.managed_ingress = Some(RemoteManagedIngressCapabilities::from_known_driver_types(
+            driver_types,
+        ));
+        self
+    }
+
+    pub fn effective_managed_ingress(&self) -> RemoteManagedIngressCapabilities {
+        if let Some(capabilities) = &self.managed_ingress {
+            return capabilities.clone();
+        }
+
+        if parse_protocol_version(&self.protocol_version)
+            == Some(LEGACY_MANAGED_INGRESS_IMPLICIT_PROTOCOL_VERSION)
+        {
+            return RemoteManagedIngressCapabilities::legacy_v4_default();
+        }
+
+        RemoteManagedIngressCapabilities::default()
     }
 
     pub fn from_stored_json(raw: &str) -> Self {
@@ -294,6 +320,61 @@ impl RemoteStorageCapabilities {
     }
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
+#[cfg_attr(all(debug_assertions, feature = "openapi"), derive(ToSchema))]
+pub struct RemoteManagedIngressCapabilities {
+    pub enabled: bool,
+    #[serde(default)]
+    pub driver_types: Vec<RemoteManagedIngressDriverType>,
+}
+
+impl RemoteManagedIngressCapabilities {
+    pub fn from_known_driver_types(driver_types: Vec<DriverType>) -> Self {
+        Self {
+            enabled: !driver_types.is_empty(),
+            driver_types: driver_types
+                .into_iter()
+                .map(RemoteManagedIngressDriverType::from_known_driver_type)
+                .collect(),
+        }
+    }
+
+    fn legacy_v4_default() -> Self {
+        Self::from_known_driver_types(vec![DriverType::Local, DriverType::S3])
+    }
+
+    pub fn supports_known_driver(&self, driver_type: DriverType) -> bool {
+        self.enabled
+            && self
+                .driver_types
+                .iter()
+                .any(|candidate| candidate.matches_known_driver(driver_type))
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[serde(transparent)]
+#[cfg_attr(all(debug_assertions, feature = "openapi"), derive(ToSchema))]
+pub struct RemoteManagedIngressDriverType(String);
+
+impl RemoteManagedIngressDriverType {
+    pub fn from_known_driver_type(driver_type: DriverType) -> Self {
+        Self(driver_type.as_str().to_string())
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    pub fn as_known_driver_type(&self) -> Option<DriverType> {
+        self.0.parse().ok()
+    }
+
+    pub fn matches_known_driver(&self, driver_type: DriverType) -> bool {
+        self.as_str() == driver_type.as_str()
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[cfg_attr(all(debug_assertions, feature = "openapi"), derive(ToSchema))]
 #[derive(Default)]
@@ -468,6 +549,15 @@ pub struct RemoteIngressProfileInfo {
 pub enum RemoteCreateIngressProfileRequest {
     Local(RemoteCreateLocalIngressProfileRequest),
     S3(RemoteCreateS3IngressProfileRequest),
+}
+
+impl RemoteCreateIngressProfileRequest {
+    pub fn driver_type(&self) -> DriverType {
+        match self {
+            Self::Local(_) => DriverType::Local,
+            Self::S3(_) => DriverType::S3,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]

--- a/src/storage/remote_protocol/tests.rs
+++ b/src/storage/remote_protocol/tests.rs
@@ -638,7 +638,7 @@ async fn remote_client_object_profile_and_compose_paths_roundtrip() {
         .probe_capabilities()
         .await
         .expect("capabilities should load");
-    assert_eq!(capabilities.protocol_version, "v4");
+    assert_eq!(capabilities.protocol_version, "v5");
     assert_eq!(capabilities.min_supported_protocol_version, "v4");
     assert!(capabilities.features.object_get);
     assert!(capabilities.features.object_head);
@@ -965,7 +965,7 @@ async fn remote_client_probe_rejects_v2_capabilities_without_capacity_support() 
         Some(StorageErrorKind::Misconfigured)
     );
     assert!(
-        capabilities.message().contains("local supports v4-v4"),
+        capabilities.message().contains("local supports v4-v5"),
         "unexpected error message: {}",
         capabilities.message()
     );
@@ -1087,7 +1087,7 @@ fn capabilities_validation_rejects_incompatible_protocol_versions() {
         error.message()
     );
     assert!(
-        error.message().contains("local supports v4-v4"),
+        error.message().contains("local supports v4-v5"),
         "unexpected error message: {}",
         error.message()
     );
@@ -1106,9 +1106,175 @@ fn capabilities_validation_rejects_v2_remote_nodes() {
         .validate_protocol("test remote node")
         .expect_err("v2 discovery should be incompatible with v4");
     assert!(
-        error.message().contains("local supports v4-v4"),
+        error.message().contains("local supports v4-v5"),
         "unexpected error message: {}",
         error.message()
+    );
+}
+
+#[test]
+fn managed_ingress_capabilities_accept_unknown_driver_ids() {
+    let capabilities: RemoteStorageCapabilities = serde_json::from_value(serde_json::json!({
+        "protocol_version": "v5",
+        "min_supported_protocol_version": "v4",
+        "managed_ingress": {
+            "enabled": true,
+            "driver_types": ["local", "plugin.example.archive"]
+        }
+    }))
+    .expect("unknown managed ingress driver ids should stay wire-compatible");
+
+    let managed_ingress = capabilities
+        .managed_ingress
+        .as_ref()
+        .expect("managed ingress capabilities should decode");
+    assert!(managed_ingress.supports_known_driver(DriverType::Local));
+    assert!(!managed_ingress.supports_known_driver(DriverType::S3));
+    assert_eq!(
+        managed_ingress.driver_types[0].as_known_driver_type(),
+        Some(DriverType::Local)
+    );
+    assert_eq!(managed_ingress.driver_types[1].as_known_driver_type(), None);
+    assert_eq!(
+        managed_ingress.driver_types[1].as_str(),
+        "plugin.example.archive"
+    );
+}
+
+#[test]
+fn managed_ingress_capabilities_require_enabled_and_matching_driver() {
+    let disabled: RemoteStorageCapabilities = serde_json::from_value(serde_json::json!({
+        "protocol_version": "v5",
+        "min_supported_protocol_version": "v4",
+        "managed_ingress": {
+            "enabled": false,
+            "driver_types": ["local", "s3"]
+        }
+    }))
+    .expect("disabled managed ingress capabilities should decode");
+    assert!(
+        !disabled
+            .effective_managed_ingress()
+            .supports_known_driver(DriverType::Local)
+    );
+
+    let enabled_without_driver_types: RemoteStorageCapabilities =
+        serde_json::from_value(serde_json::json!({
+            "protocol_version": "v5",
+            "min_supported_protocol_version": "v4",
+            "managed_ingress": {
+                "enabled": true
+            }
+        }))
+        .expect("missing managed ingress driver_types should decode as empty");
+    assert!(
+        !enabled_without_driver_types
+            .effective_managed_ingress()
+            .supports_known_driver(DriverType::Local)
+    );
+
+    let enabled_with_unknown_only: RemoteStorageCapabilities =
+        serde_json::from_value(serde_json::json!({
+            "protocol_version": "v5",
+            "min_supported_protocol_version": "v4",
+            "managed_ingress": {
+                "enabled": true,
+                "driver_types": ["plugin.example.archive"]
+            }
+        }))
+        .expect("unknown-only managed ingress capabilities should decode");
+    assert!(
+        !enabled_with_unknown_only
+            .effective_managed_ingress()
+            .supports_known_driver(DriverType::Local)
+    );
+}
+
+#[test]
+fn managed_ingress_capabilities_serialize_known_driver_ids_as_strings() {
+    let capabilities = RemoteStorageCapabilities::current()
+        .with_managed_ingress_driver_types(vec![DriverType::Local, DriverType::S3]);
+
+    let value =
+        serde_json::to_value(&capabilities).expect("managed ingress capabilities should serialize");
+    assert_eq!(
+        value["managed_ingress"]["driver_types"],
+        serde_json::json!(["local", "s3"])
+    );
+    assert_eq!(value["managed_ingress"]["enabled"], serde_json::json!(true));
+
+    let roundtripped: RemoteStorageCapabilities =
+        serde_json::from_value(value).expect("serialized capabilities should roundtrip");
+    let effective = roundtripped.effective_managed_ingress();
+    assert!(effective.supports_known_driver(DriverType::Local));
+    assert!(effective.supports_known_driver(DriverType::S3));
+    assert!(!effective.supports_known_driver(DriverType::Remote));
+}
+
+#[test]
+fn missing_managed_ingress_capabilities_default_only_for_legacy_v4() {
+    let legacy_v4: RemoteStorageCapabilities = serde_json::from_value(serde_json::json!({
+        "protocol_version": "v4",
+        "min_supported_protocol_version": "v4"
+    }))
+    .expect("legacy v4 capabilities without managed ingress should decode");
+
+    let effective_legacy = legacy_v4.effective_managed_ingress();
+    assert!(effective_legacy.supports_known_driver(DriverType::Local));
+    assert!(effective_legacy.supports_known_driver(DriverType::S3));
+    assert!(!effective_legacy.supports_known_driver(DriverType::Remote));
+
+    let unknown = RemoteStorageCapabilities::unknown();
+    assert!(
+        !unknown
+            .effective_managed_ingress()
+            .supports_known_driver(DriverType::Local)
+    );
+
+    let empty = RemoteStorageCapabilities::from_stored_json("{}");
+    assert!(
+        !empty
+            .effective_managed_ingress()
+            .supports_known_driver(DriverType::Local)
+    );
+
+    let v5_without_field: RemoteStorageCapabilities = serde_json::from_value(serde_json::json!({
+        "protocol_version": "v5",
+        "min_supported_protocol_version": "v4"
+    }))
+    .expect("v5 capabilities without managed ingress should decode conservatively");
+    assert!(
+        !v5_without_field
+            .effective_managed_ingress()
+            .supports_known_driver(DriverType::Local)
+    );
+
+    let v4_with_null_field: RemoteStorageCapabilities = serde_json::from_value(serde_json::json!({
+        "protocol_version": "v4",
+        "min_supported_protocol_version": "v4",
+        "managed_ingress": null
+    }))
+    .expect("legacy v4 capabilities with explicit null managed_ingress should decode");
+    assert!(
+        v4_with_null_field
+            .effective_managed_ingress()
+            .supports_known_driver(DriverType::Local)
+    );
+
+    let v4_with_explicit_empty_field: RemoteStorageCapabilities =
+        serde_json::from_value(serde_json::json!({
+            "protocol_version": "v4",
+            "min_supported_protocol_version": "v4",
+            "managed_ingress": {
+                "enabled": false,
+                "driver_types": []
+            }
+        }))
+        .expect("legacy v4 capabilities with explicit managed_ingress should decode");
+    assert!(
+        !v4_with_explicit_empty_field
+            .effective_managed_ingress()
+            .supports_known_driver(DriverType::Local)
     );
 }
 

--- a/src/types/auth.rs
+++ b/src/types/auth.rs
@@ -81,6 +81,20 @@ impl ExternalAuthProviderKind {
     }
 }
 
+impl std::str::FromStr for ExternalAuthProviderKind {
+    type Err = ();
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        Self::parse(value).ok_or(())
+    }
+}
+
+impl AsRef<str> for ExternalAuthProviderKind {
+    fn as_ref(&self) -> &str {
+        self.as_str()
+    }
+}
+
 /// 外部认证协议族。
 #[derive(Debug, Clone, Copy, PartialEq, Eq, EnumIter, DeriveActiveEnum, Serialize, Deserialize)]
 #[cfg_attr(all(debug_assertions, feature = "openapi"), derive(ToSchema))]

--- a/src/types/storage_credential.rs
+++ b/src/types/storage_credential.rs
@@ -32,6 +32,20 @@ impl StorageCredentialProvider {
     }
 }
 
+impl std::str::FromStr for StorageCredentialProvider {
+    type Err = ();
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        Self::parse(value).ok_or(())
+    }
+}
+
+impl AsRef<str> for StorageCredentialProvider {
+    fn as_ref(&self) -> &str {
+        self.as_str()
+    }
+}
+
 /// Authentication material shape for a storage policy credential.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, EnumIter, DeriveActiveEnum, Serialize, Deserialize)]
 #[cfg_attr(all(debug_assertions, feature = "openapi"), derive(ToSchema))]

--- a/src/types/storage_policy.rs
+++ b/src/types/storage_policy.rs
@@ -41,6 +41,32 @@ impl DriverType {
             Self::OneDrive => "onedrive",
         }
     }
+
+    pub fn parse(value: &str) -> Option<Self> {
+        match value {
+            "local" => Some(Self::Local),
+            "s3" => Some(Self::S3),
+            "azure_blob" => Some(Self::AzureBlob),
+            "tencent_cos" => Some(Self::TencentCos),
+            "remote" => Some(Self::Remote),
+            "onedrive" => Some(Self::OneDrive),
+            _ => None,
+        }
+    }
+}
+
+impl std::str::FromStr for DriverType {
+    type Err = ();
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        Self::parse(value).ok_or(())
+    }
+}
+
+impl AsRef<str> for DriverType {
+    fn as_ref(&self) -> &str {
+        self.as_str()
+    }
 }
 
 /// 上传 session 状态

--- a/src/utils/id.rs
+++ b/src/utils/id.rs
@@ -70,11 +70,6 @@ pub fn new_short_token() -> String {
     Uuid::new_v4().simple().to_string()
 }
 
-/// 生成分享链接 token（32 字符 UUID v4 hex）
-pub fn new_share_token() -> String {
-    Uuid::new_v4().simple().to_string()
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -186,8 +181,8 @@ mod tests {
     }
 
     #[test]
-    fn new_share_token_uses_uuid_v4_hex_entropy() {
-        let token = new_share_token();
+    fn new_short_token_uses_uuid_v4_hex_entropy() {
+        let token = new_short_token();
 
         assert_eq!(token.len(), 32);
         assert!(!token.contains('-'));

--- a/tests/test_remote_storage.rs
+++ b/tests/test_remote_storage.rs
@@ -31,9 +31,9 @@ use aster_drive::storage::remote_protocol::{
     INTERNAL_AUTH_TIMESTAMP_HEADER, INTERNAL_STORAGE_BASE_PATH,
     INTERNAL_STORAGE_MIN_SUPPORTED_PROTOCOL_VERSION_LABEL, INTERNAL_STORAGE_PROTOCOL_VERSION_LABEL,
     RemoteBindingSyncRequest, RemoteCreateIngressProfileRequest,
-    RemoteCreateLocalIngressProfileRequest, RemoteStorageCapabilities, RemoteStorageClient,
-    RemoteStorageComposeRequest, RemoteUpdateIngressProfileRequest, sign_internal_request,
-    sign_presigned_request,
+    RemoteCreateLocalIngressProfileRequest, RemoteCreateS3IngressProfileRequest,
+    RemoteStorageCapabilities, RemoteStorageClient, RemoteStorageComposeRequest,
+    RemoteUpdateIngressProfileRequest, sign_internal_request, sign_presigned_request,
 };
 use aster_drive::types::{
     DriverType, RemoteDownloadStrategy, RemoteNodeTransportMode, RemoteUploadStrategy,
@@ -942,6 +942,211 @@ async fn test_remote_ingress_profiles_auto_empty_base_url_uses_reverse_tunnel() 
 
     stop_test_reverse_tunnel_worker(tunnel_shutdown, tunnel_handle).await;
     provider_server.stop().await;
+}
+
+#[tokio::test]
+async fn test_remote_ingress_profile_create_rejects_driver_missing_from_capabilities() {
+    let consumer_state = common::setup().await;
+    let consumer_node = managed_follower_service::create(
+        &consumer_state,
+        managed_follower_service::CreateRemoteNodeInput {
+            name: "managed-ingress-capability-create-node".to_string(),
+            base_url: "http://127.0.0.1:9".to_string(),
+            transport_mode: RemoteNodeTransportMode::Direct,
+            is_enabled: true,
+        },
+    )
+    .await
+    .expect("consumer remote node should be created");
+    mark_remote_node_enrollment_completed(&consumer_state, consumer_node.id).await;
+    seed_remote_capabilities(
+        &consumer_state,
+        consumer_node.id,
+        RemoteStorageCapabilities::current()
+            .with_managed_ingress_driver_types(vec![DriverType::Local]),
+    )
+    .await;
+
+    let error = managed_ingress_profile_service::create_remote(
+        &consumer_state,
+        consumer_node.id,
+        RemoteCreateIngressProfileRequest::S3(RemoteCreateS3IngressProfileRequest {
+            name: "Unsupported S3".to_string(),
+            endpoint: "https://s3.example.com".to_string(),
+            bucket: "bucket".to_string(),
+            access_key: "access".to_string(),
+            secret_key: "secret".to_string(),
+            base_path: "unsupported-s3".to_string(),
+            max_file_size: 0,
+            is_default: true,
+        }),
+    )
+    .await
+    .expect_err("primary should reject S3 when remote capabilities only declare local ingress");
+
+    assert_eq!(
+        error.api_error_code(),
+        ApiErrorCode::ManagedIngressDriverUnsupported
+    );
+    assert!(
+        error
+            .message()
+            .contains("does not declare managed ingress support for the s3 driver"),
+        "unexpected error message: {}",
+        error.message()
+    );
+}
+
+#[tokio::test]
+async fn test_remote_ingress_profile_update_rejects_driver_missing_from_capabilities() {
+    let consumer_state = common::setup().await;
+    let consumer_node = managed_follower_service::create(
+        &consumer_state,
+        managed_follower_service::CreateRemoteNodeInput {
+            name: "managed-ingress-capability-update-node".to_string(),
+            base_url: "http://127.0.0.1:9".to_string(),
+            transport_mode: RemoteNodeTransportMode::Direct,
+            is_enabled: true,
+        },
+    )
+    .await
+    .expect("consumer remote node should be created");
+    mark_remote_node_enrollment_completed(&consumer_state, consumer_node.id).await;
+    seed_remote_capabilities(
+        &consumer_state,
+        consumer_node.id,
+        RemoteStorageCapabilities::current()
+            .with_managed_ingress_driver_types(vec![DriverType::Local]),
+    )
+    .await;
+
+    let error = managed_ingress_profile_service::update_remote(
+        &consumer_state,
+        consumer_node.id,
+        "profile-a",
+        RemoteUpdateIngressProfileRequest {
+            driver_type: Some(DriverType::S3),
+            endpoint: Some("https://s3.example.com".to_string()),
+            bucket: Some("bucket".to_string()),
+            access_key: Some("access".to_string()),
+            secret_key: Some("secret".to_string()),
+            base_path: Some("unsupported-s3".to_string()),
+            ..Default::default()
+        },
+    )
+    .await
+    .expect_err(
+        "primary should reject update to S3 when remote capabilities only declare local ingress",
+    );
+
+    assert_eq!(
+        error.api_error_code(),
+        ApiErrorCode::ManagedIngressDriverUnsupported
+    );
+    assert!(
+        error
+            .message()
+            .contains("does not declare managed ingress support for the s3 driver"),
+        "unexpected error message: {}",
+        error.message()
+    );
+}
+
+#[tokio::test]
+async fn test_remote_ingress_profile_update_without_driver_change_keeps_remote_authoritative() {
+    let consumer_state = common::setup().await;
+    let consumer_node = managed_follower_service::create(
+        &consumer_state,
+        managed_follower_service::CreateRemoteNodeInput {
+            name: "managed-ingress-capability-no-driver-update-node".to_string(),
+            base_url: "http://127.0.0.1:9".to_string(),
+            transport_mode: RemoteNodeTransportMode::Direct,
+            is_enabled: true,
+        },
+    )
+    .await
+    .expect("consumer remote node should be created");
+    mark_remote_node_enrollment_completed(&consumer_state, consumer_node.id).await;
+    seed_remote_capabilities(
+        &consumer_state,
+        consumer_node.id,
+        RemoteStorageCapabilities::current().with_managed_ingress_driver_types(vec![]),
+    )
+    .await;
+
+    let error = managed_ingress_profile_service::update_remote(
+        &consumer_state,
+        consumer_node.id,
+        "profile-a",
+        RemoteUpdateIngressProfileRequest {
+            name: Some("Rename Only".to_string()),
+            ..Default::default()
+        },
+    )
+    .await
+    .expect_err("rename-only update should still be sent to the remote follower");
+
+    assert_ne!(
+        error.api_error_code(),
+        ApiErrorCode::ManagedIngressDriverUnsupported
+    );
+    assert!(
+        error.message().contains("update remote ingress profile"),
+        "unexpected error message: {}",
+        error.message()
+    );
+}
+
+#[actix_web::test]
+async fn test_remote_ingress_profile_driver_descriptors_follow_remote_capabilities() {
+    let consumer_state = common::setup().await;
+    let consumer_node = managed_follower_service::create(
+        &consumer_state,
+        managed_follower_service::CreateRemoteNodeInput {
+            name: "managed-ingress-driver-descriptor-node".to_string(),
+            base_url: "http://127.0.0.1:9".to_string(),
+            transport_mode: RemoteNodeTransportMode::Direct,
+            is_enabled: true,
+        },
+    )
+    .await
+    .expect("consumer remote node should be created");
+    mark_remote_node_enrollment_completed(&consumer_state, consumer_node.id).await;
+    seed_remote_capabilities(
+        &consumer_state,
+        consumer_node.id,
+        RemoteStorageCapabilities::current()
+            .with_managed_ingress_driver_types(vec![DriverType::Local]),
+    )
+    .await;
+
+    let app = create_test_app!(consumer_state.clone());
+    let (token, _) = register_and_login!(app);
+    let req = test::TestRequest::get()
+        .uri(&format!(
+            "/api/v1/admin/remote-nodes/{}/ingress-profile-drivers",
+            consumer_node.id
+        ))
+        .insert_header(("Cookie", common::access_cookie_header(&token)))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+
+    assert_eq!(resp.status(), actix_web::http::StatusCode::OK);
+    let body: serde_json::Value = test::read_body_json(resp).await;
+    let descriptors = body["data"]
+        .as_array()
+        .expect("driver descriptors response should contain data array");
+    assert_eq!(descriptors.len(), 1);
+    assert_eq!(descriptors[0]["driver_type"], "local");
+    assert_eq!(
+        descriptors[0]["fields"]
+            .as_array()
+            .expect("local descriptor fields should be an array")
+            .iter()
+            .map(|field| field["name"].as_str().unwrap_or_default())
+            .collect::<Vec<_>>(),
+        vec!["base_path", "max_file_size", "is_default"]
+    );
 }
 
 async fn write_temp_upload_file(
@@ -2385,6 +2590,11 @@ async fn test_internal_storage_capabilities_probe_does_not_require_ingress_profi
     assert_eq!(body["data"]["features"]["object_head"], true);
     assert_eq!(body["data"]["features"]["browser_presigned_cors"], true);
     assert_eq!(body["data"]["supports_range_read"], true);
+    assert_eq!(body["data"]["managed_ingress"]["enabled"], true);
+    assert_eq!(
+        body["data"]["managed_ingress"]["driver_types"],
+        serde_json::json!(["local", "s3"])
+    );
 }
 
 #[actix_web::test]


### PR DESCRIPTION
Introduce driver descriptor discovery for managed ingress profiles to enable dynamic driver support validation between primary and follower nodes.

## Changes:

**Backend (Rust):**
- Add `ManagedIngressDriverDescriptor` and `ManagedIngressDriverFieldDescriptor` types to represent driver capabilities and field schemas
- Implement driver descriptor registry with built-in support for local and S3 drivers
- Add `list_remote_node_ingress_profile_drivers` API endpoint to fetch supported drivers from remote nodes
- Extend `RemoteStorageCapabilities` with `managed_ingress` field containing driver type declarations
- Update internal storage protocol version from v4 to v5 to include managed ingress capabilities
- Add validation to reject ingress profile creation/update when driver type is not declared in remote capabilities
- Implement legacy v4 compatibility layer that assumes local and S3 support when capabilities field is absent
- Support unknown driver type identifiers in protocol for forward compatibility with plugins
- Normalize driver-specific fields using descriptor-driven validation
- Add `FromStr` and `AsRef<str>` implementations for `DriverType`, `ExternalAuthProviderKind`, and `StorageCredentialProvider`

**Frontend (TypeScript/React):**
- Add driver descriptor fetching to remote node management workflow
- Render ingress profile form fields dynamically based on active driver descriptor
- Display driver-specific help text and placeholders from descriptors
- Show validation error when selected driver is not supported by remote node
- Disable profile creation when no supported driver descriptors are available
- Update tests to include driver descriptor mocks and validation scenarios
- Add translation key for unsupported driver error message (EN/ZH)

**Cleanup:**
- Remove `readiness_service.rs` (re-exports moved to `health_service`)
- Consolidate `new_share_token()` into generic `new_short_token()` function
- Simplify driver type audit name lookups using `DriverType::as_str()`

closed #332 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **新功能**
  * 远程节点的“受管入口”配置新增可用驱动类型展示，并支持按驱动动态渲染对应表单字段。
  * 编辑/创建时同步加载驱动描述符，并在界面中展示驱动数量、加载状态与错误信息。

* **Bug 修复**
  * 当节点不支持所选驱动时，会给出明确提示并阻止提交。
  * 当没有可用驱动时，“创建配置”入口自动禁用，避免进入无效流程。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->