### PR TITLE
Clarify storage descriptor and normalization contracts

### DIFF
--- a/developer-docs/en/README.md
+++ b/developer-docs/en/README.md
@@ -14,6 +14,7 @@ The `docs/` tree is reserved for deployment-facing and end-user documentation, s
 - [Architecture Overview](./architecture.md)
 - [Core Module Design Notes](./module-designs.md)
 - [External Authentication Module](./external-auth.md)
+- [Storage Descriptor and Field Normalization Contract](./storage-descriptor-normalization-contract.md)
 - [API Overview](./api/index.md)
 - [Tags API](./api/tags.md)
 - [Testing and Database Backends](./testing.md)

--- a/developer-docs/en/storage-descriptor-normalization-contract.md
+++ b/developer-docs/en/storage-descriptor-normalization-contract.md
@@ -1,0 +1,53 @@
+# Storage Descriptor and Field Normalization Contract
+
+This document records the current development contract for AsterDrive storage policy connector descriptors and remote storage target driver descriptors. It is for backend and frontend contributors, not an end-user guide.
+
+## Scope
+
+AsterDrive currently has two related but distinct descriptor surfaces:
+
+- `src/storage/connector_descriptor.rs` and `src/storage/connectors/`: storage policy management forms, connection tests, authorization, policy actions, upload workflows, and connector capabilities.
+- `src/services/remote_storage_target_service/driver.rs`: follower-side remote storage target drivers, fields, and local normalization rules.
+
+Do not collapse these into one universal descriptor. Storage policy descriptors describe primary-side policy behavior and upload/download workflows. Remote storage target descriptors describe follower-side ingress target configuration.
+
+Shared field meanings and pure normalization helpers live in `src/storage/field_contract.rs`. Product-specific descriptor DTOs remain separate.
+
+## Descriptor Rules
+
+- Admin fields, actions, capabilities, and UI helper metadata must come from backend descriptors first. The frontend must not infer connection tests, authorization, upload strategy, native processing, remote binding, or field visibility from a local `driver_type` capability matrix.
+- `label_key`, `help_key`, `placeholder`, `required_message_key`, and similar fields are stable localization keys or hint parameters. The frontend owns final localized text, but field presence, required state, sensitivity, and supported actions are backend descriptor concerns.
+- `secret: true` or secret field kind means the frontend must render a sensitive input and backend logs / `Debug` output must not expose plaintext. Create flows follow descriptor `required` plus backend validation. Edit flows treat omitted secret fields as "preserve the stored value"; explicit values replace the stored secret after normalization.
+- Unsupported drivers must produce stable backend errors. Remote storage targets may expose only known registered drivers that the remote capability payload declares. Unknown wire-level driver ids may be preserved, but they are not locally configurable drivers.
+- When descriptors, remote capabilities, or capability parsing are missing, the frontend may only fall back conservatively by hiding risky actions or showing an unavailable state. It must not recreate a local capability matrix in that fallback path.
+- Action descriptors declare whether an entry point requires a saved policy, authorization credential, or remote-state mutation. Routes and services still perform final validation; hidden buttons are not authorization.
+
+## Normalization Rules
+
+Field normalization belongs in backend use cases or connector/driver-specific pure helpers. It must not be scattered in handlers or frontend components.
+
+- Shared field semantics and normalization helpers live in `src/storage/field_contract.rs`.
+- Local remote storage target `base_path` uses `normalize_relative_local_target_path` through the remote target service wrapper: trim whitespace, collapse `.` segments, reject blanks, absolute paths, `..`, Windows prefixes, and backslash escapes, then resolve within `server.follower.remote_storage_target_local_root`.
+- Object-storage remote storage target `base_path` is a prefix: trim whitespace and outer `/`; an empty prefix means bucket/container root.
+- Storage policy object-storage endpoint/bucket normalization uses `normalize_s3_endpoint_and_bucket` plus connector-specific API error mapping. Non-empty endpoints must be `http://` or `https://` and include a hostname; bucket/container is required.
+- `max_file_size = 0` means no extra policy limit; negative values are invalid at the service boundary. Upload paths still perform final size checks when applying a policy or target.
+- Same-driver edits preserve omitted `access_key` / `secret_key` values. Explicit replacements are trimmed and revalidated.
+- When changing a remote storage target driver, old driver-specific fields must not leak into the new driver. Endpoint, bucket, access key, and secret key reset; base path follows the new driver input/default semantics and is normalized again.
+
+## Implementation Boundaries
+
+- Route layers only adapt protocol shape, authenticate/authorize, extract parameters, call services, and map responses. They do not build descriptors or run driver-specific normalization.
+- Service layers orchestrate use cases: load context, call normalization helpers, check capabilities, call repositories, and run required side effects.
+- `src/storage/connectors/` owns storage policy connector descriptors, connection field normalization, connection tests, authorization, and connector actions.
+- `src/services/remote_storage_target_service/driver.rs` owns remote storage target driver descriptors, driver-field normalization, target-to-policy materialization, and driver build/validate.
+- `src/storage/remote_protocol/` handles wire models, signing, path encoding, transport, and response parsing. It does not decide UI fields or policy target selection.
+
+## Tests
+
+When descriptor or normalization behavior changes, add focused unit tests:
+
+- Descriptor tests must cover every built-in driver field, secret marker, action, and key capability.
+- Normalization tests must cover trimming, blank values, path escapes, prefix slash trimming, negative `max_file_size`, same-driver secret preservation, explicit secret replacement, and driver-change field reset.
+- For storage policy descriptor behavior, run `cargo test --lib storage::connectors` or a narrower filter.
+- For remote storage target normalization, run `cargo test --lib remote_storage_target_service::tests::<filter>`.
+- OpenAPI schema changes require OpenAPI export and frontend SDK regeneration. This contract slice does not change public API shapes.

--- a/developer-docs/zh-CN/storage-descriptor-normalization-contract.md
+++ b/developer-docs/zh-CN/storage-descriptor-normalization-contract.md
@@ -11,6 +11,8 @@
 
 这两类 descriptor 可以共享命名和字段语义，但不要强行合成一个万能 descriptor。storage policy 描述的是主控侧策略和上传/下载工作流；remote storage target 描述的是 follower 接收远端写入时的落点配置。
 
+共享字段语义和纯规范化 helper 放在 `src/storage/field_contract.rs`。产品侧 descriptor DTO 继续保持独立。
+
 ## Descriptor 规则
 
 - 管理端字段、动作、能力和 UI 辅助元数据必须优先来自后端 descriptor。前端不能用本地 `driver_type` 白名单或矩阵推断连接测试、授权、上传策略、原生处理、远端绑定、字段可见性等能力。

--- a/frontend-panel/src/components/admin/admin-remote-nodes-page/RemoteNodeRemoteStorageTargetForm.tsx
+++ b/frontend-panel/src/components/admin/admin-remote-nodes-page/RemoteNodeRemoteStorageTargetForm.tsx
@@ -90,6 +90,10 @@ export function RemoteNodeRemoteStorageTargetForm({
 	const accessKeyField = field("access_key");
 	const secretKeyField = field("secret_key");
 	const isDefaultField = field("is_default");
+	const canPreserveSecretOnEdit =
+		draftMode === "edit" &&
+		editingProfile?.driver_type === form.driver_type &&
+		secretKeyField?.secret === true;
 
 	return (
 		<div className="mt-4 rounded-2xl border border-border/70 bg-muted/10 p-4">
@@ -260,14 +264,10 @@ export function RemoteNodeRemoteStorageTargetForm({
 									}
 									className={ADMIN_CONTROL_HEIGHT_CLASS}
 									aria-invalid={secretKeyError ? true : undefined}
-									placeholder={
-										draftMode === "edit" && editingProfile?.driver_type === "s3"
-											? "••••••••"
-											: undefined
-									}
+									placeholder={canPreserveSecretOnEdit ? "••••••••" : undefined}
 								/>
 								<p className="text-xs text-muted-foreground">
-									{draftMode === "edit" && editingProfile?.driver_type === "s3"
+									{canPreserveSecretOnEdit
 										? t("remote_node_ingress_profile_credentials_optional_hint")
 										: t("remote_node_ingress_profile_credentials_hint")}
 								</p>

--- a/frontend-panel/src/components/admin/admin-remote-nodes-page/RemoteNodeRemoteStorageTargetSection.test.tsx
+++ b/frontend-panel/src/components/admin/admin-remote-nodes-page/RemoteNodeRemoteStorageTargetSection.test.tsx
@@ -549,7 +549,7 @@ describe("RemoteNodeRemoteStorageTargetSection", () => {
 		});
 	});
 
-	it("edits existing S3 targets without requiring unchanged credentials", async () => {
+	it("edits existing S3 targets while requiring access key but preserving secret", async () => {
 		const existing = profile({
 			base_path: "prefix",
 			bucket: "bucket-a",
@@ -565,8 +565,15 @@ describe("RemoteNodeRemoteStorageTargetSection", () => {
 		expect(
 			screen.getByLabelText("remote_node_ingress_profile_default_toggle"),
 		).toBeDisabled();
+		expect(screen.getByRole("button", { name: /save_changes/ })).toBeDisabled();
+		expect(
+			screen.getByText("remote_node_ingress_profile_access_key_required"),
+		).toBeInTheDocument();
 		fireEvent.change(screen.getByLabelText("core:name"), {
 			target: { value: "S3 renamed" },
+		});
+		fireEvent.change(screen.getByLabelText("access_key"), {
+			target: { value: "rotated-access" },
 		});
 		fireEvent.change(screen.getByLabelText("base_path"), {
 			target: { value: "next-prefix" },
@@ -576,6 +583,7 @@ describe("RemoteNodeRemoteStorageTargetSection", () => {
 		await waitFor(() => {
 			expect(onUpdateTarget).toHaveBeenCalledWith("s3-default", {
 				base_path: "next-prefix",
+				access_key: "rotated-access",
 				bucket: "bucket-a",
 				driver_type: "s3",
 				endpoint: "https://s3.example.com",

--- a/frontend-panel/src/components/admin/admin-remote-nodes-page/RemoteNodeRemoteStorageTargetSection.tsx
+++ b/frontend-panel/src/components/admin/admin-remote-nodes-page/RemoteNodeRemoteStorageTargetSection.tsx
@@ -159,7 +159,7 @@ export function RemoteNodeRemoteStorageTargetSection({
 		: t("remote_node_ingress_profile_name_required");
 	const localPathCandidate = form.base_path.trim().replaceAll("\\", "/");
 	const requiresLocalRelativePath =
-		basePathField?.help_key === "remote_node_ingress_profile_local_path_hint";
+		basePathField?.validation?.relative_local_path === true;
 	const localPathError =
 		basePathField?.required && !form.base_path.trim()
 			? t("remote_node_ingress_profile_base_path_required")

--- a/frontend-panel/src/components/admin/admin-remote-nodes-page/RemoteNodeRemoteStorageTargetSection.tsx
+++ b/frontend-panel/src/components/admin/admin-remote-nodes-page/RemoteNodeRemoteStorageTargetSection.tsx
@@ -180,18 +180,17 @@ export function RemoteNodeRemoteStorageTargetSection({
 		bucketField?.required && !form.bucket.trim()
 			? t("remote_node_ingress_profile_bucket_required")
 			: null;
-	const preservesExistingCredentialValues =
+	const preservesExistingSecretValue =
 		activeDraftMode === "edit" &&
-		editingTarget?.driver_type === form.driver_type;
+		editingTarget?.driver_type === form.driver_type &&
+		secretKeyField?.secret === true;
 	const accessKeyError =
-		accessKeyField?.required &&
-		!preservesExistingCredentialValues &&
-		!form.access_key.trim()
+		accessKeyField?.required && !form.access_key.trim()
 			? t("remote_node_ingress_profile_access_key_required")
 			: null;
 	const secretKeyError =
 		secretKeyField?.required &&
-		!preservesExistingCredentialValues &&
+		!preservesExistingSecretValue &&
 		!form.secret_key.trim()
 			? t("remote_node_ingress_profile_secret_key_required")
 			: null;

--- a/frontend-panel/src/components/admin/admin-remote-nodes-page/RemoteNodeRemoteStorageTargetSection.tsx
+++ b/frontend-panel/src/components/admin/admin-remote-nodes-page/RemoteNodeRemoteStorageTargetSection.tsx
@@ -108,6 +108,15 @@ export function RemoteNodeRemoteStorageTargetSection({
 	const activeFieldNames = new Set(
 		activeDriverDescriptor?.fields.map((field) => field.name) ?? [],
 	);
+	const activeFieldByName = new Map(
+		activeDriverDescriptor?.fields.map((field) => [field.name, field]) ?? [],
+	);
+	const activeField = (name: string) => activeFieldByName.get(name);
+	const basePathField = activeField("base_path");
+	const endpointField = activeField("endpoint");
+	const bucketField = activeField("bucket");
+	const accessKeyField = activeField("access_key");
+	const secretKeyField = activeField("secret_key");
 	const activePendingDeleteTargetKey = targets.some(
 		(target) => target.target_key === pendingDeleteTargetKey,
 	)
@@ -149,33 +158,41 @@ export function RemoteNodeRemoteStorageTargetSection({
 		? null
 		: t("remote_node_ingress_profile_name_required");
 	const localPathCandidate = form.base_path.trim().replaceAll("\\", "/");
+	const requiresLocalRelativePath =
+		basePathField?.help_key === "remote_node_ingress_profile_local_path_hint";
 	const localPathError =
-		activeFieldNames.has("base_path") && form.driver_type === "local"
-			? !form.base_path.trim()
-				? t("remote_node_ingress_profile_base_path_required")
-				: localPathCandidate.startsWith("/") ||
-						/^[A-Za-z]:/.test(localPathCandidate) ||
-						localPathCandidate.split("/").some((segment) => segment === "..")
-					? t("remote_node_ingress_profile_base_path_relative")
-					: null
-			: null;
+		basePathField?.required && !form.base_path.trim()
+			? t("remote_node_ingress_profile_base_path_required")
+			: basePathField && requiresLocalRelativePath
+				? !form.base_path.trim()
+					? t("remote_node_ingress_profile_base_path_required")
+					: localPathCandidate.startsWith("/") ||
+							/^[A-Za-z]:/.test(localPathCandidate) ||
+							localPathCandidate.split("/").some((segment) => segment === "..")
+						? t("remote_node_ingress_profile_base_path_relative")
+						: null
+				: null;
 	const endpointError =
-		activeFieldNames.has("endpoint") && !form.endpoint.trim()
+		endpointField?.required && !form.endpoint.trim()
 			? t("remote_node_ingress_profile_endpoint_required")
 			: null;
 	const bucketError =
-		activeFieldNames.has("bucket") && !form.bucket.trim()
+		bucketField?.required && !form.bucket.trim()
 			? t("remote_node_ingress_profile_bucket_required")
 			: null;
-	const requiresS3Credentials =
-		activeFieldNames.has("access_key") &&
-		(activeDraftMode === "create" || editingTarget?.driver_type !== "s3");
+	const preservesExistingCredentialValues =
+		activeDraftMode === "edit" &&
+		editingTarget?.driver_type === form.driver_type;
 	const accessKeyError =
-		requiresS3Credentials && !form.access_key.trim()
+		accessKeyField?.required &&
+		!preservesExistingCredentialValues &&
+		!form.access_key.trim()
 			? t("remote_node_ingress_profile_access_key_required")
 			: null;
 	const secretKeyError =
-		requiresS3Credentials && !form.secret_key.trim()
+		secretKeyField?.required &&
+		!preservesExistingCredentialValues &&
+		!form.secret_key.trim()
 			? t("remote_node_ingress_profile_secret_key_required")
 			: null;
 	const defaultToggleLocked =

--- a/frontend-panel/src/services/api.generated.ts
+++ b/frontend-panel/src/services/api.generated.ts
@@ -6994,9 +6994,13 @@ export interface components {
             placeholder?: string | null;
             required: boolean;
             secret: boolean;
+            validation?: null | components["schemas"]["RemoteStorageTargetDriverFieldValidation"];
         };
         /** @enum {string} */
         RemoteStorageTargetDriverFieldKind: "text" | "secret" | "boolean" | "number";
+        RemoteStorageTargetDriverFieldValidation: {
+            relative_local_path: boolean;
+        };
         RemoteStorageTargetDriverType: string;
         RemoteStorageTargetInfo: {
             /** Format: int64 */

--- a/src/services/policy_service/policies.rs
+++ b/src/services/policy_service/policies.rs
@@ -147,6 +147,8 @@ pub async fn create(
     let allowed_types = allowed_types.unwrap_or_default();
     let options = options.unwrap_or_default().normalized();
     let serialized_options = serialize_options(&options)?;
+    let max_file_size =
+        crate::storage::field_contract::normalize_storage_policy_max_file_size(max_file_size)?;
     let chunk_size = chunk_size.unwrap_or(5_242_880);
     crate::storage::connectors::validate_policy_options(
         state.writer_db(),
@@ -451,7 +453,8 @@ pub async fn update(
         active.remote_storage_target_key = Set(final_remote_storage_target_key);
     }
     if let Some(v) = max_file_size {
-        active.max_file_size = Set(v);
+        active.max_file_size =
+            Set(crate::storage::field_contract::normalize_storage_policy_max_file_size(v)?);
     }
     if let Some(v) = chunk_size {
         active.chunk_size = Set(v);
@@ -939,6 +942,92 @@ mod tests {
         assert_eq!(diagnostic.kind, "transient");
         assert_eq!(diagnostic.message, "capacity probe timed out");
         assert!(diagnostic.retryable);
+    }
+
+    #[tokio::test]
+    async fn create_rejects_negative_max_file_size_at_service_boundary() {
+        let state = setup_state("storage-token-test-master-key-32bytes").await;
+
+        let error = create(
+            &state,
+            CreateStoragePolicyInput {
+                name: "Local".to_string(),
+                connection: StoragePolicyConnectionInput {
+                    driver_type: DriverType::Local,
+                    endpoint: "data/uploads".to_string(),
+                    bucket: String::new(),
+                    access_key: String::new(),
+                    secret_key: String::new(),
+                    base_path: "data/uploads".to_string(),
+                    remote_node_id: None,
+                    remote_storage_target_key: None,
+                    options: StoragePolicyOptions::default(),
+                },
+                max_file_size: -1,
+                chunk_size: Some(5_242_880),
+                is_default: false,
+                allowed_types: None,
+                options: None,
+                remote_storage_target_key: None,
+                application_config: Default::default(),
+            },
+        )
+        .await
+        .expect_err("negative max_file_size should be rejected");
+
+        assert!(
+            error
+                .message()
+                .contains("max_file_size must be non-negative")
+        );
+    }
+
+    #[tokio::test]
+    async fn update_rejects_negative_max_file_size_at_service_boundary() {
+        let state = setup_state("storage-token-test-master-key-32bytes").await;
+        let policy = create(
+            &state,
+            CreateStoragePolicyInput {
+                name: "Local".to_string(),
+                connection: StoragePolicyConnectionInput {
+                    driver_type: DriverType::Local,
+                    endpoint: "data/uploads".to_string(),
+                    bucket: String::new(),
+                    access_key: String::new(),
+                    secret_key: String::new(),
+                    base_path: "data/uploads".to_string(),
+                    remote_node_id: None,
+                    remote_storage_target_key: None,
+                    options: StoragePolicyOptions::default(),
+                },
+                max_file_size: 0,
+                chunk_size: Some(5_242_880),
+                is_default: false,
+                allowed_types: None,
+                options: None,
+                remote_storage_target_key: None,
+                application_config: Default::default(),
+            },
+        )
+        .await
+        .expect("policy should create");
+
+        let error = update(
+            &state,
+            policy.id,
+            UpdateStoragePolicyInput {
+                max_file_size: Some(-1),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect_err("negative max_file_size should be rejected");
+
+        assert!(
+            error
+                .message()
+                .contains("max_file_size must be non-negative")
+        );
     }
 
     #[tokio::test]

--- a/src/services/remote_storage_target_service/driver.rs
+++ b/src/services/remote_storage_target_service/driver.rs
@@ -64,6 +64,14 @@ impl TryFrom<StorageDescriptorFieldKind> for RemoteStorageTargetDriverFieldKind 
     }
 }
 
+fn remote_storage_target_field_kind(
+    kind: StorageDescriptorFieldKind,
+) -> Result<RemoteStorageTargetDriverFieldKind> {
+    RemoteStorageTargetDriverFieldKind::try_from(kind).map_err(|message| {
+        AsterError::internal_error(format!("build managed ingress descriptor field: {message}"))
+    })
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[cfg_attr(all(debug_assertions, feature = "openapi"), derive(ToSchema))]
 pub struct RemoteStorageTargetDriverFieldValidation {
@@ -102,7 +110,7 @@ fn remote_storage_target_text_field(
     help_key: Option<&str>,
     required: bool,
     secret: bool,
-) -> RemoteStorageTargetDriverFieldDescriptor {
+) -> Result<RemoteStorageTargetDriverFieldDescriptor> {
     remote_storage_target_text_field_with_validation(
         name,
         label_key,
@@ -122,25 +130,22 @@ fn remote_storage_target_text_field_with_validation(
     required: bool,
     secret: bool,
     validation: Option<RemoteStorageTargetDriverFieldValidation>,
-) -> RemoteStorageTargetDriverFieldDescriptor {
+) -> Result<RemoteStorageTargetDriverFieldDescriptor> {
     let semantics = if secret {
         StorageDescriptorFieldSemantics::secret(required)
     } else {
         StorageDescriptorFieldSemantics::text(required)
     };
-    RemoteStorageTargetDriverFieldDescriptor {
+    Ok(RemoteStorageTargetDriverFieldDescriptor {
         name: name.to_string(),
-        kind: semantics
-            .kind
-            .try_into()
-            .expect("text/secret storage target fields must map to managed ingress field kinds"),
+        kind: remote_storage_target_field_kind(semantics.kind)?,
         required: semantics.required,
         secret: semantics.secret,
         label_key: label_key.to_string(),
         placeholder: placeholder.map(str::to_string),
         help_key: help_key.map(str::to_string),
         validation,
-    }
+    })
 }
 
 fn remote_storage_target_boolean_field(
@@ -148,27 +153,24 @@ fn remote_storage_target_boolean_field(
     label_key: &str,
     help_key: Option<&str>,
     required: bool,
-) -> RemoteStorageTargetDriverFieldDescriptor {
+) -> Result<RemoteStorageTargetDriverFieldDescriptor> {
     let semantics = StorageDescriptorFieldSemantics::boolean(required);
-    RemoteStorageTargetDriverFieldDescriptor {
+    Ok(RemoteStorageTargetDriverFieldDescriptor {
         name: name.to_string(),
-        kind: semantics
-            .kind
-            .try_into()
-            .expect("boolean storage target fields must map to managed ingress field kinds"),
+        kind: remote_storage_target_field_kind(semantics.kind)?,
         required: semantics.required,
         secret: semantics.secret,
         label_key: label_key.to_string(),
         placeholder: None,
         help_key: help_key.map(str::to_string),
         validation: None,
-    }
+    })
 }
 
 trait RemoteStorageTargetDriverConnector {
     fn driver_type() -> DriverType;
 
-    fn descriptor() -> RemoteStorageTargetDriverDescriptor;
+    fn descriptor() -> Result<RemoteStorageTargetDriverDescriptor>;
 
     fn normalize_fields(
         fields: RemoteStorageTargetDriverFields,
@@ -191,8 +193,8 @@ impl RemoteStorageTargetDriverConnector for LocalRemoteStorageTargetDriverConnec
         DriverType::Local
     }
 
-    fn descriptor() -> RemoteStorageTargetDriverDescriptor {
-        RemoteStorageTargetDriverDescriptor {
+    fn descriptor() -> Result<RemoteStorageTargetDriverDescriptor> {
+        Ok(RemoteStorageTargetDriverDescriptor {
             driver_type: Self::driver_type(),
             label_key: "remote_node_ingress_profile_driver_local".to_string(),
             description_key: "remote_node_ingress_profile_local_scope_hint".to_string(),
@@ -207,15 +209,15 @@ impl RemoteStorageTargetDriverConnector for LocalRemoteStorageTargetDriverConnec
                     Some(RemoteStorageTargetDriverFieldValidation {
                         relative_local_path: true,
                     }),
-                ),
+                )?,
                 remote_storage_target_boolean_field(
                     "is_default",
                     "remote_node_ingress_profile_default_toggle",
                     Some("remote_node_ingress_profile_default_hint"),
                     false,
-                ),
+                )?,
             ],
-        }
+        })
     }
 
     fn normalize_fields(
@@ -271,8 +273,8 @@ impl RemoteStorageTargetDriverConnector for S3RemoteStorageTargetDriverConnector
         DriverType::S3
     }
 
-    fn descriptor() -> RemoteStorageTargetDriverDescriptor {
-        RemoteStorageTargetDriverDescriptor {
+    fn descriptor() -> Result<RemoteStorageTargetDriverDescriptor> {
+        Ok(RemoteStorageTargetDriverDescriptor {
             driver_type: Self::driver_type(),
             label_key: "remote_node_ingress_profile_driver_s3".to_string(),
             description_key: "remote_node_ingress_profile_s3_path_hint".to_string(),
@@ -284,8 +286,8 @@ impl RemoteStorageTargetDriverConnector for S3RemoteStorageTargetDriverConnector
                     None,
                     true,
                     false,
-                ),
-                remote_storage_target_text_field("bucket", "bucket", None, None, true, false),
+                )?,
+                remote_storage_target_text_field("bucket", "bucket", None, None, true, false)?,
                 remote_storage_target_text_field(
                     "access_key",
                     "access_key",
@@ -293,7 +295,7 @@ impl RemoteStorageTargetDriverConnector for S3RemoteStorageTargetDriverConnector
                     None,
                     true,
                     false,
-                ),
+                )?,
                 remote_storage_target_text_field(
                     "secret_key",
                     "secret_key",
@@ -301,7 +303,7 @@ impl RemoteStorageTargetDriverConnector for S3RemoteStorageTargetDriverConnector
                     None,
                     true,
                     true,
-                ),
+                )?,
                 remote_storage_target_text_field(
                     "base_path",
                     "base_path",
@@ -309,15 +311,15 @@ impl RemoteStorageTargetDriverConnector for S3RemoteStorageTargetDriverConnector
                     Some("remote_node_ingress_profile_s3_path_hint"),
                     false,
                     false,
-                ),
+                )?,
                 remote_storage_target_boolean_field(
                     "is_default",
                     "remote_node_ingress_profile_default_toggle",
                     Some("remote_node_ingress_profile_default_hint"),
                     false,
-                ),
+                )?,
             ],
-        }
+        })
     }
 
     fn normalize_fields(
@@ -363,7 +365,7 @@ enum BuiltinRemoteStorageTargetDriverConnector {
 }
 
 impl BuiltinRemoteStorageTargetDriverConnector {
-    fn descriptor(self) -> RemoteStorageTargetDriverDescriptor {
+    fn descriptor(self) -> Result<RemoteStorageTargetDriverDescriptor> {
         match self {
             Self::Local => LocalRemoteStorageTargetDriverConnector::descriptor(),
             Self::S3 => S3RemoteStorageTargetDriverConnector::descriptor(),
@@ -435,17 +437,17 @@ pub(crate) fn registered_remote_storage_target_driver_types() -> Vec<DriverType>
 
 #[cfg(test)]
 pub(crate) fn list_registered_remote_storage_target_driver_descriptors()
--> Vec<RemoteStorageTargetDriverDescriptor> {
+-> Result<Vec<RemoteStorageTargetDriverDescriptor>> {
     REMOTE_STORAGE_TARGET_DRIVER_REGISTRATIONS
         .iter()
         .map(|registration| registration.connector.descriptor())
-        .collect()
+        .collect::<Result<Vec<_>>>()
 }
 
 pub fn remote_storage_target_driver_descriptor(
     driver_type: DriverType,
 ) -> Result<RemoteStorageTargetDriverDescriptor> {
-    Ok(registration_for(driver_type)?.connector.descriptor())
+    registration_for(driver_type)?.connector.descriptor()
 }
 
 pub(in crate::services::remote_storage_target_service) fn normalize_driver_fields(

--- a/src/services/remote_storage_target_service/driver.rs
+++ b/src/services/remote_storage_target_service/driver.rs
@@ -8,6 +8,10 @@ use crate::runtime::FollowerRuntimeState;
 use crate::storage::StorageDriver;
 use crate::storage::drivers::s3_config::normalize_s3_endpoint_and_bucket;
 use crate::storage::drivers::{local::LocalDriver, s3::S3Driver};
+use crate::storage::field_contract::{
+    StorageDescriptorFieldKind, StorageDescriptorFieldSemantics, normalize_object_storage_prefix,
+    normalize_required_storage_field,
+};
 use crate::types::{DriverType, StoredStoragePolicyAllowedTypes, StoredStoragePolicyOptions};
 use serde::{Deserialize, Serialize};
 #[cfg(all(debug_assertions, feature = "openapi"))]
@@ -44,6 +48,20 @@ pub enum RemoteStorageTargetDriverFieldKind {
     Number,
 }
 
+impl From<StorageDescriptorFieldKind> for RemoteStorageTargetDriverFieldKind {
+    fn from(value: StorageDescriptorFieldKind) -> Self {
+        match value {
+            StorageDescriptorFieldKind::Text => Self::Text,
+            StorageDescriptorFieldKind::Secret => Self::Secret,
+            StorageDescriptorFieldKind::Boolean => Self::Boolean,
+            StorageDescriptorFieldKind::Number => Self::Number,
+            StorageDescriptorFieldKind::Select => {
+                panic!("managed ingress target descriptors do not support select fields")
+            }
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[cfg_attr(all(debug_assertions, feature = "openapi"), derive(ToSchema))]
 pub struct RemoteStorageTargetDriverFieldDescriptor {
@@ -75,15 +93,16 @@ fn remote_storage_target_text_field(
     required: bool,
     secret: bool,
 ) -> RemoteStorageTargetDriverFieldDescriptor {
+    let semantics = if secret {
+        StorageDescriptorFieldSemantics::secret(required)
+    } else {
+        StorageDescriptorFieldSemantics::text(required)
+    };
     RemoteStorageTargetDriverFieldDescriptor {
         name: name.to_string(),
-        kind: if secret {
-            RemoteStorageTargetDriverFieldKind::Secret
-        } else {
-            RemoteStorageTargetDriverFieldKind::Text
-        },
-        required,
-        secret,
+        kind: semantics.kind.into(),
+        required: semantics.required,
+        secret: semantics.secret,
         label_key: label_key.to_string(),
         placeholder: placeholder.map(str::to_string),
         help_key: help_key.map(str::to_string),
@@ -96,11 +115,12 @@ fn remote_storage_target_boolean_field(
     help_key: Option<&str>,
     required: bool,
 ) -> RemoteStorageTargetDriverFieldDescriptor {
+    let semantics = StorageDescriptorFieldSemantics::boolean(required);
     RemoteStorageTargetDriverFieldDescriptor {
         name: name.to_string(),
-        kind: RemoteStorageTargetDriverFieldKind::Boolean,
-        required,
-        secret: false,
+        kind: semantics.kind.into(),
+        required: semantics.required,
+        secret: semantics.secret,
         label_key: label_key.to_string(),
         placeholder: None,
         help_key: help_key.map(str::to_string),
@@ -268,9 +288,9 @@ impl RemoteStorageTargetDriverConnector for S3RemoteStorageTargetDriverConnector
             driver_type: Self::driver_type(),
             endpoint: normalized.endpoint,
             bucket: normalized.bucket,
-            access_key: normalize_non_blank("access_key", &fields.access_key)?,
-            secret_key: normalize_non_blank("secret_key", &fields.secret_key)?,
-            base_path: fields.base_path.trim().trim_matches('/').to_string(),
+            access_key: normalize_required_storage_field("access_key", &fields.access_key)?,
+            secret_key: normalize_required_storage_field("secret_key", &fields.secret_key)?,
+            base_path: normalize_object_storage_prefix(&fields.base_path),
         })
     }
 
@@ -453,14 +473,4 @@ fn build_policy_model<S: FollowerRuntimeState>(
         created_at: target.created_at,
         updated_at: target.updated_at,
     })
-}
-
-fn normalize_non_blank(field: &str, value: &str) -> Result<String> {
-    let trimmed = value.trim();
-    if trimmed.is_empty() {
-        return Err(AsterError::validation_error(format!(
-            "{field} cannot be blank"
-        )));
-    }
-    Ok(trimmed.to_string())
 }

--- a/src/services/remote_storage_target_service/driver.rs
+++ b/src/services/remote_storage_target_service/driver.rs
@@ -48,18 +48,26 @@ pub enum RemoteStorageTargetDriverFieldKind {
     Number,
 }
 
-impl From<StorageDescriptorFieldKind> for RemoteStorageTargetDriverFieldKind {
-    fn from(value: StorageDescriptorFieldKind) -> Self {
+impl TryFrom<StorageDescriptorFieldKind> for RemoteStorageTargetDriverFieldKind {
+    type Error = &'static str;
+
+    fn try_from(value: StorageDescriptorFieldKind) -> std::result::Result<Self, Self::Error> {
         match value {
-            StorageDescriptorFieldKind::Text => Self::Text,
-            StorageDescriptorFieldKind::Secret => Self::Secret,
-            StorageDescriptorFieldKind::Boolean => Self::Boolean,
-            StorageDescriptorFieldKind::Number => Self::Number,
+            StorageDescriptorFieldKind::Text => Ok(Self::Text),
+            StorageDescriptorFieldKind::Secret => Ok(Self::Secret),
+            StorageDescriptorFieldKind::Boolean => Ok(Self::Boolean),
+            StorageDescriptorFieldKind::Number => Ok(Self::Number),
             StorageDescriptorFieldKind::Select => {
-                panic!("managed ingress target descriptors do not support select fields")
+                Err("managed ingress target descriptors do not support select fields")
             }
         }
     }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(all(debug_assertions, feature = "openapi"), derive(ToSchema))]
+pub struct RemoteStorageTargetDriverFieldValidation {
+    pub relative_local_path: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -74,6 +82,8 @@ pub struct RemoteStorageTargetDriverFieldDescriptor {
     pub placeholder: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub help_key: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub validation: Option<RemoteStorageTargetDriverFieldValidation>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -93,6 +103,26 @@ fn remote_storage_target_text_field(
     required: bool,
     secret: bool,
 ) -> RemoteStorageTargetDriverFieldDescriptor {
+    remote_storage_target_text_field_with_validation(
+        name,
+        label_key,
+        placeholder,
+        help_key,
+        required,
+        secret,
+        None,
+    )
+}
+
+fn remote_storage_target_text_field_with_validation(
+    name: &str,
+    label_key: &str,
+    placeholder: Option<&str>,
+    help_key: Option<&str>,
+    required: bool,
+    secret: bool,
+    validation: Option<RemoteStorageTargetDriverFieldValidation>,
+) -> RemoteStorageTargetDriverFieldDescriptor {
     let semantics = if secret {
         StorageDescriptorFieldSemantics::secret(required)
     } else {
@@ -100,12 +130,16 @@ fn remote_storage_target_text_field(
     };
     RemoteStorageTargetDriverFieldDescriptor {
         name: name.to_string(),
-        kind: semantics.kind.into(),
+        kind: semantics
+            .kind
+            .try_into()
+            .expect("text/secret storage target fields must map to managed ingress field kinds"),
         required: semantics.required,
         secret: semantics.secret,
         label_key: label_key.to_string(),
         placeholder: placeholder.map(str::to_string),
         help_key: help_key.map(str::to_string),
+        validation,
     }
 }
 
@@ -118,12 +152,16 @@ fn remote_storage_target_boolean_field(
     let semantics = StorageDescriptorFieldSemantics::boolean(required);
     RemoteStorageTargetDriverFieldDescriptor {
         name: name.to_string(),
-        kind: semantics.kind.into(),
+        kind: semantics
+            .kind
+            .try_into()
+            .expect("boolean storage target fields must map to managed ingress field kinds"),
         required: semantics.required,
         secret: semantics.secret,
         label_key: label_key.to_string(),
         placeholder: None,
         help_key: help_key.map(str::to_string),
+        validation: None,
     }
 }
 
@@ -159,13 +197,16 @@ impl RemoteStorageTargetDriverConnector for LocalRemoteStorageTargetDriverConnec
             label_key: "remote_node_ingress_profile_driver_local".to_string(),
             description_key: "remote_node_ingress_profile_local_scope_hint".to_string(),
             fields: vec![
-                remote_storage_target_text_field(
+                remote_storage_target_text_field_with_validation(
                     "base_path",
                     "base_path",
                     Some("tenant-a/incoming"),
                     Some("remote_node_ingress_profile_local_path_hint"),
                     true,
                     false,
+                    Some(RemoteStorageTargetDriverFieldValidation {
+                        relative_local_path: true,
+                    }),
                 ),
                 remote_storage_target_boolean_field(
                     "is_default",

--- a/src/services/remote_storage_target_service/normalization.rs
+++ b/src/services/remote_storage_target_service/normalization.rs
@@ -1,5 +1,8 @@
 use crate::entities::remote_storage_target;
-use crate::errors::{AsterError, Result};
+use crate::errors::Result;
+use crate::storage::field_contract::{
+    normalize_required_storage_field, preserve_secret_when_omitted,
+};
 use crate::storage::remote_protocol::{
     RemoteCreateLocalStorageTargetRequest, RemoteCreateS3StorageTargetRequest,
     RemoteCreateStorageTargetRequest, RemoteUpdateStorageTargetRequest,
@@ -39,7 +42,7 @@ pub(in crate::services::remote_storage_target_service) fn normalize_create_input
             base_path,
             is_default,
         }) => normalize_target_fields(StorageTargetFields {
-            name: normalize_non_blank("name", &name)?,
+            name: normalize_required_storage_field("name", &name)?,
             driver_type: DriverType::Local,
             endpoint: String::new(),
             bucket: String::new(),
@@ -57,7 +60,7 @@ pub(in crate::services::remote_storage_target_service) fn normalize_create_input
             base_path,
             is_default,
         }) => normalize_target_fields(StorageTargetFields {
-            name: normalize_non_blank("name", &name)?,
+            name: normalize_required_storage_field("name", &name)?,
             driver_type: DriverType::S3,
             endpoint,
             bucket,
@@ -75,11 +78,21 @@ pub(in crate::services::remote_storage_target_service) fn normalize_update_input
 ) -> Result<NormalizedStorageTargetInput> {
     let driver_type = input.driver_type.unwrap_or(existing.driver_type);
     let same_driver_type = driver_type == existing.driver_type;
+    let access_key = if same_driver_type {
+        preserve_secret_when_omitted("access_key", &existing.access_key, input.access_key)?
+    } else {
+        input.access_key.unwrap_or_default()
+    };
+    let secret_key = if same_driver_type {
+        preserve_secret_when_omitted("secret_key", &existing.secret_key, input.secret_key)?
+    } else {
+        input.secret_key.unwrap_or_default()
+    };
     normalize_target_fields(StorageTargetFields {
         name: input
             .name
             .as_deref()
-            .map(|value| normalize_non_blank("name", value))
+            .map(|value| normalize_required_storage_field("name", value))
             .transpose()?
             .unwrap_or(existing.name),
         driver_type,
@@ -97,20 +110,8 @@ pub(in crate::services::remote_storage_target_service) fn normalize_update_input
                 String::new()
             }
         }),
-        access_key: input.access_key.unwrap_or_else(|| {
-            if same_driver_type {
-                existing.access_key.clone()
-            } else {
-                String::new()
-            }
-        }),
-        secret_key: input.secret_key.unwrap_or_else(|| {
-            if same_driver_type {
-                existing.secret_key.clone()
-            } else {
-                String::new()
-            }
-        }),
+        access_key,
+        secret_key,
         base_path: input.base_path.unwrap_or_else(|| {
             if same_driver_type {
                 existing.base_path.clone()
@@ -157,14 +158,4 @@ fn normalize_target_fields(fields: StorageTargetFields) -> Result<NormalizedStor
         base_path: normalized.base_path,
         is_default,
     })
-}
-
-fn normalize_non_blank(field: &str, value: &str) -> Result<String> {
-    let trimmed = value.trim();
-    if trimmed.is_empty() {
-        return Err(AsterError::validation_error(format!(
-            "{field} cannot be blank"
-        )));
-    }
-    Ok(trimmed.to_string())
 }

--- a/src/services/remote_storage_target_service/paths.rs
+++ b/src/services/remote_storage_target_service/paths.rs
@@ -1,9 +1,12 @@
 use std::ffi::OsString;
 use std::fs;
-use std::path::{Component, Path, PathBuf};
+use std::path::{Path, PathBuf};
 
 use crate::api::api_error_code::ApiErrorCode;
 use crate::errors::{AsterError, MapAsterErr, Result, validation_error_with_code};
+use crate::storage::field_contract::{
+    RelativeLocalPathNormalizationError, normalize_relative_local_target_path,
+};
 
 pub(in crate::services::remote_storage_target_service) fn resolve_remote_storage_target_local_path(
     root: &str,
@@ -92,32 +95,14 @@ pub(in crate::services::remote_storage_target_service) fn resolve_remote_storage
 pub(in crate::services::remote_storage_target_service) fn normalize_relative_local_path(
     value: &str,
 ) -> Result<String> {
-    let trimmed = value.trim();
-    if trimmed.is_empty() {
-        return Err(AsterError::validation_error(
+    match normalize_relative_local_target_path(value) {
+        Ok(normalized) => Ok(normalized),
+        Err(RelativeLocalPathNormalizationError::Blank) => Err(AsterError::validation_error(
             "base_path cannot be blank for local remote storage targets",
-        ));
-    }
-
-    let safe_value = trimmed.replace('\\', "/");
-    let candidate = Path::new(&safe_value);
-    let mut normalized = PathBuf::new();
-    for component in candidate.components() {
-        match component {
-            Component::CurDir => {}
-            Component::Normal(segment) => normalized.push(segment),
-            Component::ParentDir | Component::RootDir | Component::Prefix(_) => {
-                return Err(validation_error_with_code(
-                    ApiErrorCode::ManagedIngressLocalPathInvalid,
-                    "local remote storage target base_path must stay within server.follower.remote_storage_target_local_root",
-                ));
-            }
-        }
-    }
-
-    if normalized.as_os_str().is_empty() {
-        Ok(".".to_string())
-    } else {
-        Ok(normalized.to_string_lossy().replace('\\', "/"))
+        )),
+        Err(RelativeLocalPathNormalizationError::EscapesRoot) => Err(validation_error_with_code(
+            ApiErrorCode::ManagedIngressLocalPathInvalid,
+            "local remote storage target base_path must stay within server.follower.remote_storage_target_local_root",
+        )),
     }
 }

--- a/src/services/remote_storage_target_service/tests.rs
+++ b/src/services/remote_storage_target_service/tests.rs
@@ -432,6 +432,18 @@ fn remote_storage_target_driver_descriptors_cover_builtin_profile_fields() {
             .collect::<Vec<_>>(),
         vec!["base_path", "is_default"]
     );
+    let local_base_path = local
+        .fields
+        .iter()
+        .find(|field| field.name == "base_path")
+        .expect("local base_path descriptor should exist");
+    assert_eq!(
+        local_base_path
+            .validation
+            .as_ref()
+            .map(|validation| validation.relative_local_path),
+        Some(true)
+    );
 
     let s3 = descriptors
         .iter()
@@ -456,6 +468,12 @@ fn remote_storage_target_driver_descriptors_cover_builtin_profile_fields() {
             .iter()
             .any(|field| field.name == "secret_key" && field.secret)
     );
+    let s3_base_path = s3
+        .fields
+        .iter()
+        .find(|field| field.name == "base_path")
+        .expect("s3 base_path descriptor should exist");
+    assert_eq!(s3_base_path.validation, None);
 }
 
 #[test]

--- a/src/services/remote_storage_target_service/tests.rs
+++ b/src/services/remote_storage_target_service/tests.rs
@@ -417,7 +417,8 @@ fn managed_ingress_driver_registry_contains_supported_builtin_drivers() {
 
 #[test]
 fn remote_storage_target_driver_descriptors_cover_builtin_profile_fields() {
-    let descriptors = list_registered_remote_storage_target_driver_descriptors();
+    let descriptors = list_registered_remote_storage_target_driver_descriptors()
+        .expect("registered remote storage target descriptors should build");
     assert_eq!(descriptors.len(), 2);
 
     let local = descriptors

--- a/src/storage/connector_descriptor.rs
+++ b/src/storage/connector_descriptor.rs
@@ -10,6 +10,8 @@ use utoipa::ToSchema;
 
 use crate::types::{DriverType, OBJECT_MULTIPART_MIN_PART_SIZE};
 
+use super::field_contract::{StorageDescriptorFieldKind, StorageDescriptorFieldSemantics};
+
 /// 为 connector 提供静态/半静态 descriptor。
 ///
 /// 内置 connector 目前直接返回静态结构；未来 plugin connector 也应该走同一层，
@@ -100,6 +102,30 @@ pub enum StorageConnectorFieldKind {
     Select,
     Boolean,
     Number,
+}
+
+impl From<StorageDescriptorFieldKind> for StorageConnectorFieldKind {
+    fn from(value: StorageDescriptorFieldKind) -> Self {
+        match value {
+            StorageDescriptorFieldKind::Text => Self::Text,
+            StorageDescriptorFieldKind::Secret => Self::Secret,
+            StorageDescriptorFieldKind::Select => Self::Select,
+            StorageDescriptorFieldKind::Boolean => Self::Boolean,
+            StorageDescriptorFieldKind::Number => Self::Number,
+        }
+    }
+}
+
+impl From<StorageConnectorFieldKind> for StorageDescriptorFieldKind {
+    fn from(value: StorageConnectorFieldKind) -> Self {
+        match value {
+            StorageConnectorFieldKind::Text => Self::Text,
+            StorageConnectorFieldKind::Secret => Self::Secret,
+            StorageConnectorFieldKind::Select => Self::Select,
+            StorageConnectorFieldKind::Boolean => Self::Boolean,
+            StorageConnectorFieldKind::Number => Self::Number,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -764,18 +790,23 @@ pub(crate) struct StorageConnectorFieldDisplayInput<'a> {
 pub(crate) fn storage_connector_field_with_display(
     input: StorageConnectorFieldDisplayInput<'_>,
 ) -> StorageConnectorFieldDescriptor {
+    let semantics = StorageDescriptorFieldSemantics::from_descriptor_bits(
+        input.kind.into(),
+        input.required,
+        input.secret,
+    );
     StorageConnectorFieldDescriptor {
         name: input.name.to_string(),
         scope: input.scope,
-        kind: input.kind,
+        kind: semantics.kind.into(),
         label_key: input.label_key.to_string(),
         placeholder: input.placeholder.map(ToOwned::to_owned),
         help_key: input.help_key.map(ToOwned::to_owned),
         required_message_key: input.required_message_key.map(ToOwned::to_owned),
         invalid_protocol_message_key: input.invalid_protocol_message_key.map(ToOwned::to_owned),
         trim_on_blur: input.trim_on_blur,
-        required: input.required,
-        secret: input.secret,
+        required: semantics.required,
+        secret: semantics.secret,
         options: Vec::new(),
         visible_when_driver_types: input.visible_when_driver_types,
     }

--- a/src/storage/field_contract.rs
+++ b/src/storage/field_contract.rs
@@ -1,0 +1,244 @@
+//! Shared storage descriptor field semantics and pure normalization helpers.
+//!
+//! This module intentionally does not define a universal product descriptor.
+//! Storage policy connectors and managed ingress targets keep their own DTOs,
+//! but common field meanings and normalization rules live here so the two
+//! surfaces do not drift.
+
+use std::path::{Component, Path, PathBuf};
+
+use crate::errors::{AsterError, Result};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StorageDescriptorFieldKind {
+    Text,
+    Secret,
+    Select,
+    Boolean,
+    Number,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StorageSecretEditSemantics {
+    /// A secret is required while creating the resource, but an omitted value
+    /// while editing preserves the currently stored secret.
+    RequiredOnCreatePreserveWhenOmittedOnEdit,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct StorageDescriptorFieldSemantics {
+    pub kind: StorageDescriptorFieldKind,
+    pub required: bool,
+    pub secret: bool,
+    pub secret_edit_semantics: Option<StorageSecretEditSemantics>,
+}
+
+impl StorageDescriptorFieldSemantics {
+    pub const fn text(required: bool) -> Self {
+        Self {
+            kind: StorageDescriptorFieldKind::Text,
+            required,
+            secret: false,
+            secret_edit_semantics: None,
+        }
+    }
+
+    pub const fn secret(required: bool) -> Self {
+        Self {
+            kind: StorageDescriptorFieldKind::Secret,
+            required,
+            secret: true,
+            secret_edit_semantics: Some(
+                StorageSecretEditSemantics::RequiredOnCreatePreserveWhenOmittedOnEdit,
+            ),
+        }
+    }
+
+    pub const fn boolean(required: bool) -> Self {
+        Self {
+            kind: StorageDescriptorFieldKind::Boolean,
+            required,
+            secret: false,
+            secret_edit_semantics: None,
+        }
+    }
+
+    pub const fn from_descriptor_bits(
+        kind: StorageDescriptorFieldKind,
+        required: bool,
+        secret: bool,
+    ) -> Self {
+        let secret_edit_semantics = if secret {
+            Some(StorageSecretEditSemantics::RequiredOnCreatePreserveWhenOmittedOnEdit)
+        } else {
+            None
+        };
+        Self {
+            kind,
+            required,
+            secret,
+            secret_edit_semantics,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RelativeLocalPathNormalizationError {
+    Blank,
+    EscapesRoot,
+}
+
+pub fn normalize_required_storage_field(field: &str, value: &str) -> Result<String> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return Err(AsterError::validation_error(format!(
+            "{field} cannot be blank"
+        )));
+    }
+    Ok(trimmed.to_string())
+}
+
+pub fn preserve_secret_when_omitted(
+    field: &str,
+    existing: &str,
+    replacement: Option<String>,
+) -> Result<String> {
+    match replacement {
+        Some(value) => normalize_required_storage_field(field, &value),
+        None => Ok(existing.to_string()),
+    }
+}
+
+pub fn normalize_object_storage_prefix(value: &str) -> String {
+    value.trim().trim_matches('/').to_string()
+}
+
+pub fn normalize_storage_policy_max_file_size(value: i64) -> Result<i64> {
+    if value < 0 {
+        return Err(AsterError::validation_error(
+            "max_file_size must be non-negative",
+        ));
+    }
+    Ok(value)
+}
+
+pub fn normalize_relative_local_target_path(
+    value: &str,
+) -> std::result::Result<String, RelativeLocalPathNormalizationError> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return Err(RelativeLocalPathNormalizationError::Blank);
+    }
+
+    let safe_value = trimmed.replace('\\', "/");
+    let candidate = Path::new(&safe_value);
+    let mut normalized = PathBuf::new();
+    for component in candidate.components() {
+        match component {
+            Component::CurDir => {}
+            Component::Normal(segment) => normalized.push(segment),
+            Component::ParentDir | Component::RootDir | Component::Prefix(_) => {
+                return Err(RelativeLocalPathNormalizationError::EscapesRoot);
+            }
+        }
+    }
+
+    if normalized.as_os_str().is_empty() {
+        Ok(".".to_string())
+    } else {
+        Ok(normalized.to_string_lossy().replace('\\', "/"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn descriptor_field_semantics_marks_secret_edit_contract() {
+        let secret = StorageDescriptorFieldSemantics::secret(true);
+
+        assert_eq!(secret.kind, StorageDescriptorFieldKind::Secret);
+        assert!(secret.required);
+        assert!(secret.secret);
+        assert_eq!(
+            secret.secret_edit_semantics,
+            Some(StorageSecretEditSemantics::RequiredOnCreatePreserveWhenOmittedOnEdit)
+        );
+
+        let text = StorageDescriptorFieldSemantics::text(false);
+        assert_eq!(text.kind, StorageDescriptorFieldKind::Text);
+        assert!(!text.required);
+        assert!(!text.secret);
+        assert_eq!(text.secret_edit_semantics, None);
+    }
+
+    #[test]
+    fn required_storage_field_trims_and_rejects_blank_values() {
+        assert_eq!(
+            normalize_required_storage_field("secret_key", " value ").unwrap(),
+            "value"
+        );
+
+        let error = normalize_required_storage_field("secret_key", " \t ").unwrap_err();
+        assert!(error.message().contains("secret_key cannot be blank"));
+    }
+
+    #[test]
+    fn omitted_secret_preserves_existing_value_and_replacement_is_normalized() {
+        assert_eq!(
+            preserve_secret_when_omitted("secret_key", "stored", None).unwrap(),
+            "stored"
+        );
+        assert_eq!(
+            preserve_secret_when_omitted("secret_key", "stored", Some(" next ".to_string()))
+                .unwrap(),
+            "next"
+        );
+        assert!(
+            preserve_secret_when_omitted("secret_key", "stored", Some(" ".to_string())).is_err()
+        );
+    }
+
+    #[test]
+    fn object_storage_prefix_trims_outer_slashes_only() {
+        assert_eq!(
+            normalize_object_storage_prefix(" /tenant/archive/ "),
+            "tenant/archive"
+        );
+        assert_eq!(normalize_object_storage_prefix(""), "");
+        assert_eq!(normalize_object_storage_prefix("///"), "");
+    }
+
+    #[test]
+    fn max_file_size_zero_means_unlimited_and_negative_is_invalid() {
+        assert_eq!(normalize_storage_policy_max_file_size(0).unwrap(), 0);
+        assert_eq!(normalize_storage_policy_max_file_size(42).unwrap(), 42);
+        assert!(normalize_storage_policy_max_file_size(-1).is_err());
+    }
+
+    #[test]
+    fn relative_local_target_path_normalizes_safe_segments() {
+        assert_eq!(
+            normalize_relative_local_target_path(" ./archive/2026 ").unwrap(),
+            "archive/2026"
+        );
+        assert_eq!(normalize_relative_local_target_path("././").unwrap(), ".");
+    }
+
+    #[test]
+    fn relative_local_target_path_rejects_blank_and_escape_segments() {
+        assert_eq!(
+            normalize_relative_local_target_path(" ").unwrap_err(),
+            RelativeLocalPathNormalizationError::Blank
+        );
+        assert_eq!(
+            normalize_relative_local_target_path("../secret").unwrap_err(),
+            RelativeLocalPathNormalizationError::EscapesRoot
+        );
+        assert_eq!(
+            normalize_relative_local_target_path("..\\secret").unwrap_err(),
+            RelativeLocalPathNormalizationError::EscapesRoot
+        );
+    }
+}

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -8,6 +8,7 @@ pub mod connector_descriptor;
 pub mod connectors;
 pub mod drivers;
 pub mod error;
+pub(crate) mod field_contract;
 mod metrics_driver;
 pub mod object_key;
 pub mod policy_snapshot;


### PR DESCRIPTION
## Summary
- add shared storage field semantics and normalization helpers
- reuse the helpers from storage policy and managed ingress normalization paths
- document descriptor-driven storage UI contracts in English and link the existing Chinese contract
- align remote target form validation with backend descriptor field metadata

## Verification
- cargo test --lib storage::field_contract
- cargo test --lib remote_storage_target_service::tests::normalize
- cargo test --lib storage::connectors
- cargo test --lib max_file_size_at_service_boundary
- cargo check
- bun run test -- RemoteNodeRemoteStorageTargetSection remoteStorageTargetDialogShared
- bunx biome check src/components/admin/admin-remote-nodes-page/RemoteNodeRemoteStorageTargetSection.tsx src/components/admin/admin-remote-nodes-page/RemoteNodeRemoteStorageTargetForm.tsx

Closes #372

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 新增“存储字段契约”文档，补充驱动字段作用域、归一化规则及密钥保留/保守降级策略，并更新开发入口。
  * 远程存储目标驱动字段增加对相对本地路径的校验信息（用于更准确的输入约束）。
* **Bug 修复**
  * 编辑远程存储目标时，secret 仅在“驱动未变且字段标记允许”时保留；placeholder 与校验提示同步调整。
  * 表单校验改为基于驱动字段定义计算必填与路径校验，更一致的错误提示。
  * 存储策略 `max_file_size` 创建与更新均拒绝负值，并覆盖边界校验。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->