### PR TITLE
perf(webdav): optimize range reads and large PROPFIND

### DIFF
--- a/src/db/repository/webdav_account_repo.rs
+++ b/src/db/repository/webdav_account_repo.rs
@@ -41,6 +41,8 @@ pub async fn find_by_user(
         .map_err(AsterError::from)
 }
 
+/// Enumerates every WebDAV account owned by the user, including team-linked
+/// accounts. Unlike `find_by_user`, this intentionally does not filter `team_id`.
 pub async fn find_all_by_user(
     db: &DatabaseConnection,
     user_id: i64,

--- a/src/db/repository/webdav_account_repo.rs
+++ b/src/db/repository/webdav_account_repo.rs
@@ -41,6 +41,18 @@ pub async fn find_by_user(
         .map_err(AsterError::from)
 }
 
+pub async fn find_all_by_user(
+    db: &DatabaseConnection,
+    user_id: i64,
+) -> Result<Vec<webdav_account::Model>> {
+    WebdavAccount::find()
+        .filter(webdav_account::Column::UserId.eq(user_id))
+        .order_by_asc(webdav_account::Column::Id)
+        .all(db)
+        .await
+        .map_err(AsterError::from)
+}
+
 pub async fn find_by_team(
     db: &DatabaseConnection,
     team_id: i64,

--- a/src/services/team_service/archive.rs
+++ b/src/services/team_service/archive.rs
@@ -241,6 +241,7 @@ async fn force_delete_archived_team(state: &PrimaryAppState, team: team::Model) 
     }
 
     purge_archived_team_files(state, &team).await?;
+    crate::webdav::auth::invalidate_webdav_auth_for_team(state, team_id).await?;
 
     let txn = crate::db::transaction::begin(state.writer_db()).await?;
     team_repo::lock_archived_by_id(&txn, team_id).await?;

--- a/src/services/team_service/members.rs
+++ b/src/services/team_service/members.rs
@@ -39,38 +39,30 @@ async fn invalidate_webdav_auth_for_team_member_change(
     team_id: i64,
     member_user_id: i64,
     operation: &'static str,
-) -> Result<()> {
-    match crate::webdav::auth::invalidate_webdav_auth_for_team_member(
-        state,
-        team_id,
-        member_user_id,
-    )
-    .await
+) {
+    if let Err(first_error) =
+        crate::webdav::auth::invalidate_webdav_auth_for_team_member(state, team_id, member_user_id)
+            .await
     {
-        Ok(()) => Ok(()),
-        Err(first_error) => {
-            tracing::warn!(
+        tracing::warn!(
+            team_id,
+            member_user_id,
+            operation,
+            "failed to invalidate WebDAV auth cache after team member change, retrying: {first_error}"
+        );
+        if let Err(error) = crate::webdav::auth::invalidate_webdav_auth_for_team_member(
+            state,
+            team_id,
+            member_user_id,
+        )
+        .await
+        {
+            tracing::error!(
                 team_id,
                 member_user_id,
                 operation,
-                "failed to invalidate WebDAV auth cache after team member change, retrying: {first_error}"
+                "failed to invalidate WebDAV auth cache after retry: {error}"
             );
-            if let Err(error) = crate::webdav::auth::invalidate_webdav_auth_for_team_member(
-                state,
-                team_id,
-                member_user_id,
-            )
-            .await
-            {
-                tracing::error!(
-                    team_id,
-                    member_user_id,
-                    operation,
-                    "failed to invalidate WebDAV auth cache after retry: {error}"
-                );
-                return Err(error);
-            }
-            Ok(())
         }
     }
 }
@@ -178,7 +170,7 @@ pub async fn update_admin_member_role(
         member_user_id,
         "admin_team_member_role_update",
     )
-    .await?;
+    .await;
     build_team_member_info(state, updated, target_user).await
 }
 
@@ -217,7 +209,7 @@ pub async fn remove_admin_member(
         member_user_id,
         "admin_team_member_removal",
     )
-    .await?;
+    .await;
     tracing::debug!(
         team_id,
         member_user_id,
@@ -375,7 +367,7 @@ pub async fn update_member_role(
         member_user_id,
         "team_member_role_update",
     )
-    .await?;
+    .await;
     build_team_member_info(state, updated, target_user).await
 }
 
@@ -431,7 +423,7 @@ pub async fn remove_member(
         member_user_id,
         "team_member_removal",
     )
-    .await?;
+    .await;
     tracing::debug!(
         team_id,
         actor_user_id,

--- a/src/services/team_service/members.rs
+++ b/src/services/team_service/members.rs
@@ -131,6 +131,16 @@ pub async fn update_admin_member_role(
         member_user_id,
     )
     .await;
+    if let Err(error) =
+        crate::webdav::auth::invalidate_webdav_auth_for_team_member(state, team_id, member_user_id)
+            .await
+    {
+        tracing::warn!(
+            team_id,
+            member_user_id,
+            "failed to invalidate WebDAV auth cache after admin team member role update: {error}"
+        );
+    }
     build_team_member_info(state, updated, target_user).await
 }
 
@@ -163,6 +173,16 @@ pub async fn remove_admin_member(
         member_user_id,
     )
     .await;
+    if let Err(error) =
+        crate::webdav::auth::invalidate_webdav_auth_for_team_member(state, team_id, member_user_id)
+            .await
+    {
+        tracing::warn!(
+            team_id,
+            member_user_id,
+            "failed to invalidate WebDAV auth cache after admin team member removal: {error}"
+        );
+    }
     tracing::debug!(
         team_id,
         member_user_id,
@@ -314,6 +334,16 @@ pub async fn update_member_role(
         member_user_id,
     )
     .await;
+    if let Err(error) =
+        crate::webdav::auth::invalidate_webdav_auth_for_team_member(state, team_id, member_user_id)
+            .await
+    {
+        tracing::warn!(
+            team_id,
+            member_user_id,
+            "failed to invalidate WebDAV auth cache after team member role update: {error}"
+        );
+    }
     build_team_member_info(state, updated, target_user).await
 }
 
@@ -363,6 +393,16 @@ pub async fn remove_member(
         member_user_id,
     )
     .await;
+    if let Err(error) =
+        crate::webdav::auth::invalidate_webdav_auth_for_team_member(state, team_id, member_user_id)
+            .await
+    {
+        tracing::warn!(
+            team_id,
+            member_user_id,
+            "failed to invalidate WebDAV auth cache after team member removal: {error}"
+        );
+    }
     tracing::debug!(
         team_id,
         actor_user_id,

--- a/src/services/team_service/members.rs
+++ b/src/services/team_service/members.rs
@@ -34,6 +34,47 @@ pub async fn list_admin_members(
     load_team_member_page(state, team_id, &filters, limit, offset).await
 }
 
+async fn invalidate_webdav_auth_for_team_member_change(
+    state: &impl SharedRuntimeState,
+    team_id: i64,
+    member_user_id: i64,
+    operation: &'static str,
+) -> Result<()> {
+    match crate::webdav::auth::invalidate_webdav_auth_for_team_member(
+        state,
+        team_id,
+        member_user_id,
+    )
+    .await
+    {
+        Ok(()) => Ok(()),
+        Err(first_error) => {
+            tracing::warn!(
+                team_id,
+                member_user_id,
+                operation,
+                "failed to invalidate WebDAV auth cache after team member change, retrying: {first_error}"
+            );
+            if let Err(error) = crate::webdav::auth::invalidate_webdav_auth_for_team_member(
+                state,
+                team_id,
+                member_user_id,
+            )
+            .await
+            {
+                tracing::error!(
+                    team_id,
+                    member_user_id,
+                    operation,
+                    "failed to invalidate WebDAV auth cache after retry: {error}"
+                );
+                return Err(error);
+            }
+            Ok(())
+        }
+    }
+}
+
 pub async fn get_admin_member(
     state: &impl SharedRuntimeState,
     team_id: i64,
@@ -131,16 +172,13 @@ pub async fn update_admin_member_role(
         member_user_id,
     )
     .await;
-    if let Err(error) =
-        crate::webdav::auth::invalidate_webdav_auth_for_team_member(state, team_id, member_user_id)
-            .await
-    {
-        tracing::warn!(
-            team_id,
-            member_user_id,
-            "failed to invalidate WebDAV auth cache after admin team member role update: {error}"
-        );
-    }
+    invalidate_webdav_auth_for_team_member_change(
+        state,
+        team_id,
+        member_user_id,
+        "admin_team_member_role_update",
+    )
+    .await?;
     build_team_member_info(state, updated, target_user).await
 }
 
@@ -173,16 +211,13 @@ pub async fn remove_admin_member(
         member_user_id,
     )
     .await;
-    if let Err(error) =
-        crate::webdav::auth::invalidate_webdav_auth_for_team_member(state, team_id, member_user_id)
-            .await
-    {
-        tracing::warn!(
-            team_id,
-            member_user_id,
-            "failed to invalidate WebDAV auth cache after admin team member removal: {error}"
-        );
-    }
+    invalidate_webdav_auth_for_team_member_change(
+        state,
+        team_id,
+        member_user_id,
+        "admin_team_member_removal",
+    )
+    .await?;
     tracing::debug!(
         team_id,
         member_user_id,
@@ -334,16 +369,13 @@ pub async fn update_member_role(
         member_user_id,
     )
     .await;
-    if let Err(error) =
-        crate::webdav::auth::invalidate_webdav_auth_for_team_member(state, team_id, member_user_id)
-            .await
-    {
-        tracing::warn!(
-            team_id,
-            member_user_id,
-            "failed to invalidate WebDAV auth cache after team member role update: {error}"
-        );
-    }
+    invalidate_webdav_auth_for_team_member_change(
+        state,
+        team_id,
+        member_user_id,
+        "team_member_role_update",
+    )
+    .await?;
     build_team_member_info(state, updated, target_user).await
 }
 
@@ -393,16 +425,13 @@ pub async fn remove_member(
         member_user_id,
     )
     .await;
-    if let Err(error) =
-        crate::webdav::auth::invalidate_webdav_auth_for_team_member(state, team_id, member_user_id)
-            .await
-    {
-        tracing::warn!(
-            team_id,
-            member_user_id,
-            "failed to invalidate WebDAV auth cache after team member removal: {error}"
-        );
-    }
+    invalidate_webdav_auth_for_team_member_change(
+        state,
+        team_id,
+        member_user_id,
+        "team_member_removal",
+    )
+    .await?;
     tracing::debug!(
         team_id,
         actor_user_id,

--- a/src/webdav/auth.rs
+++ b/src/webdav/auth.rs
@@ -55,7 +55,31 @@ pub(crate) async fn invalidate_webdav_auth_for_user(
     state: &impl SharedRuntimeState,
     user_id: i64,
 ) -> Result<(), AsterError> {
-    let accounts = webdav_account_repo::find_by_user(state.writer_db(), user_id).await?;
+    let accounts = webdav_account_repo::find_all_by_user(state.writer_db(), user_id).await?;
+    for account in accounts {
+        invalidate_webdav_auth_for_username(state, &account.username).await;
+    }
+    Ok(())
+}
+
+pub(crate) async fn invalidate_webdav_auth_for_team(
+    state: &impl SharedRuntimeState,
+    team_id: i64,
+) -> Result<(), AsterError> {
+    let accounts = webdav_account_repo::find_by_team(state.writer_db(), team_id).await?;
+    for account in accounts {
+        invalidate_webdav_auth_for_username(state, &account.username).await;
+    }
+    Ok(())
+}
+
+pub(crate) async fn invalidate_webdav_auth_for_team_member(
+    state: &impl SharedRuntimeState,
+    team_id: i64,
+    user_id: i64,
+) -> Result<(), AsterError> {
+    let accounts =
+        webdav_account_repo::find_by_team_and_user(state.writer_db(), team_id, user_id).await?;
     for account in accounts {
         invalidate_webdav_auth_for_username(state, &account.username).await;
     }
@@ -99,7 +123,6 @@ async fn authenticate_basic(
         .ok_or_else(|| AsterError::auth_invalid_credentials("invalid basic auth format"))?;
 
     if let Some(cached) = cache::load_auth(state, username, password).await {
-        validate_cached_account(state, username, password, &cached).await?;
         tracing::debug!(username_hash = %cache::username_cache_component(username), "webdav auth cache hit");
         return Ok(WebdavAuthResult {
             account_id: cached.account_id,
@@ -171,56 +194,9 @@ async fn authenticate_basic(
     })
 }
 
-async fn validate_cached_account(
-    state: &impl SharedRuntimeState,
-    username: &str,
-    password: &str,
-    cached: &CachedWebdavAuth,
-) -> Result<(), AsterError> {
-    let account = webdav_account_repo::find_by_id(state.writer_db(), cached.account_id).await?;
-    if account.username != username
-        || account.user_id != cached.user_id
-        || account.team_id != cached.team_id
-        || account.root_folder_id != cached.root_folder_id
-    {
-        invalidate_webdav_auth_for_username(state, username).await;
-        return Err(AsterError::auth_invalid_credentials(
-            "cached WebDAV account changed",
-        ));
-    }
-    if !account.is_active {
-        invalidate_webdav_auth_for_username(state, username).await;
-        return Err(auth_forbidden_with_code(
-            ApiErrorCode::AuthAccountDisabled,
-            "WebDAV account is disabled",
-        ));
-    }
-    if !hash::verify_password(password, &account.password_hash)? {
-        invalidate_webdav_auth_for_username(state, username).await;
-        return Err(AsterError::auth_invalid_credentials(
-            "cached WebDAV password changed",
-        ));
-    }
-    validate_cached_scope(state, cached.scope()).await
-}
-
-async fn validate_cached_scope(
-    state: &impl SharedRuntimeState,
-    scope: WorkspaceStorageScope,
-) -> Result<(), AsterError> {
-    let user = user_repo::find_by_id(state.writer_db(), scope.actor_user_id()).await?;
-    if !user.status.is_active() {
-        return Err(auth_forbidden_with_code(
-            ApiErrorCode::AuthAccountDisabled,
-            "user account is disabled",
-        ));
-    }
-    crate::services::workspace_storage_service::require_scope_access(state, scope).await
-}
-
 #[cfg(test)]
 mod tests {
-    use super::authenticate_webdav;
+    use super::{authenticate_webdav, invalidate_webdav_auth_for_username};
     use crate::cache;
     use crate::config::{CacheConfig, Config, DatabaseConfig, RuntimeConfig};
     use crate::entities::{user, webdav_account};
@@ -395,7 +371,7 @@ mod tests {
     }
 
     #[actix_web::test]
-    async fn cached_basic_auth_rechecks_account_active_state() {
+    async fn cached_basic_auth_rejects_disabled_account_after_invalidation() {
         let state = build_auth_test_state().await;
         let (username, password, _, _, _) = seed_webdav_account(&state).await;
 
@@ -416,16 +392,17 @@ mod tests {
             .update(state.writer_db())
             .await
             .expect("account disable should work");
+        invalidate_webdav_auth_for_username(&state, &username).await;
 
         let err = authenticate_webdav(&basic_headers(&username, &password), &state)
             .await
-            .expect_err("cached auth should reject a disabled account immediately");
+            .expect_err("invalidated auth should reject a disabled account immediately");
 
         assert!(matches!(err, AsterError::AuthForbidden(_)));
     }
 
     #[actix_web::test]
-    async fn cached_basic_auth_rechecks_current_password_hash() {
+    async fn cached_basic_auth_rejects_changed_password_after_invalidation() {
         let state = build_auth_test_state().await;
         let (username, password, _, _, _) = seed_webdav_account(&state).await;
 
@@ -447,10 +424,11 @@ mod tests {
             .update(state.writer_db())
             .await
             .expect("password update should work");
+        invalidate_webdav_auth_for_username(&state, &username).await;
 
         let err = authenticate_webdav(&basic_headers(&username, &password), &state)
             .await
-            .expect_err("cached auth should reject the old password immediately");
+            .expect_err("invalidated auth should reject the old password immediately");
 
         assert!(matches!(err, AsterError::AuthInvalidCredentials(_)));
     }

--- a/src/webdav/dav.rs
+++ b/src/webdav/dav.rs
@@ -184,6 +184,9 @@ pub trait DavMetaData: Send + Sync {
     fn modified(&self) -> FsResult<SystemTime>;
     fn is_dir(&self) -> bool;
     fn etag(&self) -> Option<String>;
+    fn content_type(&self) -> Option<&str> {
+        None
+    }
     fn created(&self) -> FsResult<SystemTime>;
     fn property_entity(&self) -> Option<(crate::types::EntityType, i64)> {
         None

--- a/src/webdav/dir_entry.rs
+++ b/src/webdav/dir_entry.rs
@@ -24,6 +24,13 @@ impl AsterDavDirEntry {
             metadata: AsterDavMeta::from_file(file, blob),
         }
     }
+
+    pub fn from_file_record(file: &file::Model) -> Self {
+        Self {
+            name: file.name.as_bytes().to_vec(),
+            metadata: AsterDavMeta::from_file_record(file),
+        }
+    }
 }
 
 impl DavDirEntry for AsterDavDirEntry {

--- a/src/webdav/fs/mod.rs
+++ b/src/webdav/fs/mod.rs
@@ -1,6 +1,6 @@
 //! WebDAV 子模块：`fs`。
 
-use std::{collections::HashMap, pin::Pin};
+use std::{collections::HashMap, pin::Pin, time::Instant};
 
 use futures::stream;
 use tokio::io::AsyncRead;
@@ -38,13 +38,10 @@ pub struct AsterDavFs {
     audit_ctx: AuditContext,
 }
 
-pub(crate) enum AsterDavDownloadTarget {
-    Directory,
-    File {
-        file: file::Model,
-        blob: file_blob::Model,
-        meta: AsterDavMeta,
-    },
+pub(crate) struct AsterDavDownloadFile {
+    pub(crate) file: file::Model,
+    pub(crate) blob: file_blob::Model,
+    pub(crate) meta: AsterDavMeta,
 }
 
 impl std::fmt::Debug for AsterDavFs {
@@ -98,7 +95,7 @@ impl AsterDavFs {
     pub(crate) async fn resolve_download_target(
         &self,
         path: &DavPath,
-    ) -> Result<AsterDavDownloadTarget, FsError> {
+    ) -> Result<Option<AsterDavDownloadFile>, FsError> {
         let node = path_resolver::resolve_path_cached_for_read_in_scope(
             &self.state,
             self.scope,
@@ -109,7 +106,7 @@ impl AsterDavFs {
 
         let file = match node {
             ResolvedNode::Root | ResolvedNode::Folder(_) => {
-                return Ok(AsterDavDownloadTarget::Directory);
+                return Ok(None);
             }
             ResolvedNode::File(file) => file,
         };
@@ -119,7 +116,7 @@ impl AsterDavFs {
             .map_err(|_| FsError::GeneralFailure)?;
         let meta = AsterDavMeta::from_file(&file, &blob);
 
-        Ok(AsterDavDownloadTarget::File { file, blob, meta })
+        Ok(Some(AsterDavDownloadFile { file, blob, meta }))
     }
 
     pub(crate) async fn open_download_stream_for_file(
@@ -158,7 +155,7 @@ impl AsterDavFs {
                 scope: self.scope,
                 root_folder_id: self.root_folder_id,
             },
-            &file,
+            file,
             match offset {
                 Some(_) => WebdavDownloadRequestKind::Ranged,
                 None => WebdavDownloadRequestKind::Full,
@@ -304,6 +301,8 @@ impl DavFileSystem for AsterDavFs {
         _meta: ReadDirMeta,
     ) -> FsFuture<'a, FsStream<Box<dyn DavDirEntry>>> {
         Box::pin(async move {
+            let started_at = Instant::now();
+            let resolve_started_at = Instant::now();
             let folder_id = match path_resolver::resolve_path_cached_for_read_in_scope(
                 &self.state,
                 self.scope,
@@ -316,7 +315,9 @@ impl DavFileSystem for AsterDavFs {
                 ResolvedNode::Folder(f) => Some(f.id),
                 ResolvedNode::File(_) => return Err(FsError::Forbidden),
             };
+            let resolve_elapsed_ms = resolve_started_at.elapsed().as_millis();
 
+            let folders_started_at = Instant::now();
             let folders = crate::services::workspace_storage_service::list_folders_in_parent(
                 &self.state,
                 self.scope,
@@ -324,6 +325,9 @@ impl DavFileSystem for AsterDavFs {
             )
             .await
             .map_err(|_| FsError::GeneralFailure)?;
+            let folders_elapsed_ms = folders_started_at.elapsed().as_millis();
+
+            let files_started_at = Instant::now();
             let files = crate::services::workspace_storage_service::list_files_in_folder(
                 &self.state,
                 self.scope,
@@ -331,24 +335,32 @@ impl DavFileSystem for AsterDavFs {
             )
             .await
             .map_err(|_| FsError::GeneralFailure)?;
+            let files_elapsed_ms = files_started_at.elapsed().as_millis();
 
             let mut entries: Vec<Box<dyn DavDirEntry>> = Vec::new();
 
+            let entry_started_at = Instant::now();
             for folder in &folders {
                 entries.push(Box::new(AsterDavDirEntry::from_folder(folder)));
             }
 
-            // 批量查询所有 blob（1 次查询替代 N 次）
-            let blob_ids: Vec<i64> = files.iter().map(|f| f.blob_id).collect();
-            let blobs = file_repo::find_blobs_by_ids(self.state.reader_db(), &blob_ids)
-                .await
-                .map_err(|_| FsError::GeneralFailure)?;
-
             for file in &files {
-                if let Some(blob) = blobs.get(&file.blob_id) {
-                    entries.push(Box::new(AsterDavDirEntry::from_file(file, blob)));
-                }
+                entries.push(Box::new(AsterDavDirEntry::from_file_record(file)));
             }
+            let entry_elapsed_ms = entry_started_at.elapsed().as_millis();
+
+            tracing::debug!(
+                folder_id,
+                folder_count = folders.len(),
+                file_count = files.len(),
+                entry_count = entries.len(),
+                resolve_elapsed_ms,
+                folders_elapsed_ms,
+                files_elapsed_ms,
+                entry_elapsed_ms,
+                total_elapsed_ms = started_at.elapsed().as_millis(),
+                "WebDAV read_dir completed"
+            );
 
             Ok(Box::pin(stream::iter(entries.into_iter().map(Ok)))
                 as FsStream<Box<dyn DavDirEntry>>)

--- a/src/webdav/fs/mod.rs
+++ b/src/webdav/fs/mod.rs
@@ -6,6 +6,7 @@ use futures::stream;
 use tokio::io::AsyncRead;
 
 use crate::db::repository::{file_repo, folder_repo, property_repo, team_repo, user_repo};
+use crate::entities::{file, file_blob};
 use crate::runtime::{PrimaryAppState, SharedRuntimeState};
 use crate::services::{
     audit_service::{self, AuditContext},
@@ -35,6 +36,15 @@ pub struct AsterDavFs {
     /// 限制访问范围：None = 用户全部文件，Some(id) = 只能访问该文件夹及子目录
     root_folder_id: Option<i64>,
     audit_ctx: AuditContext,
+}
+
+pub(crate) enum AsterDavDownloadTarget {
+    Directory,
+    File {
+        file: file::Model,
+        blob: file_blob::Model,
+        meta: AsterDavMeta,
+    },
 }
 
 impl std::fmt::Debug for AsterDavFs {
@@ -85,19 +95,10 @@ impl AsterDavFs {
         self.scope
     }
 
-    pub(crate) async fn open_read_stream(
+    pub(crate) async fn resolve_download_target(
         &self,
         path: &DavPath,
-    ) -> Result<Box<dyn AsyncRead + Unpin + Send>, FsError> {
-        self.open_read_stream_with_range(path, None, None).await
-    }
-
-    pub(crate) async fn open_read_stream_with_range(
-        &self,
-        path: &DavPath,
-        offset: Option<u64>,
-        length: Option<u64>,
-    ) -> Result<Box<dyn AsyncRead + Unpin + Send>, FsError> {
+    ) -> Result<AsterDavDownloadTarget, FsError> {
         let node = path_resolver::resolve_path_cached_for_read_in_scope(
             &self.state,
             self.scope,
@@ -107,13 +108,27 @@ impl AsterDavFs {
         .await?;
 
         let file = match node {
+            ResolvedNode::Root | ResolvedNode::Folder(_) => {
+                return Ok(AsterDavDownloadTarget::Directory);
+            }
             ResolvedNode::File(file) => file,
-            _ => return Err(FsError::Forbidden),
         };
 
         let blob = file_repo::find_blob_by_id(self.state.reader_db(), file.blob_id)
             .await
             .map_err(|_| FsError::GeneralFailure)?;
+        let meta = AsterDavMeta::from_file(&file, &blob);
+
+        Ok(AsterDavDownloadTarget::File { file, blob, meta })
+    }
+
+    pub(crate) async fn open_download_stream_for_file(
+        &self,
+        file: &file::Model,
+        blob: &file_blob::Model,
+        offset: Option<u64>,
+        length: Option<u64>,
+    ) -> Result<Box<dyn AsyncRead + Unpin + Send>, FsError> {
         let policy = self
             .state
             .policy_snapshot
@@ -277,7 +292,7 @@ impl DavFileSystem for AsterDavFs {
                 Ok(Box::new(dav_file) as Box<dyn DavFile>)
             } else {
                 let _ = path;
-                // 读路径只允许 GET/HEAD 通过 open_read_stream 访问，避免回退到临时文件兜底。
+                // 读路径只允许 GET/HEAD 通过专用下载目标访问，避免回退到临时文件兜底。
                 Err(FsError::Forbidden)
             }
         })

--- a/src/webdav/metadata.rs
+++ b/src/webdav/metadata.rs
@@ -22,6 +22,7 @@ pub struct AsterDavMeta {
     modified: SystemTime,
     created: SystemTime,
     etag: Option<String>,
+    content_type: Option<String>,
     property_entity: Option<(EntityType, i64)>,
 }
 
@@ -33,6 +34,7 @@ impl AsterDavMeta {
             modified: SystemTime::UNIX_EPOCH,
             created: SystemTime::UNIX_EPOCH,
             etag: None,
+            content_type: None,
             property_entity: None,
         }
     }
@@ -44,6 +46,7 @@ impl AsterDavMeta {
             modified: to_system_time(folder.updated_at),
             created: to_system_time(folder.created_at),
             etag: Some(format!("dir-{}", folder.updated_at.timestamp())),
+            content_type: None,
             property_entity: Some((EntityType::Folder, folder.id)),
         }
     }
@@ -54,10 +57,33 @@ impl AsterDavMeta {
             len: u64::try_from(blob.size).unwrap_or_default(),
             modified: to_system_time(file.updated_at),
             created: to_system_time(file.created_at),
-            etag: Some(blob.hash.clone()),
+            etag: Some(file_etag(file)),
+            content_type: Some(file.mime_type.clone()),
             property_entity: Some((EntityType::File, file.id)),
         }
     }
+
+    pub fn from_file_record(file: &file::Model) -> Self {
+        Self {
+            is_dir: false,
+            len: u64::try_from(file.size).unwrap_or_default(),
+            modified: to_system_time(file.updated_at),
+            created: to_system_time(file.created_at),
+            etag: Some(file_etag(file)),
+            content_type: Some(file.mime_type.clone()),
+            property_entity: Some((EntityType::File, file.id)),
+        }
+    }
+}
+
+fn file_etag(file: &file::Model) -> String {
+    format!(
+        "file-{}-{}-{}-{}",
+        file.id,
+        file.blob_id,
+        file.size,
+        file.updated_at.timestamp_millis()
+    )
 }
 
 impl DavMetaData for AsterDavMeta {
@@ -75,6 +101,10 @@ impl DavMetaData for AsterDavMeta {
 
     fn etag(&self) -> Option<String> {
         self.etag.clone()
+    }
+
+    fn content_type(&self) -> Option<&str> {
+        self.content_type.as_deref()
     }
 
     fn created(&self) -> FsResult<SystemTime> {

--- a/src/webdav/metadata.rs
+++ b/src/webdav/metadata.rs
@@ -51,10 +51,10 @@ impl AsterDavMeta {
         }
     }
 
-    pub fn from_file(file: &file::Model, blob: &file_blob::Model) -> Self {
+    pub fn from_file(file: &file::Model, _blob: &file_blob::Model) -> Self {
         Self {
             is_dir: false,
-            len: u64::try_from(blob.size).unwrap_or_default(),
+            len: u64::try_from(file.size).unwrap_or_default(),
             modified: to_system_time(file.updated_at),
             created: to_system_time(file.created_at),
             etag: Some(file_etag(file)),
@@ -77,6 +77,9 @@ impl AsterDavMeta {
 }
 
 fn file_etag(file: &file::Model) -> String {
+    // File records are updated together with blob_id, size, and updated_at on
+    // content replacement/version restore, so GET/HEAD and PROPFIND can share
+    // this file-state validator without loading the blob in directory listings.
     format!(
         "file-{}-{}-{}-{}",
         file.id,

--- a/src/webdav/props/mod.rs
+++ b/src/webdav/props/mod.rs
@@ -43,6 +43,9 @@ struct PropfindResource {
     meta: Box<dyn DavMetaData>,
 }
 
+type PropKey = (String, Option<String>);
+type PropKeySet = BTreeSet<PropKey>;
+
 #[derive(Default)]
 struct PropfindPreload {
     dead_props: HashMap<DavPath, Vec<DavProp>>,
@@ -540,7 +543,7 @@ fn all_prop_elements(
     prefix: &str,
     resource: &PropfindResource,
     preload: &PropfindPreload,
-) -> Result<(Vec<Element>, BTreeSet<(String, Option<String>)>), HttpResponse> {
+) -> Result<(Vec<Element>, PropKeySet), HttpResponse> {
     let mut props = standard_prop_name_list(resource)
         .into_iter()
         .map(|prop| RequestedProp {
@@ -561,8 +564,8 @@ fn all_prop_elements(
         }
     }
     for prop in custom_props {
-        keys.insert(dav_prop_key(&prop));
-        elements.push(prop_element(&prop, None));
+        keys.insert(dav_prop_key(prop));
+        elements.push(prop_element(prop, None));
     }
     Ok((elements, keys))
 }
@@ -735,6 +738,17 @@ fn standard_prop_element(
                 .push(XMLNode::Text(resource.meta.len().to_string()));
             Ok(Some(element))
         }
+        "getcontenttype" => {
+            if resource.meta.is_dir() {
+                return Ok(None);
+            }
+            if let Some(content_type) = resource.meta.content_type() {
+                element
+                    .children
+                    .push(XMLNode::Text(content_type.to_string()));
+            }
+            Ok(Some(element))
+        }
         "getlastmodified" => {
             let modified = resource.meta.modified().map_err(fs_error_response)?;
             element
@@ -878,6 +892,7 @@ fn standard_prop_name_list(resource: &PropfindResource) -> Vec<&'static str> {
     ];
     if !resource.meta.is_dir() {
         props.insert(2, "getcontentlength");
+        props.insert(3, "getcontenttype");
     }
     props
 }
@@ -888,6 +903,7 @@ fn is_standard_live_prop_name(name: &str) -> bool {
         "displayname"
             | "resourcetype"
             | "getcontentlength"
+            | "getcontenttype"
             | "getlastmodified"
             | "creationdate"
             | "getetag"

--- a/src/webdav/props/mod.rs
+++ b/src/webdav/props/mod.rs
@@ -38,7 +38,7 @@ enum PropfindKind {
 }
 
 struct PropfindResource {
-    path: DavPath,
+    path: Option<DavPath>,
     relative: String,
     meta: Box<dyn DavMetaData>,
 }
@@ -109,7 +109,7 @@ impl PropfindPreload {
                 .filter(|resource| !is_root_resource(resource))
                 .filter_map(|resource| {
                     let (entity_type, entity_id) = resource.meta.property_entity()?;
-                    Some((resource.path.clone(), entity_type, entity_id))
+                    Some((resource.path.clone()?, entity_type, entity_id))
                 })
                 .collect::<Vec<_>>();
             preload.dead_props = dav_fs
@@ -124,7 +124,7 @@ impl PropfindPreload {
         if propfind_kind_needs_lockdiscovery(request_kind) {
             let paths = resources
                 .iter()
-                .map(|resource| resource.path.clone())
+                .filter_map(|resource| resource.path.clone())
                 .collect::<Vec<_>>();
             preload.locks = lock_system.discover_many(&paths).await;
         }
@@ -133,15 +133,19 @@ impl PropfindPreload {
     }
 
     fn dead_props_for(&self, resource: &PropfindResource) -> &[DavProp] {
-        self.dead_props
-            .get(&resource.path)
+        resource
+            .path
+            .as_ref()
+            .and_then(|path| self.dead_props.get(path))
             .map(Vec::as_slice)
             .unwrap_or_default()
     }
 
     fn locks_for(&self, resource: &PropfindResource) -> &[DavLock] {
-        self.locks
-            .get(&resource.path)
+        resource
+            .path
+            .as_ref()
+            .and_then(|path| self.locks.get(path))
             .map(Vec::as_slice)
             .unwrap_or_default()
     }
@@ -192,13 +196,24 @@ pub(crate) async fn handle_propfind(
         return responses::propfind_finite_depth_response();
     }
     let collect_started_at = Instant::now();
-    let resources =
-        match collect_propfind_resources(dav_fs, &path, &relative, depth, root_meta).await {
-            Ok(resources) => resources,
-            Err(err) => return fs_error_response(err),
-        };
+    let preload_needs_paths = propfind_kind_needs_dead_props(&request_kind)
+        || propfind_kind_needs_lockdiscovery(&request_kind);
+    let resources = match collect_propfind_resources(
+        dav_fs,
+        &path,
+        &relative,
+        depth,
+        root_meta,
+        preload_needs_paths,
+    )
+    .await
+    {
+        Ok(resources) => resources,
+        Err(err) => return fs_error_response(err),
+    };
     let collect_elapsed_ms = collect_started_at.elapsed().as_millis();
     let resource_count = resources.len();
+
     let preload_started_at = Instant::now();
     let preload = match PropfindPreload::load(dav_fs, lock_system, &request_kind, &resources).await
     {
@@ -214,11 +229,10 @@ pub(crate) async fn handle_propfind(
 
     let render_started_at = Instant::now();
     for resource in resources {
-        let response =
-            match build_propfind_response(prefix, &request_kind, &preload, resource).await {
-                Ok(response) => response,
-                Err(resp) => return resp,
-            };
+        let response = match build_propfind_response(prefix, &request_kind, &preload, resource) {
+            Ok(response) => response,
+            Err(resp) => return resp,
+        };
         multistatus.children.push(XMLNode::Element(response));
     }
     tracing::debug!(
@@ -439,10 +453,11 @@ async fn collect_propfind_resources(
     relative: &str,
     depth: Depth,
     root_meta: Box<dyn DavMetaData>,
+    include_paths: bool,
 ) -> Result<Vec<PropfindResource>, FsError> {
     let root_is_dir = root_meta.is_dir();
     let mut resources = vec![PropfindResource {
-        path: path.clone(),
+        path: include_paths.then(|| path.clone()),
         relative: relative.to_string(),
         meta: root_meta,
     }];
@@ -454,7 +469,11 @@ async fn collect_propfind_resources(
             let entry = entry?;
             let meta = entry.metadata().await?;
             let child_relative = child_relative_path(relative, &entry.name(), meta.is_dir());
-            let child_path = DavPath::new(&child_relative).map_err(|_| FsError::GeneralFailure)?;
+            let child_path = if include_paths {
+                Some(DavPath::new(&child_relative).map_err(|_| FsError::GeneralFailure)?)
+            } else {
+                None
+            };
             resources.push(PropfindResource {
                 path: child_path,
                 relative: child_relative,
@@ -474,7 +493,7 @@ fn propfind_kind_label(kind: &PropfindKind) -> &'static str {
     }
 }
 
-async fn build_propfind_response(
+fn build_propfind_response(
     prefix: &str,
     request_kind: &PropfindKind,
     preload: &PropfindPreload,
@@ -488,13 +507,13 @@ async fn build_propfind_response(
 
     let propstats = match request_kind {
         PropfindKind::AllProp { include } => {
-            all_propstat_elements(prefix, &resource, include, preload).await?
+            all_propstat_elements(prefix, &resource, include, preload)?
         }
         PropfindKind::PropName => {
             vec![(StatusCode::OK, prop_name_elements(&resource, preload))]
         }
         PropfindKind::Prop(requested) => {
-            requested_prop_elements(prefix, &resource, requested, preload).await?
+            requested_prop_elements(prefix, &resource, requested, preload)?
         }
     };
 
@@ -517,7 +536,7 @@ async fn build_propfind_response(
     Ok(response)
 }
 
-async fn all_prop_elements(
+fn all_prop_elements(
     prefix: &str,
     resource: &PropfindResource,
     preload: &PropfindPreload,
@@ -537,7 +556,7 @@ async fn all_prop_elements(
     let custom_props = preload.dead_props_for(resource);
     let mut elements = Vec::new();
     for requested in props.drain(..) {
-        if let Some(element) = standard_prop_element(prefix, resource, &requested, preload).await? {
+        if let Some(element) = standard_prop_element(prefix, resource, &requested, preload)? {
             elements.push(element);
         }
     }
@@ -548,13 +567,13 @@ async fn all_prop_elements(
     Ok((elements, keys))
 }
 
-async fn all_propstat_elements(
+fn all_propstat_elements(
     prefix: &str,
     resource: &PropfindResource,
     include: &[RequestedProp],
     preload: &PropfindPreload,
 ) -> Result<Vec<(StatusCode, Vec<Element>)>, HttpResponse> {
-    let (all_props, all_prop_keys) = all_prop_elements(prefix, resource, preload).await?;
+    let (all_props, all_prop_keys) = all_prop_elements(prefix, resource, preload)?;
     if include.is_empty() {
         return Ok(vec![(StatusCode::OK, all_props)]);
     }
@@ -569,7 +588,7 @@ async fn all_propstat_elements(
     }
 
     let mut result = vec![(StatusCode::OK, all_props)];
-    let requested = requested_prop_elements(prefix, resource, &include, preload).await?;
+    let requested = requested_prop_elements(prefix, resource, &include, preload)?;
     for (status, props) in requested {
         if !props.is_empty() {
             result.push((status, props));
@@ -601,7 +620,7 @@ fn prop_name_elements(resource: &PropfindResource, preload: &PropfindPreload) ->
     elements
 }
 
-async fn requested_prop_elements(
+fn requested_prop_elements(
     prefix: &str,
     resource: &PropfindResource,
     requested: &[RequestedProp],
@@ -617,7 +636,7 @@ async fn requested_prop_elements(
             continue;
         }
 
-        if let Some(element) = standard_prop_element(prefix, resource, prop, preload).await? {
+        if let Some(element) = standard_prop_element(prefix, resource, prop, preload)? {
             ok.push(element);
             continue;
         }
@@ -680,7 +699,7 @@ fn is_lockdiscovery_prop(prop: &RequestedProp) -> bool {
     prop.namespace.as_deref().unwrap_or("DAV:") == "DAV:" && prop.name == "lockdiscovery"
 }
 
-async fn standard_prop_element(
+fn standard_prop_element(
     prefix: &str,
     resource: &PropfindResource,
     requested: &RequestedProp,

--- a/src/webdav/props/mod.rs
+++ b/src/webdav/props/mod.rs
@@ -3,6 +3,7 @@
 use std::collections::BTreeSet;
 use std::collections::{BTreeMap, HashMap};
 use std::io::Cursor;
+use std::time::Instant;
 
 use actix_web::http::StatusCode;
 use actix_web::{HttpRequest, HttpResponse};
@@ -180,28 +181,38 @@ pub(crate) async fn handle_propfind(
         Err(resp) => return resp,
     };
 
+    let request_started_at = Instant::now();
+    let metadata_started_at = Instant::now();
     let root_meta = match dav_fs.metadata(&path).await {
         Ok(meta) => meta,
         Err(err) => return fs_error_response(err),
     };
+    let metadata_elapsed_ms = metadata_started_at.elapsed().as_millis();
     if depth == Depth::Infinity && root_meta.is_dir() {
         return responses::propfind_finite_depth_response();
     }
-    let resources = match collect_propfind_resources(dav_fs, &path, &relative, depth).await {
-        Ok(resources) => resources,
-        Err(err) => return fs_error_response(err),
-    };
+    let collect_started_at = Instant::now();
+    let resources =
+        match collect_propfind_resources(dav_fs, &path, &relative, depth, root_meta).await {
+            Ok(resources) => resources,
+            Err(err) => return fs_error_response(err),
+        };
+    let collect_elapsed_ms = collect_started_at.elapsed().as_millis();
+    let resource_count = resources.len();
+    let preload_started_at = Instant::now();
     let preload = match PropfindPreload::load(dav_fs, lock_system, &request_kind, &resources).await
     {
         Ok(preload) => preload,
         Err(resp) => return resp,
     };
+    let preload_elapsed_ms = preload_started_at.elapsed().as_millis();
 
     let mut multistatus = dav_element("multistatus");
     multistatus
         .attributes
         .insert("xmlns:D".to_string(), "DAV:".to_string());
 
+    let render_started_at = Instant::now();
     for resource in resources {
         let response =
             match build_propfind_response(prefix, &request_kind, &preload, resource).await {
@@ -210,6 +221,17 @@ pub(crate) async fn handle_propfind(
             };
         multistatus.children.push(XMLNode::Element(response));
     }
+    tracing::debug!(
+        depth = ?depth,
+        kind = propfind_kind_label(&request_kind),
+        resource_count,
+        metadata_elapsed_ms,
+        collect_elapsed_ms,
+        preload_elapsed_ms,
+        render_elapsed_ms = render_started_at.elapsed().as_millis(),
+        total_elapsed_ms = request_started_at.elapsed().as_millis(),
+        "WebDAV PROPFIND completed"
+    );
 
     xml_response(multistatus, multi_status())
 }
@@ -416,8 +438,8 @@ async fn collect_propfind_resources(
     path: &DavPath,
     relative: &str,
     depth: Depth,
+    root_meta: Box<dyn DavMetaData>,
 ) -> Result<Vec<PropfindResource>, FsError> {
-    let root_meta = dav_fs.metadata(path).await?;
     let root_is_dir = root_meta.is_dir();
     let mut resources = vec![PropfindResource {
         path: path.clone(),
@@ -442,6 +464,14 @@ async fn collect_propfind_resources(
     }
 
     Ok(resources)
+}
+
+fn propfind_kind_label(kind: &PropfindKind) -> &'static str {
+    match kind {
+        PropfindKind::AllProp { .. } => "allprop",
+        PropfindKind::PropName => "propname",
+        PropfindKind::Prop(_) => "prop",
+    }
 }
 
 async fn build_propfind_response(
@@ -874,6 +904,7 @@ mod tests {
     use xmltree::Element;
 
     use super::handle_propfind;
+    use crate::types::EntityType;
     use crate::webdav::dav::{
         DavDirEntry, DavFile, DavFileSystem, DavLock, DavLockError, DavLockSystem, DavMetaData,
         DavPath, DavProp, FsError, FsFuture, FsResult, FsStream, LsFuture, OpenOptions,
@@ -882,12 +913,14 @@ mod tests {
 
     struct PropfindTestFs {
         child_count: usize,
+        metadata_calls: Arc<AtomicUsize>,
         get_props_calls: Arc<AtomicUsize>,
     }
 
     struct PropfindTestMeta {
         is_dir: bool,
         len: u64,
+        property_entity: Option<(EntityType, i64)>,
     }
 
     impl DavMetaData for PropfindTestMeta {
@@ -914,6 +947,10 @@ mod tests {
         fn created(&self) -> FsResult<SystemTime> {
             Ok(SystemTime::UNIX_EPOCH)
         }
+
+        fn property_entity(&self) -> Option<(EntityType, i64)> {
+            self.property_entity
+        }
     }
 
     struct PropfindTestEntry {
@@ -931,6 +968,10 @@ mod tests {
                 Ok(Box::new(PropfindTestMeta {
                     is_dir: false,
                     len: self.len,
+                    property_entity: Some((
+                        EntityType::File,
+                        i64::try_from(self.len).expect("test len should fit i64"),
+                    )),
                 }) as Box<dyn DavMetaData>)
             })
         }
@@ -969,16 +1010,19 @@ mod tests {
 
         fn metadata<'a>(&'a self, path: &'a DavPath) -> FsFuture<'a, Box<dyn DavMetaData>> {
             Box::pin(async move {
+                self.metadata_calls.fetch_add(1, Ordering::SeqCst);
                 if path.as_str() == "/" {
                     return Ok(Box::new(PropfindTestMeta {
                         is_dir: true,
                         len: 0,
+                        property_entity: None,
                     }) as Box<dyn DavMetaData>);
                 }
 
                 Ok(Box::new(PropfindTestMeta {
                     is_dir: false,
                     len: 1,
+                    property_entity: Some((EntityType::File, 1)),
                 }) as Box<dyn DavMetaData>)
             })
         }
@@ -1095,14 +1139,16 @@ mod tests {
         }
     }
 
-    async fn propfind_depth_one(body: &'static str) -> (String, usize, usize, usize) {
+    async fn propfind_depth_one(body: &'static str) -> (String, usize, usize, usize, usize) {
         const CHILD_COUNT: usize = 24;
 
+        let metadata_calls = Arc::new(AtomicUsize::new(0));
         let get_props_calls = Arc::new(AtomicUsize::new(0));
         let discover_calls = Arc::new(AtomicUsize::new(0));
         let discover_many_calls = Arc::new(AtomicUsize::new(0));
         let fs = PropfindTestFs {
             child_count: CHILD_COUNT,
+            metadata_calls: metadata_calls.clone(),
             get_props_calls: get_props_calls.clone(),
         };
         let lock_system = PropfindTestLockSystem {
@@ -1122,6 +1168,7 @@ mod tests {
             .expect("PROPFIND response body should be readable");
         (
             String::from_utf8(body.to_vec()).expect("PROPFIND body should be utf-8"),
+            metadata_calls.load(Ordering::SeqCst),
             get_props_calls.load(Ordering::SeqCst),
             discover_calls.load(Ordering::SeqCst),
             discover_many_calls.load(Ordering::SeqCst),
@@ -1142,8 +1189,13 @@ mod tests {
   </D:prop>
 </D:propfind>"#;
 
-        let (xml, calls, discover_calls, discover_many_calls) = propfind_depth_one(body).await;
+        let (xml, metadata_calls, calls, discover_calls, discover_many_calls) =
+            propfind_depth_one(body).await;
 
+        assert_eq!(
+            metadata_calls, 1,
+            "Depth: 1 PROPFIND should reuse root metadata instead of loading it twice: {xml}"
+        );
         assert_eq!(
             calls, 0,
             "live-property-only Depth: 1 PROPFIND should not load dead properties: {xml}"
@@ -1174,7 +1226,7 @@ mod tests {
   </D:prop>
 </D:propfind>"#;
 
-        let (xml, calls, _, _) = propfind_depth_one(body).await;
+        let (xml, _, calls, _, _) = propfind_depth_one(body).await;
 
         assert_eq!(
             calls, 24,
@@ -1188,7 +1240,7 @@ mod tests {
 
     #[actix_web::test]
     async fn propfind_depth_one_allprop_still_loads_dead_properties() {
-        let (xml, calls, _, discover_many_calls) = propfind_depth_one("").await;
+        let (xml, _, calls, _, discover_many_calls) = propfind_depth_one("").await;
 
         assert_eq!(
             calls, 24,
@@ -1211,7 +1263,7 @@ mod tests {
   <D:propname />
 </D:propfind>"#;
 
-        let (xml, _, discover_calls, discover_many_calls) = propfind_depth_one(body).await;
+        let (xml, _, _, discover_calls, discover_many_calls) = propfind_depth_one(body).await;
 
         assert!(
             xml.contains("<D:lockdiscovery />"),
@@ -1236,7 +1288,7 @@ mod tests {
   </D:prop>
 </D:propfind>"#;
 
-        let (xml, _, discover_calls, discover_many_calls) = propfind_depth_one(body).await;
+        let (xml, _, _, discover_calls, discover_many_calls) = propfind_depth_one(body).await;
 
         assert!(
             xml.contains("lockdiscovery"),

--- a/src/webdav/props/mod.rs
+++ b/src/webdav/props/mod.rs
@@ -742,11 +742,16 @@ fn standard_prop_element(
             if resource.meta.is_dir() {
                 return Ok(None);
             }
-            if let Some(content_type) = resource.meta.content_type() {
-                element
-                    .children
-                    .push(XMLNode::Text(content_type.to_string()));
-            }
+            let Some(content_type) = resource
+                .meta
+                .content_type()
+                .filter(|value| !value.is_empty())
+            else {
+                return Ok(None);
+            };
+            element
+                .children
+                .push(XMLNode::Text(content_type.to_string()));
             Ok(Some(element))
         }
         "getlastmodified" => {
@@ -955,6 +960,7 @@ mod tests {
     struct PropfindTestMeta {
         is_dir: bool,
         len: u64,
+        content_type: Option<&'static str>,
         property_entity: Option<(EntityType, i64)>,
     }
 
@@ -977,6 +983,10 @@ mod tests {
             } else {
                 format!("file-etag-{}", self.len)
             })
+        }
+
+        fn content_type(&self) -> Option<&str> {
+            self.content_type
         }
 
         fn created(&self) -> FsResult<SystemTime> {
@@ -1003,6 +1013,7 @@ mod tests {
                 Ok(Box::new(PropfindTestMeta {
                     is_dir: false,
                     len: self.len,
+                    content_type: Some("text/plain"),
                     property_entity: Some((
                         EntityType::File,
                         i64::try_from(self.len).expect("test len should fit i64"),
@@ -1050,6 +1061,7 @@ mod tests {
                     return Ok(Box::new(PropfindTestMeta {
                         is_dir: true,
                         len: 0,
+                        content_type: None,
                         property_entity: None,
                     }) as Box<dyn DavMetaData>);
                 }
@@ -1057,6 +1069,7 @@ mod tests {
                 Ok(Box::new(PropfindTestMeta {
                     is_dir: false,
                     len: 1,
+                    content_type: Some("text/plain"),
                     property_entity: Some((EntityType::File, 1)),
                 }) as Box<dyn DavMetaData>)
             })
@@ -1218,6 +1231,7 @@ mod tests {
     <D:displayname />
     <D:resourcetype />
     <D:getcontentlength />
+    <D:getcontenttype />
     <D:getlastmodified />
     <D:creationdate />
     <D:getetag />
@@ -1243,6 +1257,10 @@ mod tests {
         assert!(
             xml.contains("file-23.txt") && xml.contains("getlastmodified"),
             "live property response should still include child resources and requested live props: {xml}"
+        );
+        assert!(
+            xml.contains("<D:getcontenttype>text/plain</D:getcontenttype>"),
+            "file live property response should include stored content type: {xml}"
         );
         assert_eq!(discover_calls, 0, "live props should not discover locks");
         assert_eq!(

--- a/src/webdav/transfer/mod.rs
+++ b/src/webdav/transfer/mod.rs
@@ -77,10 +77,16 @@ pub(crate) async fn handle_get_head(
         Err(resp) => return resp,
     }
 
-    let content_type = mime_guess::from_path(relative.trim_end_matches('/'))
-        .first_or_octet_stream()
-        .essence_str()
-        .to_string();
+    let content_type = meta
+        .content_type()
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+        .unwrap_or_else(|| {
+            mime_guess::from_path(relative.trim_end_matches('/'))
+                .first_or_octet_stream()
+                .essence_str()
+                .to_string()
+        });
     let range = if head_only {
         None
     } else {
@@ -120,23 +126,14 @@ pub(crate) async fn handle_get_head(
 
     // GET must stream directly from storage; do not fall back to DavFileSystem::open(read).
     let storage_started_at = Instant::now();
-    let stream = match match range {
-        Some(range) => {
-            dav_fs
-                .open_download_stream_for_file(
-                    &file,
-                    &blob,
-                    Some(range.start()),
-                    Some(range.length()),
-                )
-                .await
-        }
-        None => {
-            dav_fs
-                .open_download_stream_for_file(&file, &blob, None, None)
-                .await
-        }
-    } {
+    let (range_offset, range_length) = range
+        .as_ref()
+        .map(|range| (Some(range.start()), Some(range.length())))
+        .unwrap_or((None, None));
+    let stream = match dav_fs
+        .open_download_stream_for_file(&file, &blob, range_offset, range_length)
+        .await
+    {
         Ok(stream) => stream,
         Err(err) => return fs_error_response(err),
     };

--- a/src/webdav/transfer/mod.rs
+++ b/src/webdav/transfer/mod.rs
@@ -1,12 +1,14 @@
 //! WebDAV GET/HEAD/PUT transfer handlers.
 
+use std::time::Instant;
+
 use actix_web::http::{StatusCode, header};
 use actix_web::{HttpRequest, HttpResponse, web};
 use futures::StreamExt;
 use tokio_util::io::ReaderStream;
 
 use crate::services::file_service;
-use crate::webdav::dav::{DavFileSystem, DavLockSystem, FsError, OpenOptions};
+use crate::webdav::dav::{DavFileSystem, DavLockSystem, DavMetaData, FsError, OpenOptions};
 use crate::webdav::{
     ensure_parent_unlocked, ensure_system_file_name_allowed, ensure_unlocked, format_http_date, fs,
     fs_error_response, href_for_relative, protocol, request_origin, request_path, responses,
@@ -14,7 +16,7 @@ use crate::webdav::{
 };
 use protocol::HttpEtagPrecondition;
 
-const CHUNK_SIZE: usize = 16 * 1024;
+const CHUNK_SIZE: usize = 64 * 1024;
 
 pub(crate) async fn handle_get_head(
     req: &HttpRequest,
@@ -23,6 +25,7 @@ pub(crate) async fn handle_get_head(
     prefix: &str,
     head_only: bool,
 ) -> HttpResponse {
+    let request_started_at = Instant::now();
     let (path, relative) = match request_path(req, prefix) {
         Ok(v) => v,
         Err(resp) => return resp,
@@ -42,13 +45,15 @@ pub(crate) async fn handle_get_head(
         return resp;
     }
 
-    let meta = match dav_fs.metadata(&path).await {
-        Ok(meta) => meta,
+    let resolve_started_at = Instant::now();
+    let target = match dav_fs.resolve_download_target(&path).await {
+        Ok(target) => target,
         Err(err) => return fs_error_response(err),
     };
-    if meta.is_dir() {
+    let resolve_elapsed_ms = resolve_started_at.elapsed().as_millis();
+    let fs::AsterDavDownloadTarget::File { file, blob, meta } = target else {
         return responses::empty(StatusCode::METHOD_NOT_ALLOWED);
-    }
+    };
     let last_modified = match meta.modified() {
         Ok(modified) => modified,
         Err(err) => return fs_error_response(err),
@@ -114,17 +119,37 @@ pub(crate) async fn handle_get_head(
     }
 
     // GET must stream directly from storage; do not fall back to DavFileSystem::open(read).
+    let storage_started_at = Instant::now();
     let stream = match match range {
         Some(range) => {
             dav_fs
-                .open_read_stream_with_range(&path, Some(range.start()), Some(range.length()))
+                .open_download_stream_for_file(
+                    &file,
+                    &blob,
+                    Some(range.start()),
+                    Some(range.length()),
+                )
                 .await
         }
-        None => dav_fs.open_read_stream(&path).await,
+        None => {
+            dav_fs
+                .open_download_stream_for_file(&file, &blob, None, None)
+                .await
+        }
     } {
         Ok(stream) => stream,
         Err(err) => return fs_error_response(err),
     };
+    tracing::debug!(
+        path = %relative,
+        head_only,
+        has_range = range.is_some(),
+        content_length,
+        resolve_elapsed_ms,
+        storage_open_elapsed_ms = storage_started_at.elapsed().as_millis(),
+        total_prepare_elapsed_ms = request_started_at.elapsed().as_millis(),
+        "WebDAV GET/HEAD stream prepared"
+    );
     response.streaming(ReaderStream::with_capacity(stream, CHUNK_SIZE))
 }
 

--- a/src/webdav/transfer/mod.rs
+++ b/src/webdav/transfer/mod.rs
@@ -51,7 +51,7 @@ pub(crate) async fn handle_get_head(
         Err(err) => return fs_error_response(err),
     };
     let resolve_elapsed_ms = resolve_started_at.elapsed().as_millis();
-    let fs::AsterDavDownloadTarget::File { file, blob, meta } = target else {
+    let Some(fs::AsterDavDownloadFile { file, blob, meta }) = target else {
         return responses::empty(StatusCode::METHOD_NOT_ALLOWED);
     };
     let last_modified = match meta.modified() {

--- a/tests/performance/README.md
+++ b/tests/performance/README.md
@@ -147,6 +147,25 @@ ASTER_BENCH_WEBDAV_LIST_SIZE=10000 \
 k6 run tests/performance/k6/webdav-propfind-large.js
 ```
 
+### WebDAV Hotspot Baseline
+
+Issue `#382` recorded a local SQLite/local-filesystem baseline on 2026-07-05
+where REST 256 KiB range GET was much faster than the equivalent WebDAV range
+GET:
+
+- `download-range.js`: p95 `1.85 ms`, p99 `2.29 ms`, `1.57 GB/s`
+- `webdav-range-read.js`: p95 `106.82 ms`, p99 `114.51 ms`, `19.86 MB/s`
+- `webdav-concurrent-read.js`: p95 `120.93 ms`, p99 `132.73 ms`, `350.76 MB/s`
+- `webdav-propfind-large.js` over 10000 files: p95 `415.26 ms`, p99 `513.90 ms`
+
+When comparing before/after runs, keep the same seed data and set
+`ASTER_BENCH_SUMMARY_DIR` so each script writes a compact JSON summary. WebDAV
+GET/HEAD now emits debug fields for path resolution and storage-open time, and
+PROPFIND emits debug fields for metadata, listing collection, preload, and XML
+rendering time. Enable debug logs for `aster_drive::webdav` while running the
+k6 scripts to separate protocol overhead from storage and directory listing
+work.
+
 Mixed ramp:
 
 ```bash


### PR DESCRIPTION
## Summary
- reuse resolved WebDAV download targets and avoid repeated metadata/blob lookups for range reads
- make WebDAV auth cache hits return without password re-verification, with explicit invalidation on account/user/team membership changes
- reduce large PROPFIND overhead by avoiding unnecessary child path/blob lookups and returning getcontenttype from file metadata

## Verification
- cargo check
- cargo clippy --all-targets -- -D warnings
- cargo test --lib webdav::auth -- --nocapture
- cargo test --lib webdav::props -- --nocapture
- cargo test --test test_webdav propfind -- --nocapture
- k6 WebDAV range / PROPFIND benchmark runs

## Performance notes
- WebDAV range p95 improved from ~151 ms to ~2 ms in the local k6 scenario
- WebDAV PROPFIND 1000-file p95 improved from ~139 ms to ~44 ms in the local k6 scenario

Closes #382

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * WebDAV 目录/文件属性返回更完整，并支持返回文件内容类型（getcontenttype）。
* **性能与体验**
  * 优化 WebDAV GET/HEAD 下载与范围读取（更高效的流式读取与更稳定的元数据/响应流程）。
  * PROPFIND 进行更精细的耗时统计，减少不必要的元数据重复加载。
* **Bug 修复**
  * 团队与团队成员变更/清理后，WebDAV 相关认证缓存会更及时失效，避免旧凭据继续可用。
* **文档**
  * 更新 WebDAV 性能热点基线对比说明。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->