### PR TITLE
feat(batch): add cross-workspace copy via workspace transfer API

### DIFF
--- a/frontend-panel/src/components/common/BatchActionBar.test.tsx
+++ b/frontend-panel/src/components/common/BatchActionBar.test.tsx
@@ -12,6 +12,8 @@ const mockState = vi.hoisted(() => ({
 	batchCopy: vi.fn(),
 	batchDelete: vi.fn(),
 	clearSelection: vi.fn(),
+	copyToWorkspace: vi.fn(),
+	currentWorkspace: { kind: "personal" as const },
 	formatBatchToast: vi.fn(),
 	handleApiError: vi.fn(),
 	moveToFolder: vi.fn(),
@@ -78,13 +80,35 @@ vi.mock("@/components/files/BatchTargetFolderDialog", () => ({
 	}: {
 		mode: "copy" | "move";
 		open: boolean;
-		onConfirm: (targetFolderId: number | null) => void;
+		onConfirm: (selection: {
+			workspace: { kind: "personal" } | { kind: "team"; teamId: number };
+			folderId: number | null;
+		}) => void;
 	}) =>
 		open ? (
 			<div>
 				<div>{`target-dialog:${mode}`}</div>
-				<button type="button" onClick={() => onConfirm(99)}>
+				<button
+					type="button"
+					onClick={() =>
+						onConfirm({
+							workspace: mockState.currentWorkspace,
+							folderId: 99,
+						})
+					}
+				>
 					confirm-target
+				</button>
+				<button
+					type="button"
+					onClick={() =>
+						onConfirm({
+							workspace: { kind: "team", teamId: 9 },
+							folderId: 12,
+						})
+					}
+				>
+					confirm-team-target
 				</button>
 			</div>
 		) : null,
@@ -120,6 +144,7 @@ vi.mock("@/services/batchService", () => ({
 	batchService: {
 		batchCopy: (...args: unknown[]) => mockState.batchCopy(...args),
 		batchDelete: (...args: unknown[]) => mockState.batchDelete(...args),
+		copyToWorkspace: (...args: unknown[]) => mockState.copyToWorkspace(...args),
 	},
 }));
 
@@ -156,7 +181,7 @@ vi.mock("@/stores/fileStore", () => ({
 
 vi.mock("@/stores/workspaceStore", () => ({
 	useWorkspaceStore: {
-		getState: () => ({ workspace: { kind: "personal" } }),
+		getState: () => ({ workspace: mockState.currentWorkspace }),
 	},
 }));
 
@@ -169,6 +194,8 @@ describe("BatchActionBar", () => {
 		mockState.batchCopy.mockReset();
 		mockState.batchDelete.mockReset();
 		mockState.clearSelection.mockReset();
+		mockState.copyToWorkspace.mockReset();
+		mockState.currentWorkspace = { kind: "personal" };
 		mockState.formatBatchToast.mockReset();
 		mockState.handleApiError.mockReset();
 		mockState.moveToFolder.mockReset();
@@ -185,6 +212,11 @@ describe("BatchActionBar", () => {
 			succeeded: 3,
 		});
 		mockState.batchDelete.mockResolvedValue({
+			errors: [],
+			failed: 0,
+			succeeded: 3,
+		});
+		mockState.copyToWorkspace.mockResolvedValue({
 			errors: [],
 			failed: 0,
 			succeeded: 3,
@@ -298,7 +330,27 @@ describe("BatchActionBar", () => {
 
 		await waitFor(() => {
 			expect(mockState.batchCopy).toHaveBeenCalledWith([1, 2], [5], 99);
+			expect(mockState.copyToWorkspace).not.toHaveBeenCalled();
 		});
+		expect(mockState.clearSelection).toHaveBeenCalledTimes(1);
+		expect(mockState.refresh).toHaveBeenCalledTimes(1);
+	});
+
+	it("copies selected items to another workspace through workspace transfer", async () => {
+		render(<BatchActionBar />);
+
+		fireEvent.click(screen.getByText("copy_to"));
+		fireEvent.click(screen.getByText("confirm-team-target"));
+
+		await waitFor(() => {
+			expect(mockState.copyToWorkspace).toHaveBeenCalledWith(
+				{ kind: "team", teamId: 9 },
+				[1, 2],
+				[5],
+				12,
+			);
+		});
+		expect(mockState.batchCopy).not.toHaveBeenCalled();
 		expect(mockState.clearSelection).toHaveBeenCalledTimes(1);
 		expect(mockState.refresh).toHaveBeenCalledTimes(1);
 	});

--- a/frontend-panel/src/components/common/BatchActionBar.test.tsx
+++ b/frontend-panel/src/components/common/BatchActionBar.test.tsx
@@ -146,6 +146,34 @@ vi.mock("@/services/batchService", () => ({
 		batchDelete: (...args: unknown[]) => mockState.batchDelete(...args),
 		copyToWorkspace: (...args: unknown[]) => mockState.copyToWorkspace(...args),
 	},
+	resolveCopyDispatch: ({
+		currentWorkspace,
+		fileIds,
+		folderIds,
+		targetFolderId,
+		targetWorkspace,
+	}: {
+		currentWorkspace: { kind: "personal" } | { kind: "team"; teamId: number };
+		fileIds: number[];
+		folderIds: number[];
+		targetFolderId: number | null;
+		targetWorkspace: { kind: "personal" } | { kind: "team"; teamId: number };
+	}) => {
+		const sameWorkspace =
+			currentWorkspace.kind === targetWorkspace.kind &&
+			(currentWorkspace.kind !== "team" ||
+				(currentWorkspace.kind === "team" &&
+					targetWorkspace.kind === "team" &&
+					currentWorkspace.teamId === targetWorkspace.teamId));
+		return sameWorkspace
+			? mockState.batchCopy(fileIds, folderIds, targetFolderId)
+			: mockState.copyToWorkspace(
+					targetWorkspace,
+					fileIds,
+					folderIds,
+					targetFolderId,
+				);
+	},
 }));
 
 vi.mock("@/stores/authStore", () => ({

--- a/frontend-panel/src/components/common/BatchActionBar.tsx
+++ b/frontend-panel/src/components/common/BatchActionBar.tsx
@@ -9,8 +9,8 @@ import { handleApiError } from "@/hooks/useApiError";
 import { useConfirmDialog } from "@/hooks/useConfirmDialog";
 import { formatBatchToast } from "@/lib/formatBatchToast";
 import { beginLocalStorageDeleteMutation } from "@/lib/storageMutationCoordinator";
-import { type Workspace, workspaceEquals } from "@/lib/workspace";
-import { batchService } from "@/services/batchService";
+import type { Workspace } from "@/lib/workspace";
+import { batchService, resolveCopyDispatch } from "@/services/batchService";
 import type { BreadcrumbItem } from "@/stores/fileStore";
 import { useFileStore } from "@/stores/fileStore";
 import { useWorkspaceStore } from "@/stores/workspaceStore";
@@ -117,14 +117,13 @@ export function BatchActionBar({
 			const result =
 				targetDialogMode === "move"
 					? await moveToFolder(fileIds, folderIds, targetFolderId)
-					: workspaceEquals(currentWorkspace, targetWorkspace)
-						? await batchService.batchCopy(fileIds, folderIds, targetFolderId)
-						: await batchService.copyToWorkspace(
-								targetWorkspace,
-								fileIds,
-								folderIds,
-								targetFolderId,
-							);
+					: await resolveCopyDispatch({
+							currentWorkspace,
+							targetWorkspace,
+							fileIds,
+							folderIds,
+							targetFolderId,
+						});
 			const batchToast = formatBatchToast(t, targetDialogMode, result);
 			if (batchToast.variant === "error") {
 				toast.error(batchToast.title, { description: batchToast.description });

--- a/frontend-panel/src/components/common/BatchActionBar.tsx
+++ b/frontend-panel/src/components/common/BatchActionBar.tsx
@@ -9,6 +9,7 @@ import { handleApiError } from "@/hooks/useApiError";
 import { useConfirmDialog } from "@/hooks/useConfirmDialog";
 import { formatBatchToast } from "@/lib/formatBatchToast";
 import { beginLocalStorageDeleteMutation } from "@/lib/storageMutationCoordinator";
+import { type Workspace, workspaceEquals } from "@/lib/workspace";
 import { batchService } from "@/services/batchService";
 import type { BreadcrumbItem } from "@/stores/fileStore";
 import { useFileStore } from "@/stores/fileStore";
@@ -102,14 +103,28 @@ export function BatchActionBar({
 		}
 	};
 
-	const handleTargetConfirm = async (targetFolderId: number | null) => {
+	const handleTargetConfirm = async ({
+		workspace: targetWorkspace,
+		folderId: targetFolderId,
+	}: {
+		workspace: Workspace;
+		folderId: number | null;
+	}) => {
 		if (!targetDialogMode) return;
 
 		try {
+			const currentWorkspace = useWorkspaceStore.getState().workspace;
 			const result =
 				targetDialogMode === "move"
 					? await moveToFolder(fileIds, folderIds, targetFolderId)
-					: await batchService.batchCopy(fileIds, folderIds, targetFolderId);
+					: workspaceEquals(currentWorkspace, targetWorkspace)
+						? await batchService.batchCopy(fileIds, folderIds, targetFolderId)
+						: await batchService.copyToWorkspace(
+								targetWorkspace,
+								fileIds,
+								folderIds,
+								targetFolderId,
+							);
 			const batchToast = formatBatchToast(t, targetDialogMode, result);
 			if (batchToast.variant === "error") {
 				toast.error(batchToast.title, { description: batchToast.description });

--- a/frontend-panel/src/components/files/BatchTargetFolderDialog.test.tsx
+++ b/frontend-panel/src/components/files/BatchTargetFolderDialog.test.tsx
@@ -5,9 +5,13 @@ import { FOLDER_LIMIT } from "@/lib/constants";
 
 const mockState = vi.hoisted(() => ({
 	createFolder: vi.fn(),
+	currentWorkspace: { kind: "personal" as const },
 	handleApiError: vi.fn(),
+	ensureTeamsLoaded: vi.fn(),
 	listFolder: vi.fn(),
 	listRoot: vi.fn(),
+	teams: [] as Array<{ id: number; name: string }>,
+	teamsLoading: false,
 	translate: (key: string, opts?: Record<string, unknown>) => {
 		if (key === "files:root") return "Root";
 		if (key === "files:batch_move") return "batch-move";
@@ -15,6 +19,10 @@ const mockState = vi.hoisted(() => ({
 		if (key === "files:move_to_current_folder") return "move-here";
 		if (key === "files:copy_to_current_folder") return "copy-here";
 		if (key === "files:batch_target_folder_desc") return "target-desc";
+		if (key === "files:batch_target_workspace") return "target-workspace";
+		if (key === "files:batch_target_current_workspace") {
+			return `workspace:${opts?.name}`;
+		}
 		if (key === "files:create_folder") return "create-folder";
 		if (key === "files:folder_name") return "folder-name";
 		if (key === "files:processing") return "processing";
@@ -28,6 +36,9 @@ const mockState = vi.hoisted(() => ({
 		if (key === "files:batch_target_current_folder") {
 			return `current:${opts?.name}`;
 		}
+		if (key === "core:my_drive") return "My Drive";
+		if (key === "core:workspace_personal_label") return "Personal";
+		if (key === "core:workspace_team_label") return "Team";
 		if (key === "cancel") return "cancel";
 		return key;
 	},
@@ -145,6 +156,47 @@ vi.mock("@/components/ui/input", () => ({
 	),
 }));
 
+vi.mock("@/components/ui/select", () => ({
+	Select: ({
+		items,
+		onValueChange,
+		value,
+	}: {
+		children: React.ReactNode;
+		items: Array<{ label: string; value: string }>;
+		onValueChange?: (value: string) => void;
+		value?: string;
+	}) => (
+		<select
+			aria-label="target-workspace"
+			value={value}
+			onChange={(event) => onValueChange?.(event.currentTarget.value)}
+		>
+			{items.map((item) => (
+				<option key={item.value} value={item.value}>
+					{item.label}
+				</option>
+			))}
+		</select>
+	),
+	SelectContent: ({ children }: { children: React.ReactNode }) => (
+		<div>{children}</div>
+	),
+	SelectItem: ({
+		children,
+		value,
+	}: {
+		children: React.ReactNode;
+		value: string;
+	}) => <div data-value={value}>{children}</div>,
+	SelectTrigger: ({ children }: { children: React.ReactNode }) => (
+		<div>{children}</div>
+	),
+	SelectValue: ({ children }: { children: React.ReactNode }) => (
+		<div>{children}</div>
+	),
+}));
+
 vi.mock("@/components/ui/scroll-area", () => ({
 	ScrollArea: ({
 		children,
@@ -160,11 +212,42 @@ vi.mock("@/hooks/useApiError", () => ({
 }));
 
 vi.mock("@/services/fileService", () => ({
-	fileService: {
-		createFolder: (...args: unknown[]) => mockState.createFolder(...args),
-		listFolder: (...args: unknown[]) => mockState.listFolder(...args),
-		listRoot: (...args: unknown[]) => mockState.listRoot(...args),
-	},
+	createFileService: (workspace: unknown) => ({
+		createFolder: (...args: unknown[]) =>
+			mockState.createFolder(workspace, ...args),
+		listFolder: (...args: unknown[]) =>
+			mockState.listFolder(workspace, ...args),
+		listRoot: (...args: unknown[]) => mockState.listRoot(workspace, ...args),
+	}),
+}));
+
+vi.mock("@/stores/authStore", () => ({
+	useAuthStore: (
+		selector: (state: { user: { id: number } | null }) => unknown,
+	) => selector({ user: { id: 42 } }),
+}));
+
+vi.mock("@/stores/teamStore", () => ({
+	useTeamStore: (
+		selector: (state: {
+			teams: Array<{ id: number; name: string }>;
+			loading: boolean;
+			ensureLoaded: (userId: number | null) => Promise<void>;
+		}) => unknown,
+	) =>
+		selector({
+			teams: mockState.teams,
+			loading: mockState.teamsLoading,
+			ensureLoaded: mockState.ensureTeamsLoaded,
+		}),
+}));
+
+vi.mock("@/stores/workspaceStore", () => ({
+	useWorkspaceStore: (
+		selector: (state: {
+			workspace: { kind: "personal" } | { kind: "team"; teamId: number };
+		}) => unknown,
+	) => selector({ workspace: mockState.currentWorkspace }),
 }));
 
 const rootFolder = {
@@ -207,9 +290,14 @@ function renderDialog(
 describe("BatchTargetFolderDialog", () => {
 	beforeEach(() => {
 		mockState.createFolder.mockReset();
+		mockState.currentWorkspace = { kind: "personal" };
+		mockState.ensureTeamsLoaded.mockReset();
+		mockState.ensureTeamsLoaded.mockResolvedValue(undefined);
 		mockState.handleApiError.mockReset();
 		mockState.listFolder.mockReset();
 		mockState.listRoot.mockReset();
+		mockState.teams = [];
+		mockState.teamsLoading = false;
 		mockState.toastSuccess.mockReset();
 		mockState.createFolder.mockResolvedValue(undefined);
 		mockState.listRoot.mockResolvedValue({ folders: [] } as never);
@@ -245,10 +333,14 @@ describe("BatchTargetFolderDialog", () => {
 		fireEvent.click(rootButton);
 
 		await waitFor(() => {
-			expect(mockState.listFolder).toHaveBeenCalledWith(1, {
-				file_limit: 0,
-				folder_limit: FOLDER_LIMIT,
-			});
+			expect(mockState.listFolder).toHaveBeenCalledWith(
+				{ kind: "personal" },
+				1,
+				{
+					file_limit: 0,
+					folder_limit: FOLDER_LIMIT,
+				},
+			);
 		});
 		expect(screen.getByText("current:Projects")).toBeInTheDocument();
 
@@ -259,9 +351,61 @@ describe("BatchTargetFolderDialog", () => {
 		fireEvent.click(confirmButton);
 
 		await waitFor(() => {
-			expect(onConfirm).toHaveBeenCalledWith(1);
+			expect(onConfirm).toHaveBeenCalledWith({
+				workspace: { kind: "personal" },
+				folderId: 1,
+			});
 		});
 		expect(onOpenChange).toHaveBeenCalledWith(false);
+	});
+
+	it("lets copy targets switch workspace and resets the browser to that root", async () => {
+		mockState.teams = [{ id: 7, name: "Design Team" }];
+		mockState.listRoot
+			.mockResolvedValueOnce({ folders: [rootFolder] } as never)
+			.mockResolvedValueOnce({ folders: [draftsFolder] } as never);
+
+		const { onConfirm } = renderDialog({
+			mode: "copy",
+			currentFolderId: null,
+		});
+
+		await screen.findByRole("button", { name: "Projects" });
+		expect(mockState.ensureTeamsLoaded).toHaveBeenCalledWith(42);
+		fireEvent.change(screen.getByLabelText("target-workspace"), {
+			target: { value: "team:7" },
+		});
+
+		await waitFor(() => {
+			expect(mockState.listRoot).toHaveBeenLastCalledWith(
+				{ kind: "team", teamId: 7 },
+				{
+					file_limit: 0,
+					folder_limit: FOLDER_LIMIT,
+				},
+			);
+		});
+		expect(screen.getByText("workspace:Design Team")).toBeInTheDocument();
+		expect(screen.getByText("current:Root")).toBeInTheDocument();
+		expect(screen.getByRole("button", { name: "Drafts" })).toBeInTheDocument();
+
+		fireEvent.click(screen.getByRole("button", { name: "copy-here" }));
+
+		await waitFor(() => {
+			expect(onConfirm).toHaveBeenCalledWith({
+				workspace: { kind: "team", teamId: 7 },
+				folderId: null,
+			});
+		});
+	});
+
+	it("does not show the workspace picker for move targets", async () => {
+		mockState.teams = [{ id: 7, name: "Design Team" }];
+		renderDialog({ mode: "move" });
+
+		await screen.findByText("empty");
+		expect(screen.queryByLabelText("target-workspace")).not.toBeInTheDocument();
+		expect(mockState.ensureTeamsLoaded).not.toHaveBeenCalled();
 	});
 
 	it("blocks descendant targets and lets the user navigate back to a valid parent", async () => {
@@ -299,7 +443,10 @@ describe("BatchTargetFolderDialog", () => {
 		fireEvent.click(screen.getByRole("button", { name: "move-here" }));
 
 		await waitFor(() => {
-			expect(onConfirm).toHaveBeenCalledWith(null);
+			expect(onConfirm).toHaveBeenCalledWith({
+				workspace: { kind: "personal" },
+				folderId: null,
+			});
 		});
 		expect(onOpenChange).toHaveBeenCalledWith(false);
 	});
@@ -328,15 +475,23 @@ describe("BatchTargetFolderDialog", () => {
 		fireEvent.keyDown(input, { key: "Enter" });
 
 		await waitFor(() => {
-			expect(mockState.createFolder).toHaveBeenCalledWith("Drafts", 5);
+			expect(mockState.createFolder).toHaveBeenCalledWith(
+				{ kind: "personal" },
+				"Drafts",
+				5,
+			);
 		});
 		expect(mockState.toastSuccess).toHaveBeenCalledWith("folder-created");
 
 		await waitFor(() => {
-			expect(mockState.listFolder).toHaveBeenLastCalledWith(5, {
-				file_limit: 0,
-				folder_limit: FOLDER_LIMIT,
-			});
+			expect(mockState.listFolder).toHaveBeenLastCalledWith(
+				{ kind: "personal" },
+				5,
+				{
+					file_limit: 0,
+					folder_limit: FOLDER_LIMIT,
+				},
+			);
 		});
 		expect(
 			screen.queryByPlaceholderText("folder-name"),

--- a/frontend-panel/src/components/files/BatchTargetFolderDialog.tsx
+++ b/frontend-panel/src/components/files/BatchTargetFolderDialog.tsx
@@ -17,26 +17,64 @@ import {
 import { Button } from "@/components/ui/button";
 import { Icon } from "@/components/ui/icon";
 import { Input } from "@/components/ui/input";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/components/ui/select";
 import { handleApiError } from "@/hooks/useApiError";
 import { usePendingAction } from "@/hooks/usePendingAction";
 import { FOLDER_LIMIT } from "@/lib/constants";
 import { isImeComposingKeyEvent } from "@/lib/keyboard";
 import { cn } from "@/lib/utils";
-import { fileService } from "@/services/fileService";
+import {
+	isTeamWorkspace,
+	PERSONAL_WORKSPACE,
+	type Workspace,
+	workspaceEquals,
+	workspaceKey,
+} from "@/lib/workspace";
+import { createFileService } from "@/services/fileService";
+import { useAuthStore } from "@/stores/authStore";
 import type { BreadcrumbItem as FileBreadcrumbItem } from "@/stores/fileStore";
+import { useTeamStore } from "@/stores/teamStore";
+import { useWorkspaceStore } from "@/stores/workspaceStore";
 import type { FolderListItem } from "@/types/api";
 
 const EMPTY_SELECTED_FOLDER_IDS: number[] = [];
+
+export interface BatchTargetFolderSelection {
+	workspace: Workspace;
+	folderId: number | null;
+}
 
 interface BatchTargetFolderDialogProps {
 	open: boolean;
 	onOpenChange: (open: boolean) => void;
 	onOpenChangeComplete?: (open: boolean) => void;
 	mode: "move" | "copy";
-	onConfirm: (targetFolderId: number | null) => Promise<void>;
+	onConfirm: (selection: BatchTargetFolderSelection) => Promise<void>;
 	currentFolderId: number | null;
 	initialBreadcrumb: FileBreadcrumbItem[];
 	selectedFolderIds?: number[];
+}
+
+interface WorkspaceOption {
+	workspace: Workspace;
+	value: string;
+	label: string;
+	meta: string;
+}
+
+function workspaceFromKey(value: string): Workspace | null {
+	if (value === "personal") return PERSONAL_WORKSPACE;
+	const teamId = Number(value.replace("team:", ""));
+	if (Number.isSafeInteger(teamId) && teamId > 0) {
+		return { kind: "team", teamId };
+	}
+	return null;
 }
 
 export function BatchTargetFolderDialog({
@@ -50,6 +88,11 @@ export function BatchTargetFolderDialog({
 	selectedFolderIds = EMPTY_SELECTED_FOLDER_IDS,
 }: BatchTargetFolderDialogProps) {
 	const { t } = useTranslation(["files", "core"]);
+	const currentWorkspace = useWorkspaceStore((state) => state.workspace);
+	const user = useAuthStore((state) => state.user);
+	const teams = useTeamStore((state) => state.teams);
+	const teamsLoading = useTeamStore((state) => state.loading);
+	const ensureTeamsLoaded = useTeamStore((state) => state.ensureLoaded);
 	const [loading, setLoading] = useState(false);
 	const { pending: submitting, runWithPending: runConfirmWithPending } =
 		usePendingAction();
@@ -61,6 +104,8 @@ export function BatchTargetFolderDialog({
 	const [newFolderName, setNewFolderName] = useState("");
 	const [folders, setFolders] = useState<FolderListItem[]>([]);
 	const [activeFolderId, setActiveFolderId] = useState<number | null>(null);
+	const [targetWorkspace, setTargetWorkspace] =
+		useState<Workspace>(currentWorkspace);
 	const createFolderInputComposingRef = useRef(false);
 	const createFolderInputCompositionEndAtRef = useRef(0);
 	const [breadcrumb, setBreadcrumb] = useState<FileBreadcrumbItem[]>([
@@ -89,22 +134,60 @@ export function BatchTargetFolderDialog({
 		[mode, t],
 	);
 
-	const loadFolder = useCallback(async (folderId: number | null) => {
-		setLoading(true);
-		try {
-			const folderOnlyParams = { file_limit: 0, folder_limit: FOLDER_LIMIT };
-			const contents =
-				folderId === null
-					? await fileService.listRoot(folderOnlyParams)
-					: await fileService.listFolder(folderId, folderOnlyParams);
-			setFolders(contents.folders);
-			setActiveFolderId(folderId);
-		} catch (error) {
-			handleApiError(error);
-		} finally {
-			setLoading(false);
-		}
-	}, []);
+	const workspaceOptions = useMemo<WorkspaceOption[]>(() => {
+		const options: WorkspaceOption[] = [
+			{
+				workspace: PERSONAL_WORKSPACE,
+				value: "personal",
+				label: t("core:my_drive"),
+				meta: t("core:workspace_personal_label"),
+			},
+		];
+		const teamById = new Map(teams.map((team) => [team.id, team]));
+		const addTeamOption = (teamId: number) => {
+			if (options.some((option) => option.value === `team:${teamId}`)) return;
+			const team = teamById.get(teamId);
+			options.push({
+				workspace: { kind: "team", teamId },
+				value: `team:${teamId}`,
+				label: team?.name ?? t("core:workspace_team_fallback", { id: teamId }),
+				meta: t("core:workspace_team_label"),
+			});
+		};
+
+		for (const team of teams) addTeamOption(team.id);
+		if (isTeamWorkspace(currentWorkspace))
+			addTeamOption(currentWorkspace.teamId);
+		if (isTeamWorkspace(targetWorkspace)) addTeamOption(targetWorkspace.teamId);
+
+		return options;
+	}, [currentWorkspace, targetWorkspace, teams, t]);
+
+	const targetWorkspaceValue = workspaceKey(targetWorkspace);
+	const targetWorkspaceLabel =
+		workspaceOptions.find((option) => option.value === targetWorkspaceValue)
+			?.label ?? t("core:my_drive");
+
+	const loadFolder = useCallback(
+		async (workspace: Workspace, folderId: number | null) => {
+			setLoading(true);
+			try {
+				const folderOnlyParams = { file_limit: 0, folder_limit: FOLDER_LIMIT };
+				const targetFileService = createFileService(workspace);
+				const contents =
+					folderId === null
+						? await targetFileService.listRoot(folderOnlyParams)
+						: await targetFileService.listFolder(folderId, folderOnlyParams);
+				setFolders(contents.folders);
+				setActiveFolderId(folderId);
+			} catch (error) {
+				handleApiError(error);
+			} finally {
+				setLoading(false);
+			}
+		},
+		[],
+	);
 
 	useEffect(() => {
 		if (!open) return;
@@ -118,10 +201,35 @@ export function BatchTargetFolderDialog({
 				: [{ id: null, name: t("files:root") }];
 
 		setBreadcrumb(normalizedBreadcrumb);
+		setTargetWorkspace(currentWorkspace);
 		setShowCreateFolder(false);
 		setNewFolderName("");
-		loadFolder(currentFolderId);
-	}, [open, currentFolderId, initialBreadcrumb, loadFolder, t]);
+		loadFolder(currentWorkspace, currentFolderId);
+	}, [
+		open,
+		currentFolderId,
+		currentWorkspace,
+		initialBreadcrumb,
+		loadFolder,
+		t,
+	]);
+
+	useEffect(() => {
+		if (!open || mode !== "copy") return;
+		ensureTeamsLoaded(user?.id ?? null).catch(handleApiError);
+	}, [ensureTeamsLoaded, mode, open, user?.id]);
+
+	const handleWorkspaceChange = async (value: string | null) => {
+		if (!value) return;
+		const nextWorkspace = workspaceFromKey(value);
+		if (!nextWorkspace || workspaceEquals(nextWorkspace, targetWorkspace))
+			return;
+		setTargetWorkspace(nextWorkspace);
+		setBreadcrumb([{ id: null, name: t("files:root") }]);
+		setShowCreateFolder(false);
+		setNewFolderName("");
+		await loadFolder(nextWorkspace, null);
+	};
 
 	const navigateTo = async (folder: FolderListItem) => {
 		const existingIndex = breadcrumb.findIndex((item) => item.id === folder.id);
@@ -130,7 +238,7 @@ export function BatchTargetFolderDialog({
 		} else {
 			setBreadcrumb((prev) => [...prev, { id: folder.id, name: folder.name }]);
 		}
-		await loadFolder(folder.id);
+		await loadFolder(targetWorkspace, folder.id);
 	};
 
 	const navigateBreadcrumb = async (
@@ -138,7 +246,7 @@ export function BatchTargetFolderDialog({
 		index: number,
 	) => {
 		setBreadcrumb((prev) => prev.slice(0, index + 1));
-		await loadFolder(item.id);
+		await loadFolder(targetWorkspace, item.id);
 	};
 
 	const handleGoUp = async () => {
@@ -152,6 +260,7 @@ export function BatchTargetFolderDialog({
 		.filter((id): id is number => id !== null);
 
 	const validationMessage =
+		workspaceEquals(targetWorkspace, currentWorkspace) &&
 		renderedSelectedFolderIds.length > 0 &&
 		renderedSelectedFolderIds.some((folderId) =>
 			targetPathIds.includes(folderId),
@@ -164,11 +273,12 @@ export function BatchTargetFolderDialog({
 		if (!trimmedName) return;
 		await runCreateFolderWithPending(async () => {
 			try {
-				await fileService.createFolder(trimmedName, activeFolderId);
+				const targetFileService = createFileService(targetWorkspace);
+				await targetFileService.createFolder(trimmedName, activeFolderId);
 				toast.success(t("files:create_folder_success"));
 				setNewFolderName("");
 				setShowCreateFolder(false);
-				await loadFolder(activeFolderId);
+				await loadFolder(targetWorkspace, activeFolderId);
 			} catch (error) {
 				handleApiError(error);
 			}
@@ -178,12 +288,66 @@ export function BatchTargetFolderDialog({
 	const handleConfirm = async () => {
 		if (validationMessage) return;
 		await runConfirmWithPending(async () => {
-			await onConfirm(activeFolderId);
+			await onConfirm({ workspace: targetWorkspace, folderId: activeFolderId });
 			onOpenChange(false);
 		});
 	};
 	const controls = (
 		<div className="space-y-3">
+			{mode === "copy" && (
+				<div className="space-y-1.5">
+					<label
+						htmlFor="batch-target-workspace"
+						className="text-xs font-medium text-muted-foreground"
+					>
+						{t("files:batch_target_workspace")}
+					</label>
+					<Select
+						items={workspaceOptions.map((option) => ({
+							label: option.label,
+							value: option.value,
+						}))}
+						value={targetWorkspaceValue}
+						onValueChange={(value) => {
+							void handleWorkspaceChange(value);
+						}}
+					>
+						<SelectTrigger id="batch-target-workspace">
+							<SelectValue>
+								<span className="flex min-w-0 items-center gap-2">
+									<Icon
+										name={isTeamWorkspace(targetWorkspace) ? "Cloud" : "House"}
+										className="size-3.5 shrink-0 text-muted-foreground"
+									/>
+									<span className="truncate">{targetWorkspaceLabel}</span>
+									{teamsLoading && (
+										<Icon
+											name="Spinner"
+											className="size-3.5 shrink-0 animate-spin text-muted-foreground"
+										/>
+									)}
+								</span>
+							</SelectValue>
+						</SelectTrigger>
+						<SelectContent>
+							{workspaceOptions.map((option) => (
+								<SelectItem key={option.value} value={option.value}>
+									<Icon
+										name={isTeamWorkspace(option.workspace) ? "Cloud" : "House"}
+										className="size-3.5 text-muted-foreground"
+									/>
+									<span className="min-w-0">
+										<span className="block truncate">{option.label}</span>
+										<span className="block truncate text-[11px] text-muted-foreground">
+											{option.meta}
+										</span>
+									</span>
+								</SelectItem>
+							))}
+						</SelectContent>
+					</Select>
+				</div>
+			)}
 			<div className="flex items-center justify-between gap-3">
 				<Breadcrumb>
 					<BreadcrumbList>
@@ -303,6 +467,13 @@ export function BatchTargetFolderDialog({
 										breadcrumb[breadcrumb.length - 1]?.name ?? t("files:root"),
 								})}
 							</div>
+							{mode === "copy" && (
+								<div>
+									{t("files:batch_target_current_workspace", {
+										name: targetWorkspaceLabel,
+									})}
+								</div>
+							)}
 							{validationMessage && (
 								<div className="text-destructive">{validationMessage}</div>
 							)}

--- a/frontend-panel/src/i18n/locales/en/files/batch.json
+++ b/frontend-panel/src/i18n/locales/en/files/batch.json
@@ -8,6 +8,8 @@
 	"batch_move": "Move Selected",
 	"batch_copy": "Copy Selected",
 	"batch_target_folder_desc": "Choose the destination folder for the selected items.",
+	"batch_target_workspace": "Destination workspace",
+	"batch_target_current_workspace": "Workspace: {{name}}",
 	"batch_target_current_folder": "Current destination: {{name}}",
 	"batch_target_current_folder_hint": "Confirm to place the selected items in this folder.",
 	"batch_target_back": "Go up",

--- a/frontend-panel/src/i18n/locales/zh/files/batch.json
+++ b/frontend-panel/src/i18n/locales/zh/files/batch.json
@@ -8,6 +8,8 @@
 	"batch_move": "移动所选",
 	"batch_copy": "复制所选",
 	"batch_target_folder_desc": "请选择要移动或复制到的目标文件夹。",
+	"batch_target_workspace": "目标工作空间",
+	"batch_target_current_workspace": "工作空间：{{name}}",
 	"batch_target_current_folder": "当前目标：{{name}}",
 	"batch_target_current_folder_hint": "确认后会把所选项目放到这个目录。",
 	"batch_target_back": "返回上一级",

--- a/frontend-panel/src/pages/FileBrowserPage.test.tsx
+++ b/frontend-panel/src/pages/FileBrowserPage.test.tsx
@@ -1020,6 +1020,23 @@ vi.mock("@/services/batchService", () => ({
 		streamArchiveDownload: (...args: unknown[]) =>
 			mockState.streamArchiveDownload(...args),
 	},
+	resolveCopyDispatch: ({
+		fileIds,
+		folderIds,
+		targetFolderId,
+		targetWorkspace,
+	}: {
+		fileIds: number[];
+		folderIds: number[];
+		targetFolderId: number | null;
+		targetWorkspace: { kind: "personal" } | { kind: "team"; teamId: number };
+	}) =>
+		mockState.copyToWorkspace(
+			targetWorkspace,
+			fileIds,
+			folderIds,
+			targetFolderId,
+		),
 }));
 
 vi.mock("@/services/fileService", () => ({
@@ -1283,11 +1300,20 @@ describe("FileBrowserPage", () => {
 		mockState.getArchivePreview.mockResolvedValue({ entries: [] });
 		mockState.createPreviewLink.mockResolvedValue("preview-link");
 		mockState.createWopiSession.mockResolvedValue({ session: "wopi" });
-		mockState.formatBatchToast.mockImplementation((_t, action: string) => ({
-			description: `${action}:desc`,
-			title: `${action}:ok`,
-			variant: "success",
-		}));
+		mockState.formatBatchToast.mockImplementation(
+			(_t, action: string, result?: { failed?: number }) =>
+				result?.failed
+					? {
+							description: `${action}:error-desc`,
+							title: `${action}:error`,
+							variant: "error",
+						}
+					: {
+							description: `${action}:desc`,
+							title: `${action}:ok`,
+							variant: "success",
+						},
+		);
 		mockState.refreshUser.mockResolvedValue(undefined);
 		mockState.readInternalDragData.mockReturnValue(null);
 
@@ -1824,7 +1850,57 @@ describe("FileBrowserPage", () => {
 			);
 		});
 		expect(mockState.copyFile).not.toHaveBeenCalled();
-		expect(mockState.toastSuccess).toHaveBeenCalledWith("copy_success");
+		expect(mockState.formatBatchToast).toHaveBeenCalledWith(
+			expect.any(Function),
+			"copy",
+			expect.objectContaining({ succeeded: 1, failed: 0 }),
+		);
+		expect(mockState.toastSuccess).toHaveBeenCalledWith("copy:ok", {
+			description: "copy:desc",
+		});
+		expect(mockState.store.refresh).toHaveBeenCalledTimes(1);
+	});
+
+	it("shows an error toast when single-item workspace transfer reports failures", async () => {
+		mockState.copyToWorkspace.mockResolvedValueOnce({
+			errors: [
+				{
+					entity_id: 9,
+					entity_type: "file",
+					message: "copy failed",
+				},
+			],
+			failed: 1,
+			succeeded: 0,
+		});
+
+		render(<FileBrowserPage />);
+
+		fireEvent.click(screen.getByRole("button", { name: "copy-file" }));
+		expect(await screen.findByText("batch-dialog:copy")).toBeInTheDocument();
+		fireEvent.click(
+			screen.getByRole("button", { name: "confirm-team-batch-dialog" }),
+		);
+
+		await waitFor(() => {
+			expect(mockState.copyToWorkspace).toHaveBeenCalledWith(
+				{ kind: "team", teamId: 9 },
+				[9],
+				[],
+				21,
+			);
+		});
+		expect(mockState.formatBatchToast).toHaveBeenCalledWith(
+			expect.any(Function),
+			"copy",
+			expect.objectContaining({ failed: 1, succeeded: 0 }),
+		);
+		expect(mockState.toastError).toHaveBeenCalledWith("copy:error", {
+			description: "copy:error-desc",
+		});
+		expect(mockState.toastSuccess).not.toHaveBeenCalledWith("copy:ok", {
+			description: "copy:desc",
+		});
 		expect(mockState.store.refresh).toHaveBeenCalledTimes(1);
 	});
 

--- a/frontend-panel/src/pages/FileBrowserPage.test.tsx
+++ b/frontend-panel/src/pages/FileBrowserPage.test.tsx
@@ -17,6 +17,7 @@ import FileBrowserPage from "@/pages/FileBrowserPage";
 
 const mockState = vi.hoisted(() => ({
 	batchDelete: vi.fn(),
+	copyToWorkspace: vi.fn(),
 	createArchiveCompressTask: vi.fn(),
 	createArchiveExtractTask: vi.fn(),
 	copyFile: vi.fn(),
@@ -497,14 +498,36 @@ vi.mock("@/components/files/BatchTargetFolderDialog", () => ({
 	}: {
 		onOpenChange?: (open: boolean) => void;
 		mode: string;
-		onConfirm: (targetFolderId: number | null) => Promise<void>;
+		onConfirm: (selection: {
+			workspace: { kind: "personal" } | { kind: "team"; teamId: number };
+			folderId: number | null;
+		}) => Promise<void>;
 		open: boolean;
 	}) =>
 		open ? (
 			<div>
 				<div>{`batch-dialog:${mode}`}</div>
-				<button type="button" onClick={() => void onConfirm(20)}>
+				<button
+					type="button"
+					onClick={() =>
+						void onConfirm({
+							workspace: mockState.workspace,
+							folderId: 20,
+						})
+					}
+				>
 					confirm-batch-dialog
+				</button>
+				<button
+					type="button"
+					onClick={() =>
+						void onConfirm({
+							workspace: { kind: "team", teamId: 9 },
+							folderId: 21,
+						})
+					}
+				>
+					confirm-team-batch-dialog
 				</button>
 				<button type="button" onClick={() => onOpenChange?.(false)}>
 					{`close-batch-dialog:${mode}`}
@@ -991,6 +1014,7 @@ vi.mock("@/lib/utils", () => ({
 vi.mock("@/services/batchService", () => ({
 	batchService: {
 		batchDelete: (...args: unknown[]) => mockState.batchDelete(...args),
+		copyToWorkspace: (...args: unknown[]) => mockState.copyToWorkspace(...args),
 		createArchiveCompressTask: (...args: unknown[]) =>
 			mockState.createArchiveCompressTask(...args),
 		streamArchiveDownload: (...args: unknown[]) =>
@@ -1152,6 +1176,7 @@ describe("FileBrowserPage", () => {
 		mockState.createArchiveExtractTask.mockReset();
 		mockState.copyFile.mockReset();
 		mockState.copyFolder.mockReset();
+		mockState.copyToWorkspace.mockReset();
 		mockState.getArchivePreview.mockReset();
 		mockState.createPreviewLink.mockReset();
 		mockState.createWopiSession.mockReset();
@@ -1250,6 +1275,11 @@ describe("FileBrowserPage", () => {
 		});
 		mockState.copyFile.mockResolvedValue(undefined);
 		mockState.copyFolder.mockResolvedValue(undefined);
+		mockState.copyToWorkspace.mockResolvedValue({
+			errors: [],
+			failed: 0,
+			succeeded: 1,
+		});
 		mockState.getArchivePreview.mockResolvedValue({ entries: [] });
 		mockState.createPreviewLink.mockResolvedValue("preview-link");
 		mockState.createWopiSession.mockResolvedValue({ session: "wopi" });
@@ -1773,6 +1803,29 @@ describe("FileBrowserPage", () => {
 			expect(mockState.copyFolder).toHaveBeenCalledWith(10, 20);
 		});
 		expect(mockState.store.refresh).toHaveBeenCalledTimes(2);
+	});
+
+	it("copies a single item to another workspace through workspace transfer", async () => {
+		render(<FileBrowserPage />);
+
+		fireEvent.click(screen.getByRole("button", { name: "copy-file" }));
+		expect(await screen.findByText("batch-dialog:copy")).toBeInTheDocument();
+
+		fireEvent.click(
+			screen.getByRole("button", { name: "confirm-team-batch-dialog" }),
+		);
+
+		await waitFor(() => {
+			expect(mockState.copyToWorkspace).toHaveBeenCalledWith(
+				{ kind: "team", teamId: 9 },
+				[9],
+				[],
+				21,
+			);
+		});
+		expect(mockState.copyFile).not.toHaveBeenCalled();
+		expect(mockState.toastSuccess).toHaveBeenCalledWith("copy_success");
+		expect(mockState.store.refresh).toHaveBeenCalledTimes(1);
 	});
 
 	it("opens the share dialog with the mode implied by the chosen menu entry", async () => {

--- a/frontend-panel/src/pages/ShareViewPage.test.tsx
+++ b/frontend-panel/src/pages/ShareViewPage.test.tsx
@@ -241,6 +241,10 @@ class MockIntersectionObserver {
 }
 
 vi.mock("react-i18next", () => ({
+	initReactI18next: {
+		type: "3rdParty",
+		init: vi.fn(),
+	},
 	useTranslation: () => ({
 		t: mockState.translate,
 	}),

--- a/frontend-panel/src/pages/file-browser/FileBrowserDialogs.tsx
+++ b/frontend-panel/src/pages/file-browser/FileBrowserDialogs.tsx
@@ -1,4 +1,5 @@
 import { Suspense } from "react";
+import type { BatchTargetFolderSelection } from "@/components/files/BatchTargetFolderDialog";
 import { FilePreview } from "@/components/files/FilePreview";
 import type { ImagePreviewNavigation } from "@/components/files/preview/navigation/imagePreviewNavigation";
 import type { FilePreviewResources } from "@/components/files/preview/resources/filePreviewResources";
@@ -51,7 +52,7 @@ interface FileBrowserDialogsProps {
 		filenameEncoding?: ArchiveFilenameEncoding,
 	) => Promise<void>;
 	onCopyClose: () => void;
-	onCopyConfirm: (targetFolderId: number | null) => Promise<void>;
+	onCopyConfirm: (selection: BatchTargetFolderSelection) => Promise<void>;
 	onCreateFileOpenChange: (open: boolean) => void;
 	onCreateFolderOpenChange: (open: boolean) => void;
 	onFolderPolicyClose: () => void;
@@ -279,7 +280,7 @@ export function FileBrowserDialogs({
 					}}
 					onOpenChangeComplete={handleMoveOpenChangeComplete}
 					mode="move"
-					onConfirm={onMoveConfirm}
+					onConfirm={({ folderId }) => onMoveConfirm(folderId)}
 					currentFolderId={currentFolderId}
 					initialBreadcrumb={breadcrumb}
 					selectedFolderIds={retainedMoveTarget?.folderIds ?? []}

--- a/frontend-panel/src/pages/file-browser/useFileBrowserBatchActions.test.tsx
+++ b/frontend-panel/src/pages/file-browser/useFileBrowserBatchActions.test.tsx
@@ -147,6 +147,34 @@ vi.mock("@/services/batchService", () => ({
 		batchDelete: (...args: unknown[]) => mockState.batchDelete(...args),
 		copyToWorkspace: (...args: unknown[]) => mockState.copyToWorkspace(...args),
 	},
+	resolveCopyDispatch: ({
+		currentWorkspace,
+		fileIds,
+		folderIds,
+		targetFolderId,
+		targetWorkspace,
+	}: {
+		currentWorkspace: { kind: "personal" } | { kind: "team"; teamId: number };
+		fileIds: number[];
+		folderIds: number[];
+		targetFolderId: number | null;
+		targetWorkspace: { kind: "personal" } | { kind: "team"; teamId: number };
+	}) => {
+		const sameWorkspace =
+			currentWorkspace.kind === targetWorkspace.kind &&
+			(currentWorkspace.kind !== "team" ||
+				(currentWorkspace.kind === "team" &&
+					targetWorkspace.kind === "team" &&
+					currentWorkspace.teamId === targetWorkspace.teamId));
+		return sameWorkspace
+			? mockState.batchCopy(fileIds, folderIds, targetFolderId)
+			: mockState.copyToWorkspace(
+					targetWorkspace,
+					fileIds,
+					folderIds,
+					targetFolderId,
+				);
+	},
 }));
 
 vi.mock("@/stores/authStore", () => ({

--- a/frontend-panel/src/pages/file-browser/useFileBrowserBatchActions.test.tsx
+++ b/frontend-panel/src/pages/file-browser/useFileBrowserBatchActions.test.tsx
@@ -10,6 +10,8 @@ const mockState = vi.hoisted(() => ({
 	batchCopy: vi.fn(),
 	batchDelete: vi.fn(),
 	clearSelection: vi.fn(),
+	copyToWorkspace: vi.fn(),
+	currentWorkspace: { kind: "personal" as const },
 	formatBatchToast: vi.fn(),
 	handleApiError: vi.fn(),
 	moveToFolder: vi.fn(),
@@ -69,13 +71,37 @@ vi.mock("@/components/files/BatchTargetFolderDialog", () => ({
 		open,
 	}: {
 		mode: "move" | "copy";
-		onConfirm: (targetFolderId: number | null) => Promise<void>;
+		onConfirm: (selection: {
+			workspace: { kind: "personal" } | { kind: "team"; teamId: number };
+			folderId: number | null;
+		}) => Promise<void>;
 		open: boolean;
 	}) =>
 		open ? (
-			<button type="button" onClick={() => void onConfirm(99)}>
-				{`confirm-target:${mode}`}
-			</button>
+			<div>
+				<button
+					type="button"
+					onClick={() =>
+						void onConfirm({
+							workspace: mockState.currentWorkspace,
+							folderId: 99,
+						})
+					}
+				>
+					{`confirm-target:${mode}`}
+				</button>
+				<button
+					type="button"
+					onClick={() =>
+						void onConfirm({
+							workspace: { kind: "team", teamId: 11 },
+							folderId: 22,
+						})
+					}
+				>
+					{`confirm-team-target:${mode}`}
+				</button>
+			</div>
 		) : null,
 }));
 
@@ -119,6 +145,7 @@ vi.mock("@/services/batchService", () => ({
 	batchService: {
 		batchCopy: (...args: unknown[]) => mockState.batchCopy(...args),
 		batchDelete: (...args: unknown[]) => mockState.batchDelete(...args),
+		copyToWorkspace: (...args: unknown[]) => mockState.copyToWorkspace(...args),
 	},
 }));
 
@@ -140,7 +167,7 @@ vi.mock("@/stores/workspaceStore", () => ({
 		factory: (workspace: { kind: "personal" }) => unknown,
 	) => factory({ kind: "personal" }),
 	useWorkspaceStore: {
-		getState: () => ({ workspace: { kind: "personal" } }),
+		getState: () => ({ workspace: mockState.currentWorkspace }),
 	},
 }));
 
@@ -249,6 +276,8 @@ describe("useFileBrowserBatchActions", () => {
 		mockState.batchCopy.mockReset();
 		mockState.batchDelete.mockReset();
 		mockState.clearSelection.mockReset();
+		mockState.copyToWorkspace.mockReset();
+		mockState.currentWorkspace = { kind: "personal" };
 		mockState.formatBatchToast.mockReset();
 		mockState.handleApiError.mockReset();
 		mockState.moveToFolder.mockReset();
@@ -267,6 +296,11 @@ describe("useFileBrowserBatchActions", () => {
 			succeeded: 3,
 		});
 		mockState.batchDelete.mockResolvedValue({
+			errors: [],
+			failed: 0,
+			succeeded: 3,
+		});
+		mockState.copyToWorkspace.mockResolvedValue({
 			errors: [],
 			failed: 0,
 			succeeded: 3,
@@ -473,6 +507,31 @@ describe("useFileBrowserBatchActions", () => {
 		await waitFor(() => {
 			expect(mockState.batchCopy).toHaveBeenCalledWith([1, 2], [5], 99);
 		});
+		expect(mockState.copyToWorkspace).not.toHaveBeenCalled();
+		expect(mockState.clearSelection).toHaveBeenCalledTimes(1);
+		expect(mockState.refresh).toHaveBeenCalledTimes(1);
+	});
+
+	it("copies selected items to a different workspace through workspace transfer", async () => {
+		mockState.selectedFileIds = new Set([1, 2]);
+		mockState.selectedFolderIds = new Set([5]);
+		mockStore.selectedFileIds = mockState.selectedFileIds;
+		mockStore.selectedFolderIds = mockState.selectedFolderIds;
+
+		render(<Harness />);
+
+		fireEvent.click(screen.getByText("copy-selected"));
+		fireEvent.click(screen.getByText("confirm-team-target:copy"));
+
+		await waitFor(() => {
+			expect(mockState.copyToWorkspace).toHaveBeenCalledWith(
+				{ kind: "team", teamId: 11 },
+				[1, 2],
+				[5],
+				22,
+			);
+		});
+		expect(mockState.batchCopy).not.toHaveBeenCalled();
 		expect(mockState.clearSelection).toHaveBeenCalledTimes(1);
 		expect(mockState.refresh).toHaveBeenCalledTimes(1);
 	});

--- a/frontend-panel/src/pages/file-browser/useFileBrowserBatchActions.tsx
+++ b/frontend-panel/src/pages/file-browser/useFileBrowserBatchActions.tsx
@@ -17,8 +17,8 @@ import { handleApiError } from "@/hooks/useApiError";
 import { useConfirmDialog } from "@/hooks/useConfirmDialog";
 import { formatBatchToast } from "@/lib/formatBatchToast";
 import { beginLocalStorageDeleteMutation } from "@/lib/storageMutationCoordinator";
-import { type Workspace, workspaceEquals } from "@/lib/workspace";
-import { batchService } from "@/services/batchService";
+import type { Workspace } from "@/lib/workspace";
+import { batchService, resolveCopyDispatch } from "@/services/batchService";
 import { useFileStore } from "@/stores/fileStore";
 import { useWorkspaceStore } from "@/stores/workspaceStore";
 import type { BatchResult, FileListItem, FolderListItem } from "@/types/api";
@@ -233,14 +233,13 @@ export function useFileBrowserBatchActions({
 								folderIds,
 								targetFolderId,
 							)
-						: workspaceEquals(currentWorkspace, targetWorkspace)
-							? await batchService.batchCopy(fileIds, folderIds, targetFolderId)
-							: await batchService.copyToWorkspace(
-									targetWorkspace,
-									fileIds,
-									folderIds,
-									targetFolderId,
-								);
+						: await resolveCopyDispatch({
+								currentWorkspace,
+								targetWorkspace,
+								fileIds,
+								folderIds,
+								targetFolderId,
+							});
 				const batchToast = formatBatchToast(t, targetDialogMode, result);
 				if (batchToast.variant === "error") {
 					toast.error(batchToast.title, {

--- a/frontend-panel/src/pages/file-browser/useFileBrowserBatchActions.tsx
+++ b/frontend-panel/src/pages/file-browser/useFileBrowserBatchActions.tsx
@@ -17,6 +17,7 @@ import { handleApiError } from "@/hooks/useApiError";
 import { useConfirmDialog } from "@/hooks/useConfirmDialog";
 import { formatBatchToast } from "@/lib/formatBatchToast";
 import { beginLocalStorageDeleteMutation } from "@/lib/storageMutationCoordinator";
+import { type Workspace, workspaceEquals } from "@/lib/workspace";
 import { batchService } from "@/services/batchService";
 import { useFileStore } from "@/stores/fileStore";
 import { useWorkspaceStore } from "@/stores/workspaceStore";
@@ -212,10 +213,17 @@ export function useFileBrowserBatchActions({
 	]);
 
 	const handleTargetConfirm = useCallback(
-		async (targetFolderId: number | null) => {
+		async ({
+			workspace: targetWorkspace,
+			folderId: targetFolderId,
+		}: {
+			workspace: Workspace;
+			folderId: number | null;
+		}) => {
 			if (!targetDialogMode) return;
 
 			try {
+				const currentWorkspace = useWorkspaceStore.getState().workspace;
 				const customMoveHandler =
 					targetDialogMode === "move" ? onMoveToFolder : undefined;
 				const result =
@@ -225,7 +233,14 @@ export function useFileBrowserBatchActions({
 								folderIds,
 								targetFolderId,
 							)
-						: await batchService.batchCopy(fileIds, folderIds, targetFolderId);
+						: workspaceEquals(currentWorkspace, targetWorkspace)
+							? await batchService.batchCopy(fileIds, folderIds, targetFolderId)
+							: await batchService.copyToWorkspace(
+									targetWorkspace,
+									fileIds,
+									folderIds,
+									targetFolderId,
+								);
 				const batchToast = formatBatchToast(t, targetDialogMode, result);
 				if (batchToast.variant === "error") {
 					toast.error(batchToast.title, {

--- a/frontend-panel/src/pages/file-browser/useFileBrowserPageState.ts
+++ b/frontend-panel/src/pages/file-browser/useFileBrowserPageState.ts
@@ -5,6 +5,7 @@ import { toast } from "sonner";
 import type { BatchTargetFolderSelection } from "@/components/files/BatchTargetFolderDialog";
 import type { TagManagerTarget } from "@/components/files/TagManagerDialog";
 import { handleApiError } from "@/hooks/useApiError";
+import { formatBatchToast } from "@/lib/formatBatchToast";
 import { workspaceEquals } from "@/lib/workspace";
 import {
 	BatchTargetFolderDialog,
@@ -21,7 +22,7 @@ import type {
 	FileBrowserShareTarget,
 	FileBrowserVersionTarget,
 } from "@/pages/file-browser/types";
-import { batchService } from "@/services/batchService";
+import { resolveCopyDispatch } from "@/services/batchService";
 import { fileService } from "@/services/fileService";
 import { useFileStore } from "@/stores/fileStore";
 import { useWorkspaceStore } from "@/stores/workspaceStore";
@@ -206,18 +207,30 @@ export function useFileBrowserPageState({
 			try {
 				const currentWorkspace = useWorkspaceStore.getState().workspace;
 				if (!workspaceEquals(currentWorkspace, targetWorkspace)) {
-					await batchService.copyToWorkspace(
+					const result = await resolveCopyDispatch({
+						currentWorkspace,
 						targetWorkspace,
-						copyTarget.type === "file" ? [copyTarget.id] : [],
-						copyTarget.type === "folder" ? [copyTarget.id] : [],
+						fileIds: copyTarget.type === "file" ? [copyTarget.id] : [],
+						folderIds: copyTarget.type === "folder" ? [copyTarget.id] : [],
 						targetFolderId,
-					);
+					});
+					const batchToast = formatBatchToast(t, "copy", result);
+					if (batchToast.variant === "error") {
+						toast.error(batchToast.title, {
+							description: batchToast.description,
+						});
+					} else {
+						toast.success(batchToast.title, {
+							description: batchToast.description,
+						});
+					}
 				} else if (copyTarget.type === "file") {
 					await fileService.copyFile(copyTarget.id, targetFolderId);
+					toast.success(t("copy_success"));
 				} else {
 					await fileService.copyFolder(copyTarget.id, targetFolderId);
+					toast.success(t("copy_success"));
 				}
-				toast.success(t("copy_success"));
 				setCopyTarget(null);
 				await refresh();
 			} catch (err) {

--- a/frontend-panel/src/pages/file-browser/useFileBrowserPageState.ts
+++ b/frontend-panel/src/pages/file-browser/useFileBrowserPageState.ts
@@ -2,8 +2,10 @@ import type { TFunction } from "i18next";
 import { useCallback, useEffect, useState } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import { toast } from "sonner";
+import type { BatchTargetFolderSelection } from "@/components/files/BatchTargetFolderDialog";
 import type { TagManagerTarget } from "@/components/files/TagManagerDialog";
 import { handleApiError } from "@/hooks/useApiError";
+import { workspaceEquals } from "@/lib/workspace";
 import {
 	BatchTargetFolderDialog,
 	RenameDialog,
@@ -19,8 +21,10 @@ import type {
 	FileBrowserShareTarget,
 	FileBrowserVersionTarget,
 } from "@/pages/file-browser/types";
+import { batchService } from "@/services/batchService";
 import { fileService } from "@/services/fileService";
 import { useFileStore } from "@/stores/fileStore";
+import { useWorkspaceStore } from "@/stores/workspaceStore";
 import type {
 	EntityType,
 	FileInfo,
@@ -194,10 +198,21 @@ export function useFileBrowserPageState({
 	}, []);
 
 	const handleCopyConfirm = useCallback(
-		async (targetFolderId: number | null) => {
+		async ({
+			workspace: targetWorkspace,
+			folderId: targetFolderId,
+		}: BatchTargetFolderSelection) => {
 			if (!copyTarget) return;
 			try {
-				if (copyTarget.type === "file") {
+				const currentWorkspace = useWorkspaceStore.getState().workspace;
+				if (!workspaceEquals(currentWorkspace, targetWorkspace)) {
+					await batchService.copyToWorkspace(
+						targetWorkspace,
+						copyTarget.type === "file" ? [copyTarget.id] : [],
+						copyTarget.type === "folder" ? [copyTarget.id] : [],
+						targetFolderId,
+					);
+				} else if (copyTarget.type === "file") {
 					await fileService.copyFile(copyTarget.id, targetFolderId);
 				} else {
 					await fileService.copyFolder(copyTarget.id, targetFolderId);

--- a/frontend-panel/src/services/api.generated.ts
+++ b/frontend-panel/src/services/api.generated.ts
@@ -4126,6 +4126,22 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/workspace-transfer/copy": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: operations["workspace_transfer_copy"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/health": {
         parameters: {
             query?: never;
@@ -8484,6 +8500,27 @@ export interface components {
         WopiLockOwnerInfo: {
             app_key: string;
             lock: string;
+        };
+        WorkspaceRef: {
+            /** @enum {string} */
+            kind: "personal";
+        } | {
+            /** @enum {string} */
+            kind: "team";
+            /** Format: int64 */
+            team_id: number;
+        };
+        /** @description Copy files and folders between workspaces. */
+        WorkspaceTransferCopyReq: {
+            destination_workspace: components["schemas"]["WorkspaceRef"];
+            file_ids?: number[];
+            folder_ids?: number[];
+            source_workspace: components["schemas"]["WorkspaceRef"];
+            /**
+             * Format: int64
+             * @description Destination folder ID (`None` = destination root directory).
+             */
+            target_folder_id?: number | null;
         };
     };
     responses: never;
@@ -26924,6 +26961,62 @@ export interface operations {
         responses: {
             /** @description WOPI CheckFileInfo response */
             200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    workspace_transfer_copy: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["WorkspaceTransferCopyReq"];
+            };
+        };
+        responses: {
+            /** @description Workspace transfer copy result */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        code: components["schemas"]["ApiErrorCode"];
+                        data?: {
+                            errors: components["schemas"]["BatchItemError"][];
+                            /** Format: int32 */
+                            failed: number;
+                            /** Format: int32 */
+                            succeeded: number;
+                        };
+                        error?: null | components["schemas"]["ApiErrorInfo"];
+                        msg: string;
+                    };
+                };
+            };
+            /** @description Invalid request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden */
+            403: {
                 headers: {
                     [name: string]: unknown;
                 };

--- a/frontend-panel/src/services/batchService.test.ts
+++ b/frontend-panel/src/services/batchService.test.ts
@@ -1,5 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { batchService, createBatchService } from "@/services/batchService";
+import {
+	batchService,
+	createBatchService,
+	resolveCopyDispatch,
+} from "@/services/batchService";
 
 const apiPost = vi.hoisted(() => vi.fn());
 
@@ -74,6 +78,42 @@ describe("batchService", () => {
 			destination_workspace: { kind: "team", team_id: 9 },
 			target_folder_id: 6,
 		});
+	});
+
+	it("dispatches copy through the workspace-aware helper", async () => {
+		const dispatcher = {
+			batchCopy: vi
+				.fn()
+				.mockResolvedValue({ errors: [], failed: 0, succeeded: 2 }),
+			copyToWorkspace: vi
+				.fn()
+				.mockResolvedValue({ errors: [], failed: 0, succeeded: 2 }),
+		};
+
+		await resolveCopyDispatch({
+			currentWorkspace: { kind: "personal" },
+			targetWorkspace: { kind: "personal" },
+			fileIds: [1],
+			folderIds: [2],
+			targetFolderId: null,
+			dispatcher,
+		});
+		await resolveCopyDispatch({
+			currentWorkspace: { kind: "personal" },
+			targetWorkspace: { kind: "team", teamId: 9 },
+			fileIds: [3],
+			folderIds: [4],
+			targetFolderId: 5,
+			dispatcher,
+		});
+
+		expect(dispatcher.batchCopy).toHaveBeenCalledWith([1], [2], null);
+		expect(dispatcher.copyToWorkspace).toHaveBeenCalledWith(
+			{ kind: "team", teamId: 9 },
+			[3],
+			[4],
+			5,
+		);
 	});
 
 	it("creates archive download tickets with JSON bodies and triggers iframe downloads", async () => {

--- a/frontend-panel/src/services/batchService.test.ts
+++ b/frontend-panel/src/services/batchService.test.ts
@@ -39,6 +39,7 @@ describe("batchService", () => {
 		teamBatchService.batchDelete([1], []);
 		teamBatchService.batchMove([], [2], 8);
 		teamBatchService.batchCopy([3], [], null);
+		teamBatchService.copyToWorkspace({ kind: "personal" }, [7], [8], null);
 
 		expect(apiPost).toHaveBeenNthCalledWith(4, "/teams/4/batch/delete", {
 			file_ids: [1],
@@ -53,6 +54,25 @@ describe("batchService", () => {
 			file_ids: [3],
 			folder_ids: [],
 			target_folder_id: null,
+		});
+		expect(apiPost).toHaveBeenNthCalledWith(7, "/workspace-transfer/copy", {
+			source_workspace: { kind: "team", team_id: 4 },
+			file_ids: [7],
+			folder_ids: [8],
+			destination_workspace: { kind: "personal" },
+			target_folder_id: null,
+		});
+	});
+
+	it("posts workspace transfer copy payloads from personal workspaces", () => {
+		batchService.copyToWorkspace({ kind: "team", teamId: 9 }, [1], [2], 6);
+
+		expect(apiPost).toHaveBeenCalledWith("/workspace-transfer/copy", {
+			source_workspace: { kind: "personal" },
+			file_ids: [1],
+			folder_ids: [2],
+			destination_workspace: { kind: "team", team_id: 9 },
+			target_folder_id: 6,
 		});
 	});
 

--- a/frontend-panel/src/services/batchService.ts
+++ b/frontend-panel/src/services/batchService.ts
@@ -4,6 +4,7 @@ import {
 	buildWorkspacePath,
 	PERSONAL_WORKSPACE,
 	type Workspace,
+	workspaceEquals,
 } from "@/lib/workspace";
 import { api } from "@/services/http";
 import { bindWorkspaceService } from "@/stores/workspaceStore";
@@ -47,6 +48,47 @@ export function workspaceToTransferRef(workspace: Workspace): WorkspaceRef {
 	return workspace.kind === "team"
 		? { kind: "team", team_id: workspace.teamId }
 		: { kind: "personal" };
+}
+
+interface WorkspaceCopyDispatcher {
+	batchCopy: (
+		fileIds: number[],
+		folderIds: number[],
+		targetFolderId: number | null,
+	) => Promise<BatchResult>;
+	copyToWorkspace: (
+		destinationWorkspace: Workspace,
+		fileIds: number[],
+		folderIds: number[],
+		targetFolderId: number | null,
+	) => Promise<BatchResult>;
+}
+
+interface ResolveCopyDispatchInput {
+	currentWorkspace: Workspace;
+	targetWorkspace: Workspace;
+	fileIds: number[];
+	folderIds: number[];
+	targetFolderId: number | null;
+	dispatcher?: WorkspaceCopyDispatcher;
+}
+
+export function resolveCopyDispatch({
+	currentWorkspace,
+	targetWorkspace,
+	fileIds,
+	folderIds,
+	targetFolderId,
+	dispatcher = batchService,
+}: ResolveCopyDispatchInput) {
+	return workspaceEquals(currentWorkspace, targetWorkspace)
+		? dispatcher.batchCopy(fileIds, folderIds, targetFolderId)
+		: dispatcher.copyToWorkspace(
+				targetWorkspace,
+				fileIds,
+				folderIds,
+				targetFolderId,
+			);
 }
 
 function buildArchiveDownloadUrl(

--- a/frontend-panel/src/services/batchService.ts
+++ b/frontend-panel/src/services/batchService.ts
@@ -7,7 +7,12 @@ import {
 } from "@/lib/workspace";
 import { api } from "@/services/http";
 import { bindWorkspaceService } from "@/stores/workspaceStore";
-import type { BatchResult, TaskInfo } from "@/types/api";
+import type {
+	BatchResult,
+	TaskInfo,
+	WorkspaceRef,
+	WorkspaceTransferCopyRequest,
+} from "@/types/api";
 
 export interface StreamTicketInfo {
 	token: string;
@@ -36,6 +41,12 @@ export function buildArchiveDownloadPayload(
 		folder_ids: folderIds,
 		...(archiveName === undefined ? {} : { archive_name: archiveName }),
 	};
+}
+
+export function workspaceToTransferRef(workspace: Workspace): WorkspaceRef {
+	return workspace.kind === "team"
+		? { kind: "team", team_id: workspace.teamId }
+		: { kind: "personal" };
 }
 
 function buildArchiveDownloadUrl(
@@ -81,6 +92,22 @@ export function createBatchService(workspace: Workspace = PERSONAL_WORKSPACE) {
 				folder_ids: folderIds,
 				target_folder_id: targetFolderId,
 			}),
+
+		copyToWorkspace: (
+			destinationWorkspace: Workspace,
+			fileIds: number[],
+			folderIds: number[],
+			targetFolderId: number | null,
+		) => {
+			const payload: WorkspaceTransferCopyRequest = {
+				source_workspace: workspaceToTransferRef(workspace),
+				file_ids: fileIds,
+				folder_ids: folderIds,
+				destination_workspace: workspaceToTransferRef(destinationWorkspace),
+				target_folder_id: targetFolderId,
+			};
+			return api.post<BatchResult>("/workspace-transfer/copy", payload);
+		},
 
 		streamArchiveDownload: (
 			fileIds: number[],

--- a/frontend-panel/src/types/api.ts
+++ b/frontend-panel/src/types/api.ts
@@ -537,6 +537,9 @@ export type TaskPage = components["schemas"]["OffsetPage_TaskInfo"];
 // Upload and batch
 export type BatchItemError = components["schemas"]["BatchItemError"];
 export type BatchResult = components["schemas"]["BatchResult"];
+export type WorkspaceRef = components["schemas"]["WorkspaceRef"];
+export type WorkspaceTransferCopyRequest =
+	components["schemas"]["WorkspaceTransferCopyReq"];
 export type ChunkUploadResponse = components["schemas"]["ChunkUploadResponse"];
 export type CompletedPart = components["schemas"]["CompletedPartReq"];
 export type FileQuery = components["schemas"]["FileQuery"];

--- a/src/api/dto/batch.rs
+++ b/src/api/dto/batch.rs
@@ -1,6 +1,6 @@
 //! `batch` API DTO 定义。
 
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 #[cfg(all(debug_assertions, feature = "openapi"))]
 use utoipa::ToSchema;
 use validator::{Validate, ValidationError};
@@ -44,6 +44,30 @@ pub struct BatchCopyReq {
     pub target_folder_id: Option<i64>,
 }
 
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+#[cfg_attr(all(debug_assertions, feature = "openapi"), derive(ToSchema))]
+pub enum WorkspaceRef {
+    Personal,
+    Team { team_id: i64 },
+}
+
+/// Copy files and folders between workspaces.
+#[derive(Deserialize, Validate)]
+#[validate(schema(function = "validate_workspace_transfer_copy_req"))]
+#[cfg_attr(all(debug_assertions, feature = "openapi"), derive(ToSchema))]
+pub struct WorkspaceTransferCopyReq {
+    pub source_workspace: WorkspaceRef,
+    #[serde(default)]
+    pub file_ids: Vec<i64>,
+    #[serde(default)]
+    pub folder_ids: Vec<i64>,
+    pub destination_workspace: WorkspaceRef,
+    /// Destination folder ID (`None` = destination root directory).
+    #[validate(range(min = 1, message = "target_folder_id must be greater than 0"))]
+    pub target_folder_id: Option<i64>,
+}
+
 /// Request an archive download ticket for the selected files and folders.
 #[derive(Debug, Deserialize, Validate)]
 #[validate(schema(function = "validate_archive_download_req"))]
@@ -82,6 +106,14 @@ fn validate_batch_copy_req(value: &BatchCopyReq) -> std::result::Result<(), Vali
     validate_batch_selection(&value.file_ids, &value.folder_ids)
 }
 
+fn validate_workspace_transfer_copy_req(
+    value: &WorkspaceTransferCopyReq,
+) -> std::result::Result<(), ValidationError> {
+    validate_workspace_ref(&value.source_workspace)?;
+    validate_workspace_ref(&value.destination_workspace)?;
+    validate_batch_selection(&value.file_ids, &value.folder_ids)
+}
+
 fn validate_archive_download_req(
     value: &ArchiveDownloadReq,
 ) -> std::result::Result<(), ValidationError> {
@@ -116,6 +148,16 @@ fn validate_positive_ids(
         ));
     }
     Ok(())
+}
+
+fn validate_workspace_ref(value: &WorkspaceRef) -> std::result::Result<(), ValidationError> {
+    match value {
+        WorkspaceRef::Personal => Ok(()),
+        WorkspaceRef::Team { team_id } if *team_id > 0 => Ok(()),
+        WorkspaceRef::Team { .. } => Err(crate::api::dto::validation::message_validation_error(
+            "team_id must be greater than 0",
+        )),
+    }
 }
 
 fn validate_archive_name(value: Option<&str>) -> std::result::Result<(), ValidationError> {

--- a/src/api/openapi.rs
+++ b/src/api/openapi.rs
@@ -142,6 +142,7 @@ use utoipa::{Modify, OpenApi};
         crate::api::routes::batch::archive_compress,
         crate::api::routes::batch::archive_download,
         crate::api::routes::batch::archive_download_stream,
+        crate::api::routes::workspace_transfer::copy_to_workspace,
 
         // shares：登录用户创建和维护个人文件/文件夹分享的接口。
         crate::api::routes::shares::create_share,
@@ -775,6 +776,8 @@ use utoipa::{Modify, OpenApi};
             crate::api::routes::batch::BatchDeleteReq,
             crate::api::routes::batch::BatchMoveReq,
             crate::api::routes::batch::BatchCopyReq,
+            crate::api::routes::batch::WorkspaceRef,
+            crate::api::routes::batch::WorkspaceTransferCopyReq,
             crate::services::batch_service::BatchResult,
             crate::services::batch_service::BatchItemError,
         ),

--- a/src/api/primary.rs
+++ b/src/api/primary.rs
@@ -21,6 +21,7 @@ pub fn configure_primary(cfg: &mut web::ServiceConfig, db: &sea_orm::DatabaseCon
             .service(routes::trash::routes(rl, network_trust))
             .service(routes::properties::routes(rl, network_trust))
             .service(routes::batch::routes(rl, network_trust))
+            .service(routes::workspace_transfer::routes(rl, network_trust))
             .service(routes::search::routes(rl, network_trust))
             .service(routes::tags::routes(rl, network_trust))
             .service(routes::tasks::routes(rl, network_trust))

--- a/src/api/routes/mod.rs
+++ b/src/api/routes/mod.rs
@@ -22,6 +22,7 @@ pub mod teams;
 pub mod trash;
 pub mod webdav_accounts;
 pub mod wopi;
+pub mod workspace_transfer;
 
 pub(crate) fn team_scope(team_id: i64, user_id: i64) -> WorkspaceStorageScope {
     WorkspaceStorageScope::Team {

--- a/src/api/routes/workspace_transfer.rs
+++ b/src/api/routes/workspace_transfer.rs
@@ -1,0 +1,81 @@
+//! API 路由：跨工作空间资源复制。
+
+use crate::api::dto::batch::{WorkspaceRef, WorkspaceTransferCopyReq};
+use crate::api::dto::validate_request;
+use crate::api::middleware::auth::JwtAuth;
+use crate::api::middleware::rate_limit;
+use crate::api::response::ApiResponse;
+use crate::config::{NetworkTrustConfig, RateLimitConfig};
+use crate::errors::Result;
+use crate::runtime::PrimaryAppState;
+use crate::services::{
+    audit_service::AuditContext, auth_service::Claims, batch_service,
+    workspace_storage_service::WorkspaceStorageScope,
+};
+use actix_governor::Governor;
+use actix_web::middleware::Condition;
+use actix_web::{HttpRequest, HttpResponse, web};
+
+pub fn routes(
+    rl: &RateLimitConfig,
+    network_trust: &NetworkTrustConfig,
+) -> impl actix_web::dev::HttpServiceFactory + use<> {
+    let limiter = rate_limit::build_governor(&rl.write, &network_trust.trusted_proxies);
+
+    web::scope("/workspace-transfer")
+        .wrap(JwtAuth)
+        .wrap(Condition::new(rl.enabled, Governor::new(&limiter)))
+        .route("/copy", web::post().to(copy_to_workspace))
+}
+
+#[api_docs_macros::path(
+    post,
+    path = "/api/v1/workspace-transfer/copy",
+    tag = "batch",
+    operation_id = "workspace_transfer_copy",
+    request_body = WorkspaceTransferCopyReq,
+    responses(
+        (status = 200, description = "Workspace transfer copy result", body = inline(ApiResponse<batch_service::BatchResult>)),
+        (status = 400, description = "Invalid request"),
+        (status = 401, description = crate::api::constants::OPENAPI_UNAUTHORIZED),
+        (status = 403, description = "Forbidden"),
+    ),
+    security(("bearer" = [])),
+)]
+pub async fn copy_to_workspace(
+    state: web::Data<PrimaryAppState>,
+    claims: web::ReqData<Claims>,
+    req: HttpRequest,
+    body: web::Json<WorkspaceTransferCopyReq>,
+) -> Result<HttpResponse> {
+    let body = body.into_inner();
+    validate_request(&body)?;
+
+    let source_scope = workspace_ref_to_scope(&body.source_workspace, claims.user_id);
+    let dest_scope = workspace_ref_to_scope(&body.destination_workspace, claims.user_id);
+    let ctx = AuditContext::from_request(&req, &claims);
+    let result = batch_service::batch_copy_between_scopes_with_audit(
+        state.get_ref(),
+        source_scope,
+        dest_scope,
+        &body.file_ids,
+        &body.folder_ids,
+        body.target_folder_id,
+        &ctx,
+    )
+    .await?;
+
+    Ok(HttpResponse::Ok().json(ApiResponse::ok(result)))
+}
+
+fn workspace_ref_to_scope(value: &WorkspaceRef, actor_user_id: i64) -> WorkspaceStorageScope {
+    match value {
+        WorkspaceRef::Personal => WorkspaceStorageScope::Personal {
+            user_id: actor_user_id,
+        },
+        WorkspaceRef::Team { team_id } => WorkspaceStorageScope::Team {
+            team_id: *team_id,
+            actor_user_id,
+        },
+    }
+}

--- a/src/services/audit_service/details.rs
+++ b/src/services/audit_service/details.rs
@@ -141,6 +141,24 @@ pub struct BatchTransferDetails<'a> {
 }
 
 #[derive(Serialize)]
+pub struct WorkspaceTransferScopeDetails {
+    pub kind: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub team_id: Option<i64>,
+}
+
+#[derive(Serialize)]
+pub struct WorkspaceTransferCopyDetails<'a> {
+    pub source_workspace: WorkspaceTransferScopeDetails,
+    pub destination_workspace: WorkspaceTransferScopeDetails,
+    pub file_ids: &'a [i64],
+    pub folder_ids: &'a [i64],
+    pub target_folder_id: Option<i64>,
+    pub succeeded: u32,
+    pub failed: u32,
+}
+
+#[derive(Serialize)]
 pub struct ArchiveSelectionAuditDetails<'a> {
     pub file_ids: &'a [i64],
     pub folder_ids: &'a [i64],

--- a/src/services/audit_service/mod.rs
+++ b/src/services/audit_service/mod.rs
@@ -30,7 +30,8 @@ pub use details::{
     TeamMemberAddAuditDetails, TeamMemberRemoveAuditDetails, TeamMemberUpdateAuditDetails,
     TrashPurgeAllAuditDetails, UploadCancelAuditDetails, UserAvatarSourceAuditDetails,
     UserAvatarUploadAuditDetails, UserLoginAuditDetails, UserMfaManageAuditDetails,
-    UserPreferencesAuditDetails, UserProfileAuditDetails, UserWopiInfoAuditDetails, details,
+    UserPreferencesAuditDetails, UserProfileAuditDetails, UserWopiInfoAuditDetails,
+    WorkspaceTransferCopyDetails, WorkspaceTransferScopeDetails, details,
 };
 pub use filters::{AuditLogFilterQuery, AuditLogFilters};
 pub use manager::{

--- a/src/services/batch_service/copy.rs
+++ b/src/services/batch_service/copy.rs
@@ -25,19 +25,31 @@ pub(crate) async fn batch_copy_in_scope(
     folder_ids: &[i64],
     target_folder_id: Option<i64>,
 ) -> Result<BatchResult> {
+    batch_copy_between_scopes(state, scope, scope, file_ids, folder_ids, target_folder_id).await
+}
+
+pub(crate) async fn batch_copy_between_scopes(
+    state: &PrimaryAppState,
+    source_scope: WorkspaceStorageScope,
+    dest_scope: WorkspaceStorageScope,
+    file_ids: &[i64],
+    folder_ids: &[i64],
+    target_folder_id: Option<i64>,
+) -> Result<BatchResult> {
     let mut result = BatchResult::new();
     let NormalizedSelection {
         file_ids: normalized_file_ids,
         folder_ids: normalized_folder_ids,
         file_map,
         folder_map: _,
-    } = load_normalized_selection_in_scope(state, scope, file_ids, folder_ids).await?;
-    let target_error = load_target_folder_in_scope(state, scope, target_folder_id)
+    } = load_normalized_selection_in_scope(state, source_scope, file_ids, folder_ids).await?;
+    workspace_storage_service::require_scope_access(state, dest_scope).await?;
+    let target_error = load_target_folder_in_scope(state, dest_scope, target_folder_id)
         .await
         .err();
 
     let mut reserved_file_names: HashSet<String> = if target_error.is_none() {
-        workspace_storage_service::list_files_in_folder(state, scope, target_folder_id)
+        workspace_storage_service::list_files_in_folder(state, dest_scope, target_folder_id)
             .await?
             .into_iter()
             .map(|file| file.name)
@@ -47,7 +59,7 @@ pub(crate) async fn batch_copy_in_scope(
     };
 
     let (mut planned_storage_used, storage_quota) =
-        workspace_storage_service::load_storage_limits(state, scope).await?;
+        workspace_storage_service::load_storage_limits(state, dest_scope).await?;
     let mut file_copy_specs = Vec::new();
 
     for &id in &normalized_file_ids {
@@ -59,7 +71,7 @@ pub(crate) async fn batch_copy_in_scope(
             );
             continue;
         };
-        if let Err(err) = workspace_storage_service::ensure_active_file_scope(file, scope) {
+        if let Err(err) = workspace_storage_service::ensure_active_file_scope(file, source_scope) {
             result.record_failure("file", id, err.to_string());
             continue;
         }
@@ -102,7 +114,7 @@ pub(crate) async fn batch_copy_in_scope(
         })?;
         let created_files = file_service::batch_duplicate_file_records_with_specs_in_scope(
             state,
-            scope,
+            dest_scope,
             &file_copy_specs,
             target_folder_id,
         )
@@ -111,7 +123,7 @@ pub(crate) async fn batch_copy_in_scope(
             state,
             storage_change_service::StorageChangeEvent::new(
                 storage_change_service::StorageChangeKind::FileCreated,
-                scope,
+                dest_scope,
                 created_files.into_iter().map(|file| file.id).collect(),
                 vec![],
                 vec![target_folder_id],
@@ -130,8 +142,14 @@ pub(crate) async fn batch_copy_in_scope(
     let mut folder_copy_results =
         stream::iter(normalized_folder_ids.iter().copied().enumerate().map(
             |(index, id)| async move {
-                let copy_result =
-                    folder_service::copy_folder_in_scope(state, scope, id, target_folder_id).await;
+                let copy_result = folder_service::copy_folder_between_scopes(
+                    state,
+                    source_scope,
+                    dest_scope,
+                    id,
+                    target_folder_id,
+                )
+                .await;
                 (index, id, copy_result)
             },
         ))

--- a/src/services/batch_service/mod.rs
+++ b/src/services/batch_service/mod.rs
@@ -157,3 +157,60 @@ pub(crate) async fn batch_copy_in_scope_with_audit(
     .await;
     Ok(result)
 }
+
+pub(crate) async fn batch_copy_between_scopes_with_audit(
+    state: &PrimaryAppState,
+    source_scope: WorkspaceStorageScope,
+    dest_scope: WorkspaceStorageScope,
+    file_ids: &[i64],
+    folder_ids: &[i64],
+    target_folder_id: Option<i64>,
+    audit_ctx: &AuditContext,
+) -> Result<BatchResult> {
+    validate_batch_ids(file_ids, folder_ids)?;
+    let result = copy::batch_copy_between_scopes(
+        state,
+        source_scope,
+        dest_scope,
+        file_ids,
+        folder_ids,
+        target_folder_id,
+    )
+    .await?;
+    audit_service::log_with_details(
+        state,
+        audit_ctx,
+        audit_service::AuditAction::BatchCopy,
+        audit_service::AuditEntityType::Batch,
+        None,
+        None,
+        || {
+            audit_service::details(audit_service::WorkspaceTransferCopyDetails {
+                source_workspace: scope_details(source_scope),
+                destination_workspace: scope_details(dest_scope),
+                file_ids,
+                folder_ids,
+                target_folder_id,
+                succeeded: result.succeeded,
+                failed: result.failed,
+            })
+        },
+    )
+    .await;
+    Ok(result)
+}
+
+fn scope_details(scope: WorkspaceStorageScope) -> audit_service::WorkspaceTransferScopeDetails {
+    match scope {
+        WorkspaceStorageScope::Personal { .. } => audit_service::WorkspaceTransferScopeDetails {
+            kind: "personal",
+            team_id: None,
+        },
+        WorkspaceStorageScope::Team { team_id, .. } => {
+            audit_service::WorkspaceTransferScopeDetails {
+                kind: "team",
+                team_id: Some(team_id),
+            }
+        }
+    }
+}

--- a/src/services/folder_service/copy.rs
+++ b/src/services/folder_service/copy.rs
@@ -32,9 +32,10 @@ struct PlannedChildFolderCopy {
     policy_id: Option<i64>,
 }
 
-async fn copy_frontier_files_in_scope(
+async fn copy_frontier_files_between_scopes(
     state: &PrimaryAppState,
-    scope: WorkspaceStorageScope,
+    source_scope: WorkspaceStorageScope,
+    dest_scope: WorkspaceStorageScope,
     frontier: &[FrontierFolderCopy],
 ) -> Result<i64> {
     if frontier.is_empty() {
@@ -48,7 +49,7 @@ async fn copy_frontier_files_in_scope(
         .map(|item| (item.src_folder_id, item.dest_folder_id))
         .collect();
 
-    let files = match scope {
+    let files = match source_scope {
         WorkspaceStorageScope::Personal { user_id } => {
             file_repo::find_by_folders(db, user_id, &src_folder_ids).await?
         }
@@ -83,15 +84,16 @@ async fn copy_frontier_files_in_scope(
 
     crate::services::file_service::batch_duplicate_file_records_to_mixed_folders_in_scope(
         state,
-        scope,
+        dest_scope,
         &copy_specs,
     )
     .await
 }
 
-async fn load_frontier_child_plans_in_scope(
+async fn load_frontier_child_plans_between_scopes(
     state: &PrimaryAppState,
-    scope: WorkspaceStorageScope,
+    source_scope: WorkspaceStorageScope,
+    preserve_policy_id: bool,
     frontier: &[FrontierFolderCopy],
 ) -> Result<Vec<PlannedChildFolderCopy>> {
     if frontier.is_empty() {
@@ -105,7 +107,7 @@ async fn load_frontier_child_plans_in_scope(
         .map(|item| (item.src_folder_id, item.dest_folder_id))
         .collect();
 
-    let children = match scope {
+    let children = match source_scope {
         WorkspaceStorageScope::Personal { user_id } => {
             folder_repo::find_children_in_parents(db, user_id, &src_folder_ids).await?
         }
@@ -135,7 +137,7 @@ async fn load_frontier_child_plans_in_scope(
                 src_folder_id: child.id,
                 dest_parent_id,
                 dest_name: child.name.clone(),
-                policy_id: child.policy_id,
+                policy_id: preserve_policy_id.then_some(child.policy_id).flatten(),
             })
         })
         .collect()
@@ -221,22 +223,42 @@ pub(crate) async fn copy_folder_tree_in_scope(
     dest_parent_id: Option<i64>,
     dest_name: &str,
 ) -> Result<(folder::Model, i64)> {
+    copy_folder_tree_between_scopes(
+        state,
+        scope,
+        scope,
+        src_folder_id,
+        dest_parent_id,
+        dest_name,
+    )
+    .await
+}
+
+pub(crate) async fn copy_folder_tree_between_scopes(
+    state: &PrimaryAppState,
+    source_scope: WorkspaceStorageScope,
+    dest_scope: WorkspaceStorageScope,
+    src_folder_id: i64,
+    dest_parent_id: Option<i64>,
+    dest_name: &str,
+) -> Result<(folder::Model, i64)> {
     let db = state.writer_db();
     let now = Utc::now();
     let src_folder = folder_repo::find_by_id(db, src_folder_id).await?;
-    ensure_folder_model_in_scope(&src_folder, scope)?;
-    let created_by_username = load_scope_actor_username(db, scope).await?;
+    ensure_folder_model_in_scope(&src_folder, source_scope)?;
+    let created_by_username = load_scope_actor_username(db, dest_scope).await?;
+    let preserve_policy_id = same_workspace_resource(source_scope, dest_scope);
 
     let new_folder = folder_repo::create(
         db,
         folder::ActiveModel {
             name: Set(dest_name.to_string()),
             parent_id: Set(dest_parent_id),
-            team_id: Set(scope.team_id()),
-            owner_user_id: Set(scope.owner_user_id()),
-            created_by_user_id: Set(Some(scope.actor_user_id())),
+            team_id: Set(dest_scope.team_id()),
+            owner_user_id: Set(dest_scope.owner_user_id()),
+            created_by_user_id: Set(Some(dest_scope.actor_user_id())),
             created_by_username: Set(created_by_username),
-            policy_id: Set(src_folder.policy_id),
+            policy_id: Set(preserve_policy_id.then_some(src_folder.policy_id).flatten()),
             created_at: Set(now),
             updated_at: Set(now),
             ..Default::default()
@@ -253,13 +275,19 @@ pub(crate) async fn copy_folder_tree_in_scope(
         // 先并发完成当前层的“文件批量复制”和“下一层子目录读取”，
         // 但把子目录真正写库放在文件复制成功之后，避免扩大失败时的半成品范围。
         let (frontier_storage_delta, child_plans) = tokio::try_join!(
-            copy_frontier_files_in_scope(state, scope, &frontier),
-            load_frontier_child_plans_in_scope(state, scope, &frontier),
+            copy_frontier_files_between_scopes(state, source_scope, dest_scope, &frontier),
+            load_frontier_child_plans_between_scopes(
+                state,
+                source_scope,
+                preserve_policy_id,
+                &frontier
+            ),
         )?;
         storage_delta = storage_delta
             .checked_add(frontier_storage_delta)
             .ok_or_else(|| AsterError::internal_error("folder copy storage delta overflow"))?;
-        frontier = create_frontier_children_from_plans_in_scope(state, scope, child_plans).await?;
+        frontier =
+            create_frontier_children_from_plans_in_scope(state, dest_scope, child_plans).await?;
     }
 
     Ok((new_folder, storage_delta))
@@ -271,34 +299,47 @@ pub(crate) async fn copy_folder_in_scope(
     src_id: i64,
     dest_parent_id: Option<i64>,
 ) -> Result<folder::Model> {
+    copy_folder_between_scopes(state, scope, scope, src_id, dest_parent_id).await
+}
+
+pub(crate) async fn copy_folder_between_scopes(
+    state: &PrimaryAppState,
+    source_scope: WorkspaceStorageScope,
+    dest_scope: WorkspaceStorageScope,
+    src_id: i64,
+    dest_parent_id: Option<i64>,
+) -> Result<folder::Model> {
     let db = state.writer_db();
     tracing::debug!(
-        scope = ?scope,
+        source_scope = ?source_scope,
+        dest_scope = ?dest_scope,
         src_folder_id = src_id,
         dest_parent_id,
         "copying folder tree"
     );
-    let src = workspace_storage_service::verify_folder_access(state, scope, src_id).await?;
+    let src = workspace_storage_service::verify_folder_access(state, source_scope, src_id).await?;
 
     if let Some(parent_id) = dest_parent_id {
-        workspace_storage_service::verify_folder_access(state, scope, parent_id).await?;
+        workspace_storage_service::verify_folder_access(state, dest_scope, parent_id).await?;
 
-        let mut cursor = Some(parent_id);
-        while let Some(cur_id) = cursor {
-            if cur_id == src_id {
-                return Err(AsterError::validation_error(
-                    "cannot copy folder into its own subfolder",
-                ));
+        if same_workspace_resource(source_scope, dest_scope) {
+            let mut cursor = Some(parent_id);
+            while let Some(cur_id) = cursor {
+                if cur_id == src_id {
+                    return Err(AsterError::validation_error(
+                        "cannot copy folder into its own subfolder",
+                    ));
+                }
+                let current = folder_repo::find_by_id(db, cur_id).await?;
+                ensure_folder_model_in_scope(&current, dest_scope)?;
+                cursor = current.parent_id;
             }
-            let current = folder_repo::find_by_id(db, cur_id).await?;
-            ensure_folder_model_in_scope(&current, scope)?;
-            cursor = current.parent_id;
         }
     }
 
     let mut dest_name = src.name.clone();
     for _ in 0..MAX_COPY_NAME_RETRIES {
-        let exists = match scope {
+        let exists = match dest_scope {
             WorkspaceStorageScope::Personal { user_id } => {
                 folder_repo::find_by_name_in_parent(db, user_id, dest_parent_id, &dest_name)
                     .await?
@@ -316,13 +357,22 @@ pub(crate) async fn copy_folder_in_scope(
             continue;
         }
 
-        match copy_folder_tree_in_scope(state, scope, src_id, dest_parent_id, &dest_name).await {
+        match copy_folder_tree_between_scopes(
+            state,
+            source_scope,
+            dest_scope,
+            src_id,
+            dest_parent_id,
+            &dest_name,
+        )
+        .await
+        {
             Ok((copied, storage_delta)) => {
                 storage_change_service::publish(
                     state,
                     storage_change_service::StorageChangeEvent::new(
                         storage_change_service::StorageChangeKind::FolderCreated,
-                        scope,
+                        dest_scope,
                         vec![],
                         vec![copied.id],
                         vec![copied.parent_id],
@@ -330,7 +380,8 @@ pub(crate) async fn copy_folder_in_scope(
                     .with_storage_delta(storage_delta),
                 );
                 tracing::debug!(
-                    scope = ?scope,
+                    source_scope = ?source_scope,
+                    dest_scope = ?dest_scope,
                     src_folder_id = src_id,
                     copied_folder_id = copied.id,
                     parent_id = copied.parent_id,
@@ -350,6 +401,24 @@ pub(crate) async fn copy_folder_in_scope(
         "failed to allocate a unique copy name for '{}'",
         src.name
     )))
+}
+
+fn same_workspace_resource(left: WorkspaceStorageScope, right: WorkspaceStorageScope) -> bool {
+    match (left, right) {
+        (
+            WorkspaceStorageScope::Personal { user_id: left_id },
+            WorkspaceStorageScope::Personal { user_id: right_id },
+        ) => left_id == right_id,
+        (
+            WorkspaceStorageScope::Team {
+                team_id: left_id, ..
+            },
+            WorkspaceStorageScope::Team {
+                team_id: right_id, ..
+            },
+        ) => left_id == right_id,
+        _ => false,
+    }
 }
 
 /// 复制文件夹（递归复制所有文件和子文件夹）

--- a/src/services/folder_service/mod.rs
+++ b/src/services/folder_service/mod.rs
@@ -42,7 +42,9 @@ pub(crate) use access::{
     ensure_folder_model_in_scope, ensure_personal_folder_scope, verify_folder_in_scope,
 };
 pub(crate) use cache::{FOLDER_PATH_CACHE_PREFIX, folder_path_cache_key};
-pub(crate) use copy::{copy_folder_in_scope, copy_folder_tree_in_scope};
+pub(crate) use copy::{
+    copy_folder_between_scopes, copy_folder_in_scope, copy_folder_tree_in_scope,
+};
 pub(crate) use hierarchy::{
     get_ancestors_in_scope, invalidate_folder_path_cache, invalidate_folder_path_cache_for_ids,
 };

--- a/tests/test_audit.rs
+++ b/tests/test_audit.rs
@@ -646,6 +646,54 @@ async fn test_audit_log_recorded_on_batch_actions_after_refactor() {
 }
 
 #[actix_web::test]
+async fn test_audit_log_records_workspace_transfer_copy_scopes() {
+    let state = common::setup().await;
+    let app = create_test_app!(state);
+    let (token, _) = register_and_login!(app);
+
+    let file_id = upload_test_file_named!(app, token, "workspace-transfer-audit.txt");
+
+    let req = test::TestRequest::post()
+        .uri("/api/v1/teams")
+        .insert_header(("Cookie", common::access_cookie_header(&token)))
+        .insert_header(common::csrf_header_for(&token))
+        .set_json(serde_json::json!({ "name": "Workspace Transfer Audit Team" }))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), 201);
+    let body: Value = test::read_body_json(resp).await;
+    let team_id = body["data"]["id"].as_i64().unwrap();
+
+    let req = test::TestRequest::post()
+        .uri("/api/v1/workspace-transfer/copy")
+        .insert_header(("Cookie", common::access_cookie_header(&token)))
+        .insert_header(common::csrf_header_for(&token))
+        .set_json(serde_json::json!({
+            "source_workspace": { "kind": "personal" },
+            "file_ids": [file_id],
+            "folder_ids": [],
+            "destination_workspace": { "kind": "team", "team_id": team_id },
+            "target_folder_id": null
+        }))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), 200);
+
+    let items = fetch_audit_items!(app, token);
+    let entry = assert_action_present(&items, "batch_copy");
+    let details: Value = serde_json::from_str(entry["details"].as_str().unwrap()).unwrap();
+    assert_eq!(details["source_workspace"]["kind"], "personal");
+    assert!(details["source_workspace"].get("team_id").is_none());
+    assert_eq!(details["destination_workspace"]["kind"], "team");
+    assert_eq!(details["destination_workspace"]["team_id"], team_id);
+    assert_eq!(details["file_ids"], serde_json::json!([file_id]));
+    assert_eq!(details["folder_ids"], serde_json::json!([]));
+    assert!(details["target_folder_id"].is_null());
+    assert_eq!(details["succeeded"], 1);
+    assert_eq!(details["failed"], 0);
+}
+
+#[actix_web::test]
 async fn test_audit_log_recorded_on_share_config_and_admin_user_actions_after_refactor() {
     let state = common::setup().await;
     let app = create_test_app!(state);

--- a/tests/test_batch.rs
+++ b/tests/test_batch.rs
@@ -3,6 +3,7 @@
 #[macro_use]
 mod common;
 use aster_drive::api::api_error_code::ApiErrorCode;
+use aster_drive::db::repository::folder_repo;
 use aster_drive::entities::{file, folder};
 use aster_drive::runtime::SharedRuntimeState;
 
@@ -71,6 +72,40 @@ macro_rules! add_team_member {
             .to_request();
         let resp = test::call_service(&$app, req).await;
         assert_eq!(resp.status(), 201);
+    }};
+}
+
+macro_rules! create_local_policy {
+    ($app:expr, $token:expr, $name:expr, $base_path:expr) => {{
+        let req = test::TestRequest::post()
+            .uri("/api/v1/admin/policies")
+            .insert_header(("Cookie", common::access_cookie_header(&$token)))
+            .insert_header(common::csrf_header_for(&$token))
+            .set_json(serde_json::json!({
+                "name": $name,
+                "driver_type": "local",
+                "base_path": $base_path,
+                "max_file_size": 0,
+                "is_default": false
+            }))
+            .to_request();
+        let resp = test::call_service(&$app, req).await;
+        assert_eq!(resp.status(), 201);
+        let body: Value = test::read_body_json(resp).await;
+        body["data"]["id"].as_i64().unwrap()
+    }};
+}
+
+macro_rules! set_folder_policy {
+    ($app:expr, $token:expr, $folder_id:expr, $policy_id:expr) => {{
+        let req = test::TestRequest::put()
+            .uri(&format!("/api/v1/admin/folders/{}/policy", $folder_id))
+            .insert_header(("Cookie", common::access_cookie_header(&$token)))
+            .insert_header(common::csrf_header_for(&$token))
+            .set_json(serde_json::json!({ "policy_id": $policy_id }))
+            .to_request();
+        let resp = test::call_service(&$app, req).await;
+        assert_eq!(resp.status(), 200);
     }};
 }
 
@@ -2136,6 +2171,138 @@ async fn test_workspace_transfer_copy_folder_name_conflict_preserves_descendants
     let resp = test::call_service(&app, req).await;
     let body: Value = test::read_body_json(resp).await;
     assert_eq!(body["data"]["files"][0]["name"], "inside.txt");
+}
+
+#[actix_web::test]
+async fn test_workspace_transfer_copy_preserves_policy_only_within_same_workspace() {
+    let state = common::setup().await;
+    let db = state.writer_db().clone();
+    let mail_sender = state.mail_sender.clone();
+    let app = create_test_app!(state);
+
+    let _user_id = register_user!(
+        app,
+        db,
+        mail_sender,
+        "xcpolicyscope",
+        "xcopy-policy-scope@example.com"
+    );
+    let token = login_user!(app, "xcpolicyscope");
+    let root_policy_id = create_local_policy!(
+        app,
+        token,
+        "Workspace Transfer Root Policy",
+        "/tmp/test-workspace-transfer-root-policy"
+    );
+    let child_policy_id = create_local_policy!(
+        app,
+        token,
+        "Workspace Transfer Child Policy",
+        "/tmp/test-workspace-transfer-child-policy"
+    );
+    let source_id = create_personal_folder!(app, token, "PolicyFolder", Option::<i64>::None);
+    let child_id = create_personal_folder!(app, token, "PolicyChild", Some(source_id));
+    set_folder_policy!(app, token, source_id, root_policy_id);
+    set_folder_policy!(app, token, child_id, child_policy_id);
+
+    let req = test::TestRequest::post()
+        .uri("/api/v1/workspace-transfer/copy")
+        .insert_header(("Cookie", common::access_cookie_header(&token)))
+        .insert_header(common::csrf_header_for(&token))
+        .set_json(serde_json::json!({
+            "source_workspace": { "kind": "personal" },
+            "file_ids": [],
+            "folder_ids": [source_id],
+            "destination_workspace": { "kind": "personal" },
+            "target_folder_id": null
+        }))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), 200);
+    let body: Value = test::read_body_json(resp).await;
+    assert_eq!(body["data"]["succeeded"], 1);
+    assert_eq!(body["data"]["failed"], 0);
+
+    let req = test::TestRequest::get()
+        .uri("/api/v1/folders")
+        .insert_header(("Cookie", common::access_cookie_header(&token)))
+        .insert_header(common::csrf_header_for(&token))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    let body: Value = test::read_body_json(resp).await;
+    let same_workspace_copy_id = body["data"]["folders"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|folder| folder["name"] == "PolicyFolder (1)")
+        .and_then(|folder| folder["id"].as_i64())
+        .expect("same-workspace transfer copy should get a unique name");
+    let copied_root = folder_repo::find_by_id(&db, same_workspace_copy_id)
+        .await
+        .unwrap();
+    assert_eq!(copied_root.policy_id, Some(root_policy_id));
+
+    let req = test::TestRequest::get()
+        .uri(&format!("/api/v1/folders/{same_workspace_copy_id}"))
+        .insert_header(("Cookie", common::access_cookie_header(&token)))
+        .insert_header(common::csrf_header_for(&token))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    let body: Value = test::read_body_json(resp).await;
+    let copied_child_id = body["data"]["folders"][0]["id"].as_i64().unwrap();
+    let copied_child = folder_repo::find_by_id(&db, copied_child_id).await.unwrap();
+    assert_eq!(copied_child.policy_id, Some(child_policy_id));
+
+    let team_id = create_team!(app, token, "Policy Copy Destination");
+    let req = test::TestRequest::post()
+        .uri("/api/v1/workspace-transfer/copy")
+        .insert_header(("Cookie", common::access_cookie_header(&token)))
+        .insert_header(common::csrf_header_for(&token))
+        .set_json(serde_json::json!({
+            "source_workspace": { "kind": "personal" },
+            "file_ids": [],
+            "folder_ids": [source_id],
+            "destination_workspace": { "kind": "team", "team_id": team_id },
+            "target_folder_id": null
+        }))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), 200);
+    let body: Value = test::read_body_json(resp).await;
+    assert_eq!(body["data"]["succeeded"], 1);
+    assert_eq!(body["data"]["failed"], 0);
+
+    let req = test::TestRequest::get()
+        .uri(&format!("/api/v1/teams/{team_id}/folders"))
+        .insert_header(("Cookie", common::access_cookie_header(&token)))
+        .insert_header(common::csrf_header_for(&token))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    let body: Value = test::read_body_json(resp).await;
+    let cross_workspace_copy_id = body["data"]["folders"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|folder| folder["name"] == "PolicyFolder")
+        .and_then(|folder| folder["id"].as_i64())
+        .expect("cross-workspace transfer copy should exist in team root");
+    let copied_root = folder_repo::find_by_id(&db, cross_workspace_copy_id)
+        .await
+        .unwrap();
+    assert_eq!(copied_root.policy_id, None);
+
+    let req = test::TestRequest::get()
+        .uri(&format!(
+            "/api/v1/teams/{team_id}/folders/{cross_workspace_copy_id}"
+        ))
+        .insert_header(("Cookie", common::access_cookie_header(&token)))
+        .insert_header(common::csrf_header_for(&token))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    let body: Value = test::read_body_json(resp).await;
+    let copied_child_id = body["data"]["folders"][0]["id"].as_i64().unwrap();
+    let copied_child = folder_repo::find_by_id(&db, copied_child_id).await.unwrap();
+    assert_eq!(copied_child.policy_id, None);
 }
 
 #[actix_web::test]

--- a/tests/test_batch.rs
+++ b/tests/test_batch.rs
@@ -7,8 +7,163 @@ use aster_drive::entities::{file, folder};
 use aster_drive::runtime::SharedRuntimeState;
 
 use actix_web::test;
-use sea_orm::{ColumnTrait, EntityTrait, QueryFilter, sea_query::Expr};
+use sea_orm::{ActiveModelTrait, ColumnTrait, EntityTrait, QueryFilter, Set, sea_query::Expr};
 use serde_json::Value;
+
+macro_rules! register_user {
+    ($app:expr, $db:expr, $mail_sender:expr, $username:expr, $email:expr) => {{
+        let req = test::TestRequest::post()
+            .uri("/api/v1/auth/register")
+            .peer_addr("127.0.0.1:12345".parse().unwrap())
+            .set_json(serde_json::json!({
+                "username": $username,
+                "email": $email,
+                "password": "password123"
+            }))
+            .to_request();
+        let resp = test::call_service(&$app, req).await;
+        assert_eq!(resp.status(), 201);
+        let body: Value = test::read_body_json(resp).await;
+        let user_id = body["data"]["id"].as_i64().unwrap();
+        let _ = confirm_latest_contact_verification!($app, $db, $mail_sender);
+        user_id
+    }};
+}
+
+macro_rules! login_user {
+    ($app:expr, $identifier:expr) => {{
+        let req = test::TestRequest::post()
+            .uri("/api/v1/auth/login")
+            .peer_addr("127.0.0.1:12345".parse().unwrap())
+            .set_json(serde_json::json!({
+                "identifier": $identifier,
+                "password": "password123"
+            }))
+            .to_request();
+        let resp = test::call_service(&$app, req).await;
+        assert_eq!(resp.status(), 200);
+        common::extract_cookie(&resp, "aster_access").unwrap()
+    }};
+}
+
+macro_rules! create_team {
+    ($app:expr, $token:expr, $name:expr) => {{
+        let req = test::TestRequest::post()
+            .uri("/api/v1/teams")
+            .insert_header(("Cookie", common::access_cookie_header(&$token)))
+            .insert_header(common::csrf_header_for(&$token))
+            .set_json(serde_json::json!({ "name": $name }))
+            .to_request();
+        let resp = test::call_service(&$app, req).await;
+        assert_eq!(resp.status(), 201);
+        let body: Value = test::read_body_json(resp).await;
+        body["data"]["id"].as_i64().unwrap()
+    }};
+}
+
+macro_rules! add_team_member {
+    ($app:expr, $token:expr, $team_id:expr, $user_id:expr) => {{
+        let req = test::TestRequest::post()
+            .uri(&format!("/api/v1/teams/{}/members", $team_id))
+            .insert_header(("Cookie", common::access_cookie_header(&$token)))
+            .insert_header(common::csrf_header_for(&$token))
+            .set_json(serde_json::json!({ "user_id": $user_id }))
+            .to_request();
+        let resp = test::call_service(&$app, req).await;
+        assert_eq!(resp.status(), 201);
+    }};
+}
+
+macro_rules! create_personal_folder {
+    ($app:expr, $token:expr, $name:expr, $parent_id:expr) => {{
+        let req = test::TestRequest::post()
+            .uri("/api/v1/folders")
+            .insert_header(("Cookie", common::access_cookie_header(&$token)))
+            .insert_header(common::csrf_header_for(&$token))
+            .set_json(serde_json::json!({
+                "name": $name,
+                "parent_id": $parent_id
+            }))
+            .to_request();
+        let resp = test::call_service(&$app, req).await;
+        assert_eq!(resp.status(), 201);
+        let body: Value = test::read_body_json(resp).await;
+        body["data"]["id"].as_i64().unwrap()
+    }};
+}
+
+macro_rules! create_team_folder {
+    ($app:expr, $token:expr, $team_id:expr, $name:expr, $parent_id:expr) => {{
+        let req = test::TestRequest::post()
+            .uri(&format!("/api/v1/teams/{}/folders", $team_id))
+            .insert_header(("Cookie", common::access_cookie_header(&$token)))
+            .insert_header(common::csrf_header_for(&$token))
+            .set_json(serde_json::json!({
+                "name": $name,
+                "parent_id": $parent_id
+            }))
+            .to_request();
+        let resp = test::call_service(&$app, req).await;
+        assert_eq!(resp.status(), 201);
+        let body: Value = test::read_body_json(resp).await;
+        body["data"]["id"].as_i64().unwrap()
+    }};
+}
+
+macro_rules! upload_personal_file {
+    ($app:expr, $token:expr, $folder_id:expr, $name:expr, $content:expr) => {{
+        let boundary = "----WorkspaceTransferBoundary";
+        let payload = upload_named_file($name, $content, "text/plain", boundary);
+        let uri = match $folder_id {
+            Some(folder_id) => format!("/api/v1/files/upload?folder_id={folder_id}"),
+            None => "/api/v1/files/upload".to_string(),
+        };
+        let req = test::TestRequest::post()
+            .uri(&uri)
+            .insert_header(("Cookie", common::access_cookie_header(&$token)))
+            .insert_header(common::csrf_header_for(&$token))
+            .insert_header((
+                "Content-Type",
+                format!("multipart/form-data; boundary={boundary}"),
+            ))
+            .set_payload(payload)
+            .to_request();
+        let resp = test::call_service(&$app, req).await;
+        assert_eq!(resp.status(), 201);
+        let body: Value = test::read_body_json(resp).await;
+        body["data"]["id"].as_i64().unwrap()
+    }};
+}
+
+macro_rules! upload_team_file {
+    ($app:expr, $token:expr, $team_id:expr, $folder_id:expr, $name:expr, $content:expr) => {{
+        let boundary = "----WorkspaceTransferTeamBoundary";
+        let payload = upload_named_file($name, $content, "text/plain", boundary);
+        let uri = match $folder_id {
+            Some(folder_id) => {
+                format!(
+                    "/api/v1/teams/{}/files/upload?folder_id={folder_id}",
+                    $team_id
+                )
+            }
+            None => format!("/api/v1/teams/{}/files/upload", $team_id),
+        };
+        let req = test::TestRequest::post()
+            .uri(&uri)
+            .insert_header(("Cookie", common::access_cookie_header(&$token)))
+            .insert_header(common::csrf_header_for(&$token))
+            .insert_header((
+                "Content-Type",
+                format!("multipart/form-data; boundary={boundary}"),
+            ))
+            .set_payload(payload)
+            .to_request();
+        let resp = test::call_service(&$app, req).await;
+        assert_eq!(resp.status(), 201);
+        let body: Value = test::read_body_json(resp).await;
+        body["data"]["id"].as_i64().unwrap()
+    }};
+}
 
 fn upload_named_file(name: &str, content: &str, mime: &str, boundary: &str) -> String {
     format!(
@@ -1264,6 +1419,723 @@ async fn test_batch_copy_preserves_partial_failures_for_quota() {
     assert_eq!(resp.status(), 200);
     let body: Value = test::read_body_json(resp).await;
     assert_eq!(body["data"]["files"].as_array().unwrap().len(), 2);
+}
+
+#[actix_web::test]
+async fn test_workspace_transfer_copy_personal_file_to_team_root_resolves_name_conflict() {
+    let state = common::setup().await;
+    let storage_change_tx = state.storage_change_tx.clone();
+    let db = state.writer_db().clone();
+    let mail_sender = state.mail_sender.clone();
+    let app = create_test_app!(state);
+
+    let _user_id = register_user!(
+        app,
+        db,
+        mail_sender,
+        "xcpersonalteam",
+        "xcopy-personal-team@example.com"
+    );
+    let token = login_user!(app, "xcpersonalteam");
+    let team_id = create_team!(app, token, "Cross Copy Team");
+    let source_folder_id =
+        create_personal_folder!(app, token, "Personal Source", Option::<i64>::None);
+    let file_id = upload_personal_file!(
+        app,
+        token,
+        Some(source_folder_id),
+        "conflict.txt",
+        "personal body"
+    );
+    upload_team_file!(
+        app,
+        token,
+        team_id,
+        None::<i64>,
+        "conflict.txt",
+        "existing team body"
+    );
+
+    let mut rx = storage_change_tx.subscribe();
+    let req = test::TestRequest::post()
+        .uri("/api/v1/workspace-transfer/copy")
+        .insert_header(("Cookie", common::access_cookie_header(&token)))
+        .insert_header(common::csrf_header_for(&token))
+        .set_json(serde_json::json!({
+            "source_workspace": { "kind": "personal" },
+            "file_ids": [file_id],
+            "folder_ids": [],
+            "destination_workspace": { "kind": "team", "team_id": team_id },
+            "target_folder_id": null
+        }))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), 200);
+    let body: Value = test::read_body_json(resp).await;
+    assert_eq!(body["data"]["succeeded"], 1);
+    assert_eq!(body["data"]["failed"], 0);
+
+    let event = tokio::time::timeout(std::time::Duration::from_secs(1), rx.recv())
+        .await
+        .expect("should receive destination storage change")
+        .expect("storage change channel should stay open");
+    assert_eq!(
+        event.workspace,
+        Some(
+            aster_drive::services::storage_change_service::StorageChangeWorkspace::Team { team_id }
+        )
+    );
+    assert_eq!(
+        event.kind,
+        aster_drive::services::storage_change_service::StorageChangeKind::FileCreated
+    );
+    assert_eq!(event.file_ids.len(), 1);
+    assert!(event.root_affected);
+
+    let req = test::TestRequest::get()
+        .uri(&format!("/api/v1/teams/{team_id}/folders"))
+        .insert_header(("Cookie", common::access_cookie_header(&token)))
+        .insert_header(common::csrf_header_for(&token))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), 200);
+    let body: Value = test::read_body_json(resp).await;
+    let mut names: Vec<_> = body["data"]["files"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|item| item["name"].as_str().unwrap().to_string())
+        .collect();
+    names.sort();
+    assert_eq!(names, vec!["conflict (1).txt", "conflict.txt"]);
+
+    let req = test::TestRequest::get()
+        .uri(&format!("/api/v1/folders/{source_folder_id}"))
+        .insert_header(("Cookie", common::access_cookie_header(&token)))
+        .insert_header(common::csrf_header_for(&token))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    let body: Value = test::read_body_json(resp).await;
+    assert_eq!(body["data"]["files"].as_array().unwrap().len(), 1);
+}
+
+#[actix_web::test]
+async fn test_workspace_transfer_copy_team_folder_to_personal_root() {
+    let state = common::setup().await;
+    let db = state.writer_db().clone();
+    let mail_sender = state.mail_sender.clone();
+    let app = create_test_app!(state);
+
+    let _user_id = register_user!(
+        app,
+        db,
+        mail_sender,
+        "xcteampersonal",
+        "xcopy-team-personal@example.com"
+    );
+    let token = login_user!(app, "xcteampersonal");
+    let team_id = create_team!(app, token, "Team To Personal");
+    let source_id = create_team_folder!(app, token, team_id, "TeamFolder", Option::<i64>::None);
+    let child_id = create_team_folder!(app, token, team_id, "Nested", Some(source_id));
+    upload_team_file!(
+        app,
+        token,
+        team_id,
+        Some(child_id),
+        "nested.txt",
+        "nested body"
+    );
+
+    let req = test::TestRequest::post()
+        .uri("/api/v1/workspace-transfer/copy")
+        .insert_header(("Cookie", common::access_cookie_header(&token)))
+        .insert_header(common::csrf_header_for(&token))
+        .set_json(serde_json::json!({
+            "source_workspace": { "kind": "team", "team_id": team_id },
+            "file_ids": [],
+            "folder_ids": [source_id],
+            "destination_workspace": { "kind": "personal" },
+            "target_folder_id": null
+        }))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), 200);
+    let body: Value = test::read_body_json(resp).await;
+    assert_eq!(body["data"]["succeeded"], 1);
+
+    let req = test::TestRequest::get()
+        .uri("/api/v1/folders")
+        .insert_header(("Cookie", common::access_cookie_header(&token)))
+        .insert_header(common::csrf_header_for(&token))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    let body: Value = test::read_body_json(resp).await;
+    let copied_id = body["data"]["folders"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|folder| folder["name"] == "TeamFolder")
+        .and_then(|folder| folder["id"].as_i64())
+        .expect("copied folder should be in personal root");
+
+    let req = test::TestRequest::get()
+        .uri(&format!("/api/v1/folders/{copied_id}"))
+        .insert_header(("Cookie", common::access_cookie_header(&token)))
+        .insert_header(common::csrf_header_for(&token))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    let body: Value = test::read_body_json(resp).await;
+    let copied_child_id = body["data"]["folders"][0]["id"].as_i64().unwrap();
+    assert_eq!(body["data"]["folders"][0]["name"], "Nested");
+
+    let req = test::TestRequest::get()
+        .uri(&format!("/api/v1/folders/{copied_child_id}"))
+        .insert_header(("Cookie", common::access_cookie_header(&token)))
+        .insert_header(common::csrf_header_for(&token))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    let body: Value = test::read_body_json(resp).await;
+    assert_eq!(body["data"]["files"][0]["name"], "nested.txt");
+}
+
+#[actix_web::test]
+async fn test_workspace_transfer_copy_between_team_workspaces_to_target_folder() {
+    let state = common::setup().await;
+    let db = state.writer_db().clone();
+    let mail_sender = state.mail_sender.clone();
+    let app = create_test_app!(state);
+
+    let _user_id = register_user!(
+        app,
+        db,
+        mail_sender,
+        "xcopyteamteam",
+        "xcopy-team-team@example.com"
+    );
+    let token = login_user!(app, "xcopyteamteam");
+    let source_team_id = create_team!(app, token, "Source Team");
+    let dest_team_id = create_team!(app, token, "Destination Team");
+    let source_folder_id = create_team_folder!(
+        app,
+        token,
+        source_team_id,
+        "SourceFolder",
+        Option::<i64>::None
+    );
+    let target_folder_id = create_team_folder!(
+        app,
+        token,
+        dest_team_id,
+        "TargetFolder",
+        Option::<i64>::None
+    );
+    let file_id = upload_team_file!(
+        app,
+        token,
+        source_team_id,
+        Some(source_folder_id),
+        "team-a.txt",
+        "team a body"
+    );
+
+    let req = test::TestRequest::post()
+        .uri("/api/v1/workspace-transfer/copy")
+        .insert_header(("Cookie", common::access_cookie_header(&token)))
+        .insert_header(common::csrf_header_for(&token))
+        .set_json(serde_json::json!({
+            "source_workspace": { "kind": "team", "team_id": source_team_id },
+            "file_ids": [file_id],
+            "folder_ids": [],
+            "destination_workspace": { "kind": "team", "team_id": dest_team_id },
+            "target_folder_id": target_folder_id
+        }))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), 200);
+    let body: Value = test::read_body_json(resp).await;
+    assert_eq!(body["data"]["succeeded"], 1);
+
+    let req = test::TestRequest::get()
+        .uri(&format!(
+            "/api/v1/teams/{dest_team_id}/folders/{target_folder_id}"
+        ))
+        .insert_header(("Cookie", common::access_cookie_header(&token)))
+        .insert_header(common::csrf_header_for(&token))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    let body: Value = test::read_body_json(resp).await;
+    assert_eq!(body["data"]["files"][0]["name"], "team-a.txt");
+}
+
+#[actix_web::test]
+async fn test_workspace_transfer_copy_rejects_missing_destination_access() {
+    let state = common::setup().await;
+    let db = state.writer_db().clone();
+    let mail_sender = state.mail_sender.clone();
+    let app = create_test_app!(state);
+
+    let _owner_id = register_user!(
+        app,
+        db,
+        mail_sender,
+        "xcopydestowner",
+        "xcopy-dest-owner@example.com"
+    );
+    let member_id = register_user!(
+        app,
+        db,
+        mail_sender,
+        "xcopydestmember",
+        "xcopy-dest-member@example.com"
+    );
+    let owner_token = login_user!(app, "xcopydestowner");
+    let member_token = login_user!(app, "xcopydestmember");
+    let source_team_id = create_team!(app, owner_token, "Readable Source Team");
+    let dest_team_id = create_team!(app, owner_token, "Forbidden Destination Team");
+    add_team_member!(app, owner_token, source_team_id, member_id);
+    let file_id = upload_team_file!(
+        app,
+        owner_token,
+        source_team_id,
+        None::<i64>,
+        "source.txt",
+        "source body"
+    );
+
+    let req = test::TestRequest::post()
+        .uri("/api/v1/workspace-transfer/copy")
+        .insert_header(("Cookie", common::access_cookie_header(&member_token)))
+        .insert_header(common::csrf_header_for(&member_token))
+        .set_json(serde_json::json!({
+            "source_workspace": { "kind": "team", "team_id": source_team_id },
+            "file_ids": [file_id],
+            "folder_ids": [],
+            "destination_workspace": { "kind": "team", "team_id": dest_team_id },
+            "target_folder_id": null
+        }))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), 403);
+}
+
+#[actix_web::test]
+async fn test_workspace_transfer_copy_rejects_missing_source_access() {
+    let state = common::setup().await;
+    let db = state.writer_db().clone();
+    let mail_sender = state.mail_sender.clone();
+    let app = create_test_app!(state);
+
+    let _owner_id = register_user!(
+        app,
+        db,
+        mail_sender,
+        "xcsourceowner",
+        "xcopy-source-owner@example.com"
+    );
+    let member_id = register_user!(
+        app,
+        db,
+        mail_sender,
+        "xcsourcemember",
+        "xcopy-source-member@example.com"
+    );
+    let owner_token = login_user!(app, "xcsourceowner");
+    let member_token = login_user!(app, "xcsourcemember");
+    let source_team_id = create_team!(app, owner_token, "Forbidden Source Team");
+    let dest_team_id = create_team!(app, owner_token, "Writable Destination Team");
+    add_team_member!(app, owner_token, dest_team_id, member_id);
+    let file_id = upload_team_file!(
+        app,
+        owner_token,
+        source_team_id,
+        None::<i64>,
+        "private.txt",
+        "private body"
+    );
+
+    let req = test::TestRequest::post()
+        .uri("/api/v1/workspace-transfer/copy")
+        .insert_header(("Cookie", common::access_cookie_header(&member_token)))
+        .insert_header(common::csrf_header_for(&member_token))
+        .set_json(serde_json::json!({
+            "source_workspace": { "kind": "team", "team_id": source_team_id },
+            "file_ids": [file_id],
+            "folder_ids": [],
+            "destination_workspace": { "kind": "team", "team_id": dest_team_id },
+            "target_folder_id": null
+        }))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), 403);
+}
+
+#[actix_web::test]
+async fn test_workspace_transfer_copy_respects_destination_quota() {
+    let state = common::setup().await;
+    let db = state.writer_db().clone();
+    let mail_sender = state.mail_sender.clone();
+    let app = create_test_app!(state);
+
+    let _user_id = register_user!(
+        app,
+        db,
+        mail_sender,
+        "xcopyquota",
+        "xcopy-quota@example.com"
+    );
+    let token = login_user!(app, "xcopyquota");
+    let team_id = create_team!(app, token, "Quota Destination Team");
+    let source_folder_id = create_personal_folder!(app, token, "Quota Source", None::<i64>);
+    let first_file_id = upload_personal_file!(
+        app,
+        token,
+        Some(source_folder_id),
+        "first.txt",
+        "first-body"
+    );
+    let second_file_id = upload_personal_file!(
+        app,
+        token,
+        Some(source_folder_id),
+        "second.txt",
+        "second-body"
+    );
+    let first_file = aster_drive::db::repository::file_repo::find_by_id(&db, first_file_id)
+        .await
+        .unwrap();
+    let team = aster_drive::db::repository::team_repo::find_active_by_id(&db, team_id)
+        .await
+        .unwrap();
+    let mut active: aster_drive::entities::team::ActiveModel = team.into();
+    active.storage_quota = Set(first_file.size);
+    active.update(&db).await.unwrap();
+
+    let req = test::TestRequest::post()
+        .uri("/api/v1/workspace-transfer/copy")
+        .insert_header(("Cookie", common::access_cookie_header(&token)))
+        .insert_header(common::csrf_header_for(&token))
+        .set_json(serde_json::json!({
+            "source_workspace": { "kind": "personal" },
+            "file_ids": [first_file_id, second_file_id],
+            "folder_ids": [],
+            "destination_workspace": { "kind": "team", "team_id": team_id },
+            "target_folder_id": null
+        }))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), 200);
+    let body: Value = test::read_body_json(resp).await;
+    assert_eq!(body["data"]["succeeded"], 1);
+    assert_eq!(body["data"]["failed"], 1);
+    assert_eq!(body["data"]["errors"][0]["entity_id"], second_file_id);
+
+    let req = test::TestRequest::get()
+        .uri(&format!("/api/v1/teams/{team_id}/folders"))
+        .insert_header(("Cookie", common::access_cookie_header(&token)))
+        .insert_header(common::csrf_header_for(&token))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    let body: Value = test::read_body_json(resp).await;
+    let files = body["data"]["files"].as_array().unwrap();
+    assert_eq!(files.len(), 1);
+    assert_eq!(files[0]["name"], "first.txt");
+}
+
+#[actix_web::test]
+async fn test_workspace_transfer_copy_validates_request_boundaries() {
+    let state = common::setup().await;
+    let app = create_test_app!(state);
+    let (token, _) = register_and_login!(app);
+
+    for payload in [
+        serde_json::json!({
+            "source_workspace": { "kind": "personal" },
+            "file_ids": [],
+            "folder_ids": [],
+            "destination_workspace": { "kind": "personal" },
+            "target_folder_id": null
+        }),
+        serde_json::json!({
+            "source_workspace": { "kind": "team", "team_id": 0 },
+            "file_ids": [1],
+            "folder_ids": [],
+            "destination_workspace": { "kind": "personal" },
+            "target_folder_id": null
+        }),
+        serde_json::json!({
+            "source_workspace": { "kind": "personal" },
+            "file_ids": [1],
+            "folder_ids": [],
+            "destination_workspace": { "kind": "personal" },
+            "target_folder_id": 0
+        }),
+        serde_json::json!({
+            "source_workspace": { "kind": "personal" },
+            "file_ids": [-1],
+            "folder_ids": [],
+            "destination_workspace": { "kind": "personal" },
+            "target_folder_id": null
+        }),
+    ] {
+        let req = test::TestRequest::post()
+            .uri("/api/v1/workspace-transfer/copy")
+            .insert_header(("Cookie", common::access_cookie_header(&token)))
+            .insert_header(common::csrf_header_for(&token))
+            .set_json(payload)
+            .to_request();
+        let resp = test::call_service(&app, req).await;
+        assert_eq!(resp.status(), 400);
+    }
+}
+
+#[actix_web::test]
+async fn test_workspace_transfer_copy_reports_source_scope_mismatch_per_item() {
+    let state = common::setup().await;
+    let db = state.writer_db().clone();
+    let mail_sender = state.mail_sender.clone();
+    let app = create_test_app!(state);
+
+    let _user_id = register_user!(
+        app,
+        db,
+        mail_sender,
+        "xcsrcmismatch",
+        "xcopy-source-mismatch@example.com"
+    );
+    let token = login_user!(app, "xcsrcmismatch");
+    let source_folder_id = create_personal_folder!(app, token, "Mismatch Source", None::<i64>);
+    let personal_file_id = upload_personal_file!(
+        app,
+        token,
+        Some(source_folder_id),
+        "personal-only.txt",
+        "personal body"
+    );
+    let team_id = create_team!(app, token, "Declared Source Team");
+
+    let req = test::TestRequest::post()
+        .uri("/api/v1/workspace-transfer/copy")
+        .insert_header(("Cookie", common::access_cookie_header(&token)))
+        .insert_header(common::csrf_header_for(&token))
+        .set_json(serde_json::json!({
+            "source_workspace": { "kind": "team", "team_id": team_id },
+            "file_ids": [personal_file_id],
+            "folder_ids": [],
+            "destination_workspace": { "kind": "personal" },
+            "target_folder_id": null
+        }))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), 200);
+    let body: Value = test::read_body_json(resp).await;
+    assert_eq!(body["data"]["succeeded"], 0);
+    assert_eq!(body["data"]["failed"], 1);
+    assert_eq!(body["data"]["errors"][0]["entity_type"], "file");
+    assert_eq!(body["data"]["errors"][0]["entity_id"], personal_file_id);
+
+    let req = test::TestRequest::get()
+        .uri("/api/v1/folders")
+        .insert_header(("Cookie", common::access_cookie_header(&token)))
+        .insert_header(common::csrf_header_for(&token))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    let body: Value = test::read_body_json(resp).await;
+    assert!(body["data"]["files"].as_array().unwrap().is_empty());
+}
+
+#[actix_web::test]
+async fn test_workspace_transfer_copy_rejects_target_folder_outside_destination_scope() {
+    let state = common::setup().await;
+    let db = state.writer_db().clone();
+    let mail_sender = state.mail_sender.clone();
+    let app = create_test_app!(state);
+
+    let _user_id = register_user!(
+        app,
+        db,
+        mail_sender,
+        "xctargetscope",
+        "xcopy-target-scope@example.com"
+    );
+    let token = login_user!(app, "xctargetscope");
+    let source_folder_id = create_personal_folder!(app, token, "Target Scope Source", None::<i64>);
+    let personal_target_id = create_personal_folder!(app, token, "Personal Target", None::<i64>);
+    let file_id = upload_personal_file!(
+        app,
+        token,
+        Some(source_folder_id),
+        "target-scope.txt",
+        "target body"
+    );
+    let team_id = create_team!(app, token, "Target Scope Team");
+
+    let req = test::TestRequest::post()
+        .uri("/api/v1/workspace-transfer/copy")
+        .insert_header(("Cookie", common::access_cookie_header(&token)))
+        .insert_header(common::csrf_header_for(&token))
+        .set_json(serde_json::json!({
+            "source_workspace": { "kind": "personal" },
+            "file_ids": [file_id],
+            "folder_ids": [],
+            "destination_workspace": { "kind": "team", "team_id": team_id },
+            "target_folder_id": personal_target_id
+        }))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), 200);
+    let body: Value = test::read_body_json(resp).await;
+    assert_eq!(body["data"]["succeeded"], 0);
+    assert_eq!(body["data"]["failed"], 1);
+    assert_eq!(body["data"]["errors"][0]["entity_type"], "file");
+
+    let req = test::TestRequest::get()
+        .uri(&format!("/api/v1/teams/{team_id}/folders"))
+        .insert_header(("Cookie", common::access_cookie_header(&token)))
+        .insert_header(common::csrf_header_for(&token))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    let body: Value = test::read_body_json(resp).await;
+    assert!(body["data"]["files"].as_array().unwrap().is_empty());
+}
+
+#[actix_web::test]
+async fn test_workspace_transfer_copy_duplicate_file_ids_allocate_unique_destination_names() {
+    let state = common::setup().await;
+    let db = state.writer_db().clone();
+    let mail_sender = state.mail_sender.clone();
+    let app = create_test_app!(state);
+
+    let _user_id = register_user!(
+        app,
+        db,
+        mail_sender,
+        "xcdupefiles",
+        "xcopy-duplicate-files@example.com"
+    );
+    let token = login_user!(app, "xcdupefiles");
+    let team_id = create_team!(app, token, "Duplicate File Destination");
+    let source_folder_id = create_personal_folder!(app, token, "Duplicate Source", None::<i64>);
+    let file_id = upload_personal_file!(
+        app,
+        token,
+        Some(source_folder_id),
+        "repeat.txt",
+        "repeat body"
+    );
+
+    let req = test::TestRequest::post()
+        .uri("/api/v1/workspace-transfer/copy")
+        .insert_header(("Cookie", common::access_cookie_header(&token)))
+        .insert_header(common::csrf_header_for(&token))
+        .set_json(serde_json::json!({
+            "source_workspace": { "kind": "personal" },
+            "file_ids": [file_id, file_id],
+            "folder_ids": [],
+            "destination_workspace": { "kind": "team", "team_id": team_id },
+            "target_folder_id": null
+        }))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), 200);
+    let body: Value = test::read_body_json(resp).await;
+    assert_eq!(body["data"]["succeeded"], 2);
+    assert_eq!(body["data"]["failed"], 0);
+
+    let req = test::TestRequest::get()
+        .uri(&format!("/api/v1/teams/{team_id}/folders"))
+        .insert_header(("Cookie", common::access_cookie_header(&token)))
+        .insert_header(common::csrf_header_for(&token))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    let body: Value = test::read_body_json(resp).await;
+    let mut names: Vec<String> = body["data"]["files"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|item| item["name"].as_str().unwrap().to_string())
+        .collect();
+    names.sort();
+    assert_eq!(names, vec!["repeat (1).txt", "repeat.txt"]);
+}
+
+#[actix_web::test]
+async fn test_workspace_transfer_copy_folder_name_conflict_preserves_descendants() {
+    let state = common::setup().await;
+    let db = state.writer_db().clone();
+    let mail_sender = state.mail_sender.clone();
+    let app = create_test_app!(state);
+
+    let _user_id = register_user!(
+        app,
+        db,
+        mail_sender,
+        "xcfolderconflict",
+        "xcopy-folder-conflict@example.com"
+    );
+    let token = login_user!(app, "xcfolderconflict");
+    let team_id = create_team!(app, token, "Folder Conflict Source");
+    let source_id = create_team_folder!(app, token, team_id, "ConflictFolder", None::<i64>);
+    let nested_id = create_team_folder!(app, token, team_id, "Nested", Some(source_id));
+    upload_team_file!(
+        app,
+        token,
+        team_id,
+        Some(nested_id),
+        "inside.txt",
+        "inside body"
+    );
+    create_personal_folder!(app, token, "ConflictFolder", None::<i64>);
+
+    let req = test::TestRequest::post()
+        .uri("/api/v1/workspace-transfer/copy")
+        .insert_header(("Cookie", common::access_cookie_header(&token)))
+        .insert_header(common::csrf_header_for(&token))
+        .set_json(serde_json::json!({
+            "source_workspace": { "kind": "team", "team_id": team_id },
+            "file_ids": [],
+            "folder_ids": [source_id],
+            "destination_workspace": { "kind": "personal" },
+            "target_folder_id": null
+        }))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), 200);
+    let body: Value = test::read_body_json(resp).await;
+    assert_eq!(body["data"]["succeeded"], 1);
+
+    let req = test::TestRequest::get()
+        .uri("/api/v1/folders")
+        .insert_header(("Cookie", common::access_cookie_header(&token)))
+        .insert_header(common::csrf_header_for(&token))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    let body: Value = test::read_body_json(resp).await;
+    let copied_id = body["data"]["folders"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|folder| folder["name"] == "ConflictFolder (1)")
+        .and_then(|folder| folder["id"].as_i64())
+        .expect("conflicting folder copy should get a unique name");
+
+    let req = test::TestRequest::get()
+        .uri(&format!("/api/v1/folders/{copied_id}"))
+        .insert_header(("Cookie", common::access_cookie_header(&token)))
+        .insert_header(common::csrf_header_for(&token))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    let body: Value = test::read_body_json(resp).await;
+    let copied_nested_id = body["data"]["folders"][0]["id"].as_i64().unwrap();
+    assert_eq!(body["data"]["folders"][0]["name"], "Nested");
+
+    let req = test::TestRequest::get()
+        .uri(&format!("/api/v1/folders/{copied_nested_id}"))
+        .insert_header(("Cookie", common::access_cookie_header(&token)))
+        .insert_header(common::csrf_header_for(&token))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    let body: Value = test::read_body_json(resp).await;
+    assert_eq!(body["data"]["files"][0]["name"], "inside.txt");
 }
 
 #[actix_web::test]


### PR DESCRIPTION
- Add `WorkspaceRef` and `WorkspaceTransferCopyReq` DTOs with validation in `batch.rs`
- Add `POST /workspace-transfer/copy` route that resolves source and destination scopes from the request body
- Refactor `batch_copy_in_scope` to delegate to a new `batch_copy_between_scopes` that accepts separate source and destination scopes
- Refactor `copy_folder_in_scope` and `copy_folder_tree_in_scope` into `*_between_scopes` variants; skip self-reference cycle check and policy ID propagation when scopes differ
- Add `copyToWorkspace` method to `createBatchService` that posts to `/workspace-transfer/copy` with serialized workspace refs
- Update `BatchTargetFolderDialog` to accept a `BatchTargetFolderSelection` (workspace + folderId) instead of a bare folder ID; add workspace picker dropdown for copy mode backed by `useTeamStore`
- Route copy confirm through `batchService.copyToWorkspace` when the target workspace differs from the current one, in `BatchActionBar`, `useFileBrowserBatchActions`, and `useFileBrowserPageState`
- Add `WorkspaceTransferCopyDetails` and `WorkspaceTransferScopeDetails` audit structs; emit `batch_copy` audit log with source and destination workspace info
- Add `WorkspaceRef` and `WorkspaceTransferCopyReq` to OpenAPI schema and register the new route in the spec
- Add i18n keys `batch_target_workspace` and `batch_target_current_workspace` in EN and ZH locales
- Add integration tests in `test_batch.rs` covering cross-workspace copy for files and folders, audit log assertions in `test_audit.rs`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 批量复制支持个人与团队工作区之间的资源转移，并在复制目标对话框中可选择目标工作区与文件夹。
  * 复制成功/失败结果与审计日志将包含源/目标工作区信息；新增中英文目标工作区文案。
* **错误修复**
  * 修正跨工作区复制的确认参数与分发逻辑，确保复制/失败时的提示、选择清理与刷新行为一致。
  * 加强目标路径校验、权限/配额校验与同名冲突处理，提升稳定性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->