### PR TITLE
Enhance upload process with concurrency limiter and staging file

### DIFF
--- a/developer-docs/zh-CN/api/files.md
+++ b/developer-docs/zh-CN/api/files.md
@@ -101,9 +101,15 @@
 
 其中 `completed_parts` 用于恢复 `relay_stream` multipart 或 `presigned_multipart` 已完成的 part 记录；普通本地 chunked 上传主要看 `chunks_on_disk`。
 
+当前新建的 server-managed chunked session 使用 offset staging：Init 在 session 临时目录预创建 `.offset-staging-v1`，每个 Chunk PUT 按 `chunk_number * chunk_size` 写入对应 range；`upload_session_parts` 中的本地 receipt 表示该 range 已 durable publish。新 session 不创建 `chunk_N` marker，Complete 也不会再次拼写整文件。
+
+本地 Chunk PUT 会先对 staging range 执行 `sync_data`，再在只含 SQL 的短 writer transaction 中 insert-only 登记 chunk receipt 并更新 `received_count`。客户端重试只校验已有 receipt，不会重写已提交 range，也不会重复计数。
+
+升级前已经存在的 payload-per-chunk session 仍走 legacy compatibility path：这类 session 的 `chunk_N` 是实际 payload，Complete 可能创建 `assembled`。新旧格式通过 `.offset-staging-v1` 专用路径区分，不通过 `assembled` 是否存在判断；legacy `assembled` 即使在失败后残留，也仍按 legacy session 重试。
+
 完成阶段的服务端行为分两类：
 
-- 本地路径：会校验大小和配额；若 local 策略开启了 `content_dedup`，还会计算 SHA-256 并做 Blob 去重，否则直接创建独立 Blob
+- 本地路径：会校验全部本地 chunk receipt、staging 总大小和配额；若 local 策略开启了 `content_dedup`，还会从 staging file 流式计算 SHA-256 并做 Blob 去重，否则直接 promote/上传 staging file 创建独立 Blob，不再额外生成完整 assembled 副本
 - 所有对象存储 / OneDrive / Remote 路径（`relay_stream` / `presigned` / `presigned_multipart` / provider resumable）：都会校验大小和配额，但不会做 Blob 去重；最终会使用上传 session 派生的占位 hash 和 `files/{upload_id}` 风格的对象路径为每次上传创建独立 Blob；这些路径都不会回读对象计算 SHA-256
 
 `POST /files/new` 创建空文件时也遵循同样规则：只有 local 显式开启 `content_dedup` 才会复用 0 字节 Blob，非本地 connector 始终创建独立 Blob。

--- a/developer-docs/zh-CN/upload-finalization-contracts.md
+++ b/developer-docs/zh-CN/upload-finalization-contracts.md
@@ -41,6 +41,71 @@
 
 `storage::store_preuploaded_nondedup` 使用本地 `VerifiedPreuploadedNondedupStoreBlob` 覆盖 streaming direct 的最终落账契约，校验 verified size、policy、storage path 和 prepared blob 一致后再进入 DB finalization。
 
+## Local chunked 的 offset-staging 契约
+
+新建的 server-managed chunked session 不再为每个 chunk 保存一份 payload，也不会在 Complete 阶段重新拼写一份完整文件。Init、Chunk PUT 和 Complete 共享以下目录契约：
+
+```text
+<upload_temp_dir>/<upload_id>/
+├── .offset-staging-v1                 # 唯一内容载体，Init 时预分配到 total_size
+├── .chunk_0.lock                      # 同一 chunk 的跨任务/进程排他锁
+└── .chunk_1.lock                      # 其他 lock 文件按需创建
+```
+
+offset-staging 的本地 receipt 存在 `upload_session_parts`：
+
+```text
+part_number = chunk_number + 1
+etag        = aster-drive-offset-staging-receipt-v1
+size        = expected_chunk_size
+```
+
+`.offset-staging-v1` 同时是显式 session 格式标识。Complete 只在该格式专用路径存在时进入 offset-staging 校验；legacy compatibility path 创建的通用 `assembled` 文件不参与判断。这个边界很重要：legacy 首次拼装后如果 storage/DB 阶段出现可重试失败，`assembled` 可能保留到下一次 Complete；若拿它判断格式，就会把 payload-sized `chunk_N` 错当成 offset receipt。
+
+### Chunk PUT 的 durable receipt 顺序
+
+同一 chunk 先取得 `.chunk_N.lock`，不同 chunk 使用不同锁，因此可以并行写各自 offset。取得锁后按下面的顺序提交：
+
+1. 在 `.offset-staging-v1` 的 `chunk_number * chunk_size` 位置完整写入 payload。
+2. 对 staging file 执行 `sync_data`，先保证内容持久化。
+3. 开启只包含数据库 SQL 的短 writer transaction。
+4. 向 `upload_session_parts` insert-only 登记本地 chunk receipt。这里复用 `(upload_id, part_number)` 唯一键；本地 receipt 使用保留的 offset-staging 标识作为 `etag`，object multipart 仍保存 provider ETag。
+5. 只有 receipt 首次插入时才增加 `upload_sessions.received_count`，然后提交 transaction。
+
+收到重复 Chunk PUT 时仍会完整校验 payload 大小。若 receipt 已存在，服务端会 drain/忽略请求 body，校验 receipt 后直接返回当前进度，不覆盖已提交 range，也不重复计数。
+
+### 崩溃与重试矩阵
+
+| 中断位置 | 可见状态 | 重试行为 |
+| --- | --- | --- |
+| staging range 写入完成前 | receipt 缺失，range 可能部分写入 | 在同一 offset 完整覆盖，不计数 |
+| staging `sync_data` 后、DB transaction 前 | durable range 存在，receipt 缺失 | 重新完整覆盖，然后登记 receipt |
+| DB receipt transaction 提交后客户端未收到响应 | receipt 和内容都存在 | 重试校验请求大小，返回当前进度，不重写、不重复计数 |
+| receipt row 缺失但 range 仍完整 | receipt 缺失，received_count 可能滞后 | 重试完整覆盖并补登记，只计一次 |
+| receipt row 损坏 | receipt 存在但 sentinel/size 不匹配 | Chunk PUT 和 Complete 明确报损坏，不静默覆盖 |
+| staging file 被截断 | receipt 可能完整但内容载体长度错误 | Complete 拒绝并保留失败状态，避免把短文件当成完整上传 |
+
+Complete 必须同时校验：
+
+- `upload_session_parts` 中恰好有 `total_chunks` 条本地 receipt，part 序号连续，sentinel 和 size 与每个 chunk 一致；
+- `.offset-staging-v1` 是普通文件；
+- staging file 长度等于 `session.total_size`。
+
+Local completion 直接消费这份 staging file：开启 `content_dedup` 时会先流式计算 SHA-256，再按 content-addressed key promote；关闭 dedup 时把同一 staging file 写入预分配的独立 Blob。两种情况都不会再完整写一份 assembled 文件。需要 generic stream upload 的 connector 从 staging file 串流到目标 driver。S3-compatible、Azure Blob、Tencent COS 等已经协商到 provider relay multipart 的 session 不走这条本地 staging 路径。
+
+### Legacy compatibility path
+
+升级前创建的 session 仍可能采用 payload-per-chunk 目录：
+
+```text
+<upload_temp_dir>/<upload_id>/
+├── chunk_0                            # payload
+├── chunk_1                            # payload
+└── assembled                          # Complete 拼装产物，失败/崩溃后可能保留
+```
+
+这条路径会在 Complete 时取得 `chunk_assembly_to_local_temp_file` limiter，然后拼装或串流 legacy chunk。它只保护 legacy assembly，不限制新 `.offset-staging-v1` session。兼容路径计划在 `0.5.0` 移除；移除前必须保留“已有 assembled 仍按 legacy 重试”的回归测试。
+
 ## 模式矩阵
 
 | 上传模式 / transport | 初始状态和写入位置 | trusted size source | quota precheck / atomic charge | finalize function | cleanup / idempotency |
@@ -48,7 +113,8 @@
 | regular multipart/server path | 不创建 upload session；`upload_with_hints` 读取 `actix_multipart::Multipart` 到 runtime temp file | 服务端读取 multipart body 时累计的 `size`；如有 `declared_size`，必须和累计值相等 | policy resolved by actual `size`；preuploaded non-dedup blob 会在对象写入前 precheck；DB 事务内再次 `check_quota`，再 `update_storage_used` | `store_from_temp_with_hints` -> `store::from_temp` / `persist_temp_store` / `write_file_record_from_temp` | 请求临时文件在 `store_from_temp_with_hints` 返回后删除；preuploaded 对象在 DB 失败时 cleanup；dedup staged 对象只有在确认没有 blob row 引用时回滚，否则交给 orphan GC |
 | local direct | 不创建 upload session；local policy 且有 `declared_size` 时直接写入 local staging path | 写入 local staging file 时累计的 `size`，必须等于 `declared_size`；dedup 时同流计算 hash | 使用已解析 local policy；和 server path 一样通过 `store_from_temp_with_hints` 做 precheck / 事务内 atomic charge | `upload_local_direct` -> `store_from_temp_with_hints` | 写入、大小不匹配、空文件或 store 结束后删除 staging file；重复请求不会通过 session 幂等，只按普通创建语义处理 |
 | streaming direct | 不创建 upload session；relay request body 到 driver 的 prepared non-dedup blob | driver `metadata(storage_path).size`，必须等于 `declared_size`，并再次检查 policy max file size | relay 前先用 `declared_size` 做 quota precheck；metadata 复验后再用 `actual_size` precheck；DB 事务内再次 `check_quota` 并 `update_storage_used` | `upload_streaming_direct` -> `store_preuploaded_nondedup` | storage upload、relay、metadata、size validation、quota validation 或 DB finalize 失败时 cleanup prepared blob；成功后按正式 blob 管理 |
-| local chunked | session status `uploading`；chunk 写入本地 upload temp dir；complete 时拼 assembled temp file | chunk 阶段每块必须等于 `expected_chunk_size_for_upload`；complete 阶段 assembled 文件累计 `size` 是最终落账大小 | 当前路径主要依赖 `finalize_upload_session_blob_with_actor_username` 内的 atomic `update_storage_used`；本地 non-dedup preuploaded blob 没有单独 quota precheck | `complete_chunked_upload_with_actor_username` -> `finalize_chunked_upload_session` -> `persist_assembled_upload` -> `finalize_upload_session_blob_with_actor_username` | 重复 chunk 通过无覆盖发布和 existing chunk size 检查幂等；complete 成功后删除 upload temp dir；preuploaded blob 在 DB 失败时 cleanup；dedup 对象不主动删，避免并发引用误删，交给 orphan GC |
+| local chunked / offset staging | session status `uploading`；Init 预创建 `.offset-staging-v1`，Chunk PUT 按 offset 写 range 并登记 DB receipt | 每块必须等于 `expected_chunk_size_for_upload`；Complete 校验全部 receipt 和 staging file 的 `session.total_size`；dedup 时从 staging 流式计算 SHA-256 | chunk receipt 与 `received_count` 在只含 SQL 的短 writer transaction 内幂等登记；最终 quota 仍由 `finalize_upload_session_blob_with_actor_username` 原子落账 | `complete_chunked_upload_with_actor_username` -> `finalize_chunked_upload_session` -> `load_offset_staging_file` -> `stage_chunked_temp_file` -> `persist_chunked_upload` | staging range 先 `sync_data`；receipt 是唯一 completion index，唯一键避免重试重复计数；Complete 成功后删除 upload temp dir |
+| legacy local chunk files | 升级前 session 的 `chunk_N` 是 payload；Complete 拼写 `assembled`，generic stream connector 则依次读取 chunk | 拼装路径按实际读取字节累计 size；legacy stream 使用 session total size 作为声明值并由下游 storage contract 校验 | 最终 quota 与当前 chunked path 相同；legacy assembly limiter 只限制本地拼装写，不影响 offset staging | `assemble_legacy_local_chunks_to_temp_file` 或 `stream_legacy_local_chunks_into_writer` -> 当前 chunked persist/finalize | `assembled` 可能在 retryable storage/DB 失败后保留，但不能触发 offset-staging 判断；进入兼容路径会 warn，计划在 `0.5.0` 移除 |
 | presigned single | session status `presigned`；客户端 PUT 到 `object_temp_key` | complete 前读取 temp object metadata；copy 到 final key 后再次读取 final object metadata；两者都必须等于 `session.total_size` | complete 阶段没有独立 quota precheck；`finalize_upload_session_file` 在 DB 事务内创建 blob/file、atomic charge、标 completed | `complete_presigned_upload` -> `copy_presigned_object_to_final_key` -> `finalize_verified_opaque_upload_session` -> `finalize_upload_session_file` | temp object 缺失或大小不匹配会失败，大小不匹配会尝试删除 temp object；DB finalize 失败后删除 copied final object；成功后 best-effort 删除 temp object；completed retry 通过 `find_file_by_session` 返回已有文件 |
 | presigned object multipart | session status `presigned`；客户端直传 object multipart parts，complete 时客户端回传 parts | provider `list_uploaded_part_details` 的 part size 求和，必须等于 `session.total_size`；multipart complete 后再读 object metadata | multipart complete 前先用 part size total `check_quota`；`finalize_upload_session_file` 在 DB 事务内 atomic charge、标 completed | `complete_presigned_multipart` -> `complete_object_multipart_upload_session` -> `finalize_verified_opaque_upload_session` -> `finalize_upload_session_file` | completed parts 和 provider uploaded parts 必须连续且数量匹配；preflight size/parts/quota 失败会 abort multipart；complete 出现 retryable storage error 且 object 已存在时继续 finalize；multipart object 一旦 complete，`VerifiedUploadedBlob.cleanup = RetainCompletedMultipartObject`，因此 `finalize_upload_session_file`/DB finalize 失败后不删除已完成对象，留给后续重试或 orphan cleanup；completed retry 返回已有文件 |
 | relay object multipart | session status `uploading`；每个 chunk 由服务端 relay 到 object multipart，并把 part metadata 写入 `upload_session_parts` | chunk 阶段按 `expected_chunk_size_for_upload` 验每个 payload；complete 阶段读取服务端 parts 清单，再用 provider part details 求和，必须等于 `session.total_size` | chunk 阶段不 charge；complete multipart 前用 verified part total precheck；`finalize_upload_session_file` 在 DB 事务内 atomic charge、标 completed | `complete_relay_multipart` -> `complete_object_multipart_upload_session` -> `finalize_verified_opaque_upload_session` -> `finalize_upload_session_file` | part claim 防止同一 part 并发重复上传；upload 或 DB 写 part metadata 失败会 release claim；complete preflight 失败会 abort multipart；multipart object 一旦 complete，`VerifiedUploadedBlob.cleanup = RetainCompletedMultipartObject`，因此 `finalize_upload_session_file`/DB finalize 失败后不删除已完成对象，留给后续重试或 orphan cleanup；completed retry 返回已有文件 |
@@ -62,7 +128,7 @@
 - `presigned` + `object_multipart_id = None` -> `CompletePresigned`。
 - `presigned` + `object_multipart_id = Some` -> `CompletePresignedMultipart`，客户端必须提交 parts。
 - `uploading` + `object_multipart_id = Some` -> `CompleteRelayMultipart`，parts 来自服务端已保存的 `upload_session_parts`。
-- 其他 `uploading` session -> `AssembleChunks`，要求 `received_count == total_chunks`。
+- 其他 `uploading` session -> `CompleteChunked`，要求 `received_count == total_chunks`；随后再由格式专用 `.offset-staging-v1` 路径区分当前 offset staging 与 legacy chunk files。
 
 `run_upload_completion_stage` 会先把 expected status 切到 `assembling`。非 retryable 失败会把 session 标为 `failed`；retryable storage error 会尝试恢复到原状态，允许客户端重试。
 
@@ -74,4 +140,5 @@
 - `store_from_temp` 路径继续使用 `VerifiedTempStoreBlob` 或同等明确的 verified finalization input；新 temp-store 入口必须显式声明 staged dedup/preuploaded cleanup 责任。
 - `store_preuploaded_nondedup` 路径继续使用 `VerifiedPreuploadedNondedupStoreBlob` 或同等明确的 verified finalization input；新 preuploaded store 入口必须显式校验 prepared blob 的 size/policy/storage path 一致性。
 - 每个被迁移路径都要补 quota、size mismatch 和 DB finalize failure cleanup 测试；`completed retry 不重复计费` 只适用于 session complete flow。
+- offset-staging 改动必须覆盖：不同 chunk 确实并行、同一 chunk 确实排他、partial range 覆盖、receipt 缺失、receipt 损坏、staging 截断和 legacy assembled 残留重试。并发测试需要 barrier/failpoint 证明任务进入了关键区，不能只用 `join!` 假设发生过竞争。
 - 保持 public API request/response、session status 语义和现有成功上传行为不变。

--- a/src/api/routes/files/access.rs
+++ b/src/api/routes/files/access.rs
@@ -1262,6 +1262,7 @@ mod tests {
             background_task_dispatch_wakeup:
                 crate::runtime::PrimaryAppState::new_background_task_dispatch_wakeup(),
             remote_protocol: crate::runtime::PrimaryAppState::new_remote_protocol(),
+            upload_runtime: crate::runtime::PrimaryAppState::new_upload_runtime(),
         };
 
         (state, user, file)

--- a/src/api/routes/frontend.rs
+++ b/src/api/routes/frontend.rs
@@ -320,6 +320,7 @@ mod tests {
             share_download_rollback,
             background_task_dispatch_wakeup: PrimaryAppState::new_background_task_dispatch_wakeup(),
             remote_protocol: PrimaryAppState::new_remote_protocol(),
+            upload_runtime: crate::runtime::PrimaryAppState::new_upload_runtime(),
         }
     }
 

--- a/src/api/routes/health.rs
+++ b/src/api/routes/health.rs
@@ -294,6 +294,7 @@ mod tests {
             background_task_dispatch_wakeup:
                 crate::runtime::PrimaryAppState::new_background_task_dispatch_wakeup(),
             remote_protocol: crate::runtime::PrimaryAppState::new_remote_protocol(),
+            upload_runtime: crate::runtime::PrimaryAppState::new_upload_runtime(),
         }
     }
 

--- a/src/api/routes/share_public.rs
+++ b/src/api/routes/share_public.rs
@@ -1393,6 +1393,7 @@ mod tests {
             background_task_dispatch_wakeup:
                 crate::runtime::PrimaryAppState::new_background_task_dispatch_wakeup(),
             remote_protocol: crate::runtime::PrimaryAppState::new_remote_protocol(),
+            upload_runtime: crate::runtime::PrimaryAppState::new_upload_runtime(),
         };
 
         (state, user, file, folder)

--- a/src/db/repository/upload_session_part_repo.rs
+++ b/src/db/repository/upload_session_part_repo.rs
@@ -2,8 +2,8 @@
 
 use chrono::Utc;
 use sea_orm::{
-    ColumnTrait, ConnectionTrait, DatabaseConnection, EntityTrait, QueryFilter, QueryOrder,
-    QuerySelect, Set, TryInsertResult, sea_query::Expr,
+    ColumnTrait, ConnectionTrait, EntityTrait, QueryFilter, QueryOrder, QuerySelect, Set,
+    TryInsertResult, sea_query::Expr,
 };
 
 use crate::entities::upload_session_part::{self, Entity as UploadSessionPart};
@@ -115,8 +115,8 @@ pub async fn upsert_part<C: ConnectionTrait>(
     Ok(UpsertPartResult { model, inserted })
 }
 
-pub async fn find_by_upload_and_part(
-    db: &DatabaseConnection,
+pub async fn find_by_upload_and_part<C: ConnectionTrait>(
+    db: &C,
     upload_id: &str,
     part_number: i32,
 ) -> Result<Option<upload_session_part::Model>> {
@@ -128,8 +128,8 @@ pub async fn find_by_upload_and_part(
         .map_err(AsterError::from)
 }
 
-pub async fn list_by_upload(
-    db: &DatabaseConnection,
+pub async fn list_by_upload<C: ConnectionTrait>(
+    db: &C,
     upload_id: &str,
 ) -> Result<Vec<upload_session_part::Model>> {
     UploadSessionPart::find()
@@ -141,7 +141,19 @@ pub async fn list_by_upload(
         .map_err(AsterError::from)
 }
 
-pub async fn list_part_numbers(db: &DatabaseConnection, upload_id: &str) -> Result<Vec<i32>> {
+pub async fn list_all_by_upload<C: ConnectionTrait>(
+    db: &C,
+    upload_id: &str,
+) -> Result<Vec<upload_session_part::Model>> {
+    UploadSessionPart::find()
+        .filter(upload_session_part::Column::UploadId.eq(upload_id))
+        .order_by_asc(upload_session_part::Column::PartNumber)
+        .all(db)
+        .await
+        .map_err(AsterError::from)
+}
+
+pub async fn list_part_numbers<C: ConnectionTrait>(db: &C, upload_id: &str) -> Result<Vec<i32>> {
     UploadSessionPart::find()
         .select_only()
         .column(upload_session_part::Column::PartNumber)
@@ -152,6 +164,44 @@ pub async fn list_part_numbers(db: &DatabaseConnection, upload_id: &str) -> Resu
         .all(db)
         .await
         .map_err(AsterError::from)
+}
+
+/// Inserts a completed local offset-staging receipt without replacing an existing row.
+///
+/// A local receipt is the durable completion index for the staging range. Keeping this
+/// operation insert-only prevents a retry from changing a provider multipart ETag or
+/// accidentally turning a corrupted local row into a valid one.
+pub async fn insert_part_if_missing<C: ConnectionTrait>(
+    db: &C,
+    upload_id: &str,
+    part_number: i32,
+    etag: &str,
+    size: i64,
+) -> Result<bool> {
+    let now = Utc::now();
+    match UploadSessionPart::insert(upload_session_part::ActiveModel {
+        upload_id: Set(upload_id.to_string()),
+        part_number: Set(part_number),
+        etag: Set(etag.to_string()),
+        size: Set(size),
+        created_at: Set(now),
+        updated_at: Set(now),
+        ..Default::default()
+    })
+    .on_conflict_do_nothing_on([
+        upload_session_part::Column::UploadId,
+        upload_session_part::Column::PartNumber,
+    ])
+    .exec(db)
+    .await
+    .map_err(AsterError::from)?
+    {
+        TryInsertResult::Inserted(_) => Ok(true),
+        TryInsertResult::Conflicted => Ok(false),
+        TryInsertResult::Empty => Err(AsterError::internal_error(
+            "insert_part_if_missing produced empty insert result",
+        )),
+    }
 }
 
 pub async fn delete_by_upload<C: ConnectionTrait>(db: &C, upload_id: &str) -> Result<u64> {

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -9,7 +9,8 @@ pub mod tasks;
 use crate::config::{Config, RuntimeConfig};
 use crate::metrics::SharedMetricsRecorder;
 use crate::services::{
-    events::storage_change::StorageChangeEvent, share::ShareDownloadRollbackQueue,
+    events::storage_change::StorageChangeEvent, files::upload::UploadRuntime,
+    share::ShareDownloadRollbackQueue,
 };
 use crate::storage::{DriverRegistry, PolicySnapshot, remote_protocol::RemoteProtocolRuntime};
 use aster_forge_db::DbHandles;
@@ -37,6 +38,8 @@ pub struct PrimaryAppState {
     pub background_task_dispatch_wakeup: Arc<Notify>,
     /// Remote storage protocol runtime, including reverse tunnel state.
     pub remote_protocol: Arc<RemoteProtocolRuntime>,
+    /// Shared execution resources for upload workflows.
+    pub upload_runtime: Arc<UploadRuntime>,
 }
 
 #[derive(Clone)]
@@ -92,6 +95,10 @@ impl PrimaryAppState {
 
     pub fn new_remote_protocol() -> Arc<RemoteProtocolRuntime> {
         Arc::new(RemoteProtocolRuntime::new())
+    }
+
+    pub fn new_upload_runtime() -> Arc<UploadRuntime> {
+        Arc::new(UploadRuntime::new())
     }
 
     pub fn sqlite_read_write_split(&self) -> bool {
@@ -354,6 +361,7 @@ mod tests {
             background_task_dispatch_wakeup:
                 crate::runtime::PrimaryAppState::new_background_task_dispatch_wakeup(),
             remote_protocol: crate::runtime::PrimaryAppState::new_remote_protocol(),
+            upload_runtime: crate::runtime::PrimaryAppState::new_upload_runtime(),
         };
         state
             .driver_registry
@@ -408,5 +416,13 @@ mod tests {
         tokio::time::timeout(std::time::Duration::from_secs(1), notified)
             .await
             .expect("background dispatcher wakeup should notify waiters");
+    }
+
+    #[tokio::test]
+    async fn primary_state_clones_share_upload_runtime() {
+        let state = setup_state().await;
+        let cloned = state.clone();
+
+        assert!(Arc::ptr_eq(&state.upload_runtime, &cloned.upload_runtime));
     }
 }

--- a/src/runtime/startup/primary.rs
+++ b/src/runtime/startup/primary.rs
@@ -58,6 +58,7 @@ pub async fn prepare_primary() -> Result<PreparedPrimaryRuntime> {
             background_task_dispatch_wakeup:
                 crate::runtime::PrimaryAppState::new_background_task_dispatch_wakeup(),
             remote_protocol,
+            upload_runtime: crate::runtime::PrimaryAppState::new_upload_runtime(),
         },
         share_download_rollback_worker,
     })

--- a/src/runtime/tasks.rs
+++ b/src/runtime/tasks.rs
@@ -729,6 +729,7 @@ pub(crate) mod test_support {
             background_task_dispatch_wakeup:
                 crate::runtime::PrimaryAppState::new_background_task_dispatch_wakeup(),
             remote_protocol: crate::runtime::PrimaryAppState::new_remote_protocol(),
+            upload_runtime: crate::runtime::PrimaryAppState::new_upload_runtime(),
         })
     }
 }

--- a/src/services/files/file/deletion/tests.rs
+++ b/src/services/files/file/deletion/tests.rs
@@ -230,6 +230,7 @@ async fn build_deletion_test_state() -> (
         background_task_dispatch_wakeup:
             crate::runtime::PrimaryAppState::new_background_task_dispatch_wakeup(),
         remote_protocol: crate::runtime::PrimaryAppState::new_remote_protocol(),
+        upload_runtime: crate::runtime::PrimaryAppState::new_upload_runtime(),
     };
 
     (state, user, policy, driver)

--- a/src/services/files/file/download/tests.rs
+++ b/src/services/files/file/download/tests.rs
@@ -370,6 +370,7 @@ where
         background_task_dispatch_wakeup:
             crate::runtime::PrimaryAppState::new_background_task_dispatch_wakeup(),
         remote_protocol: crate::runtime::PrimaryAppState::new_remote_protocol(),
+        upload_runtime: crate::runtime::PrimaryAppState::new_upload_runtime(),
     };
 
     let blob = file_repo::create_blob(

--- a/src/services/files/file/resource_handle.rs
+++ b/src/services/files/file/resource_handle.rs
@@ -628,6 +628,7 @@ mod tests {
             background_task_dispatch_wakeup:
                 crate::runtime::PrimaryAppState::new_background_task_dispatch_wakeup(),
             remote_protocol: crate::runtime::PrimaryAppState::new_remote_protocol(),
+            upload_runtime: crate::runtime::PrimaryAppState::new_upload_runtime(),
         };
 
         let blob = file_repo::create_blob(

--- a/src/services/files/lock/tests.rs
+++ b/src/services/files/lock/tests.rs
@@ -167,6 +167,7 @@ async fn build_lock_test_state() -> (PrimaryAppState, user::Model, file::Model) 
         background_task_dispatch_wakeup:
             crate::runtime::PrimaryAppState::new_background_task_dispatch_wakeup(),
         remote_protocol: crate::runtime::PrimaryAppState::new_remote_protocol(),
+        upload_runtime: crate::runtime::PrimaryAppState::new_upload_runtime(),
     };
 
     (state, user, file)

--- a/src/services/files/upload/chunk.rs
+++ b/src/services/files/upload/chunk.rs
@@ -1,8 +1,10 @@
 //! 分片上传阶段。
 //!
 //! 这里处理两类“已经进入分片模式”的 session：
-//! - 服务端本地暂存 chunk 文件
+//! - 服务端按 offset 写入预分配 staging file，并发布小型 chunk completion marker
 //! - 服务端 relay 到 object-storage multipart，并把 ETag 记入 upload_session_parts
+//!
+//! 没有 staging file 的旧 session 继续使用独立 chunk 文件，保证滚动升级兼容。
 
 use aster_forge_db::transaction;
 use bytes::Bytes;
@@ -23,6 +25,7 @@ use crate::services::files::upload::scope::{load_upload_session, personal_scope,
 use crate::services::files::upload::shared::{
     expected_chunk_size_for_upload, upload_session_chunk_unavailable_error,
 };
+use crate::services::files::upload::staging;
 use crate::types::UploadSessionStatus;
 use aster_forge_utils::numbers::{i64_to_u64, usize_to_i64};
 use aster_forge_utils::paths;
@@ -34,6 +37,55 @@ enum ExistingLocalChunk {
     Missing,
     Complete,
     RemovedCorrupt,
+}
+
+struct LocalChunkWriteLock {
+    file: std::fs::File,
+}
+
+impl Drop for LocalChunkWriteLock {
+    fn drop(&mut self) {
+        if let Err(error) = fs2::FileExt::unlock(&self.file) {
+            tracing::warn!("failed to unlock local chunk write lock: {error}");
+        }
+    }
+}
+
+async fn acquire_local_chunk_write_lock(
+    chunk_dir: &str,
+    upload_id: &str,
+    chunk_number: i32,
+) -> Result<LocalChunkWriteLock> {
+    let lock_path = paths::temp_file_path(chunk_dir, &format!(".chunk_{chunk_number}.lock"));
+    let upload_id = upload_id.to_string();
+    tokio::task::spawn_blocking(move || {
+        let file = std::fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(&lock_path)
+            .map_err(|error| {
+                chunk_upload_error_with_code(
+                    ApiErrorCode::UploadChunkPersistFailed,
+                    format!("open chunk write lock for upload {upload_id}: {error}"),
+                )
+            })?;
+        fs2::FileExt::lock_exclusive(&file).map_err(|error| {
+            chunk_upload_error_with_code(
+                ApiErrorCode::UploadChunkPersistFailed,
+                format!("lock chunk write for upload {upload_id}: {error}"),
+            )
+        })?;
+        Ok(LocalChunkWriteLock { file })
+    })
+    .await
+    .map_err(|error| {
+        chunk_upload_error_with_code(
+            ApiErrorCode::UploadChunkPersistFailed,
+            format!("chunk write lock task failed: {error}"),
+        )
+    })?
 }
 
 async fn increment_session_received_count<C: sea_orm::ConnectionTrait>(
@@ -104,6 +156,41 @@ async fn inspect_existing_local_chunk(
     Ok(ExistingLocalChunk::RemovedCorrupt)
 }
 
+async fn inspect_existing_staged_chunk_marker(
+    chunk_path: &str,
+    expected_size: i64,
+    upload_id: &str,
+    chunk_number: i32,
+) -> Result<ExistingLocalChunk> {
+    match staging::chunk_marker_matches(chunk_path, expected_size).await {
+        Ok(true) => Ok(ExistingLocalChunk::Complete),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            Ok(ExistingLocalChunk::Missing)
+        }
+        Ok(false) => {
+            tracing::warn!(
+                upload_id,
+                chunk_number,
+                chunk_path,
+                expected_size,
+                "removing corrupt staged chunk marker"
+            );
+            remove_local_chunk_file(
+                chunk_path,
+                upload_id,
+                chunk_number,
+                "corrupt staged chunk marker",
+            )
+            .await;
+            Ok(ExistingLocalChunk::RemovedCorrupt)
+        }
+        Err(error) => Err(chunk_upload_error_with_code(
+            ApiErrorCode::UploadChunkPersistFailed,
+            format!("read staged chunk marker: {error}"),
+        )),
+    }
+}
+
 async fn write_local_chunk_temp(
     temp_path: &str,
     data: &[u8],
@@ -145,6 +232,71 @@ async fn write_local_chunk_temp(
     }
 
     write_result
+}
+
+async fn write_chunk_to_staging_file(
+    state: &PrimaryAppState,
+    session: &upload_session::Model,
+    chunk_number: i32,
+    data: &[u8],
+) -> Result<()> {
+    let mut file = staging::open_for_chunk_write(state, session, chunk_number).await?;
+    file.write_all(data)
+        .await
+        .map_aster_err_ctx("write chunk staging range", |message| {
+            chunk_upload_error_with_code(ApiErrorCode::UploadChunkPersistFailed, message)
+        })?;
+    file.flush()
+        .await
+        .map_aster_err_ctx("flush chunk staging range", |message| {
+            chunk_upload_error_with_code(ApiErrorCode::UploadChunkPersistFailed, message)
+        })?;
+    Ok(())
+}
+
+async fn publish_staged_chunk_marker(
+    chunk_path: &str,
+    expected_size: i64,
+    upload_id: &str,
+    chunk_number: i32,
+) -> Result<()> {
+    let mut marker = tokio::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(chunk_path)
+        .await
+        .map_err(|error| {
+            chunk_upload_error_with_code(
+                ApiErrorCode::UploadChunkPersistFailed,
+                format!("create staged chunk marker: {error}"),
+            )
+        })?;
+    let publish_result = async {
+        marker
+            .write_all(staging::chunk_marker_contents(expected_size).as_bytes())
+            .await
+            .map_aster_err_ctx("write staged chunk marker", |message| {
+                chunk_upload_error_with_code(ApiErrorCode::UploadChunkPersistFailed, message)
+            })?;
+        marker
+            .flush()
+            .await
+            .map_aster_err_ctx("flush staged chunk marker", |message| {
+                chunk_upload_error_with_code(ApiErrorCode::UploadChunkPersistFailed, message)
+            })?;
+        Ok::<(), AsterError>(())
+    }
+    .await;
+    if publish_result.is_err() {
+        remove_local_chunk_file(
+            chunk_path,
+            upload_id,
+            chunk_number,
+            "staged chunk marker publish error",
+        )
+        .await;
+    }
+    publish_result
 }
 
 fn chunk_body_read_failed() -> AsterError {
@@ -272,6 +424,39 @@ async fn write_local_chunk_temp_stream(
     }
 
     write_result
+}
+
+async fn write_chunk_payload_to_staging_file(
+    state: &PrimaryAppState,
+    session: &upload_session::Model,
+    chunk_number: i32,
+    payload: &mut actix_web::web::Payload,
+    expected_size: i64,
+) -> Result<()> {
+    use tokio::io::BufWriter;
+
+    let file = staging::open_for_chunk_write(state, session, chunk_number).await?;
+    let mut file = BufWriter::new(file);
+    let mut size = 0i64;
+
+    while let Some(chunk) = payload.next().await {
+        let chunk = chunk.map_aster_err_with(chunk_body_read_failed)?;
+        size = add_chunk_body_len(size, chunk.len())?;
+        ensure_chunk_body_not_too_large(size, expected_size, chunk_number)?;
+        file.write_all(&chunk)
+            .await
+            .map_aster_err_ctx("write chunk staging range", |message| {
+                chunk_upload_error_with_code(ApiErrorCode::UploadChunkPersistFailed, message)
+            })?;
+    }
+
+    ensure_chunk_body_exact_size(size, expected_size, chunk_number)?;
+    file.flush()
+        .await
+        .map_aster_err_ctx("flush chunk staging range", |message| {
+            chunk_upload_error_with_code(ApiErrorCode::UploadChunkPersistFailed, message)
+        })?;
+    Ok(())
 }
 
 async fn pipe_payload_to_writer(
@@ -589,6 +774,46 @@ async fn upload_chunk_impl(
         upload_id,
         chunk_number,
     );
+    let chunk_dir = paths::upload_temp_dir(&state.config().server.upload_temp_dir, upload_id);
+
+    if staging::exists(state, upload_id).await? {
+        let _chunk_write_lock =
+            acquire_local_chunk_write_lock(&chunk_dir, upload_id, chunk_number).await?;
+        if inspect_existing_staged_chunk_marker(&chunk_path, expected_size, upload_id, chunk_number)
+            .await?
+            == ExistingLocalChunk::Complete
+        {
+            let updated = upload_session_repo::find_by_id(db, upload_id).await?;
+            tracing::debug!(
+                upload_id,
+                chunk_number,
+                received_count = updated.received_count,
+                total_chunks = updated.total_chunks,
+                "skipping already uploaded staged chunk"
+            );
+            return Ok(ChunkUploadResponse {
+                received_count: updated.received_count,
+                total_chunks: updated.total_chunks,
+            });
+        }
+
+        write_chunk_to_staging_file(state, &session, chunk_number, data.as_ref()).await?;
+        publish_staged_chunk_marker(&chunk_path, expected_size, upload_id, chunk_number).await?;
+        increment_session_received_count(db, upload_id).await?;
+
+        let updated = upload_session_repo::find_by_id(db, upload_id).await?;
+        tracing::debug!(
+            upload_id,
+            chunk_number,
+            received_count = updated.received_count,
+            total_chunks = updated.total_chunks,
+            "stored upload chunk in staging file"
+        );
+        return Ok(ChunkUploadResponse {
+            received_count: updated.received_count,
+            total_chunks: updated.total_chunks,
+        });
+    }
 
     if inspect_existing_local_chunk(&chunk_path, expected_size, upload_id, chunk_number).await?
         == ExistingLocalChunk::Complete
@@ -607,7 +832,6 @@ async fn upload_chunk_impl(
         });
     }
 
-    let chunk_dir = paths::upload_temp_dir(&state.config().server.upload_temp_dir, upload_id);
     let temp_chunk_path = paths::temp_file_path(
         &chunk_dir,
         &format!(
@@ -802,6 +1026,54 @@ async fn upload_chunk_payload_impl(
         upload_id,
         chunk_number,
     );
+    let chunk_dir = paths::upload_temp_dir(&state.config().server.upload_temp_dir, upload_id);
+
+    if staging::exists(state, upload_id).await? {
+        let _chunk_write_lock =
+            acquire_local_chunk_write_lock(&chunk_dir, upload_id, chunk_number).await?;
+        if inspect_existing_staged_chunk_marker(&chunk_path, expected_size, upload_id, chunk_number)
+            .await?
+            == ExistingLocalChunk::Complete
+        {
+            drain_chunk_payload_exact_size(&mut payload, expected_size, chunk_number).await?;
+            let updated = upload_session_repo::find_by_id(db, upload_id).await?;
+            tracing::debug!(
+                upload_id,
+                chunk_number,
+                received_count = updated.received_count,
+                total_chunks = updated.total_chunks,
+                "skipping already uploaded staged chunk"
+            );
+            return Ok(ChunkUploadResponse {
+                received_count: updated.received_count,
+                total_chunks: updated.total_chunks,
+            });
+        }
+
+        write_chunk_payload_to_staging_file(
+            state,
+            &session,
+            chunk_number,
+            &mut payload,
+            expected_size,
+        )
+        .await?;
+        publish_staged_chunk_marker(&chunk_path, expected_size, upload_id, chunk_number).await?;
+        increment_session_received_count(db, upload_id).await?;
+
+        let updated = upload_session_repo::find_by_id(db, upload_id).await?;
+        tracing::debug!(
+            upload_id,
+            chunk_number,
+            received_count = updated.received_count,
+            total_chunks = updated.total_chunks,
+            "stored upload chunk stream in staging file"
+        );
+        return Ok(ChunkUploadResponse {
+            received_count: updated.received_count,
+            total_chunks: updated.total_chunks,
+        });
+    }
 
     if inspect_existing_local_chunk(&chunk_path, expected_size, upload_id, chunk_number).await?
         == ExistingLocalChunk::Complete
@@ -821,7 +1093,6 @@ async fn upload_chunk_payload_impl(
         });
     }
 
-    let chunk_dir = paths::upload_temp_dir(&state.config().server.upload_temp_dir, upload_id);
     let temp_chunk_path = paths::temp_file_path(
         &chunk_dir,
         &format!(

--- a/src/services/files/upload/chunk.rs
+++ b/src/services/files/upload/chunk.rs
@@ -1,16 +1,22 @@
 //! 分片上传阶段。
 //!
 //! 这里处理两类“已经进入分片模式”的 session：
-//! - 服务端按 offset 写入预分配 staging file，并发布小型 chunk completion marker
+//! - 服务端按 offset 写入预分配 staging file，再幂等登记数据库 receipt
 //! - 服务端 relay 到 object-storage multipart，并把 ETag 记入 upload_session_parts
 //!
-//! 没有 staging file 的旧 session 继续使用独立 chunk 文件，保证滚动升级兼容。
+//! offset-staging 的提交边界是：先 `sync_data` 内容，再在只包含 SQL 的短 DB 事务中登记
+//! receipt/增加 `received_count`。receipt 是唯一 completion index；重试只需校验旧 receipt，
+//! 不会再次写文件或重复计数。
+//! 没有 `.offset-staging-v1` 的旧 session 继续使用独立 payload-sized chunk 文件。
 
 use aster_forge_db::transaction;
 use bytes::Bytes;
 use chrono::Utc;
 use futures::StreamExt;
 use tokio::io::AsyncWriteExt;
+
+#[cfg(debug_assertions)]
+use std::sync::{LazyLock, Mutex as StdMutex};
 
 use crate::api::api_error_code::ApiErrorCode;
 use crate::db::repository::{upload_session_part_repo, upload_session_repo};
@@ -31,6 +37,13 @@ use aster_forge_utils::numbers::{i64_to_u64, usize_to_i64};
 use aster_forge_utils::paths;
 
 const RELAY_STREAM_PIPE_BUFFER_SIZE: usize = 64 * 1024;
+
+#[cfg(debug_assertions)]
+static STAGING_WRITE_TEST_HOOKS: LazyLock<
+    StdMutex<
+        std::collections::HashMap<String, std::sync::Arc<test_support::StagingWriteTestHookState>>,
+    >,
+> = LazyLock::new(|| StdMutex::new(std::collections::HashMap::new()));
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum ExistingLocalChunk {
@@ -104,6 +117,68 @@ async fn increment_session_received_count<C: sea_orm::ConnectionTrait>(
     }
 }
 
+async fn record_staged_chunk_receipt<C: sea_orm::ConnectionTrait>(
+    db: &C,
+    upload_id: &str,
+    chunk_number: i32,
+    expected_size: i64,
+) -> Result<bool> {
+    let inserted = upload_session_part_repo::insert_part_if_missing(
+        db,
+        upload_id,
+        chunk_number + 1,
+        staging::chunk_receipt_etag(),
+        expected_size,
+    )
+    .await?;
+
+    if inserted {
+        increment_session_received_count(db, upload_id).await?;
+        return Ok(true);
+    }
+
+    let receipt =
+        upload_session_part_repo::find_by_upload_and_part(db, upload_id, chunk_number + 1)
+            .await?
+            .ok_or_else(|| {
+                chunk_upload_error_with_code(
+                    ApiErrorCode::UploadChunkPersistFailed,
+                    format!("local chunk receipt disappeared for chunk {chunk_number}"),
+                )
+            })?;
+    if receipt.etag != staging::chunk_receipt_etag() || receipt.size != expected_size {
+        return Err(chunk_upload_error_with_code(
+            ApiErrorCode::UploadChunkPersistFailed,
+            format!("local chunk receipt is corrupted for chunk {chunk_number}"),
+        ));
+    }
+    let session = upload_session_repo::find_by_id(db, upload_id).await?;
+    if session.status != UploadSessionStatus::Uploading {
+        return Err(upload_session_chunk_unavailable_error(&session));
+    }
+    Ok(false)
+}
+
+async fn has_staged_chunk_receipt(
+    db: &impl sea_orm::ConnectionTrait,
+    upload_id: &str,
+    chunk_number: i32,
+    expected_size: i64,
+) -> Result<bool> {
+    let Some(receipt) =
+        upload_session_part_repo::find_by_upload_and_part(db, upload_id, chunk_number + 1).await?
+    else {
+        return Ok(false);
+    };
+    if receipt.etag != staging::chunk_receipt_etag() || receipt.size != expected_size {
+        return Err(chunk_upload_error_with_code(
+            ApiErrorCode::UploadChunkPersistFailed,
+            format!("local chunk receipt is corrupted for chunk {chunk_number}"),
+        ));
+    }
+    Ok(true)
+}
+
 async fn remove_local_chunk_file(path: &str, upload_id: &str, chunk_number: i32, reason: &str) {
     match tokio::fs::remove_file(path).await {
         Ok(()) => {}
@@ -154,41 +229,6 @@ async fn inspect_existing_local_chunk(
     );
     remove_local_chunk_file(chunk_path, upload_id, chunk_number, "corrupt local chunk").await;
     Ok(ExistingLocalChunk::RemovedCorrupt)
-}
-
-async fn inspect_existing_staged_chunk_marker(
-    chunk_path: &str,
-    expected_size: i64,
-    upload_id: &str,
-    chunk_number: i32,
-) -> Result<ExistingLocalChunk> {
-    match staging::chunk_marker_matches(chunk_path, expected_size).await {
-        Ok(true) => Ok(ExistingLocalChunk::Complete),
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
-            Ok(ExistingLocalChunk::Missing)
-        }
-        Ok(false) => {
-            tracing::warn!(
-                upload_id,
-                chunk_number,
-                chunk_path,
-                expected_size,
-                "removing corrupt staged chunk marker"
-            );
-            remove_local_chunk_file(
-                chunk_path,
-                upload_id,
-                chunk_number,
-                "corrupt staged chunk marker",
-            )
-            .await;
-            Ok(ExistingLocalChunk::RemovedCorrupt)
-        }
-        Err(error) => Err(chunk_upload_error_with_code(
-            ApiErrorCode::UploadChunkPersistFailed,
-            format!("read staged chunk marker: {error}"),
-        )),
-    }
 }
 
 async fn write_local_chunk_temp(
@@ -246,57 +286,25 @@ async fn write_chunk_to_staging_file(
         .map_aster_err_ctx("write chunk staging range", |message| {
             chunk_upload_error_with_code(ApiErrorCode::UploadChunkPersistFailed, message)
         })?;
-    file.flush()
+    file.sync_data()
         .await
-        .map_aster_err_ctx("flush chunk staging range", |message| {
+        .map_aster_err_ctx("sync chunk staging range", |message| {
             chunk_upload_error_with_code(ApiErrorCode::UploadChunkPersistFailed, message)
         })?;
     Ok(())
 }
 
-async fn publish_staged_chunk_marker(
-    chunk_path: &str,
-    expected_size: i64,
+async fn commit_staged_chunk_receipt(
+    state: &PrimaryAppState,
     upload_id: &str,
     chunk_number: i32,
+    expected_size: i64,
 ) -> Result<()> {
-    let mut marker = tokio::fs::OpenOptions::new()
-        .write(true)
-        .create_new(true)
-        .open(chunk_path)
-        .await
-        .map_err(|error| {
-            chunk_upload_error_with_code(
-                ApiErrorCode::UploadChunkPersistFailed,
-                format!("create staged chunk marker: {error}"),
-            )
-        })?;
-    let publish_result = async {
-        marker
-            .write_all(staging::chunk_marker_contents(expected_size).as_bytes())
-            .await
-            .map_aster_err_ctx("write staged chunk marker", |message| {
-                chunk_upload_error_with_code(ApiErrorCode::UploadChunkPersistFailed, message)
-            })?;
-        marker
-            .flush()
-            .await
-            .map_aster_err_ctx("flush staged chunk marker", |message| {
-                chunk_upload_error_with_code(ApiErrorCode::UploadChunkPersistFailed, message)
-            })?;
-        Ok::<(), AsterError>(())
-    }
-    .await;
-    if publish_result.is_err() {
-        remove_local_chunk_file(
-            chunk_path,
-            upload_id,
-            chunk_number,
-            "staged chunk marker publish error",
-        )
-        .await;
-    }
-    publish_result
+    // 文件同步在事务外完成；SQLite writer lock 只覆盖这组短 SQL。
+    let txn = transaction::begin(state.writer_db()).await?;
+    record_staged_chunk_receipt(&txn, upload_id, chunk_number, expected_size).await?;
+    transaction::commit(txn).await?;
+    Ok(())
 }
 
 fn chunk_body_read_failed() -> AsterError {
@@ -454,6 +462,12 @@ async fn write_chunk_payload_to_staging_file(
     file.flush()
         .await
         .map_aster_err_ctx("flush chunk staging range", |message| {
+            chunk_upload_error_with_code(ApiErrorCode::UploadChunkPersistFailed, message)
+        })?;
+    file.get_ref()
+        .sync_data()
+        .await
+        .map_aster_err_ctx("sync chunk staging range", |message| {
             chunk_upload_error_with_code(ApiErrorCode::UploadChunkPersistFailed, message)
         })?;
     Ok(())
@@ -779,11 +793,14 @@ async fn upload_chunk_impl(
     if staging::exists(state, upload_id).await? {
         let _chunk_write_lock =
             acquire_local_chunk_write_lock(&chunk_dir, upload_id, chunk_number).await?;
-        if inspect_existing_staged_chunk_marker(&chunk_path, expected_size, upload_id, chunk_number)
-            .await?
-            == ExistingLocalChunk::Complete
-        {
+        #[cfg(debug_assertions)]
+        let _staging_write_test_guard =
+            test_support::enter_staging_write_critical_section(upload_id).await;
+        if has_staged_chunk_receipt(db, upload_id, chunk_number, expected_size).await? {
             let updated = upload_session_repo::find_by_id(db, upload_id).await?;
+            if updated.status != UploadSessionStatus::Uploading {
+                return Err(upload_session_chunk_unavailable_error(&updated));
+            }
             tracing::debug!(
                 upload_id,
                 chunk_number,
@@ -798,8 +815,7 @@ async fn upload_chunk_impl(
         }
 
         write_chunk_to_staging_file(state, &session, chunk_number, data.as_ref()).await?;
-        publish_staged_chunk_marker(&chunk_path, expected_size, upload_id, chunk_number).await?;
-        increment_session_received_count(db, upload_id).await?;
+        commit_staged_chunk_receipt(state, upload_id, chunk_number, expected_size).await?;
 
         let updated = upload_session_repo::find_by_id(db, upload_id).await?;
         tracing::debug!(
@@ -1031,12 +1047,15 @@ async fn upload_chunk_payload_impl(
     if staging::exists(state, upload_id).await? {
         let _chunk_write_lock =
             acquire_local_chunk_write_lock(&chunk_dir, upload_id, chunk_number).await?;
-        if inspect_existing_staged_chunk_marker(&chunk_path, expected_size, upload_id, chunk_number)
-            .await?
-            == ExistingLocalChunk::Complete
-        {
+        #[cfg(debug_assertions)]
+        let _staging_write_test_guard =
+            test_support::enter_staging_write_critical_section(upload_id).await;
+        if has_staged_chunk_receipt(db, upload_id, chunk_number, expected_size).await? {
             drain_chunk_payload_exact_size(&mut payload, expected_size, chunk_number).await?;
             let updated = upload_session_repo::find_by_id(db, upload_id).await?;
+            if updated.status != UploadSessionStatus::Uploading {
+                return Err(upload_session_chunk_unavailable_error(&updated));
+            }
             tracing::debug!(
                 upload_id,
                 chunk_number,
@@ -1058,8 +1077,7 @@ async fn upload_chunk_payload_impl(
             expected_size,
         )
         .await?;
-        publish_staged_chunk_marker(&chunk_path, expected_size, upload_id, chunk_number).await?;
-        increment_session_received_count(db, upload_id).await?;
+        commit_staged_chunk_receipt(state, upload_id, chunk_number, expected_size).await?;
 
         let updated = upload_session_repo::find_by_id(db, upload_id).await?;
         tracing::debug!(
@@ -1218,6 +1236,166 @@ pub async fn upload_chunk_payload_for_team(
 ) -> Result<ChunkUploadResponse> {
     let session = load_upload_session(state, team_scope(team_id, user_id), upload_id).await?;
     upload_chunk_payload_impl(state, session, chunk_number, payload).await
+}
+
+#[cfg(debug_assertions)]
+pub mod test_support {
+    //! Debug-only synchronization hooks for upload integration tests.
+    //!
+    //! Integration tests compile this crate as a dependency, so `cfg(test)` is not visible here.
+    //! Release builds omit the hooks entirely.
+
+    use std::sync::{
+        Arc,
+        atomic::{AtomicBool, AtomicUsize, Ordering},
+    };
+    use std::time::Duration;
+
+    use tokio::sync::{Barrier, Notify};
+
+    use super::STAGING_WRITE_TEST_HOOKS;
+
+    pub(super) struct StagingWriteTestHookState {
+        mode: StagingWriteTestHookMode,
+    }
+
+    enum StagingWriteTestHookMode {
+        Rendezvous(Arc<Barrier>),
+        ObserveExclusive(Arc<ExclusiveObservation>),
+    }
+
+    struct ExclusiveObservation {
+        active: AtomicUsize,
+        overlap_observed: AtomicBool,
+        first_entry_wait_pending: AtomicBool,
+        overlap: Notify,
+    }
+
+    pub struct StagingWriteTestHook {
+        upload_id: String,
+        state: Arc<StagingWriteTestHookState>,
+    }
+
+    impl StagingWriteTestHook {
+        pub fn overlap_observed(&self) -> bool {
+            match &self.state.mode {
+                StagingWriteTestHookMode::Rendezvous(_) => false,
+                StagingWriteTestHookMode::ObserveExclusive(observation) => {
+                    observation.overlap_observed.load(Ordering::SeqCst)
+                }
+            }
+        }
+    }
+
+    impl Drop for StagingWriteTestHook {
+        fn drop(&mut self) {
+            let mut hooks = STAGING_WRITE_TEST_HOOKS
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            if hooks
+                .get(&self.upload_id)
+                .is_some_and(|registered| Arc::ptr_eq(registered, &self.state))
+            {
+                hooks.remove(&self.upload_id);
+            }
+        }
+    }
+
+    pub fn install_distinct_chunk_rendezvous(
+        upload_id: &str,
+        participants: usize,
+    ) -> StagingWriteTestHook {
+        install_hook(
+            upload_id,
+            StagingWriteTestHookMode::Rendezvous(Arc::new(Barrier::new(participants))),
+        )
+    }
+
+    pub fn install_same_chunk_exclusion_observer(upload_id: &str) -> StagingWriteTestHook {
+        install_hook(
+            upload_id,
+            StagingWriteTestHookMode::ObserveExclusive(Arc::new(ExclusiveObservation {
+                active: AtomicUsize::new(0),
+                overlap_observed: AtomicBool::new(false),
+                first_entry_wait_pending: AtomicBool::new(true),
+                overlap: Notify::new(),
+            })),
+        )
+    }
+
+    fn install_hook(upload_id: &str, mode: StagingWriteTestHookMode) -> StagingWriteTestHook {
+        let state = Arc::new(StagingWriteTestHookState { mode });
+        STAGING_WRITE_TEST_HOOKS
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .insert(upload_id.to_string(), Arc::clone(&state));
+        StagingWriteTestHook {
+            upload_id: upload_id.to_string(),
+            state,
+        }
+    }
+
+    pub(super) struct StagingWriteTestGuard {
+        exclusive: Option<Arc<ExclusiveObservation>>,
+    }
+
+    impl Drop for StagingWriteTestGuard {
+        fn drop(&mut self) {
+            if let Some(observation) = &self.exclusive {
+                observation.active.fetch_sub(1, Ordering::SeqCst);
+            }
+        }
+    }
+
+    pub(super) async fn enter_staging_write_critical_section(
+        upload_id: &str,
+    ) -> StagingWriteTestGuard {
+        let hook = STAGING_WRITE_TEST_HOOKS
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .get(upload_id)
+            .cloned();
+        let Some(hook) = hook else {
+            return StagingWriteTestGuard { exclusive: None };
+        };
+
+        match &hook.mode {
+            StagingWriteTestHookMode::Rendezvous(barrier) => {
+                barrier.wait().await;
+                StagingWriteTestGuard { exclusive: None }
+            }
+            StagingWriteTestHookMode::ObserveExclusive(observation) => {
+                let previous = observation.active.fetch_add(1, Ordering::SeqCst);
+                if previous > 0 {
+                    observation.overlap_observed.store(true, Ordering::SeqCst);
+                    observation.overlap.notify_waiters();
+                } else if observation
+                    .first_entry_wait_pending
+                    .swap(false, Ordering::SeqCst)
+                {
+                    let _ = tokio::time::timeout(
+                        Duration::from_millis(250),
+                        observation.overlap.notified(),
+                    )
+                    .await;
+                }
+                StagingWriteTestGuard {
+                    exclusive: Some(Arc::clone(observation)),
+                }
+            }
+        }
+    }
+
+    pub fn offset_staging_file_path(upload_temp_dir: &str, upload_id: &str) -> String {
+        crate::services::files::upload::staging::file_path_in_upload_temp_dir(
+            upload_temp_dir,
+            upload_id,
+        )
+    }
+
+    pub fn offset_staging_receipt_etag() -> &'static str {
+        crate::services::files::upload::staging::chunk_receipt_etag()
+    }
 }
 
 #[cfg(test)]

--- a/src/services/files/upload/complete/chunked.rs
+++ b/src/services/files/upload/complete/chunked.rs
@@ -82,6 +82,13 @@ async fn finalize_chunked_upload_session(
         .await;
     }
 
+    let assembly_wait_started_at = Instant::now();
+    let assembly_permit = state
+        .upload_runtime
+        .acquire_chunk_assembly_to_local_temp_file()
+        .await?;
+    let assembly_wait_elapsed_ms = assembly_wait_started_at.elapsed().as_millis();
+
     let assemble_started_at = Instant::now();
     let assembled = assemble_local_chunks_to_temp_file(
         state,
@@ -90,6 +97,7 @@ async fn finalize_chunked_upload_session(
     )
     .await?;
     let assemble_elapsed_ms = assemble_started_at.elapsed().as_millis();
+    drop(assembly_permit);
 
     let stage_started_at = Instant::now();
     let assembled_size = assembled.size;
@@ -104,6 +112,7 @@ async fn finalize_chunked_upload_session(
                 upload_id = %session.id,
                 file_id = file.id,
                 size = assembled_size,
+                assembly_wait_elapsed_ms,
                 assemble_elapsed_ms,
                 stage_elapsed_ms,
                 persist_elapsed_ms = persist_started_at.elapsed().as_millis(),

--- a/src/services/files/upload/complete/chunked.rs
+++ b/src/services/files/upload/complete/chunked.rs
@@ -8,15 +8,16 @@ use crate::entities::{file, storage_policy, upload_session};
 use crate::errors::{AsterError, MapAsterErr, Result, upload_assembly_error_with_code};
 use crate::runtime::{PrimaryAppState, SharedRuntimeState};
 use crate::services::files::upload::shared::{
-    cleanup_upload_temp_dir, run_upload_completion_stage,
+    cleanup_upload_temp_dir, expected_chunk_size_for_upload, run_upload_completion_stage,
 };
+use crate::services::files::upload::staging;
 use crate::services::workspace::storage;
 use crate::storage::StorageDriver;
 use crate::storage::connectors::{
     StorageConnectorChunkedCompletion, resolve_policy_upload_transport,
 };
 use crate::types::UploadSessionStatus;
-use aster_forge_utils::numbers::usize_to_i64;
+use aster_forge_utils::numbers::{i64_to_u64, usize_to_i64};
 use aster_forge_utils::paths;
 use tokio::io::AsyncReadExt;
 use tokio::io::AsyncWriteExt;
@@ -25,10 +26,19 @@ use super::contract::{
     VerifiedUploadSource, VerifiedUploadedBlob, cleanup_verified_upload_after_db_failure,
 };
 
-struct AssembledTempFile {
+struct ChunkedTempFile {
     path: String,
     size: i64,
     file_hash: Option<String>,
+}
+
+fn warn_legacy_chunk_file_completion(session: &upload_session::Model, completion_mode: &str) {
+    tracing::warn!(
+        upload_id = %session.id,
+        completion_mode,
+        removal_version = "0.5.0",
+        "using deprecated legacy per-chunk file completion path"
+    );
 }
 
 pub(super) async fn complete_chunked_upload_with_actor_username(
@@ -82,43 +92,139 @@ async fn finalize_chunked_upload_session(
         .await;
     }
 
-    let assembly_wait_started_at = Instant::now();
-    let assembly_permit = state
-        .upload_runtime
-        .acquire_chunk_assembly_to_local_temp_file()
-        .await?;
-    let assembly_wait_elapsed_ms = assembly_wait_started_at.elapsed().as_millis();
-
-    let assemble_started_at = Instant::now();
-    let assembled = assemble_local_chunks_to_temp_file(
-        state,
-        session,
-        storage::local_content_dedup_enabled(policy),
-    )
-    .await?;
-    let assemble_elapsed_ms = assemble_started_at.elapsed().as_millis();
-    drop(assembly_permit);
+    let prepare_started_at = Instant::now();
+    let should_dedup = storage::local_content_dedup_enabled(policy);
+    let (chunked_temp, used_offset_staging, legacy_assembly_wait_elapsed_ms) =
+        if let Some(staged) = load_offset_staging_file(state, session, should_dedup).await? {
+            (staged, true, 0)
+        } else {
+            warn_legacy_chunk_file_completion(session, "assemble_to_local_temp_file");
+            let assembly_wait_started_at = Instant::now();
+            let assembly_permit = state
+                .upload_runtime
+                .acquire_chunk_assembly_to_local_temp_file()
+                .await?;
+            let assembly_wait_elapsed_ms = assembly_wait_started_at.elapsed().as_millis();
+            let assembled =
+                assemble_legacy_local_chunks_to_temp_file(state, session, should_dedup).await?;
+            drop(assembly_permit);
+            (assembled, false, assembly_wait_elapsed_ms)
+        };
+    let prepare_elapsed_ms = prepare_started_at.elapsed().as_millis();
 
     let stage_started_at = Instant::now();
-    let assembled_size = assembled.size;
-    let verified = stage_assembled_blob_upload(driver, policy, assembled).await?;
+    let staged_size = chunked_temp.size;
+    let verified = stage_chunked_temp_file(driver, policy, chunked_temp).await?;
     let stage_elapsed_ms = stage_started_at.elapsed().as_millis();
 
     let persist_started_at = Instant::now();
-    persist_assembled_upload(state, session, driver, &verified, actor_username)
+    persist_chunked_upload(state, session, driver, &verified, actor_username)
         .await
         .inspect(|file| {
             tracing::debug!(
                 upload_id = %session.id,
                 file_id = file.id,
-                size = assembled_size,
-                assembly_wait_elapsed_ms,
-                assemble_elapsed_ms,
+                size = staged_size,
+                used_offset_staging,
+                legacy_assembly_wait_elapsed_ms,
+                prepare_elapsed_ms,
                 stage_elapsed_ms,
                 persist_elapsed_ms = persist_started_at.elapsed().as_millis(),
                 "local chunked upload finalized"
             );
         })
+}
+
+async fn validate_offset_staging_file(
+    state: &PrimaryAppState,
+    session: &upload_session::Model,
+) -> Result<String> {
+    for chunk_number in 0..session.total_chunks {
+        let chunk_path = paths::upload_chunk_path(
+            &state.config().server.upload_temp_dir,
+            &session.id,
+            chunk_number,
+        );
+        let expected_size = expected_chunk_size_for_upload(session, chunk_number)?;
+        let marker_matches = staging::chunk_marker_matches(&chunk_path, expected_size)
+            .await
+            .map_aster_err_ctx(&format!("open chunk {chunk_number}"), |message| {
+                upload_assembly_error_with_code(ApiErrorCode::UploadAssemblyIoFailed, message)
+            })?;
+        if !marker_matches {
+            return Err(upload_assembly_error_with_code(
+                ApiErrorCode::UploadAssemblyIoFailed,
+                format!("chunk {chunk_number} marker is invalid for size {expected_size}"),
+            ));
+        }
+    }
+
+    let path = staging::file_path(state, &session.id);
+    let metadata = tokio::fs::metadata(&path)
+        .await
+        .map_aster_err_ctx("stat chunk staging file", |message| {
+            upload_assembly_error_with_code(ApiErrorCode::UploadAssemblyIoFailed, message)
+        })?;
+    let expected_size = i64_to_u64(session.total_size, "chunk staging total size")?;
+    if !metadata.is_file() || metadata.len() != expected_size {
+        return Err(upload_assembly_error_with_code(
+            ApiErrorCode::UploadAssemblyIoFailed,
+            format!(
+                "chunk staging file size mismatch: expected {expected_size}, got {}",
+                metadata.len()
+            ),
+        ));
+    }
+    Ok(path)
+}
+
+async fn load_offset_staging_file(
+    state: &PrimaryAppState,
+    session: &upload_session::Model,
+    should_dedup: bool,
+) -> Result<Option<ChunkedTempFile>> {
+    if !staging::exists(state, &session.id).await? {
+        return Ok(None);
+    }
+
+    let path = validate_offset_staging_file(state, session).await?;
+    let file_hash = if should_dedup {
+        Some(hash_staging_file(&path).await?)
+    } else {
+        None
+    };
+    Ok(Some(ChunkedTempFile {
+        path,
+        size: session.total_size,
+        file_hash,
+    }))
+}
+
+async fn hash_staging_file(path: &str) -> Result<String> {
+    use sha2::{Digest, Sha256};
+
+    const HASH_BUFFER_SIZE: usize = 64 * 1024;
+
+    let mut file = tokio::fs::File::open(path)
+        .await
+        .map_aster_err_ctx("open chunk staging file for hashing", |message| {
+            upload_assembly_error_with_code(ApiErrorCode::UploadAssemblyIoFailed, message)
+        })?;
+    let mut hasher = Sha256::new();
+    let mut buffer = vec![0u8; HASH_BUFFER_SIZE];
+    loop {
+        let read = file.read(&mut buffer).await.map_aster_err_ctx(
+            "read chunk staging file for hashing",
+            |message| {
+                upload_assembly_error_with_code(ApiErrorCode::UploadAssemblyIoFailed, message)
+            },
+        )?;
+        if read == 0 {
+            break;
+        }
+        hasher.update(&buffer[..read]);
+    }
+    Ok(aster_forge_crypto::sha256_digest_to_hex(&hasher.finalize()))
 }
 
 async fn finalize_stream_relay_chunked_upload_session(
@@ -128,11 +234,24 @@ async fn finalize_stream_relay_chunked_upload_session(
     driver: &dyn StorageDriver,
     actor_username: Option<&str>,
 ) -> Result<file::Model> {
+    if staging::exists(state, &session.id).await? {
+        return finalize_offset_staging_stream_relay(
+            state,
+            session,
+            policy,
+            driver,
+            actor_username,
+        )
+        .await;
+    }
+
+    warn_legacy_chunk_file_completion(session, "stream_local_chunk_files");
+
     const CHUNK_RELAY_BUFFER_SIZE: usize = 64 * 1024;
 
     let prepared = storage::prepare_non_dedup_blob_upload(policy, session.total_size)?;
     let (writer, reader) = tokio::io::duplex(CHUNK_RELAY_BUFFER_SIZE);
-    let relay_task = tokio::spawn(stream_local_chunks_into_writer(
+    let relay_task = tokio::spawn(stream_legacy_local_chunks_into_writer(
         state.config().server.upload_temp_dir.clone(),
         session.id.clone(),
         session.total_chunks,
@@ -187,7 +306,58 @@ async fn finalize_stream_relay_chunked_upload_session(
         })
 }
 
-async fn stream_local_chunks_into_writer(
+async fn finalize_offset_staging_stream_relay(
+    state: &PrimaryAppState,
+    session: &upload_session::Model,
+    policy: &storage_policy::Model,
+    driver: &dyn StorageDriver,
+    actor_username: Option<&str>,
+) -> Result<file::Model> {
+    let path = validate_offset_staging_file(state, session).await?;
+    let reader = tokio::fs::File::open(&path)
+        .await
+        .map_aster_err_ctx("open chunk staging file for stream upload", |message| {
+            upload_assembly_error_with_code(ApiErrorCode::UploadAssemblyIoFailed, message)
+        })?;
+    let prepared = storage::prepare_non_dedup_blob_upload(policy, session.total_size)?;
+    let upload_started_at = Instant::now();
+    if let Err(error) = storage::upload_reader_to_prepared_blob(
+        driver,
+        &prepared,
+        Box::new(reader),
+        session.total_size,
+    )
+    .await
+    {
+        storage::cleanup_preuploaded_blob_upload(
+            driver,
+            &prepared,
+            "chunk staging stream upload storage write error",
+        )
+        .await;
+        return Err(error);
+    }
+    let upload_elapsed_ms = upload_started_at.elapsed().as_millis();
+
+    let persist_started_at = Instant::now();
+    let verified = VerifiedUploadedBlob::preuploaded_non_dedup(prepared)?;
+    persist_verified_chunked_upload(state, session, driver, &verified, actor_username)
+        .await
+        .inspect(|file| {
+            tracing::debug!(
+                upload_id = %session.id,
+                file_id = file.id,
+                size = session.total_size,
+                upload_elapsed_ms,
+                persist_elapsed_ms = persist_started_at.elapsed().as_millis(),
+                "offset staging stream relay chunked upload finalized"
+            );
+        })
+}
+
+/// Compatibility path for sessions created before offset staging was introduced.
+/// Scheduled for removal in 0.5.0 after all 24-hour upload sessions have expired.
+async fn stream_legacy_local_chunks_into_writer(
     upload_temp_dir: String,
     upload_id: String,
     total_chunks: i32,
@@ -233,11 +403,13 @@ async fn stream_local_chunks_into_writer(
     Ok(())
 }
 
-async fn assemble_local_chunks_to_temp_file(
+/// Compatibility path for sessions created before offset staging was introduced.
+/// Scheduled for removal in 0.5.0 after all 24-hour upload sessions have expired.
+async fn assemble_legacy_local_chunks_to_temp_file(
     state: &PrimaryAppState,
     session: &upload_session::Model,
     should_dedup: bool,
-) -> Result<AssembledTempFile> {
+) -> Result<ChunkedTempFile> {
     use sha2::{Digest, Sha256};
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
@@ -306,7 +478,7 @@ async fn assemble_local_chunks_to_temp_file(
         })?;
     drop(out_file);
 
-    Ok(AssembledTempFile {
+    Ok(ChunkedTempFile {
         path: assembled_path,
         size,
         file_hash: hasher
@@ -314,16 +486,16 @@ async fn assemble_local_chunks_to_temp_file(
     })
 }
 
-async fn stage_assembled_blob_upload(
+async fn stage_chunked_temp_file(
     driver: &dyn StorageDriver,
     policy: &storage_policy::Model,
-    assembled: AssembledTempFile,
+    chunked_temp: ChunkedTempFile,
 ) -> Result<VerifiedUploadedBlob> {
-    let AssembledTempFile {
+    let ChunkedTempFile {
         path,
         size,
         file_hash,
-    } = assembled;
+    } = chunked_temp;
     if let Some(file_hash) = file_hash {
         let storage_path =
             aster_forge_validation::filename::storage_path_from_blob_key(&file_hash)?;
@@ -343,14 +515,14 @@ async fn stage_assembled_blob_upload(
         );
     }
 
-    // 不做 dedup 的情况下，先为 blob 预分配最终 key，再把 assembled 文件传上去。
+    // 不做 dedup 的情况下，先为 blob 预分配最终 key，再把 staging 文件传上去。
     // DB finalize 失败后的清理归属由 VerifiedUploadedBlob 的 cleanup plan 表达。
     let preuploaded = storage::prepare_non_dedup_blob_upload(policy, size)?;
     storage::upload_temp_file_to_prepared_blob(driver, &preuploaded, &path).await?;
     VerifiedUploadedBlob::preuploaded_non_dedup(preuploaded)
 }
 
-async fn persist_assembled_upload(
+async fn persist_chunked_upload(
     state: &PrimaryAppState,
     session: &upload_session::Model,
     driver: &dyn StorageDriver,
@@ -399,7 +571,7 @@ async fn persist_assembled_upload(
             cleanup_verified_upload_after_db_failure(
                 driver,
                 verified,
-                "chunked upload DB error after storing assembled blob",
+                "chunked upload DB error after storing staged blob",
             )
             .await;
             // dedup 失败不主动删 storage 对象：另一路并发上传可能正在引用同内容的 blob，

--- a/src/services/files/upload/complete/chunked.rs
+++ b/src/services/files/upload/complete/chunked.rs
@@ -1,9 +1,15 @@
+//! Server-managed chunked-upload completion.
+//!
+//! `.offset-staging-v1` is the explicit format discriminator for current sessions. The generic
+//! `assembled` path belongs only to the deprecated payload-per-chunk compatibility path and may
+//! survive a retryable storage/DB failure; its presence must never select offset-staging validation.
+
 use aster_forge_db::transaction;
 use chrono::Utc;
 use std::time::Instant;
 
 use crate::api::api_error_code::ApiErrorCode;
-use crate::db::repository::file_repo;
+use crate::db::repository::{file_repo, upload_session_part_repo};
 use crate::entities::{file, storage_policy, upload_session};
 use crate::errors::{AsterError, MapAsterErr, Result, upload_assembly_error_with_code};
 use crate::runtime::{PrimaryAppState, SharedRuntimeState};
@@ -17,7 +23,7 @@ use crate::storage::connectors::{
     StorageConnectorChunkedCompletion, resolve_policy_upload_transport,
 };
 use crate::types::UploadSessionStatus;
-use aster_forge_utils::numbers::{i64_to_u64, usize_to_i64};
+use aster_forge_utils::numbers::{i32_to_usize, i64_to_u64, usize_to_i64};
 use aster_forge_utils::paths;
 use tokio::io::AsyncReadExt;
 use tokio::io::AsyncWriteExt;
@@ -139,22 +145,29 @@ async fn validate_offset_staging_file(
     state: &PrimaryAppState,
     session: &upload_session::Model,
 ) -> Result<String> {
-    for chunk_number in 0..session.total_chunks {
-        let chunk_path = paths::upload_chunk_path(
-            &state.config().server.upload_temp_dir,
-            &session.id,
-            chunk_number,
-        );
+    let receipts =
+        upload_session_part_repo::list_all_by_upload(state.writer_db(), &session.id).await?;
+    let expected_receipt_count = i32_to_usize(session.total_chunks, "total chunk count")?;
+    if receipts.len() != expected_receipt_count {
+        return Err(upload_assembly_error_with_code(
+            ApiErrorCode::UploadAssemblyIoFailed,
+            format!(
+                "offset staging receipt count mismatch: expected {}, got {}",
+                session.total_chunks,
+                receipts.len()
+            ),
+        ));
+    }
+
+    for (chunk_number, receipt) in (0..session.total_chunks).zip(&receipts) {
         let expected_size = expected_chunk_size_for_upload(session, chunk_number)?;
-        let marker_matches = staging::chunk_marker_matches(&chunk_path, expected_size)
-            .await
-            .map_aster_err_ctx(&format!("open chunk {chunk_number}"), |message| {
-                upload_assembly_error_with_code(ApiErrorCode::UploadAssemblyIoFailed, message)
-            })?;
-        if !marker_matches {
+        if !staging::chunk_receipt_matches(receipt, chunk_number + 1, expected_size) {
             return Err(upload_assembly_error_with_code(
                 ApiErrorCode::UploadAssemblyIoFailed,
-                format!("chunk {chunk_number} marker is invalid for size {expected_size}"),
+                format!(
+                    "offset staging receipt is invalid for chunk {chunk_number}: part_number={}, etag={}, size={}, expected_size={expected_size}",
+                    receipt.part_number, receipt.etag, receipt.size
+                ),
             ));
         }
     }
@@ -183,6 +196,8 @@ async fn load_offset_staging_file(
     session: &upload_session::Model,
     should_dedup: bool,
 ) -> Result<Option<ChunkedTempFile>> {
+    // This checks the format-specific path, not the legacy `assembled` output. A stale legacy
+    // assembly must remain retryable as legacy chunk files.
     if !staging::exists(state, &session.id).await? {
         return Ok(None);
     }

--- a/src/services/files/upload/complete/mod.rs
+++ b/src/services/files/upload/complete/mod.rs
@@ -1,7 +1,7 @@
 //! 上传完成阶段。
 //!
 //! 这里把各种“临时上传状态”收口成正式文件：
-//! - 本地 chunk 文件组装
+//! - offset staging file 校验，或兼容旧 session 的本地 chunk 文件组装
 //! - presigned 单文件确认
 //! - presigned object multipart 完成
 //! - relay object multipart 完成
@@ -79,7 +79,7 @@ async fn complete_upload_impl_with_hints(
         CompletionPlan::CompleteRelayMultipart => {
             complete_relay_multipart(state, session, hints.actor_username).await
         }
-        CompletionPlan::AssembleChunks => {
+        CompletionPlan::CompleteChunked => {
             complete_chunked_upload_with_actor_username(state, session, hints.actor_username).await
         }
     };
@@ -112,7 +112,7 @@ fn upload_mode_label_from_completion_plan(plan: &CompletionPlan) -> &'static str
         CompletionPlan::CompletePresigned => "presigned",
         CompletionPlan::CompletePresignedMultipart { .. }
         | CompletionPlan::CompleteRelayMultipart => "presigned_multipart",
-        CompletionPlan::AssembleChunks => "chunked",
+        CompletionPlan::CompleteChunked => "chunked",
         CompletionPlan::ReturnCompleted => "completed_retry",
     }
 }

--- a/src/services/files/upload/complete/plan.rs
+++ b/src/services/files/upload/complete/plan.rs
@@ -13,7 +13,7 @@ pub(super) enum CompletionPlan {
     CompletePresigned,
     CompletePresignedMultipart { parts: Vec<(i32, String)> },
     CompleteRelayMultipart,
-    AssembleChunks,
+    CompleteChunked,
 }
 
 pub(super) fn determine_completion_plan(
@@ -72,7 +72,7 @@ pub(super) fn determine_completion_plan(
         ));
     }
 
-    Ok(CompletionPlan::AssembleChunks)
+    Ok(CompletionPlan::CompleteChunked)
 }
 
 pub(super) fn completion_plan_label(plan: &CompletionPlan) -> &'static str {
@@ -81,6 +81,6 @@ pub(super) fn completion_plan_label(plan: &CompletionPlan) -> &'static str {
         CompletionPlan::CompletePresigned => "complete_presigned",
         CompletionPlan::CompletePresignedMultipart { .. } => "complete_presigned_multipart",
         CompletionPlan::CompleteRelayMultipart => "complete_relay_multipart",
-        CompletionPlan::AssembleChunks => "assemble_chunks",
+        CompletionPlan::CompleteChunked => "complete_chunked",
     }
 }

--- a/src/services/files/upload/complete/tests.rs
+++ b/src/services/files/upload/complete/tests.rs
@@ -80,11 +80,11 @@ fn determine_completion_plan_marks_incomplete_chunks_with_code() {
 }
 
 #[test]
-fn determine_completion_plan_returns_chunk_assembly_when_all_chunks_arrived() {
+fn determine_completion_plan_returns_chunked_completion_when_all_chunks_arrived() {
     let plan = determine_completion_plan(&mock_session(UploadSessionStatus::Uploading), None)
         .expect("complete session should produce plan");
 
-    assert!(matches!(plan, CompletionPlan::AssembleChunks));
+    assert!(matches!(plan, CompletionPlan::CompleteChunked));
 }
 
 #[test]

--- a/src/services/files/upload/init/mod.rs
+++ b/src/services/files/upload/init/mod.rs
@@ -144,8 +144,10 @@ async fn init_chunked_upload_session(
     state: &PrimaryAppState,
     ctx: &InitUploadContext,
 ) -> Result<InitUploadResponse> {
-    // 本地 / 其他非 direct 场景：服务端维护 upload session，并预创建一个逻辑 staging
-    // 文件。每个 chunk PUT 按 offset 写入，complete 只校验 marker 后推进存储和元数据。
+    // 本地 / 其他非 direct 场景：服务端维护 upload session，并预创建格式专用的
+    // `.offset-staging-v1` 文件。每个 Chunk PUT 按 offset 写入并登记 DB receipt，Complete
+    // 只校验 receipt 和 staging 内容后推进存储和元数据；legacy `assembled` 路径不参与新
+    // session 的格式判断。
     let chunk_size = ctx.policy.chunk_size;
     let total_chunks = numbers::calc_total_chunks(ctx.total_size, chunk_size, "chunked upload")?;
     let expires_at = Utc::now() + Duration::hours(24);

--- a/src/services/files/upload/init/mod.rs
+++ b/src/services/files/upload/init/mod.rs
@@ -20,6 +20,7 @@ use crate::services::files::upload::scope::{personal_scope, team_scope};
 use crate::services::files::upload::shared::{
     UniqueUuidAttempt, delete_upload_session_record_after_init_error, with_unique_upload_id,
 };
+use crate::services::files::upload::staging;
 use crate::services::workspace::storage::{WorkspaceStorageScope, resolve_policy_upload_transport};
 use crate::types::{UploadMode, UploadSessionStatus};
 use aster_forge_utils::numbers;
@@ -143,8 +144,8 @@ async fn init_chunked_upload_session(
     state: &PrimaryAppState,
     ctx: &InitUploadContext,
 ) -> Result<InitUploadResponse> {
-    // 本地 / 其他非 direct 场景：服务端维护分片目录与 upload session，
-    // complete 阶段会把这些 chunk 组装成最终文件。
+    // 本地 / 其他非 direct 场景：服务端维护 upload session，并预创建一个逻辑 staging
+    // 文件。每个 chunk PUT 按 offset 写入，complete 只校验 marker 后推进存储和元数据。
     let chunk_size = ctx.policy.chunk_size;
     let total_chunks = numbers::calc_total_chunks(ctx.total_size, chunk_size, "chunked upload")?;
     let expires_at = Utc::now() + Duration::hours(24);
@@ -176,7 +177,10 @@ async fn init_chunked_upload_session(
     })
     .await?;
 
-    if let Err(error) = prepare_chunked_upload_temp_dir(state, &upload_id).await {
+    if let Err(error) = prepare_chunked_upload_staging_file(state, &upload_id, ctx.total_size).await
+    {
+        let temp_dir = paths::upload_temp_dir(&state.config().server.upload_temp_dir, &upload_id);
+        aster_forge_utils::fs::cleanup_temp_dir(&temp_dir).await;
         delete_upload_session_record_after_init_error(
             state.writer_db(),
             &upload_id,
@@ -205,13 +209,18 @@ async fn init_chunked_upload_session(
     ))
 }
 
-async fn prepare_chunked_upload_temp_dir(state: &PrimaryAppState, upload_id: &str) -> Result<()> {
+async fn prepare_chunked_upload_staging_file(
+    state: &PrimaryAppState,
+    upload_id: &str,
+    total_size: i64,
+) -> Result<()> {
     let temp_dir = paths::upload_temp_dir(&state.config().server.upload_temp_dir, upload_id);
     tokio::fs::create_dir_all(&temp_dir)
         .await
         .map_aster_err_ctx("create temp dir", |message| {
             chunk_upload_error_with_code(ApiErrorCode::UploadTempDirCreateFailed, message)
         })?;
+    staging::prepare(state, upload_id, total_size).await?;
     Ok(())
 }
 

--- a/src/services/files/upload/mod.rs
+++ b/src/services/files/upload/mod.rs
@@ -13,6 +13,7 @@ mod responses;
 mod runtime;
 mod scope;
 mod shared;
+mod staging;
 
 use std::time::Instant;
 

--- a/src/services/files/upload/mod.rs
+++ b/src/services/files/upload/mod.rs
@@ -23,6 +23,8 @@ use crate::services::ops::audit::{self, AuditContext};
 use crate::services::workspace::models::FileInfo;
 use crate::services::workspace::storage::{self, WorkspaceStorageScope};
 
+#[cfg(debug_assertions)]
+pub use chunk::test_support;
 pub use chunk::{
     upload_chunk, upload_chunk_bytes, upload_chunk_bytes_for_team, upload_chunk_for_team,
     upload_chunk_payload, upload_chunk_payload_for_team,

--- a/src/services/files/upload/mod.rs
+++ b/src/services/files/upload/mod.rs
@@ -10,6 +10,7 @@ mod init;
 mod lifecycle;
 mod progress;
 mod responses;
+mod runtime;
 mod scope;
 mod shared;
 
@@ -45,6 +46,7 @@ pub use responses::{
     ChunkUploadResponse, InitUploadResponse, RecoverableUploadSessionResponse,
     UploadProgressResponse,
 };
+pub use runtime::UploadRuntime;
 
 #[derive(Clone, Copy)]
 pub(crate) struct UploadInScopeParams<'a> {

--- a/src/services/files/upload/progress.rs
+++ b/src/services/files/upload/progress.rs
@@ -6,7 +6,7 @@ use crate::api::api_error_code::ApiErrorCode;
 use crate::api::constants::HOUR_SECS;
 use crate::db::repository::{upload_session_part_repo, upload_session_repo};
 use crate::entities::upload_session;
-use crate::errors::{Result, validation_error_with_code};
+use crate::errors::{Result, chunk_upload_error_with_code, validation_error_with_code};
 use crate::runtime::{PrimaryAppState, SharedRuntimeState};
 use crate::services::files::upload::responses::{
     RecoverableUploadPartResponse, RecoverableUploadSessionResponse, UploadProgressResponse,
@@ -14,6 +14,8 @@ use crate::services::files::upload::responses::{
 use crate::services::files::upload::scope::{
     load_upload_session, load_upload_session_for_read, personal_scope, team_scope,
 };
+use crate::services::files::upload::shared::expected_chunk_size_for_upload;
+use crate::services::files::upload::staging;
 use crate::services::workspace::storage::{self, resolve_policy_upload_transport};
 use crate::types::{UploadMode, UploadSessionStatus};
 use aster_forge_utils::paths;
@@ -66,6 +68,8 @@ async fn get_progress_impl(
         } else {
             scan_received_chunks(state, &session.id).await
         }
+    } else if staging::exists(state, &session.id).await? {
+        list_offset_staging_chunks(state, &session).await?
     } else {
         scan_received_chunks(state, &session.id).await
     };
@@ -88,6 +92,44 @@ async fn get_progress_impl(
         "loaded upload progress"
     );
     Ok(progress)
+}
+
+async fn list_offset_staging_chunks(
+    state: &PrimaryAppState,
+    session: &upload_session::Model,
+) -> Result<Vec<i32>> {
+    let receipts =
+        upload_session_part_repo::list_all_by_upload(state.reader_db(), &session.id).await?;
+    let mut chunks = Vec::with_capacity(receipts.len());
+    for receipt in receipts {
+        let chunk_number = receipt.part_number.checked_sub(1).ok_or_else(|| {
+            chunk_upload_error_with_code(
+                ApiErrorCode::UploadChunkPersistFailed,
+                format!(
+                    "local chunk receipt has invalid part number {}",
+                    receipt.part_number
+                ),
+            )
+        })?;
+        if chunk_number >= session.total_chunks {
+            return Err(chunk_upload_error_with_code(
+                ApiErrorCode::UploadChunkPersistFailed,
+                format!(
+                    "local chunk receipt part {} is out of range",
+                    receipt.part_number
+                ),
+            ));
+        }
+        let expected_size = expected_chunk_size_for_upload(session, chunk_number)?;
+        if !staging::chunk_receipt_matches(&receipt, chunk_number + 1, expected_size) {
+            return Err(chunk_upload_error_with_code(
+                ApiErrorCode::UploadChunkPersistFailed,
+                format!("local chunk receipt is corrupted for chunk {chunk_number}"),
+            ));
+        }
+        chunks.push(chunk_number);
+    }
+    Ok(chunks)
 }
 
 fn is_relay_multipart_policy(policy: &crate::entities::storage_policy::Model) -> Result<bool> {

--- a/src/services/files/upload/runtime.rs
+++ b/src/services/files/upload/runtime.rs
@@ -1,0 +1,178 @@
+//! Upload execution resources owned by the primary application runtime.
+
+use std::sync::Arc;
+
+use tokio::sync::{OwnedSemaphorePermit, Semaphore};
+
+use crate::errors::{AsterError, Result};
+
+const CHUNK_ASSEMBLY_TO_LOCAL_TEMP_FILE_CONCURRENCY: usize = 1;
+
+#[derive(Debug)]
+pub struct UploadRuntime {
+    chunk_assembly_to_local_temp_file: Arc<Semaphore>,
+}
+
+impl UploadRuntime {
+    pub fn new() -> Self {
+        Self {
+            chunk_assembly_to_local_temp_file: Arc::new(Semaphore::new(
+                CHUNK_ASSEMBLY_TO_LOCAL_TEMP_FILE_CONCURRENCY,
+            )),
+        }
+    }
+
+    pub(crate) async fn acquire_chunk_assembly_to_local_temp_file(
+        &self,
+    ) -> Result<OwnedSemaphorePermit> {
+        self.chunk_assembly_to_local_temp_file
+            .clone()
+            .acquire_owned()
+            .await
+            .map_err(|error| {
+                AsterError::internal_error(format!(
+                    "chunk assembly to local temp file limiter closed: {error}"
+                ))
+            })
+    }
+}
+
+impl Default for UploadRuntime {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::time::Duration;
+
+    use super::UploadRuntime;
+
+    fn update_peak(peak: &AtomicUsize, current: usize) {
+        let mut observed = peak.load(Ordering::SeqCst);
+        while current > observed {
+            match peak.compare_exchange(observed, current, Ordering::SeqCst, Ordering::SeqCst) {
+                Ok(_) => break,
+                Err(actual) => observed = actual,
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn chunk_assembly_to_local_temp_file_is_serialized() {
+        let runtime = UploadRuntime::new();
+        let first = runtime
+            .acquire_chunk_assembly_to_local_temp_file()
+            .await
+            .expect("first assembly permit should be available");
+
+        assert!(
+            tokio::time::timeout(
+                Duration::from_millis(20),
+                runtime.acquire_chunk_assembly_to_local_temp_file(),
+            )
+            .await
+            .is_err(),
+            "second assembly should wait while the first permit is held"
+        );
+
+        drop(first);
+
+        let second = tokio::time::timeout(
+            Duration::from_millis(100),
+            runtime.acquire_chunk_assembly_to_local_temp_file(),
+        )
+        .await
+        .expect("assembly permit should be released by RAII")
+        .expect("assembly limiter should remain open");
+        drop(second);
+    }
+
+    #[tokio::test]
+    async fn concurrent_chunk_assemblies_to_local_temp_file_never_exceed_one() {
+        let runtime = Arc::new(UploadRuntime::new());
+        let active = Arc::new(AtomicUsize::new(0));
+        let peak = Arc::new(AtomicUsize::new(0));
+        let mut tasks = Vec::new();
+
+        for _ in 0..8 {
+            let runtime = runtime.clone();
+            let active = active.clone();
+            let peak = peak.clone();
+            tasks.push(tokio::spawn(async move {
+                let _permit = runtime
+                    .acquire_chunk_assembly_to_local_temp_file()
+                    .await
+                    .expect("assembly permit should be available eventually");
+                let current = active.fetch_add(1, Ordering::SeqCst) + 1;
+                update_peak(&peak, current);
+                tokio::time::sleep(Duration::from_millis(5)).await;
+                active.fetch_sub(1, Ordering::SeqCst);
+            }));
+        }
+
+        for task in tasks {
+            task.await.expect("assembly task should not panic");
+        }
+
+        assert_eq!(active.load(Ordering::SeqCst), 0);
+        assert_eq!(peak.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn cancelled_waiter_does_not_consume_the_next_permit() {
+        let runtime = Arc::new(UploadRuntime::new());
+        let first = runtime
+            .acquire_chunk_assembly_to_local_temp_file()
+            .await
+            .expect("first assembly permit should be available");
+
+        let waiting_runtime = runtime.clone();
+        let waiter = tokio::spawn(async move {
+            waiting_runtime
+                .acquire_chunk_assembly_to_local_temp_file()
+                .await
+                .expect("cancelled waiter should only fail by cancellation")
+        });
+        tokio::task::yield_now().await;
+        waiter.abort();
+        let cancelled = waiter.await;
+        assert!(cancelled.is_err_and(|error| error.is_cancelled()));
+
+        drop(first);
+
+        let next = tokio::time::timeout(
+            Duration::from_millis(100),
+            runtime.acquire_chunk_assembly_to_local_temp_file(),
+        )
+        .await
+        .expect("cancelled waiter should not block the next assembly")
+        .expect("assembly limiter should remain open");
+        drop(next);
+    }
+
+    #[tokio::test]
+    async fn permit_is_released_when_guarded_work_fails() {
+        let runtime = UploadRuntime::new();
+        let guarded_result = async {
+            let _permit = runtime.acquire_chunk_assembly_to_local_temp_file().await?;
+            Err::<(), crate::errors::AsterError>(crate::errors::AsterError::internal_error(
+                "synthetic assembly failure",
+            ))
+        }
+        .await;
+        assert!(guarded_result.is_err());
+
+        let next = tokio::time::timeout(
+            Duration::from_millis(100),
+            runtime.acquire_chunk_assembly_to_local_temp_file(),
+        )
+        .await
+        .expect("failed guarded work should release its permit")
+        .expect("assembly limiter should remain open");
+        drop(next);
+    }
+}

--- a/src/services/files/upload/staging.rs
+++ b/src/services/files/upload/staging.rs
@@ -1,0 +1,99 @@
+//! Local staging-file contract for server-managed chunked uploads.
+//!
+//! New chunked sessions preallocate one logical file and write each chunk directly to its
+//! deterministic offset. Compact per-chunk marker files remain the durable completion/index contract;
+//! the staging file itself may contain unwritten sparse ranges until all markers exist.
+
+use std::io::SeekFrom;
+
+use tokio::io::AsyncSeekExt;
+
+use crate::api::api_error_code::ApiErrorCode;
+use crate::entities::upload_session;
+use crate::errors::{MapAsterErr, Result, chunk_upload_error_with_code};
+use crate::runtime::SharedRuntimeState;
+use aster_forge_utils::numbers::i64_to_u64;
+use aster_forge_utils::paths;
+
+const CHUNK_MARKER_PREFIX: &str = "aster-drive-staged-chunk-v1:";
+
+pub(crate) fn file_path(state: &impl SharedRuntimeState, upload_id: &str) -> String {
+    paths::upload_assembled_path(&state.config().server.upload_temp_dir, upload_id)
+}
+
+pub(crate) async fn prepare(
+    state: &impl SharedRuntimeState,
+    upload_id: &str,
+    total_size: i64,
+) -> Result<()> {
+    let path = file_path(state, upload_id);
+    let file = tokio::fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create_new(true)
+        .open(&path)
+        .await
+        .map_aster_err_ctx("create chunk staging file", |message| {
+            chunk_upload_error_with_code(ApiErrorCode::UploadTempFileCreateFailed, message)
+        })?;
+    file.set_len(i64_to_u64(total_size, "chunk staging total size")?)
+        .await
+        .map_aster_err_ctx("preallocate chunk staging file", |message| {
+            chunk_upload_error_with_code(ApiErrorCode::UploadTempFileWriteFailed, message)
+        })?;
+    Ok(())
+}
+
+pub(crate) async fn exists(state: &impl SharedRuntimeState, upload_id: &str) -> Result<bool> {
+    match tokio::fs::metadata(file_path(state, upload_id)).await {
+        Ok(metadata) => Ok(metadata.is_file()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(false),
+        Err(error) => Err(chunk_upload_error_with_code(
+            ApiErrorCode::UploadChunkPersistFailed,
+            format!("stat chunk staging file: {error}"),
+        )),
+    }
+}
+
+pub(crate) fn chunk_marker_contents(expected_size: i64) -> String {
+    format!("{CHUNK_MARKER_PREFIX}{expected_size}\n")
+}
+
+pub(crate) async fn chunk_marker_matches(
+    chunk_path: &str,
+    expected_size: i64,
+) -> std::io::Result<bool> {
+    let contents = tokio::fs::read_to_string(chunk_path).await?;
+    Ok(contents == chunk_marker_contents(expected_size))
+}
+
+pub(crate) async fn open_for_chunk_write(
+    state: &impl SharedRuntimeState,
+    session: &upload_session::Model,
+    chunk_number: i32,
+) -> Result<tokio::fs::File> {
+    let chunk_offset = i64::from(chunk_number)
+        .checked_mul(session.chunk_size)
+        .ok_or_else(|| {
+            chunk_upload_error_with_code(
+                ApiErrorCode::UploadChunkSizeOverflow,
+                "chunk staging offset exceeds i64 range",
+            )
+        })?;
+    let mut file = tokio::fs::OpenOptions::new()
+        .write(true)
+        .open(file_path(state, &session.id))
+        .await
+        .map_aster_err_ctx("open chunk staging file", |message| {
+            chunk_upload_error_with_code(ApiErrorCode::UploadChunkPersistFailed, message)
+        })?;
+    file.seek(SeekFrom::Start(i64_to_u64(
+        chunk_offset,
+        "chunk staging offset",
+    )?))
+    .await
+    .map_aster_err_ctx("seek chunk staging file", |message| {
+        chunk_upload_error_with_code(ApiErrorCode::UploadChunkPersistFailed, message)
+    })?;
+    Ok(file)
+}

--- a/src/services/files/upload/staging.rs
+++ b/src/services/files/upload/staging.rs
@@ -11,6 +11,8 @@
 //! completion records on retry.
 
 use std::io::SeekFrom;
+#[cfg(unix)]
+use std::path::Path;
 
 use tokio::io::AsyncSeekExt;
 
@@ -53,6 +55,38 @@ pub(crate) async fn prepare(
         .map_aster_err_ctx("preallocate chunk staging file", |message| {
             chunk_upload_error_with_code(ApiErrorCode::UploadTempFileWriteFailed, message)
         })?;
+    file.sync_all()
+        .await
+        .map_aster_err_ctx("sync chunk staging file", |message| {
+            chunk_upload_error_with_code(ApiErrorCode::UploadTempFileWriteFailed, message)
+        })?;
+    sync_parent_directory(&path).await?;
+    Ok(())
+}
+
+#[cfg(unix)]
+async fn sync_parent_directory(path: &str) -> Result<()> {
+    let parent = Path::new(path).parent().ok_or_else(|| {
+        chunk_upload_error_with_code(
+            ApiErrorCode::UploadTempFileWriteFailed,
+            "chunk staging file has no parent directory",
+        )
+    })?;
+    let directory = tokio::fs::File::open(parent)
+        .await
+        .map_aster_err_ctx("open chunk staging directory", |message| {
+            chunk_upload_error_with_code(ApiErrorCode::UploadTempFileWriteFailed, message)
+        })?;
+    directory
+        .sync_all()
+        .await
+        .map_aster_err_ctx("sync chunk staging directory", |message| {
+            chunk_upload_error_with_code(ApiErrorCode::UploadTempFileWriteFailed, message)
+        })
+}
+
+#[cfg(not(unix))]
+async fn sync_parent_directory(_path: &str) -> Result<()> {
     Ok(())
 }
 

--- a/src/services/files/upload/staging.rs
+++ b/src/services/files/upload/staging.rs
@@ -1,8 +1,14 @@
 //! Local staging-file contract for server-managed chunked uploads.
 //!
-//! New chunked sessions preallocate one logical file and write each chunk directly to its
-//! deterministic offset. Compact per-chunk marker files remain the durable completion/index contract;
-//! the staging file itself may contain unwritten sparse ranges until all markers exist.
+//! New sessions use a format-specific `.offset-staging-v1` file instead of the legacy `assembled`
+//! path. Init preallocates it to `total_size`; each Chunk PUT writes its range at
+//! `chunk_number * chunk_size`. The database receipt table is the durable completion index, while
+//! the staging file may still contain unwritten sparse ranges until every receipt exists.
+//!
+//! The distinct path is also the session-format discriminator used by Chunk PUT and Complete.
+//! Legacy completion may create `assembled` before a retryable storage/DB failure, so treating that
+//! generic output path as an offset-staging signal would misread payload-sized legacy chunks as
+//! completion records on retry.
 
 use std::io::SeekFrom;
 
@@ -15,10 +21,16 @@ use crate::runtime::SharedRuntimeState;
 use aster_forge_utils::numbers::i64_to_u64;
 use aster_forge_utils::paths;
 
-const CHUNK_MARKER_PREFIX: &str = "aster-drive-staged-chunk-v1:";
+pub(crate) const CHUNK_RECEIPT_ETAG: &str = "aster-drive-offset-staging-receipt-v1";
+const OFFSET_STAGING_FILE_NAME: &str = ".offset-staging-v1";
 
 pub(crate) fn file_path(state: &impl SharedRuntimeState, upload_id: &str) -> String {
-    paths::upload_assembled_path(&state.config().server.upload_temp_dir, upload_id)
+    file_path_in_upload_temp_dir(&state.config().server.upload_temp_dir, upload_id)
+}
+
+pub(crate) fn file_path_in_upload_temp_dir(upload_temp_dir: &str, upload_id: &str) -> String {
+    let session_temp_dir = paths::upload_temp_dir(upload_temp_dir, upload_id);
+    paths::temp_file_path(&session_temp_dir, OFFSET_STAGING_FILE_NAME)
 }
 
 pub(crate) async fn prepare(
@@ -55,16 +67,18 @@ pub(crate) async fn exists(state: &impl SharedRuntimeState, upload_id: &str) -> 
     }
 }
 
-pub(crate) fn chunk_marker_contents(expected_size: i64) -> String {
-    format!("{CHUNK_MARKER_PREFIX}{expected_size}\n")
+pub(crate) fn chunk_receipt_etag() -> &'static str {
+    CHUNK_RECEIPT_ETAG
 }
 
-pub(crate) async fn chunk_marker_matches(
-    chunk_path: &str,
+pub(crate) fn chunk_receipt_matches(
+    receipt: &crate::entities::upload_session_part::Model,
+    expected_part_number: i32,
     expected_size: i64,
-) -> std::io::Result<bool> {
-    let contents = tokio::fs::read_to_string(chunk_path).await?;
-    Ok(contents == chunk_marker_contents(expected_size))
+) -> bool {
+    receipt.part_number == expected_part_number
+        && receipt.etag == CHUNK_RECEIPT_ETAG
+        && receipt.size == expected_size
 }
 
 pub(crate) async fn open_for_chunk_write(

--- a/src/services/media/metadata/tests.rs
+++ b/src/services/media/metadata/tests.rs
@@ -578,5 +578,6 @@ async fn test_state_with_driver_and_options(
         background_task_dispatch_wakeup:
             crate::runtime::PrimaryAppState::new_background_task_dispatch_wakeup(),
         remote_protocol: crate::runtime::PrimaryAppState::new_remote_protocol(),
+        upload_runtime: crate::runtime::PrimaryAppState::new_upload_runtime(),
     }
 }

--- a/src/services/ops/audit/tests.rs
+++ b/src/services/ops/audit/tests.rs
@@ -392,6 +392,7 @@ async fn log_writes_synchronously_without_global_manager() {
         background_task_dispatch_wakeup:
             crate::runtime::PrimaryAppState::new_background_task_dispatch_wakeup(),
         remote_protocol: crate::runtime::PrimaryAppState::new_remote_protocol(),
+        upload_runtime: crate::runtime::PrimaryAppState::new_upload_runtime(),
     };
 
     super::log(
@@ -507,6 +508,7 @@ async fn log_with_details_skips_details_when_action_scope_excludes_action() {
         background_task_dispatch_wakeup:
             crate::runtime::PrimaryAppState::new_background_task_dispatch_wakeup(),
         remote_protocol: crate::runtime::PrimaryAppState::new_remote_protocol(),
+        upload_runtime: crate::runtime::PrimaryAppState::new_upload_runtime(),
     };
     let calls = AtomicUsize::new(0);
 

--- a/src/services/ops/config/system.rs
+++ b/src/services/ops/config/system.rs
@@ -484,6 +484,7 @@ mod tests {
                 background_task_dispatch_wakeup:
                     PrimaryAppState::new_background_task_dispatch_wakeup(),
                 remote_protocol: PrimaryAppState::new_remote_protocol(),
+                upload_runtime: crate::runtime::PrimaryAppState::new_upload_runtime(),
             },
             subscription,
         )

--- a/src/services/storage_policy/credential/oauth/tests.rs
+++ b/src/services/storage_policy/credential/oauth/tests.rs
@@ -251,6 +251,7 @@ async fn build_oauth_test_state(
         background_task_dispatch_wakeup:
             crate::runtime::PrimaryAppState::new_background_task_dispatch_wakeup(),
         remote_protocol: crate::runtime::PrimaryAppState::new_remote_protocol(),
+        upload_runtime: crate::runtime::PrimaryAppState::new_upload_runtime(),
     }
 }
 

--- a/src/services/storage_policy/policy/policies.rs
+++ b/src/services/storage_policy/policy/policies.rs
@@ -835,6 +835,7 @@ mod tests {
             background_task_dispatch_wakeup:
                 crate::runtime::PrimaryAppState::new_background_task_dispatch_wakeup(),
             remote_protocol: crate::runtime::PrimaryAppState::new_remote_protocol(),
+            upload_runtime: crate::runtime::PrimaryAppState::new_upload_runtime(),
         }
     }
 

--- a/src/services/task/dispatch/tests.rs
+++ b/src/services/task/dispatch/tests.rs
@@ -81,6 +81,7 @@ async fn build_dispatch_test_state() -> crate::runtime::PrimaryAppState {
         background_task_dispatch_wakeup:
             crate::runtime::PrimaryAppState::new_background_task_dispatch_wakeup(),
         remote_protocol: crate::runtime::PrimaryAppState::new_remote_protocol(),
+        upload_runtime: crate::runtime::PrimaryAppState::new_upload_runtime(),
     }
 }
 

--- a/src/services/workspace/scope/mod.rs
+++ b/src/services/workspace/scope/mod.rs
@@ -569,6 +569,7 @@ mod tests {
             background_task_dispatch_wakeup:
                 crate::runtime::PrimaryAppState::new_background_task_dispatch_wakeup(),
             remote_protocol: crate::runtime::PrimaryAppState::new_remote_protocol(),
+            upload_runtime: crate::runtime::PrimaryAppState::new_upload_runtime(),
         }
     }
 

--- a/src/services/workspace/storage/tests.rs
+++ b/src/services/workspace/storage/tests.rs
@@ -849,6 +849,7 @@ async fn build_test_state() -> (PrimaryAppState, PathBuf, storage_policy::Model,
         background_task_dispatch_wakeup:
             crate::runtime::PrimaryAppState::new_background_task_dispatch_wakeup(),
         remote_protocol: crate::runtime::PrimaryAppState::new_remote_protocol(),
+        upload_runtime: crate::runtime::PrimaryAppState::new_upload_runtime(),
     };
 
     (state, temp_root, policy, user)

--- a/src/webdav/auth.rs
+++ b/src/webdav/auth.rs
@@ -297,6 +297,7 @@ mod tests {
             background_task_dispatch_wakeup:
                 crate::runtime::PrimaryAppState::new_background_task_dispatch_wakeup(),
             remote_protocol: crate::runtime::PrimaryAppState::new_remote_protocol(),
+            upload_runtime: crate::runtime::PrimaryAppState::new_upload_runtime(),
         }
     }
 

--- a/src/webdav/file/tests.rs
+++ b/src/webdav/file/tests.rs
@@ -273,6 +273,7 @@ async fn build_s3_direct_test_state() -> (PrimaryAppState, user::Model, MockDire
         background_task_dispatch_wakeup:
             crate::runtime::PrimaryAppState::new_background_task_dispatch_wakeup(),
         remote_protocol: crate::runtime::PrimaryAppState::new_remote_protocol(),
+        upload_runtime: crate::runtime::PrimaryAppState::new_upload_runtime(),
     };
 
     (state, user, mock_driver)

--- a/src/webdav/handler_tests/mod.rs
+++ b/src/webdav/handler_tests/mod.rs
@@ -150,6 +150,7 @@ async fn build_webdav_test_state(
         background_task_dispatch_wakeup:
             crate::runtime::PrimaryAppState::new_background_task_dispatch_wakeup(),
         remote_protocol: crate::runtime::PrimaryAppState::new_remote_protocol(),
+        upload_runtime: crate::runtime::PrimaryAppState::new_upload_runtime(),
     };
 
     (state, user, policy, temp_root)

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -899,6 +899,7 @@ pub async fn setup_with_memory_cache() -> PrimaryAppState {
         share_download_rollback: base.share_download_rollback,
         background_task_dispatch_wakeup: base.background_task_dispatch_wakeup,
         remote_protocol: base.remote_protocol,
+        upload_runtime: base.upload_runtime,
     }
 }
 
@@ -1300,6 +1301,7 @@ pub async fn setup_with_database_url(database_url: &str) -> PrimaryAppState {
         background_task_dispatch_wakeup:
             aster_drive::runtime::PrimaryAppState::new_background_task_dispatch_wakeup(),
         remote_protocol,
+        upload_runtime: aster_drive::runtime::PrimaryAppState::new_upload_runtime(),
     }
 }
 

--- a/tests/test_auth.rs
+++ b/tests/test_auth.rs
@@ -4007,6 +4007,7 @@ async fn test_user_status_cached_in_auth_middleware() {
         share_download_rollback: base.share_download_rollback,
         background_task_dispatch_wakeup: base.background_task_dispatch_wakeup,
         remote_protocol: base.remote_protocol,
+        upload_runtime: base.upload_runtime,
     };
     let app = create_test_app!(state);
     let (token, _) = register_and_login!(app);
@@ -4055,6 +4056,7 @@ async fn test_disable_user_invalidates_status_cache() {
         share_download_rollback: base.share_download_rollback,
         background_task_dispatch_wakeup: base.background_task_dispatch_wakeup,
         remote_protocol: base.remote_protocol,
+        upload_runtime: base.upload_runtime,
     };
     let app = create_test_app!(state);
     let (admin_token, _) = register_and_login!(app);

--- a/tests/test_upload.rs
+++ b/tests/test_upload.rs
@@ -2380,6 +2380,27 @@ async fn test_complete_upload_marks_session_failed_after_assembly_error() {
         .unwrap_err();
     assert_eq!(retry_err.code(), "E057");
     assert!(retry_err.message().contains("previously"));
+
+    let next_init =
+        upload::init_upload(&state, user.id, "after-broken.txt", 10_485_760, None, None)
+            .await
+            .unwrap();
+    let next_upload_id = next_init.upload_id.unwrap();
+    upload::upload_chunk(&state, &next_upload_id, 0, user.id, &chunk0)
+        .await
+        .unwrap();
+    upload::upload_chunk(&state, &next_upload_id, 1, user.id, &chunk1)
+        .await
+        .unwrap();
+
+    let next_file = tokio::time::timeout(
+        std::time::Duration::from_secs(2),
+        upload::complete_upload(&state, &next_upload_id, user.id, None),
+    )
+    .await
+    .expect("assembly failure must release the limiter for the next upload")
+    .unwrap();
+    assert_eq!(next_file.name, "after-broken.txt");
 }
 
 #[actix_web::test]

--- a/tests/test_upload.rs
+++ b/tests/test_upload.rs
@@ -1711,7 +1711,7 @@ async fn test_s3_presigned_download_redirects_and_share_counts() {
 }
 
 #[actix_web::test]
-async fn test_chunked_upload_streaming_assembly_preserves_content() {
+async fn test_chunked_upload_offset_staging_preserves_content() {
     use aster_drive::db::repository::file_repo;
     use aster_drive::services::files::upload;
 
@@ -1738,6 +1738,27 @@ async fn test_chunked_upload_streaming_assembly_preserves_content() {
         .unwrap();
     assert_eq!(resp1.received_count, 2);
 
+    let staging_path = aster_forge_utils::paths::upload_assembled_path(
+        &state.config.server.upload_temp_dir,
+        &upload_id,
+    );
+    let staging_metadata = tokio::fs::metadata(&staging_path).await.unwrap();
+    assert_eq!(staging_metadata.len(), 10_485_760);
+    let staged = tokio::fs::read(&staging_path).await.unwrap();
+    assert_eq!(staged, [chunk0.as_slice(), chunk1.as_slice()].concat());
+
+    for chunk_number in 0..2 {
+        let marker = aster_forge_utils::paths::upload_chunk_path(
+            &state.config.server.upload_temp_dir,
+            &upload_id,
+            chunk_number,
+        );
+        assert!(
+            tokio::fs::metadata(marker).await.unwrap().len() < 64,
+            "chunk completion marker should stay metadata-sized instead of duplicating payload"
+        );
+    }
+
     let file = upload::complete_upload(&state, &upload_id, user.id, None)
         .await
         .unwrap();
@@ -1755,6 +1776,156 @@ async fn test_chunked_upload_streaming_assembly_preserves_content() {
 
     assert_eq!(stored, [chunk0.as_slice(), chunk1.as_slice()].concat());
     assert_eq!(blob.size, stored.len() as i64);
+}
+
+#[actix_web::test]
+async fn test_concurrent_distinct_chunks_write_to_their_staging_offsets() {
+    use aster_drive::services::files::upload;
+
+    let state = std::sync::Arc::new(common::setup().await);
+    let user = common::create_test_account(
+        &state,
+        "offsetconcurrent",
+        "offset-concurrent@test.com",
+        "password123",
+    )
+    .await
+    .unwrap();
+    let init = upload::init_upload(
+        &state,
+        user.id,
+        "offset-concurrent.bin",
+        10_485_760,
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+    let upload_id = init.upload_id.unwrap();
+    let first = vec![b'A'; TEST_CHUNK_SIZE];
+    let second = vec![b'B'; TEST_CHUNK_SIZE];
+
+    let (first_result, second_result) = tokio::join!(
+        upload::upload_chunk(&state, &upload_id, 0, user.id, &first),
+        upload::upload_chunk(&state, &upload_id, 1, user.id, &second),
+    );
+    first_result.unwrap();
+    second_result.unwrap();
+
+    let staging_path = aster_forge_utils::paths::upload_assembled_path(
+        &state.config.server.upload_temp_dir,
+        &upload_id,
+    );
+    let staged = tokio::fs::read(staging_path).await.unwrap();
+    assert_eq!(staged, [first.as_slice(), second.as_slice()].concat());
+
+    let progress = upload::get_progress(&state, &upload_id, user.id)
+        .await
+        .unwrap();
+    assert_eq!(progress.received_count, 2);
+    assert_eq!(progress.chunks_on_disk, vec![0, 1]);
+}
+
+#[actix_web::test]
+async fn test_concurrent_duplicate_staged_chunk_keeps_one_complete_payload() {
+    use aster_drive::services::files::upload;
+
+    let state = std::sync::Arc::new(common::setup().await);
+    let user = common::create_test_account(
+        &state,
+        "offsetduplicate",
+        "offset-duplicate@test.com",
+        "password123",
+    )
+    .await
+    .unwrap();
+    let init = upload::init_upload(
+        &state,
+        user.id,
+        "offset-duplicate.bin",
+        10_485_760,
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+    let upload_id = init.upload_id.unwrap();
+    let first = vec![b'A'; TEST_CHUNK_SIZE];
+    let second = vec![b'B'; TEST_CHUNK_SIZE];
+
+    let (first_result, second_result) = tokio::join!(
+        upload::upload_chunk(&state, &upload_id, 0, user.id, &first),
+        upload::upload_chunk(&state, &upload_id, 0, user.id, &second),
+    );
+    first_result.unwrap();
+    second_result.unwrap();
+
+    let staging_path = aster_forge_utils::paths::upload_assembled_path(
+        &state.config.server.upload_temp_dir,
+        &upload_id,
+    );
+    let staged = tokio::fs::read(staging_path).await.unwrap();
+    let first_range = &staged[..TEST_CHUNK_SIZE];
+    assert!(
+        first_range == first.as_slice() || first_range == second.as_slice(),
+        "concurrent duplicate writes must preserve one whole winner payload"
+    );
+    assert_eq!(
+        upload::get_progress(&state, &upload_id, user.id)
+            .await
+            .unwrap()
+            .received_count,
+        1
+    );
+}
+
+#[actix_web::test]
+async fn test_retry_overwrites_uncommitted_partial_staging_range() {
+    use aster_drive::services::files::upload;
+    use tokio::io::{AsyncSeekExt, AsyncWriteExt};
+
+    let state = common::setup().await;
+    let user = common::create_test_account(
+        &state,
+        "offsetretry",
+        "offset-retry@test.com",
+        "password123",
+    )
+    .await
+    .unwrap();
+    let init = upload::init_upload(&state, user.id, "offset-retry.bin", 10_485_760, None, None)
+        .await
+        .unwrap();
+    let upload_id = init.upload_id.unwrap();
+    let staging_path = aster_forge_utils::paths::upload_assembled_path(
+        &state.config.server.upload_temp_dir,
+        &upload_id,
+    );
+
+    let mut staging = tokio::fs::OpenOptions::new()
+        .write(true)
+        .open(&staging_path)
+        .await
+        .unwrap();
+    staging.seek(std::io::SeekFrom::Start(0)).await.unwrap();
+    staging.write_all(&vec![b'X'; 1024 * 1024]).await.unwrap();
+    staging.flush().await.unwrap();
+    drop(staging);
+
+    let committed = vec![b'A'; TEST_CHUNK_SIZE];
+    upload::upload_chunk(&state, &upload_id, 0, user.id, &committed)
+        .await
+        .unwrap();
+
+    let staged = tokio::fs::read(staging_path).await.unwrap();
+    assert_eq!(&staged[..TEST_CHUNK_SIZE], committed.as_slice());
+    assert_eq!(
+        upload::get_progress(&state, &upload_id, user.id)
+            .await
+            .unwrap()
+            .chunks_on_disk,
+        vec![0]
+    );
 }
 
 #[actix_web::test]
@@ -2328,7 +2499,7 @@ async fn test_complete_chunked_upload_quota_failure_does_not_complete_session_or
 }
 
 #[actix_web::test]
-async fn test_complete_upload_marks_session_failed_after_assembly_error() {
+async fn test_complete_upload_marks_session_failed_after_missing_chunk_marker() {
     use aster_drive::db::repository::upload_session_repo;
     use aster_drive::services::files::upload;
 
@@ -2398,9 +2569,209 @@ async fn test_complete_upload_marks_session_failed_after_assembly_error() {
         upload::complete_upload(&state, &next_upload_id, user.id, None),
     )
     .await
-    .expect("assembly failure must release the limiter for the next upload")
+    .expect("failed staging validation must not block the next upload")
     .unwrap();
     assert_eq!(next_file.name, "after-broken.txt");
+}
+
+#[actix_web::test]
+async fn test_complete_upload_rejects_truncated_offset_staging_file() {
+    use aster_drive::db::repository::upload_session_repo;
+    use aster_drive::services::files::upload;
+
+    let state = common::setup().await;
+    let user = common::create_test_account(
+        &state,
+        "truncatedstaging",
+        "truncated-staging@test.com",
+        "password123",
+    )
+    .await
+    .unwrap();
+    let init = upload::init_upload(
+        &state,
+        user.id,
+        "truncated-staging.bin",
+        10_485_760,
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+    let upload_id = init.upload_id.unwrap();
+    let chunk0 = vec![b'A'; TEST_CHUNK_SIZE];
+    let chunk1 = vec![b'B'; TEST_CHUNK_SIZE];
+    upload::upload_chunk(&state, &upload_id, 0, user.id, &chunk0)
+        .await
+        .unwrap();
+    upload::upload_chunk(&state, &upload_id, 1, user.id, &chunk1)
+        .await
+        .unwrap();
+
+    let staging_path = aster_forge_utils::paths::upload_assembled_path(
+        &state.config.server.upload_temp_dir,
+        &upload_id,
+    );
+    tokio::fs::OpenOptions::new()
+        .write(true)
+        .open(&staging_path)
+        .await
+        .unwrap()
+        .set_len(10_485_759)
+        .await
+        .unwrap();
+
+    let error = upload::complete_upload(&state, &upload_id, user.id, None)
+        .await
+        .unwrap_err();
+    assert_eq!(error.code(), "E057");
+    assert!(error.message().contains("staging file size mismatch"));
+    assert_eq!(
+        upload_session_repo::find_by_id(state.writer_db(), &upload_id)
+            .await
+            .unwrap()
+            .status,
+        aster_drive::types::UploadSessionStatus::Failed
+    );
+}
+
+#[actix_web::test]
+async fn test_legacy_assembly_failure_releases_limiter() {
+    use aster_drive::services::files::upload;
+
+    let state = common::setup().await;
+    let user = common::create_test_account(
+        &state,
+        "legacyfailure",
+        "legacy-failure@test.com",
+        "password123",
+    )
+    .await
+    .unwrap();
+
+    let broken_upload_id = new_test_upload_id();
+    create_upload_session(
+        &state,
+        user.id,
+        UploadSessionSpec::new(
+            &broken_upload_id,
+            aster_drive::types::UploadSessionStatus::Uploading,
+            chrono::Utc::now() + chrono::Duration::hours(1),
+        )
+        .chunks(2, 2),
+    )
+    .await;
+    let broken_chunk0 = aster_forge_utils::paths::upload_chunk_path(
+        &state.config.server.upload_temp_dir,
+        &broken_upload_id,
+        0,
+    );
+    tokio::fs::create_dir_all(std::path::Path::new(&broken_chunk0).parent().unwrap())
+        .await
+        .unwrap();
+    tokio::fs::write(&broken_chunk0, b"12345").await.unwrap();
+    upload::complete_upload(&state, &broken_upload_id, user.id, None)
+        .await
+        .unwrap_err();
+
+    let next_upload_id = new_test_upload_id();
+    create_upload_session(
+        &state,
+        user.id,
+        UploadSessionSpec::new(
+            &next_upload_id,
+            aster_drive::types::UploadSessionStatus::Uploading,
+            chrono::Utc::now() + chrono::Duration::hours(1),
+        )
+        .chunks(2, 2),
+    )
+    .await;
+    let next_chunk0 = aster_forge_utils::paths::upload_chunk_path(
+        &state.config.server.upload_temp_dir,
+        &next_upload_id,
+        0,
+    );
+    let next_chunk1 = aster_forge_utils::paths::upload_chunk_path(
+        &state.config.server.upload_temp_dir,
+        &next_upload_id,
+        1,
+    );
+    tokio::fs::create_dir_all(std::path::Path::new(&next_chunk0).parent().unwrap())
+        .await
+        .unwrap();
+    tokio::fs::write(&next_chunk0, b"12345").await.unwrap();
+    tokio::fs::write(&next_chunk1, b"67890").await.unwrap();
+
+    tokio::time::timeout(
+        std::time::Duration::from_secs(2),
+        upload::complete_upload(&state, &next_upload_id, user.id, None),
+    )
+    .await
+    .expect("legacy assembly failure must release the compatibility limiter")
+    .unwrap();
+}
+
+#[actix_web::test]
+async fn test_complete_legacy_chunk_files_after_upgrade() {
+    use aster_drive::db::repository::file_repo;
+    use aster_drive::services::files::upload;
+
+    let state = common::setup().await;
+    let user = common::create_test_account(
+        &state,
+        "legacychunk",
+        "legacy-chunk@test.com",
+        "password123",
+    )
+    .await
+    .unwrap();
+    let upload_id = new_test_upload_id();
+    create_upload_session(
+        &state,
+        user.id,
+        UploadSessionSpec::new(
+            &upload_id,
+            aster_drive::types::UploadSessionStatus::Uploading,
+            chrono::Utc::now() + chrono::Duration::hours(1),
+        )
+        .chunks(2, 2),
+    )
+    .await;
+
+    let chunk0 = aster_forge_utils::paths::upload_chunk_path(
+        &state.config.server.upload_temp_dir,
+        &upload_id,
+        0,
+    );
+    let chunk1 = aster_forge_utils::paths::upload_chunk_path(
+        &state.config.server.upload_temp_dir,
+        &upload_id,
+        1,
+    );
+    tokio::fs::create_dir_all(std::path::Path::new(&chunk0).parent().unwrap())
+        .await
+        .unwrap();
+    tokio::fs::write(&chunk0, b"12345").await.unwrap();
+    tokio::fs::write(&chunk1, b"67890").await.unwrap();
+
+    let file = upload::complete_upload(&state, &upload_id, user.id, None)
+        .await
+        .unwrap();
+    let blob = file_repo::find_blob_by_id(state.writer_db(), file.blob_id)
+        .await
+        .unwrap();
+    let policy =
+        aster_drive::db::repository::policy_repo::find_by_id(state.writer_db(), blob.policy_id)
+            .await
+            .unwrap();
+    let stored = state
+        .driver_registry
+        .get_driver(&policy)
+        .unwrap()
+        .get(&blob.storage_path)
+        .await
+        .unwrap();
+    assert_eq!(stored, b"1234567890");
 }
 
 #[actix_web::test]
@@ -2466,7 +2837,7 @@ async fn test_complete_upload_keeps_presigned_multipart_session_retryable_after_
 }
 
 #[actix_web::test]
-async fn test_complete_upload_keeps_remote_chunked_session_retryable_after_storage_error() {
+async fn test_complete_legacy_remote_chunk_files_remain_retryable_after_storage_error() {
     use aster_drive::db::repository::upload_session_repo;
     use aster_drive::services::files::upload;
     use aster_drive::types::UploadSessionStatus;
@@ -2534,6 +2905,76 @@ async fn test_complete_upload_keeps_remote_chunked_session_retryable_after_stora
         .unwrap();
     assert_eq!(session_after_retry.status, UploadSessionStatus::Uploading);
     assert_eq!(session_after_retry.file_id, None);
+}
+
+#[actix_web::test]
+async fn test_complete_offset_staging_stream_relay_remains_retryable_after_storage_error() {
+    use aster_drive::db::repository::upload_session_repo;
+    use aster_drive::services::files::upload;
+    use aster_drive::types::UploadSessionStatus;
+
+    let state = common::setup().await;
+    let user = common::create_test_account(
+        &state,
+        "rstagingretry",
+        "remote-staging-retry@test.com",
+        "password123",
+    )
+    .await
+    .unwrap();
+    let remote_policy = create_dead_remote_policy(&state).await;
+    let upload_id = new_test_upload_id();
+    create_upload_session(
+        &state,
+        user.id,
+        UploadSessionSpec::new(
+            &upload_id,
+            UploadSessionStatus::Uploading,
+            chrono::Utc::now() + chrono::Duration::hours(1),
+        )
+        .chunks(2, 0)
+        .policy(remote_policy.id),
+    )
+    .await;
+
+    let temp_dir =
+        aster_forge_utils::paths::upload_temp_dir(&state.config.server.upload_temp_dir, &upload_id);
+    tokio::fs::create_dir_all(&temp_dir).await.unwrap();
+    let staging_path = aster_forge_utils::paths::upload_assembled_path(
+        &state.config.server.upload_temp_dir,
+        &upload_id,
+    );
+    let staging = tokio::fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create_new(true)
+        .open(&staging_path)
+        .await
+        .unwrap();
+    staging.set_len(10).await.unwrap();
+
+    upload::upload_chunk(&state, &upload_id, 0, user.id, b"12345")
+        .await
+        .unwrap();
+    upload::upload_chunk(&state, &upload_id, 1, user.id, b"67890")
+        .await
+        .unwrap();
+
+    let error = upload::complete_upload(&state, &upload_id, user.id, None)
+        .await
+        .unwrap_err();
+    assert_eq!(error.code(), "E031");
+    let session = upload_session_repo::find_by_id(state.writer_db(), &upload_id)
+        .await
+        .unwrap();
+    assert_eq!(session.status, UploadSessionStatus::Uploading);
+    assert_eq!(session.file_id, None);
+    assert!(std::path::Path::new(&staging_path).exists());
+
+    let retry_error = upload::complete_upload(&state, &upload_id, user.id, None)
+        .await
+        .unwrap_err();
+    assert_eq!(retry_error.code(), "E031");
 }
 
 #[actix_web::test]

--- a/tests/test_upload.rs
+++ b/tests/test_upload.rs
@@ -1712,7 +1712,7 @@ async fn test_s3_presigned_download_redirects_and_share_counts() {
 
 #[actix_web::test]
 async fn test_chunked_upload_offset_staging_preserves_content() {
-    use aster_drive::db::repository::file_repo;
+    use aster_drive::db::repository::{file_repo, upload_session_part_repo};
     use aster_drive::services::files::upload;
 
     let state = common::setup().await;
@@ -1738,7 +1738,7 @@ async fn test_chunked_upload_offset_staging_preserves_content() {
         .unwrap();
     assert_eq!(resp1.received_count, 2);
 
-    let staging_path = aster_forge_utils::paths::upload_assembled_path(
+    let staging_path = upload::test_support::offset_staging_file_path(
         &state.config.server.upload_temp_dir,
         &upload_id,
     );
@@ -1747,15 +1747,25 @@ async fn test_chunked_upload_offset_staging_preserves_content() {
     let staged = tokio::fs::read(&staging_path).await.unwrap();
     assert_eq!(staged, [chunk0.as_slice(), chunk1.as_slice()].concat());
 
+    let receipts = upload_session_part_repo::list_all_by_upload(state.writer_db(), &upload_id)
+        .await
+        .unwrap();
+    assert_eq!(receipts.len(), 2);
+    assert!(receipts.iter().enumerate().all(|(index, receipt)| {
+        receipt.part_number == index as i32 + 1
+            && receipt.etag == upload::test_support::offset_staging_receipt_etag()
+            && receipt.size == TEST_CHUNK_SIZE as i64
+    }));
     for chunk_number in 0..2 {
-        let marker = aster_forge_utils::paths::upload_chunk_path(
-            &state.config.server.upload_temp_dir,
-            &upload_id,
-            chunk_number,
-        );
         assert!(
-            tokio::fs::metadata(marker).await.unwrap().len() < 64,
-            "chunk completion marker should stay metadata-sized instead of duplicating payload"
+            tokio::fs::metadata(aster_forge_utils::paths::upload_chunk_path(
+                &state.config.server.upload_temp_dir,
+                &upload_id,
+                chunk_number,
+            ))
+            .await
+            .is_err(),
+            "offset staging should not create legacy chunk marker files"
         );
     }
 
@@ -1804,15 +1814,21 @@ async fn test_concurrent_distinct_chunks_write_to_their_staging_offsets() {
     let upload_id = init.upload_id.unwrap();
     let first = vec![b'A'; TEST_CHUNK_SIZE];
     let second = vec![b'B'; TEST_CHUNK_SIZE];
+    let _write_rendezvous = upload::test_support::install_distinct_chunk_rendezvous(&upload_id, 2);
 
-    let (first_result, second_result) = tokio::join!(
-        upload::upload_chunk(&state, &upload_id, 0, user.id, &first),
-        upload::upload_chunk(&state, &upload_id, 1, user.id, &second),
-    );
+    let (first_result, second_result) =
+        tokio::time::timeout(std::time::Duration::from_secs(2), async {
+            tokio::join!(
+                upload::upload_chunk(&state, &upload_id, 0, user.id, &first),
+                upload::upload_chunk(&state, &upload_id, 1, user.id, &second),
+            )
+        })
+        .await
+        .expect("distinct chunk writes must enter their critical sections concurrently");
     first_result.unwrap();
     second_result.unwrap();
 
-    let staging_path = aster_forge_utils::paths::upload_assembled_path(
+    let staging_path = upload::test_support::offset_staging_file_path(
         &state.config.server.upload_temp_dir,
         &upload_id,
     );
@@ -1852,15 +1868,25 @@ async fn test_concurrent_duplicate_staged_chunk_keeps_one_complete_payload() {
     let upload_id = init.upload_id.unwrap();
     let first = vec![b'A'; TEST_CHUNK_SIZE];
     let second = vec![b'B'; TEST_CHUNK_SIZE];
+    let exclusion = upload::test_support::install_same_chunk_exclusion_observer(&upload_id);
 
-    let (first_result, second_result) = tokio::join!(
-        upload::upload_chunk(&state, &upload_id, 0, user.id, &first),
-        upload::upload_chunk(&state, &upload_id, 0, user.id, &second),
-    );
+    let (first_result, second_result) =
+        tokio::time::timeout(std::time::Duration::from_secs(2), async {
+            tokio::join!(
+                upload::upload_chunk(&state, &upload_id, 0, user.id, &first),
+                upload::upload_chunk(&state, &upload_id, 0, user.id, &second),
+            )
+        })
+        .await
+        .expect("duplicate chunk uploads must finish while the exclusion observer is installed");
     first_result.unwrap();
     second_result.unwrap();
+    assert!(
+        !exclusion.overlap_observed(),
+        "duplicate chunk uploads entered the staging write critical section together"
+    );
 
-    let staging_path = aster_forge_utils::paths::upload_assembled_path(
+    let staging_path = upload::test_support::offset_staging_file_path(
         &state.config.server.upload_temp_dir,
         &upload_id,
     );
@@ -1897,7 +1923,7 @@ async fn test_retry_overwrites_uncommitted_partial_staging_range() {
         .await
         .unwrap();
     let upload_id = init.upload_id.unwrap();
-    let staging_path = aster_forge_utils::paths::upload_assembled_path(
+    let staging_path = upload::test_support::offset_staging_file_path(
         &state.config.server.upload_temp_dir,
         &upload_id,
     );
@@ -1926,6 +1952,174 @@ async fn test_retry_overwrites_uncommitted_partial_staging_range() {
             .chunks_on_disk,
         vec![0]
     );
+}
+
+#[actix_web::test]
+async fn test_retry_repairs_staged_chunk_receipt_without_double_counting() {
+    use aster_drive::db::repository::{upload_session_part_repo, upload_session_repo};
+    use aster_drive::entities::upload_session;
+    use aster_drive::services::files::upload;
+    use sea_orm::{ActiveModelTrait, Set};
+
+    let state = common::setup().await;
+    let user = common::create_test_account(
+        &state,
+        "offsetreceipt",
+        "offset-receipt@test.com",
+        "password123",
+    )
+    .await
+    .unwrap();
+    let init = upload::init_upload(
+        &state,
+        user.id,
+        "offset-receipt.bin",
+        10_485_760,
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+    let upload_id = init.upload_id.unwrap();
+    let committed = vec![b'A'; TEST_CHUNK_SIZE];
+
+    upload::upload_chunk(&state, &upload_id, 0, user.id, &committed)
+        .await
+        .unwrap();
+    upload_session_part_repo::delete_by_upload_and_part(state.writer_db(), &upload_id, 1)
+        .await
+        .unwrap();
+    let mut session: upload_session::ActiveModel =
+        upload_session_repo::find_by_id(state.writer_db(), &upload_id)
+            .await
+            .unwrap()
+            .into();
+    session.received_count = Set(0);
+    session.update(state.writer_db()).await.unwrap();
+
+    let repaired = upload::upload_chunk(&state, &upload_id, 0, user.id, &committed)
+        .await
+        .unwrap();
+    assert_eq!(repaired.received_count, 1);
+    let duplicate = upload::upload_chunk(&state, &upload_id, 0, user.id, &committed)
+        .await
+        .unwrap();
+    assert_eq!(duplicate.received_count, 1);
+}
+
+#[actix_web::test]
+async fn test_retry_with_existing_receipt_keeps_committed_staging_range() {
+    use aster_drive::services::files::upload;
+
+    let state = common::setup().await;
+    let user = common::create_test_account(
+        &state,
+        "receiptretry",
+        "offset-receipt-retry@test.com",
+        "password123",
+    )
+    .await
+    .unwrap();
+    let init = upload::init_upload(
+        &state,
+        user.id,
+        "offset-receipt-retry.bin",
+        10_485_760,
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+    let upload_id = init.upload_id.unwrap();
+    let first = vec![b'A'; TEST_CHUNK_SIZE];
+    let replacement = vec![b'B'; TEST_CHUNK_SIZE];
+
+    upload::upload_chunk(&state, &upload_id, 0, user.id, &first)
+        .await
+        .unwrap();
+    let retried = upload::upload_chunk(&state, &upload_id, 0, user.id, &replacement)
+        .await
+        .unwrap();
+    assert_eq!(retried.received_count, 1);
+
+    let staging_path = upload::test_support::offset_staging_file_path(
+        &state.config.server.upload_temp_dir,
+        &upload_id,
+    );
+    let staged = tokio::fs::read(staging_path).await.unwrap();
+    assert_eq!(&staged[..TEST_CHUNK_SIZE], first.as_slice());
+}
+
+#[actix_web::test]
+async fn test_offset_staging_rejects_corrupted_receipt_on_retry_and_complete() {
+    use aster_drive::db::repository::upload_session_part_repo;
+    use aster_drive::services::files::upload;
+    use sea_orm::{ActiveModelTrait, IntoActiveModel, Set};
+
+    let state = common::setup().await;
+    let user = common::create_test_account(
+        &state,
+        "corruptreceipt",
+        "corrupt-receipt@test.com",
+        "password123",
+    )
+    .await
+    .unwrap();
+    let init = upload::init_upload(
+        &state,
+        user.id,
+        "corrupt-receipt.bin",
+        10_485_760,
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+    let upload_id = init.upload_id.unwrap();
+    let chunk0 = vec![b'A'; TEST_CHUNK_SIZE];
+    let chunk1 = vec![b'B'; TEST_CHUNK_SIZE];
+    upload::upload_chunk(&state, &upload_id, 0, user.id, &chunk0)
+        .await
+        .unwrap();
+    upload::upload_chunk(&state, &upload_id, 1, user.id, &chunk1)
+        .await
+        .unwrap();
+
+    let mut receipt =
+        upload_session_part_repo::find_by_upload_and_part(state.writer_db(), &upload_id, 1)
+            .await
+            .unwrap()
+            .unwrap()
+            .into_active_model();
+    receipt.etag = Set("corrupted-receipt".to_string());
+    receipt.update(state.writer_db()).await.unwrap();
+
+    let retry_error = match upload::upload_chunk(&state, &upload_id, 0, user.id, &chunk0).await {
+        Ok(_) => panic!("corrupted local receipt must reject a retry"),
+        Err(error) => error,
+    };
+    assert!(retry_error.message().contains("receipt is corrupted"));
+
+    let mut receipt =
+        upload_session_part_repo::find_by_upload_and_part(state.writer_db(), &upload_id, 1)
+            .await
+            .unwrap()
+            .unwrap()
+            .into_active_model();
+    receipt.etag = Set(upload::test_support::offset_staging_receipt_etag().to_string());
+    receipt.size = Set(1);
+    receipt.update(state.writer_db()).await.unwrap();
+
+    let progress_error = match upload::get_progress(&state, &upload_id, user.id).await {
+        Ok(_) => panic!("corrupted local receipt size must reject progress recovery"),
+        Err(error) => error,
+    };
+    assert!(progress_error.message().contains("receipt is corrupted"));
+
+    let complete_error = upload::complete_upload(&state, &upload_id, user.id, None)
+        .await
+        .unwrap_err();
+    assert!(complete_error.message().contains("receipt is invalid"));
 }
 
 #[actix_web::test]
@@ -2499,8 +2693,8 @@ async fn test_complete_chunked_upload_quota_failure_does_not_complete_session_or
 }
 
 #[actix_web::test]
-async fn test_complete_upload_marks_session_failed_after_missing_chunk_marker() {
-    use aster_drive::db::repository::upload_session_repo;
+async fn test_complete_upload_marks_session_failed_after_missing_chunk_receipt() {
+    use aster_drive::db::repository::{upload_session_part_repo, upload_session_repo};
     use aster_drive::services::files::upload;
 
     let state = common::setup().await;
@@ -2523,19 +2717,15 @@ async fn test_complete_upload_marks_session_failed_after_missing_chunk_marker() 
         .await
         .unwrap();
 
-    tokio::fs::remove_file(aster_forge_utils::paths::upload_chunk_path(
-        &state.config.server.upload_temp_dir,
-        &upload_id,
-        1,
-    ))
-    .await
-    .unwrap();
+    upload_session_part_repo::delete_by_upload_and_part(state.writer_db(), &upload_id, 2)
+        .await
+        .unwrap();
 
     let err = upload::complete_upload(&state, &upload_id, user.id, None)
         .await
         .unwrap_err();
     assert_eq!(err.code(), "E057");
-    assert!(err.message().contains("open chunk 1"));
+    assert!(err.message().contains("receipt count mismatch"));
 
     let session = upload_session_repo::find_by_id(state.writer_db(), &upload_id)
         .await
@@ -2608,7 +2798,7 @@ async fn test_complete_upload_rejects_truncated_offset_staging_file() {
         .await
         .unwrap();
 
-    let staging_path = aster_forge_utils::paths::upload_assembled_path(
+    let staging_path = upload::test_support::offset_staging_file_path(
         &state.config.server.upload_temp_dir,
         &upload_id,
     );
@@ -2753,6 +2943,16 @@ async fn test_complete_legacy_chunk_files_after_upgrade() {
         .unwrap();
     tokio::fs::write(&chunk0, b"12345").await.unwrap();
     tokio::fs::write(&chunk1, b"67890").await.unwrap();
+
+    // A retryable failure or process crash may leave the first legacy assembly behind. That
+    // artifact must not reclassify the session as offset staging on the next completion attempt.
+    let assembled_path = aster_forge_utils::paths::upload_assembled_path(
+        &state.config.server.upload_temp_dir,
+        &upload_id,
+    );
+    tokio::fs::write(&assembled_path, b"stale legacy assembly")
+        .await
+        .unwrap();
 
     let file = upload::complete_upload(&state, &upload_id, user.id, None)
         .await
@@ -2940,7 +3140,7 @@ async fn test_complete_offset_staging_stream_relay_remains_retryable_after_stora
     let temp_dir =
         aster_forge_utils::paths::upload_temp_dir(&state.config.server.upload_temp_dir, &upload_id);
     tokio::fs::create_dir_all(&temp_dir).await.unwrap();
-    let staging_path = aster_forge_utils::paths::upload_assembled_path(
+    let staging_path = upload::test_support::offset_staging_file_path(
         &state.config.server.upload_temp_dir,
         &upload_id,
     );


### PR DESCRIPTION
This pull request introduces a new upload staging file workflow for chunked file uploads, improving reliability and compatibility during rolling upgrades. The main changes involve adding support for pre-allocated staging files, chunk completion markers, and a locking mechanism to prevent concurrent writes. Additionally, the `PrimaryAppState` struct is updated to include shared upload runtime resources, and all relevant test and setup code is updated accordingly.

**Upload staging file workflow improvements:**

* Added logic to write chunk data directly to pre-allocated staging files and publish small chunk completion marker files, ensuring chunk integrity and supporting rolling upgrade compatibility. (`src/services/files/upload/chunk.rs` [[1]](diffhunk://#diff-178d3e1b93ca3d72dab4cd1fda74195c9b14d374b40d6c48c2c6bbc3b249582eL4-R7) [[2]](diffhunk://#diff-178d3e1b93ca3d72dab4cd1fda74195c9b14d374b40d6c48c2c6bbc3b249582eR42-R90) [[3]](diffhunk://#diff-178d3e1b93ca3d72dab4cd1fda74195c9b14d374b40d6c48c2c6bbc3b249582eR159-R193) [[4]](diffhunk://#diff-178d3e1b93ca3d72dab4cd1fda74195c9b14d374b40d6c48c2c6bbc3b249582eR237-R301) [[5]](diffhunk://#diff-178d3e1b93ca3d72dab4cd1fda74195c9b14d374b40d6c48c2c6bbc3b249582eR429-R461) [[6]](diffhunk://#diff-178d3e1b93ca3d72dab4cd1fda74195c9b14d374b40d6c48c2c6bbc3b249582eR777-R816) [[7]](diffhunk://#diff-178d3e1b93ca3d72dab4cd1fda74195c9b14d374b40d6c48c2c6bbc3b249582eL610) [[8]](diffhunk://#diff-178d3e1b93ca3d72dab4cd1fda74195c9b14d374b40d6c48c2c6bbc3b249582eR1029-R1076)
* Introduced an exclusive file lock mechanism (`LocalChunkWriteLock`) to prevent concurrent writes to the same chunk during upload. (`src/services/files/upload/chunk.rs` [src/services/files/upload/chunk.rsR42-R90](diffhunk://#diff-178d3e1b93ca3d72dab4cd1fda74195c9b14d374b40d6c48c2c6bbc3b249582eR42-R90))

**PrimaryAppState and runtime resource updates:**

* Added `upload_runtime: Arc<UploadRuntime>` to `PrimaryAppState` and provided a `new_upload_runtime()` constructor method. (`src/runtime/mod.rs` [[1]](diffhunk://#diff-d0216c50621a7a4b033431a35ef57b4bd9b0f1935ada1474a50082b320e3ca37L12-R13) [[2]](diffhunk://#diff-d0216c50621a7a4b033431a35ef57b4bd9b0f1935ada1474a50082b320e3ca37R41-R42) [[3]](diffhunk://#diff-d0216c50621a7a4b033431a35ef57b4bd9b0f1935ada1474a50082b320e3ca37R100-R103)
* Updated all test and setup code to initialize and pass the new `upload_runtime` field in `PrimaryAppState`. (`src/runtime/mod.rs` [[1]](diffhunk://#diff-d0216c50621a7a4b033431a35ef57b4bd9b0f1935ada1474a50082b320e3ca37R364) [[2]](diffhunk://#diff-d0216c50621a7a4b033431a35ef57b4bd9b0f1935ada1474a50082b320e3ca37R420-R427) `src/api/routes/files/access.rs` [[3]](diffhunk://#diff-c2e16d7806f702823f9d58c97e0153ee96076fdad945276dacd8bbe5268dcaddR1265) `src/api/routes/frontend.rs` [[4]](diffhunk://#diff-4d600e8f5dc36ea0eb3571439be414ccad3623be3300c12c9231e41a2499b20eR323) `src/api/routes/health.rs` [[5]](diffhunk://#diff-15a9315a2ba170c5984d085df148291cabed92fc4461634d499e255c6b0a5b08R297) `src/api/routes/share_public.rs` [[6]](diffhunk://#diff-2c2865631cd4ff1111eeb3a205a23d550fe0a9e32b54d7da00669e9b1026465aR1396) `src/runtime/startup/primary.rs` [[7]](diffhunk://#diff-cfe0c929a6ef55275fbc5368f03dcec0b4eb43f0e6c4bcc468aea85d189c4503R61) `src/runtime/tasks.rs` [[8]](diffhunk://#diff-a1cd3089a0f6812ccec875836bb1ac8ec66631e55a3c5fafe8cbf0c76d5ff3a7R732) `src/services/files/file/deletion/tests.rs` [[9]](diffhunk://#diff-4a82fe770cec6157c8513a678e356d92a53692bebc9179b4c5854300c983f4b7R233) `src/services/files/file/download/tests.rs` [[10]](diffhunk://#diff-11836ff1778a61dc85aaa49cb36c552cada89630d84cc9431caa159f1d5dfa57R373) `src/services/files/file/resource_handle.rs` [[11]](diffhunk://#diff-b0498f7dc7bc3eec144fdfdc198281bb77cfca649d75dadf8a8648190711378aR631) `src/services/files/lock/tests.rs` [[12]](diffhunk://#diff-5e4368c97b8acc05167ae4114a01e2ef79c23526a7be9b866e2507c297e52feaR170)

**Documentation and compatibility:**

* Updated documentation to clarify the new upload staging behavior and ensured backward compatibility for sessions without a staging file. (`src/services/files/upload/chunk.rs` [src/services/files/upload/chunk.rsL4-R7](diffhunk://#diff-178d3e1b93ca3d72dab4cd1fda74195c9b14d374b40d6c48c2c6bbc3b249582eL4-R7))

These changes lay the foundation for more robust and scalable file upload workflows, especially in environments requiring zero-downtime deployments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 本地分片上传引入 offset 暂存（`.offset-staging-v1`）：完成阶段支持基于收据的校验与去重。
  * 上传进度会反映暂存完成情况。
  * 保留对旧版分片会话的兼容完成路径。
* **问题修复**
  * 强化并发写入与重复分片幂等，提升中断续传一致性。
  * 完成/暂存异常后不会再阻塞后续重试；并改进远端错误的可重试判定。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->