### PR TITLE
refactor(xml): replace xmltree with hardened quick-xml parser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -780,6 +780,7 @@ dependencies = [
  "aster_forge_tasks",
  "aster_forge_utils",
  "aster_forge_validation",
+ "aster_forge_xml",
  "async-stream",
  "async-trait",
  "aws-credential-types",
@@ -854,14 +855,13 @@ dependencies = [
  "webauthn-authenticator-rs",
  "webauthn-rs",
  "webauthn-rs-proto",
- "xmltree",
  "zip 8.6.0",
 ]
 
 [[package]]
 name = "aster_forge_actix_middleware"
 version = "0.1.0"
-source = "git+https://github.com/AsterCommunity/AsterForge#15b01e60bd4f6d9f2a29f3efa52e2b75ed7e0b5c"
+source = "git+https://github.com/AsterCommunity/AsterForge#f1f6ba45b0e792a7ecb33c2ddc5198583e1d8cbc"
 dependencies = [
  "actix-governor",
  "actix-web",
@@ -880,7 +880,7 @@ dependencies = [
 [[package]]
 name = "aster_forge_actix_observability"
 version = "0.1.0"
-source = "git+https://github.com/AsterCommunity/AsterForge#15b01e60bd4f6d9f2a29f3efa52e2b75ed7e0b5c"
+source = "git+https://github.com/AsterCommunity/AsterForge#f1f6ba45b0e792a7ecb33c2ddc5198583e1d8cbc"
 dependencies = [
  "actix-web",
  "aster_forge_metrics",
@@ -890,7 +890,7 @@ dependencies = [
 [[package]]
 name = "aster_forge_alloc"
 version = "0.1.0"
-source = "git+https://github.com/AsterCommunity/AsterForge#15b01e60bd4f6d9f2a29f3efa52e2b75ed7e0b5c"
+source = "git+https://github.com/AsterCommunity/AsterForge#f1f6ba45b0e792a7ecb33c2ddc5198583e1d8cbc"
 dependencies = [
  "tikv-jemalloc-ctl",
  "tracing",
@@ -899,7 +899,7 @@ dependencies = [
 [[package]]
 name = "aster_forge_api"
 version = "0.1.0"
-source = "git+https://github.com/AsterCommunity/AsterForge#15b01e60bd4f6d9f2a29f3efa52e2b75ed7e0b5c"
+source = "git+https://github.com/AsterCommunity/AsterForge#f1f6ba45b0e792a7ecb33c2ddc5198583e1d8cbc"
 dependencies = [
  "chrono",
  "serde",
@@ -910,7 +910,7 @@ dependencies = [
 [[package]]
 name = "aster_forge_api_docs_macros"
 version = "0.1.0"
-source = "git+https://github.com/AsterCommunity/AsterForge#15b01e60bd4f6d9f2a29f3efa52e2b75ed7e0b5c"
+source = "git+https://github.com/AsterCommunity/AsterForge#f1f6ba45b0e792a7ecb33c2ddc5198583e1d8cbc"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -920,7 +920,7 @@ dependencies = [
 [[package]]
 name = "aster_forge_audit"
 version = "0.1.0"
-source = "git+https://github.com/AsterCommunity/AsterForge#15b01e60bd4f6d9f2a29f3efa52e2b75ed7e0b5c"
+source = "git+https://github.com/AsterCommunity/AsterForge#f1f6ba45b0e792a7ecb33c2ddc5198583e1d8cbc"
 dependencies = [
  "aster_forge_db",
  "aster_forge_mail",
@@ -932,7 +932,7 @@ dependencies = [
 [[package]]
 name = "aster_forge_cache"
 version = "0.1.0"
-source = "git+https://github.com/AsterCommunity/AsterForge#15b01e60bd4f6d9f2a29f3efa52e2b75ed7e0b5c"
+source = "git+https://github.com/AsterCommunity/AsterForge#f1f6ba45b0e792a7ecb33c2ddc5198583e1d8cbc"
 dependencies = [
  "aster_forge_runtime",
  "async-trait",
@@ -949,7 +949,7 @@ dependencies = [
 [[package]]
 name = "aster_forge_config"
 version = "0.1.0"
-source = "git+https://github.com/AsterCommunity/AsterForge#15b01e60bd4f6d9f2a29f3efa52e2b75ed7e0b5c"
+source = "git+https://github.com/AsterCommunity/AsterForge#f1f6ba45b0e792a7ecb33c2ddc5198583e1d8cbc"
 dependencies = [
  "aster_forge_utils",
  "async-trait",
@@ -968,7 +968,7 @@ dependencies = [
 [[package]]
 name = "aster_forge_crypto"
 version = "0.1.0"
-source = "git+https://github.com/AsterCommunity/AsterForge#15b01e60bd4f6d9f2a29f3efa52e2b75ed7e0b5c"
+source = "git+https://github.com/AsterCommunity/AsterForge#f1f6ba45b0e792a7ecb33c2ddc5198583e1d8cbc"
 dependencies = [
  "argon2 0.5.3",
  "rand_core 0.6.4",
@@ -979,7 +979,7 @@ dependencies = [
 [[package]]
 name = "aster_forge_db"
 version = "0.1.0"
-source = "git+https://github.com/AsterCommunity/AsterForge#15b01e60bd4f6d9f2a29f3efa52e2b75ed7e0b5c"
+source = "git+https://github.com/AsterCommunity/AsterForge#f1f6ba45b0e792a7ecb33c2ddc5198583e1d8cbc"
 dependencies = [
  "aster_forge_api",
  "aster_forge_config",
@@ -999,7 +999,7 @@ dependencies = [
 [[package]]
 name = "aster_forge_external_auth"
 version = "0.1.0"
-source = "git+https://github.com/AsterCommunity/AsterForge#15b01e60bd4f6d9f2a29f3efa52e2b75ed7e0b5c"
+source = "git+https://github.com/AsterCommunity/AsterForge#f1f6ba45b0e792a7ecb33c2ddc5198583e1d8cbc"
 dependencies = [
  "aster_forge_crypto",
  "aster_forge_utils",
@@ -1022,7 +1022,7 @@ dependencies = [
 [[package]]
 name = "aster_forge_file_classification"
 version = "0.1.0"
-source = "git+https://github.com/AsterCommunity/AsterForge#15b01e60bd4f6d9f2a29f3efa52e2b75ed7e0b5c"
+source = "git+https://github.com/AsterCommunity/AsterForge#f1f6ba45b0e792a7ecb33c2ddc5198583e1d8cbc"
 dependencies = [
  "sea-orm",
  "serde",
@@ -1033,7 +1033,7 @@ dependencies = [
 [[package]]
 name = "aster_forge_logging"
 version = "0.1.0"
-source = "git+https://github.com/AsterCommunity/AsterForge#15b01e60bd4f6d9f2a29f3efa52e2b75ed7e0b5c"
+source = "git+https://github.com/AsterCommunity/AsterForge#f1f6ba45b0e792a7ecb33c2ddc5198583e1d8cbc"
 dependencies = [
  "serde",
  "tracing-appender",
@@ -1043,7 +1043,7 @@ dependencies = [
 [[package]]
 name = "aster_forge_mail"
 version = "0.1.0"
-source = "git+https://github.com/AsterCommunity/AsterForge#15b01e60bd4f6d9f2a29f3efa52e2b75ed7e0b5c"
+source = "git+https://github.com/AsterCommunity/AsterForge#f1f6ba45b0e792a7ecb33c2ddc5198583e1d8cbc"
 dependencies = [
  "aster_forge_runtime",
  "aster_forge_tasks",
@@ -1061,7 +1061,7 @@ dependencies = [
 [[package]]
 name = "aster_forge_metrics"
 version = "0.1.0"
-source = "git+https://github.com/AsterCommunity/AsterForge#15b01e60bd4f6d9f2a29f3efa52e2b75ed7e0b5c"
+source = "git+https://github.com/AsterCommunity/AsterForge#f1f6ba45b0e792a7ecb33c2ddc5198583e1d8cbc"
 dependencies = [
  "aster_forge_alloc",
  "aster_forge_runtime",
@@ -1076,7 +1076,7 @@ dependencies = [
 [[package]]
 name = "aster_forge_panic"
 version = "0.1.0"
-source = "git+https://github.com/AsterCommunity/AsterForge#15b01e60bd4f6d9f2a29f3efa52e2b75ed7e0b5c"
+source = "git+https://github.com/AsterCommunity/AsterForge#f1f6ba45b0e792a7ecb33c2ddc5198583e1d8cbc"
 dependencies = [
  "chrono",
 ]
@@ -1084,7 +1084,7 @@ dependencies = [
 [[package]]
 name = "aster_forge_runtime"
 version = "0.1.0"
-source = "git+https://github.com/AsterCommunity/AsterForge#15b01e60bd4f6d9f2a29f3efa52e2b75ed7e0b5c"
+source = "git+https://github.com/AsterCommunity/AsterForge#f1f6ba45b0e792a7ecb33c2ddc5198583e1d8cbc"
 dependencies = [
  "aster_forge_utils",
  "async-trait",
@@ -1101,7 +1101,7 @@ dependencies = [
 [[package]]
 name = "aster_forge_tasks"
 version = "0.1.0"
-source = "git+https://github.com/AsterCommunity/AsterForge#15b01e60bd4f6d9f2a29f3efa52e2b75ed7e0b5c"
+source = "git+https://github.com/AsterCommunity/AsterForge#f1f6ba45b0e792a7ecb33c2ddc5198583e1d8cbc"
 dependencies = [
  "aster_forge_runtime",
  "aster_forge_utils",
@@ -1121,13 +1121,12 @@ dependencies = [
 [[package]]
 name = "aster_forge_utils"
 version = "0.1.0"
-source = "git+https://github.com/AsterCommunity/AsterForge#15b01e60bd4f6d9f2a29f3efa52e2b75ed7e0b5c"
+source = "git+https://github.com/AsterCommunity/AsterForge#f1f6ba45b0e792a7ecb33c2ddc5198583e1d8cbc"
 dependencies = [
  "http 1.4.2",
  "httpdate",
  "ipnet",
  "md-5",
- "quick-xml",
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
@@ -1139,10 +1138,19 @@ dependencies = [
 [[package]]
 name = "aster_forge_validation"
 version = "0.1.0"
-source = "git+https://github.com/AsterCommunity/AsterForge#15b01e60bd4f6d9f2a29f3efa52e2b75ed7e0b5c"
+source = "git+https://github.com/AsterCommunity/AsterForge#f1f6ba45b0e792a7ecb33c2ddc5198583e1d8cbc"
 dependencies = [
  "thiserror 2.0.18",
  "unicode-normalization",
+]
+
+[[package]]
+name = "aster_forge_xml"
+version = "0.1.0"
+source = "git+https://github.com/AsterCommunity/AsterForge#f1f6ba45b0e792a7ecb33c2ddc5198583e1d8cbc"
+dependencies = [
+ "quick-xml",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1240,9 +1248,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.17.1"
+version = "1.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4342d8937fc7e5dd9b1c60292261c0670c882a2cd1719cfc11b1af41731e32ad"
+checksum = "00bdb5da18dac48ca2cc7cd4a98e533e8635a58e2361d13a1a4ee3888e0d72f1"
 dependencies = [
  "aws-lc-sys",
  "untrusted 0.7.1",
@@ -1251,9 +1259,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.42.0"
+version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d9ceb1da931507a12f4fccea479dccd00da1943e1b4ae72d8e502d707361444"
+checksum = "43103168cc76fe62678a375e722fc9cb3a0146159ac5828bc4f0dfd755c2224c"
 dependencies = [
  "cc",
  "cmake",
@@ -9409,25 +9417,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "xml"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "636f85e5ca6488e96401b61eb7de54f4e44755c988af0f52cf90230c312a1a89"
-
-[[package]]
 name = "xmlparser"
 version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
-
-[[package]]
-name = "xmltree"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbc04313cab124e498ab1724e739720807b6dc405b9ed0edc5860164d2e4ff70"
-dependencies = [
- "xml",
-]
 
 [[package]]
 name = "xxhash-rust"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -119,6 +119,7 @@ aster_forge_tasks = { git = "https://github.com/AsterCommunity/AsterForge", pack
 aster_forge_panic = { git = "https://github.com/AsterCommunity/AsterForge", package = "aster_forge_panic" }
 aster_forge_runtime = { git = "https://github.com/AsterCommunity/AsterForge", package = "aster_forge_runtime" }
 aster_forge_utils = { git = "https://github.com/AsterCommunity/AsterForge", package = "aster_forge_utils" }
+aster_forge_xml = { git = "https://github.com/AsterCommunity/AsterForge", package = "aster_forge_xml" }
 aster_forge_validation = { git = "https://github.com/AsterCommunity/AsterForge", package = "aster_forge_validation" }
 async-stream = "0.3"
 async-trait = "0.1"
@@ -187,7 +188,6 @@ uuid = { version = "1", features = ["v4"] }
 validator = { version = "0.20", features = ["derive"] }
 webauthn-rs = { version = "0.6.1-dev", default-features = false, features = ["conditional-ui", "danger-allow-state-serialisation"] }
 webauthn-rs-proto = "0.6.1-dev"
-xmltree = "0.12"
 zip = { version = "8", default-features = false, features = ["deflate"] }
 lofty = "0.24.0"
 

--- a/src/services/preview/wopi/discovery/cache.rs
+++ b/src/services/preview/wopi/discovery/cache.rs
@@ -8,6 +8,8 @@ use crate::config::OUTBOUND_HTTP_USER_AGENT;
 use crate::config::wopi;
 use crate::errors::{AsterError, MapAsterErr, Result};
 use crate::runtime::SharedRuntimeState;
+use crate::storage::http_body::read_reqwest_response_body_limited;
+use aster_forge_xml::XmlSafetyPolicy;
 
 use super::parser::parse_discovery_xml;
 use super::types::{CachedWopiDiscovery, WopiDiscovery};
@@ -82,10 +84,15 @@ pub(super) async fn load_discovery(
         )));
     }
 
-    let body = response.text().await.map_aster_err_ctx(
+    let body = read_reqwest_response_body_limited(
+        response,
         "failed to read WOPI discovery",
+        XmlSafetyPolicy::untrusted().max_input_bytes,
         AsterError::validation_error,
-    )?;
+    )
+    .await?;
+    let body = String::from_utf8(body)
+        .map_err(|_| AsterError::validation_error("WOPI discovery response is not UTF-8"))?;
     let parsed = match parse_discovery_xml(&body) {
         Ok(parsed) => parsed,
         Err(error) => {

--- a/src/services/preview/wopi/discovery/parser.rs
+++ b/src/services/preview/wopi/discovery/parser.rs
@@ -1,17 +1,39 @@
-use xmltree::{Element, XMLNode};
+use aster_forge_xml::{
+    XmlElementEvent, XmlEvent, XmlSafetyPolicy, XmlWalkError, walk_validated_xml,
+};
 
-use crate::errors::{AsterError, MapAsterErr, Result};
+use crate::errors::{AsterError, Result};
 use crate::services::preview::wopi::proof::{WopiProofKeySet, parse_wopi_proof_key_set};
 
 use super::types::{WopiDiscovery, WopiDiscoveryAction};
 
 pub(crate) fn parse_discovery_xml(xml: &str) -> Result<WopiDiscovery> {
-    let root = Element::parse(xml.as_bytes())
-        .map_aster_err_ctx("invalid WOPI discovery XML", AsterError::validation_error)?;
+    let mut app_contexts = Vec::new();
     let mut actions = Vec::new();
     let mut proof_keys = None;
-    collect_discovery_proof_keys(&root, &mut proof_keys)?;
-    collect_discovery_actions(&root, None, None, &mut actions);
+
+    walk_validated_xml(xml.as_bytes(), XmlSafetyPolicy::untrusted(), |event| {
+        match event {
+            XmlEvent::Start(element) => {
+                let context =
+                    handle_element(&element, app_contexts.last(), &mut actions, &mut proof_keys)?;
+                app_contexts.push(context);
+            }
+            XmlEvent::Empty(element) => {
+                handle_element(&element, app_contexts.last(), &mut actions, &mut proof_keys)?;
+            }
+            XmlEvent::End { .. } => {
+                app_contexts.pop();
+            }
+            _ => {}
+        }
+        Ok(())
+    })
+    .map_err(|error| match error {
+        XmlWalkError::Xml(_) => AsterError::validation_error("invalid WOPI discovery XML"),
+        XmlWalkError::Visitor(error) => error,
+    })?;
+
     if actions.is_empty() {
         return Err(AsterError::validation_error(
             "WOPI discovery did not expose any actions",
@@ -24,91 +46,93 @@ pub(crate) fn parse_discovery_xml(xml: &str) -> Result<WopiDiscovery> {
     })
 }
 
-fn collect_discovery_proof_keys(
-    element: &Element,
-    out: &mut Option<WopiProofKeySet>,
-) -> Result<()> {
-    if element.name.eq_ignore_ascii_case("proof-key") {
-        let current_modulus = element_attribute(element, "modulus")
+#[derive(Clone, Default)]
+struct AppContext {
+    name: Option<String>,
+    icon_url: Option<String>,
+}
+
+fn handle_element(
+    element: &XmlElementEvent,
+    inherited_app: Option<&AppContext>,
+    actions: &mut Vec<WopiDiscoveryAction>,
+    proof_keys: &mut Option<WopiProofKeySet>,
+) -> Result<AppContext> {
+    let name = element.local_name();
+    let context = if name.eq_ignore_ascii_case("app") {
+        AppContext {
+            name: element
+                .attribute("name")
+                .map(str::to_string)
+                .or_else(|| inherited_app.and_then(|context| context.name.clone())),
+            icon_url: element
+                .attribute("favIconUrl")
+                .map(str::to_string)
+                .or_else(|| inherited_app.and_then(|context| context.icon_url.clone())),
+        }
+    } else {
+        inherited_app.cloned().unwrap_or_default()
+    };
+
+    if name.eq_ignore_ascii_case("proof-key") {
+        let modulus = element
+            .attribute("modulus")
             .ok_or_else(|| AsterError::validation_error("WOPI proof-key is missing modulus"))?;
-        let current_exponent = element_attribute(element, "exponent")
+        let exponent = element
+            .attribute("exponent")
             .ok_or_else(|| AsterError::validation_error("WOPI proof-key is missing exponent"))?;
         let parsed = parse_wopi_proof_key_set(
-            current_modulus,
-            current_exponent,
-            element_attribute(element, "oldmodulus"),
-            element_attribute(element, "oldexponent"),
+            modulus,
+            exponent,
+            element.attribute("oldmodulus"),
+            element.attribute("oldexponent"),
         )?;
-        if out.replace(parsed).is_some() {
+        if proof_keys.replace(parsed).is_some() {
             return Err(AsterError::validation_error(
                 "WOPI discovery contains multiple proof-key elements",
             ));
         }
     }
 
-    for child in &element.children {
-        if let XMLNode::Element(child) = child {
-            collect_discovery_proof_keys(child, out)?;
-        }
-    }
-
-    Ok(())
-}
-
-fn collect_discovery_actions(
-    element: &Element,
-    app_name: Option<&str>,
-    app_icon_url: Option<&str>,
-    out: &mut Vec<WopiDiscoveryAction>,
-) {
-    let (next_app_name, next_app_icon_url) = if element.name.eq_ignore_ascii_case("app") {
-        (
-            element_attribute(element, "name").or(app_name),
-            element_attribute(element, "favIconUrl").or(app_icon_url),
-        )
-    } else {
-        (app_name, app_icon_url)
-    };
-
-    if element.name.eq_ignore_ascii_case("action") {
-        let action =
-            element_attribute(element, "name").map(|value| value.trim().to_ascii_lowercase());
-        let urlsrc = element_attribute(element, "urlsrc").map(|value| value.trim().to_string());
-        if let (Some(action), Some(urlsrc)) = (action, urlsrc)
-            && !action.is_empty()
-            && !urlsrc.is_empty()
-        {
-            let ext = element_attribute(element, "ext")
-                .map(|value| value.trim().trim_start_matches('.').to_ascii_lowercase())
-                .filter(|value| !value.is_empty());
-            let mime = next_app_name
-                .map(str::trim)
-                .filter(|value| value.contains('/'))
-                .map(|value| value.to_ascii_lowercase());
-            out.push(WopiDiscoveryAction {
+    if name.eq_ignore_ascii_case("action") {
+        let action = element
+            .attribute("name")
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(str::to_ascii_lowercase);
+        let urlsrc = element
+            .attribute("urlsrc")
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(str::to_string);
+        if let (Some(action), Some(urlsrc)) = (action, urlsrc) {
+            actions.push(WopiDiscoveryAction {
                 action,
-                app_icon_url: next_app_icon_url.map(str::trim).map(ToString::to_string),
-                app_name: next_app_name.map(str::trim).map(ToString::to_string),
-                ext,
-                mime,
+                app_icon_url: context
+                    .icon_url
+                    .as_deref()
+                    .map(str::trim)
+                    .map(ToString::to_string),
+                app_name: context
+                    .name
+                    .as_deref()
+                    .map(str::trim)
+                    .map(ToString::to_string),
+                ext: element
+                    .attribute("ext")
+                    .map(str::trim)
+                    .map(|value| value.trim_start_matches('.').to_ascii_lowercase())
+                    .filter(|value| !value.is_empty()),
+                mime: context
+                    .name
+                    .as_deref()
+                    .map(str::trim)
+                    .filter(|value| value.contains('/'))
+                    .map(str::to_ascii_lowercase),
                 urlsrc,
             });
         }
     }
 
-    for child in &element.children {
-        if let XMLNode::Element(child) = child {
-            collect_discovery_actions(child, next_app_name, next_app_icon_url, out);
-        }
-    }
-}
-
-fn element_attribute<'a>(element: &'a Element, name: &str) -> Option<&'a str> {
-    element.attributes.iter().find_map(|(key, value)| {
-        if key.eq_ignore_ascii_case(name) {
-            Some(value.as_str())
-        } else {
-            None
-        }
-    })
+    Ok(context)
 }

--- a/src/services/preview/wopi/tests.rs
+++ b/src/services/preview/wopi/tests.rs
@@ -20,6 +20,7 @@ use super::types::{
 use crate::services::preview::apps::{
     PreviewAppProvider, PreviewOpenMode, PublicPreviewAppConfig, PublicPreviewAppDefinition,
 };
+use aster_forge_xml::DEFAULT_XML_MAX_TEXT_BYTES;
 
 fn test_wopi_app() -> PublicPreviewAppDefinition {
     PublicPreviewAppDefinition {
@@ -581,6 +582,69 @@ fn parse_discovery_xml_extracts_proof_keys() {
     .unwrap();
 
     assert!(discovery.proof_keys().is_some());
+}
+
+#[test]
+fn parse_discovery_xml_rejects_xml_safety_boundaries() {
+    assert!(parse_discovery_xml("<!DOCTYPE root><root/>").is_err());
+    assert!(parse_discovery_xml("junk<wopi-discovery><action name=\"view\" urlsrc=\"https://office.example/view?\"/></wopi-discovery>").is_err());
+
+    let mut deep = String::new();
+    for _ in 0..=aster_forge_xml::DEFAULT_XML_MAX_DEPTH {
+        deep.push_str("<x>");
+    }
+    deep.push_str(r#"<action name="view" urlsrc="https://office.example/view?"/>"#);
+    for _ in 0..=aster_forge_xml::DEFAULT_XML_MAX_DEPTH {
+        deep.push_str("</x>");
+    }
+    assert!(parse_discovery_xml(&deep).is_err());
+
+    let comment = "x".repeat(DEFAULT_XML_MAX_TEXT_BYTES + 1);
+    let oversized = format!(
+        "<!--{comment}--><wopi-discovery><action name=\"view\" urlsrc=\"https://office.example/view?\"/></wopi-discovery>"
+    );
+    assert!(parse_discovery_xml(&oversized).is_err());
+}
+
+#[test]
+fn parse_discovery_xml_accepts_exact_attribute_limit_and_rejects_one_more() {
+    let mut attributes =
+        String::from(r#"name="view" urlsrc="https://office.example/view?" ext="docx" "#);
+    for index in 0..61 {
+        attributes.push_str(&format!("x{index}=\"value\" "));
+    }
+    let exact = format!("<wopi-discovery><action {attributes}/></wopi-discovery>");
+    let discovery = parse_discovery_xml(&exact).expect("exact attribute budget should pass");
+    assert_eq!(
+        discovery
+            .find_action_url("view", Some("docx"), "application/octet-stream")
+            .as_deref(),
+        Some("https://office.example/view?")
+    );
+
+    let over = exact.replace("x60=\"value\"", "x60=\"value\" x61=\"value\"");
+    assert!(parse_discovery_xml(&over).is_err());
+}
+
+#[test]
+fn parse_discovery_xml_rejects_duplicate_or_incomplete_proof_keys() {
+    let mut modulus_bytes = vec![0_u8; 256];
+    modulus_bytes[0] = 0x80;
+    modulus_bytes[255] = 1;
+    let modulus = STANDARD.encode(modulus_bytes);
+    let exponent = STANDARD.encode([1_u8, 0, 1]);
+    let duplicate = format!(
+        r#"<wopi-discovery>
+          <proof-key modulus="{modulus}" exponent="{exponent}"/>
+          <proof-key modulus="{modulus}" exponent="{exponent}"/>
+          <action name="view" urlsrc="https://office.example/view?"/>
+        </wopi-discovery>"#
+    );
+    assert!(parse_discovery_xml(&duplicate).is_err());
+    assert!(parse_discovery_xml(
+        r#"<wopi-discovery><proof-key modulus="AQID"/><action name="view" urlsrc="https://office.example/view?"/></wopi-discovery>"#
+    )
+    .is_err());
 }
 
 #[test]

--- a/src/storage/drivers/tencent_cos/cors.rs
+++ b/src/storage/drivers/tencent_cos/cors.rs
@@ -1,17 +1,17 @@
-use std::io::Cursor;
 use std::time::{SystemTime, UNIX_EPOCH};
 
+use aster_forge_xml::{XmlEvent, XmlSafetyPolicy, XmlWalkError, XmlWriter, walk_validated_xml};
 use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64_STANDARD};
 use md5::{Digest as Md5Digest, Md5};
 use reqwest::StatusCode;
 use reqwest::header::CONTENT_TYPE;
-use xmltree::{Element, EmitterConfig, XMLNode};
 
 use crate::api::api_error_code::ApiErrorCode;
 use crate::errors::{AsterError, MapAsterErr, Result};
 use crate::storage::error::{
     StorageErrorKind, storage_driver_error, storage_driver_error_with_code,
 };
+use crate::storage::http_body::read_reqwest_response_body_limited;
 
 use super::TencentCosDriver;
 
@@ -86,10 +86,16 @@ impl TencentCosDriver {
             .await
             .map_aster_err_ctx("COS GET Bucket cors", AsterError::storage_driver_error)?;
         let status = response.status();
-        let body = response.text().await.map_aster_err_ctx(
+        let body = read_reqwest_response_body_limited(
+            response,
             "read COS GET Bucket cors response",
+            XmlSafetyPolicy::untrusted().max_input_bytes,
             AsterError::storage_driver_error,
-        )?;
+        )
+        .await?;
+        let body = String::from_utf8(body).map_err(|_| {
+            AsterError::storage_driver_error("COS GET Bucket cors response is not UTF-8")
+        })?;
 
         if status == StatusCode::NOT_FOUND {
             return Ok(CosCorsConfiguration {
@@ -131,10 +137,16 @@ impl TencentCosDriver {
             .get("x-cos-request-id")
             .and_then(|value| value.to_str().ok())
             .map(str::to_string);
-        let body = response.text().await.map_aster_err_ctx(
+        let body = read_reqwest_response_body_limited(
+            response,
             "read COS PUT Bucket cors response",
+            XmlSafetyPolicy::untrusted().max_input_bytes,
             AsterError::storage_driver_error,
-        )?;
+        )
+        .await?;
+        let body = String::from_utf8(body).map_err(|_| {
+            AsterError::storage_driver_error("COS PUT Bucket cors response is not UTF-8")
+        })?;
 
         if status.is_success() {
             return Ok(request_id);
@@ -168,128 +180,158 @@ pub(crate) fn asterdrive_cors_rule(allowed_origins: &[String]) -> CosCorsRule {
 }
 
 pub(crate) fn build_cors_configuration_xml(config: &CosCorsConfiguration) -> Result<String> {
-    let mut root = Element::new("CORSConfiguration");
+    let mut bytes = Vec::new();
+    let mut writer = XmlWriter::new(&mut bytes);
+    writer
+        .declaration("1.0", Some("UTF-8"))
+        .map_aster_err_ctx("serialize COS CORS XML", AsterError::storage_driver_error)?;
+    writer
+        .start("CORSConfiguration", std::iter::empty())
+        .map_aster_err_ctx("serialize COS CORS XML", AsterError::storage_driver_error)?;
     for rule in &config.rules {
-        root.children
-            .push(XMLNode::Element(cors_rule_element(rule)));
+        write_cors_rule(&mut writer, rule)?;
     }
     if let Some(response_vary) = config.response_vary {
-        push_text_child(
-            &mut root,
+        write_text_element(
+            &mut writer,
             "ResponseVary",
             if response_vary { "true" } else { "false" },
-        );
+        )?;
     }
-
-    let mut bytes = Vec::new();
-    root.write_with_config(
-        &mut bytes,
-        EmitterConfig::new()
-            .perform_indent(true)
-            .write_document_declaration(true),
-    )
-    .map_aster_err_ctx("serialize COS CORS XML", AsterError::storage_driver_error)?;
+    writer
+        .end("CORSConfiguration")
+        .map_aster_err_ctx("serialize COS CORS XML", AsterError::storage_driver_error)?;
+    writer
+        .finish()
+        .map_aster_err_ctx("serialize COS CORS XML", AsterError::storage_driver_error)?;
     String::from_utf8(bytes)
         .map_aster_err_ctx("encode COS CORS XML", AsterError::storage_driver_error)
 }
 
 pub(crate) fn parse_cors_configuration(body: &str) -> Result<CosCorsConfiguration> {
-    let root = Element::parse(Cursor::new(body.as_bytes()))
-        .map_aster_err_ctx("parse COS CORS XML", AsterError::storage_driver_error)?;
-    if !xml_name_matches(&root.name, "CORSConfiguration") {
-        return Err(storage_driver_error(
-            StorageErrorKind::Misconfigured,
-            "COS CORS XML root is not CORSConfiguration",
-        ));
-    }
-
+    let mut stack = Vec::<String>::new();
+    let mut text = Vec::<String>::new();
     let mut rules = Vec::new();
-    for child in root.children.iter().filter_map(as_element) {
-        if xml_name_matches(&child.name, "CORSRule") {
-            rules.push(parse_cors_rule(child));
-        }
-    }
+    let mut current_rule = None;
+    let mut response_vary = None;
+    let mut root_seen = false;
 
+    walk_validated_xml(body.as_bytes(), XmlSafetyPolicy::untrusted(), |event| {
+        match event {
+            XmlEvent::Start(element) => {
+                let name = element.local_name().to_string();
+                if !root_seen {
+                    root_seen = true;
+                    if name != "CORSConfiguration" {
+                        return Err(storage_driver_error(
+                            StorageErrorKind::Misconfigured,
+                            "COS CORS XML root is not CORSConfiguration",
+                        ));
+                    }
+                }
+                if name == "CORSRule" {
+                    current_rule = Some(CosCorsRule {
+                        id: None,
+                        allowed_origins: Vec::new(),
+                        allowed_methods: Vec::new(),
+                        allowed_headers: Vec::new(),
+                        expose_headers: Vec::new(),
+                        max_age_seconds: None,
+                    });
+                }
+                stack.push(name);
+                text.push(String::new());
+            }
+            XmlEvent::Text(value) | XmlEvent::CData(value) => {
+                if let Some(text) = text.last_mut() {
+                    text.push_str(&value);
+                }
+            }
+            XmlEvent::End { .. } => {
+                let Some(name) = stack.pop() else {
+                    return Err(AsterError::storage_driver_error("parse COS CORS XML"));
+                };
+                let value = text.pop().unwrap_or_default().trim().to_string();
+                let parent = stack.last().map(String::as_str);
+                if parent == Some("CORSRule") {
+                    if let Some(rule) = current_rule.as_mut() {
+                        apply_cors_rule_value(rule, &name, value);
+                    }
+                } else if parent == Some("CORSConfiguration") && name == "ResponseVary" {
+                    response_vary = (!value.is_empty()).then(|| value.eq_ignore_ascii_case("true"));
+                }
+                if name == "CORSRule"
+                    && let Some(rule) = current_rule.take()
+                {
+                    rules.push(rule);
+                }
+            }
+            _ => {}
+        }
+        Ok(())
+    })
+    .map_err(|error| match error {
+        XmlWalkError::Xml(error) => AsterError::storage_driver_error(error.to_string()),
+        XmlWalkError::Visitor(error) => error,
+    })?;
     Ok(CosCorsConfiguration {
         rules,
-        response_vary: child_text(&root, "ResponseVary")
-            .map(|value| value.eq_ignore_ascii_case("true")),
+        response_vary,
     })
 }
 
-fn cors_rule_element(rule: &CosCorsRule) -> Element {
-    let mut element = Element::new("CORSRule");
+fn write_cors_rule<W: std::io::Write>(writer: &mut XmlWriter<W>, rule: &CosCorsRule) -> Result<()> {
+    writer
+        .start("CORSRule", std::iter::empty())
+        .map_aster_err_ctx("serialize COS CORS XML", AsterError::storage_driver_error)?;
     if let Some(id) = &rule.id {
-        push_text_child(&mut element, "ID", id);
+        write_text_element(writer, "ID", id)?;
     }
     for value in &rule.allowed_origins {
-        push_text_child(&mut element, "AllowedOrigin", value);
+        write_text_element(writer, "AllowedOrigin", value)?;
     }
     for value in &rule.allowed_methods {
-        push_text_child(&mut element, "AllowedMethod", value);
+        write_text_element(writer, "AllowedMethod", value)?;
     }
     for value in &rule.allowed_headers {
-        push_text_child(&mut element, "AllowedHeader", value);
+        write_text_element(writer, "AllowedHeader", value)?;
     }
     for value in &rule.expose_headers {
-        push_text_child(&mut element, "ExposeHeader", value);
+        write_text_element(writer, "ExposeHeader", value)?;
     }
-    if let Some(value) = rule.max_age_seconds {
-        push_text_child(&mut element, "MaxAgeSeconds", &value.to_string());
+    if let Some(max_age_seconds) = rule.max_age_seconds {
+        write_text_element(writer, "MaxAgeSeconds", &max_age_seconds.to_string())?;
     }
-    element
+    writer
+        .end("CORSRule")
+        .map_aster_err_ctx("serialize COS CORS XML", AsterError::storage_driver_error)
 }
 
-fn parse_cors_rule(element: &Element) -> CosCorsRule {
-    CosCorsRule {
-        id: child_text(element, "ID"),
-        allowed_origins: child_texts(element, "AllowedOrigin"),
-        allowed_methods: child_texts(element, "AllowedMethod"),
-        allowed_headers: child_texts(element, "AllowedHeader"),
-        expose_headers: child_texts(element, "ExposeHeader"),
-        max_age_seconds: child_text(element, "MaxAgeSeconds")
-            .and_then(|value| value.parse::<u32>().ok()),
+fn write_text_element<W: std::io::Write>(
+    writer: &mut XmlWriter<W>,
+    name: &str,
+    value: &str,
+) -> Result<()> {
+    writer
+        .text_element(name, value)
+        .map_aster_err_ctx("serialize COS CORS XML", AsterError::storage_driver_error)
+}
+
+fn apply_cors_rule_value(rule: &mut CosCorsRule, name: &str, value: String) {
+    if value.is_empty() {
+        return;
     }
-}
-
-fn push_text_child(element: &mut Element, name: &str, value: &str) {
-    let mut child = Element::new(name);
-    child.children.push(XMLNode::Text(value.to_string()));
-    element.children.push(XMLNode::Element(child));
-}
-
-fn child_texts(element: &Element, name: &str) -> Vec<String> {
-    element
-        .children
-        .iter()
-        .filter_map(as_element)
-        .filter(|child| xml_name_matches(&child.name, name))
-        .filter_map(element_text)
-        .collect()
-}
-
-fn child_text(element: &Element, name: &str) -> Option<String> {
-    child_texts(element, name).into_iter().next()
-}
-
-fn element_text(element: &Element) -> Option<String> {
-    let text = element.get_text()?.trim().to_string();
-    (!text.is_empty()).then_some(text)
-}
-
-fn as_element(node: &XMLNode) -> Option<&Element> {
-    match node {
-        XMLNode::Element(element) => Some(element),
-        _ => None,
+    match name {
+        "ID" => {
+            rule.id.get_or_insert(value);
+        }
+        "AllowedOrigin" => rule.allowed_origins.push(value),
+        "AllowedMethod" => rule.allowed_methods.push(value),
+        "AllowedHeader" => rule.allowed_headers.push(value),
+        "ExposeHeader" => rule.expose_headers.push(value),
+        "MaxAgeSeconds" => rule.max_age_seconds = value.parse().ok(),
+        _ => {}
     }
-}
-
-fn xml_name_matches(actual: &str, expected: &str) -> bool {
-    actual
-        .rsplit_once(':')
-        .map(|(_, local)| local)
-        .unwrap_or(actual)
-        == expected
 }
 
 fn cos_key_time() -> Result<String> {
@@ -345,24 +387,42 @@ fn cos_cors_response_error(status: StatusCode, body: &str, action: &str) -> Aste
 }
 
 fn extract_xml_tag(body: &str, tag: &str) -> Option<String> {
-    let root = Element::parse(Cursor::new(body.as_bytes())).ok()?;
-    find_xml_tag_text(&root, tag)
-}
-
-fn find_xml_tag_text(element: &Element, tag: &str) -> Option<String> {
-    if xml_name_matches(&element.name, tag) {
-        return element_text(element);
-    }
-    element
-        .children
-        .iter()
-        .filter_map(as_element)
-        .find_map(|child| find_xml_tag_text(child, tag))
+    let mut stack = Vec::<String>::new();
+    let mut text = Vec::<String>::new();
+    let mut found = None;
+    walk_validated_xml(body.as_bytes(), XmlSafetyPolicy::untrusted(), |event| {
+        match event {
+            XmlEvent::Start(element) => {
+                stack.push(element.local_name().to_string());
+                text.push(String::new());
+            }
+            XmlEvent::Text(value) | XmlEvent::CData(value) => {
+                if let Some(text) = text.last_mut() {
+                    text.push_str(&value);
+                }
+            }
+            XmlEvent::End { .. } => {
+                let Some(name) = stack.pop() else {
+                    return Err(());
+                };
+                let value = text.pop().unwrap_or_default().trim().to_string();
+                if name == tag && !value.is_empty() {
+                    found.get_or_insert(value);
+                }
+            }
+            _ => {}
+        }
+        Ok(())
+    })
+    .ok()?;
+    found
 }
 
 #[cfg(test)]
 mod tests {
     use reqwest::StatusCode;
+
+    use aster_forge_xml::{DEFAULT_XML_MAX_DEPTH, DEFAULT_XML_MAX_TEXT_BYTES};
 
     use crate::api::api_error_code::ApiErrorCode;
 
@@ -464,6 +524,53 @@ mod tests {
             .expect_err("unexpected root should fail");
 
         assert!(error.message().contains("root is not CORSConfiguration"));
+    }
+
+    #[test]
+    fn cors_parser_covers_xml_safety_boundaries() {
+        for xml in [
+            "<!DOCTYPE CORSConfiguration><CORSConfiguration/>",
+            "junk<CORSConfiguration/>",
+            "<CORSConfiguration/>junk",
+        ] {
+            assert!(parse_cors_configuration(xml).is_err());
+        }
+
+        let comment = "x".repeat(DEFAULT_XML_MAX_TEXT_BYTES + 1);
+        assert!(
+            parse_cors_configuration(&format!("<!--{comment}--><CORSConfiguration/>")).is_err()
+        );
+
+        let mut exact_depth = String::from("<CORSConfiguration>");
+        for _ in 1..DEFAULT_XML_MAX_DEPTH {
+            exact_depth.push_str("<x>");
+        }
+        for _ in 1..DEFAULT_XML_MAX_DEPTH {
+            exact_depth.push_str("</x>");
+        }
+        exact_depth.push_str("</CORSConfiguration>");
+        assert!(parse_cors_configuration(&exact_depth).is_ok());
+
+        let mut over_depth = String::from("<CORSConfiguration>");
+        for _ in 0..DEFAULT_XML_MAX_DEPTH {
+            over_depth.push_str("<x>");
+        }
+        for _ in 0..DEFAULT_XML_MAX_DEPTH {
+            over_depth.push_str("</x>");
+        }
+        over_depth.push_str("</CORSConfiguration>");
+        assert!(parse_cors_configuration(&over_depth).is_err());
+    }
+
+    #[test]
+    fn cors_parser_accepts_exact_attribute_budget_and_rejects_one_more() {
+        let mut attributes = String::new();
+        for index in 0..64 {
+            attributes.push_str(&format!("x{index}=\"value\" "));
+        }
+        assert!(parse_cors_configuration(&format!("<CORSConfiguration {attributes}/>")).is_ok());
+        attributes.push_str("overflow=\"value\" ");
+        assert!(parse_cors_configuration(&format!("<CORSConfiguration {attributes}/>")).is_err());
     }
 
     #[test]

--- a/src/storage/drivers/tencent_cos/native_media_metadata.rs
+++ b/src/storage/drivers/tencent_cos/native_media_metadata.rs
@@ -1,11 +1,12 @@
-use std::io::Cursor;
+use std::collections::BTreeMap;
 
+use aster_forge_xml::{XmlEvent, XmlSafetyPolicy, XmlWalkError, walk_validated_xml};
 use async_trait::async_trait;
 use chrono::Utc;
-use xmltree::{Element, XMLNode};
 
 use crate::errors::{AsterError, MapAsterErr, Result};
 use crate::storage::error::{StorageErrorKind, storage_driver_error};
+use crate::storage::http_body::read_reqwest_response_body_limited;
 use crate::storage::traits::extensions::{
     NativeMediaMetadataRequest, NativeMediaMetadataResult, NativeMediaMetadataStorageDriver,
 };
@@ -68,10 +69,13 @@ impl NativeMediaMetadataStorageDriver for TencentCosDriver {
             ));
         }
 
-        let body = response.bytes().await.map_aster_err_ctx(
+        let body = read_reqwest_response_body_limited(
+            response,
             "COS native media metadata body",
+            XmlSafetyPolicy::untrusted().max_input_bytes,
             AsterError::storage_driver_error,
-        )?;
+        )
+        .await?;
         parse_cos_media_info_xml(&body, request.kind).map(Some)
     }
 }
@@ -89,13 +93,10 @@ fn parse_cos_media_info_xml(
     body: &[u8],
     kind: MediaMetadataKind,
 ) -> Result<NativeMediaMetadataResult> {
-    let root = Element::parse(Cursor::new(body)).map_aster_err_ctx(
-        "parse COS native media metadata XML",
-        AsterError::storage_driver_error,
-    )?;
+    let fields = collect_cos_media_fields(body)?;
     let metadata = match kind {
-        MediaMetadataKind::Video => MediaMetadataPayload::Video(parse_cos_video_metadata(&root)),
-        MediaMetadataKind::Audio => MediaMetadataPayload::Audio(parse_cos_audio_metadata(&root)),
+        MediaMetadataKind::Video => MediaMetadataPayload::Video(parse_cos_video_metadata(&fields)),
+        MediaMetadataKind::Audio => MediaMetadataPayload::Audio(parse_cos_audio_metadata(&fields)),
         MediaMetadataKind::Image => {
             return Err(storage_driver_error(
                 StorageErrorKind::Unsupported,
@@ -111,10 +112,76 @@ fn parse_cos_media_info_xml(
     })
 }
 
-fn parse_cos_video_metadata(root: &Element) -> VideoMediaMetadata {
-    let video = first_descendant(root, "Video");
-    let audio = first_descendant(root, "Audio");
-    let format = first_descendant(root, "Format");
+#[derive(Default)]
+struct CosMediaFields {
+    video: Option<BTreeMap<String, String>>,
+    audio: Option<BTreeMap<String, String>>,
+    format: Option<BTreeMap<String, String>>,
+    audio_stream_count: u32,
+    subtitle_stream_count: u32,
+}
+
+fn collect_cos_media_fields(body: &[u8]) -> Result<CosMediaFields> {
+    let mut stack = Vec::<String>::new();
+    let mut text = Vec::<String>::new();
+    let mut fields = CosMediaFields::default();
+    walk_validated_xml(body, XmlSafetyPolicy::untrusted(), |event| {
+        match event {
+            XmlEvent::Start(element) => {
+                let name = element.local_name().to_string();
+                if name.eq_ignore_ascii_case("Audio") {
+                    fields.audio_stream_count = fields.audio_stream_count.saturating_add(1);
+                } else if name.eq_ignore_ascii_case("Subtitle") {
+                    fields.subtitle_stream_count = fields.subtitle_stream_count.saturating_add(1);
+                }
+                stack.push(name);
+                text.push(String::new());
+            }
+            XmlEvent::Text(value) | XmlEvent::CData(value) => {
+                if let Some(text) = text.last_mut() {
+                    text.push_str(&value);
+                }
+            }
+            XmlEvent::End { .. } => {
+                let Some(name) = stack.pop() else {
+                    return Err(AsterError::storage_driver_error(
+                        "parse COS native media metadata XML",
+                    ));
+                };
+                let value = text.pop().unwrap_or_default().trim().to_string();
+                let parent = stack.last().map(String::as_str);
+                match parent {
+                    Some("Video") => insert_first_field(&mut fields.video, name, value),
+                    Some("Audio") => insert_first_field(&mut fields.audio, name, value),
+                    Some("Format") => insert_first_field(&mut fields.format, name, value),
+                    _ => {}
+                }
+            }
+            _ => {}
+        }
+        Ok(())
+    })
+    .map_err(|error| match error {
+        XmlWalkError::Xml(error) => AsterError::storage_driver_error(error.to_string()),
+        XmlWalkError::Visitor(error) => error,
+    })?;
+    Ok(fields)
+}
+
+fn insert_first_field(target: &mut Option<BTreeMap<String, String>>, name: String, value: String) {
+    if value.is_empty() {
+        return;
+    }
+    target
+        .get_or_insert_with(BTreeMap::new)
+        .entry(name)
+        .or_insert(value);
+}
+
+fn parse_cos_video_metadata(fields: &CosMediaFields) -> VideoMediaMetadata {
+    let video = fields.video.as_ref();
+    let audio = fields.audio.as_ref();
+    let format = fields.format.as_ref();
     let width = video.and_then(|node| child_u32(node, &["Width"]));
     let height = video.and_then(|node| child_u32(node, &["Height"]));
     let rotation_degrees = video.and_then(|node| child_i32(node, &["Rotate", "Rotation"]));
@@ -145,17 +212,17 @@ fn parse_cos_video_metadata(root: &Element) -> VideoMediaMetadata {
         audio_channels: audio.and_then(|node| child_u32(node, &["Channel", "Channels"])),
         audio_sample_rate: audio.and_then(|node| child_u32(node, &["SampleRate"])),
         audio_bitrate: audio.and_then(|node| child_u64(node, &["Bitrate", "BitRate"])),
-        audio_stream_count: descendant_count(root, "Audio"),
-        subtitle_stream_count: descendant_count(root, "Subtitle"),
+        audio_stream_count: fields.audio_stream_count,
+        subtitle_stream_count: fields.subtitle_stream_count,
         creation_time: format
             .and_then(|node| child_string(node, &["CreationTime"]))
             .or_else(|| video.and_then(|node| child_string(node, &["CreationTime"]))),
     }
 }
 
-fn parse_cos_audio_metadata(root: &Element) -> AudioMediaMetadata {
-    let audio = first_descendant(root, "Audio");
-    let format = first_descendant(root, "Format");
+fn parse_cos_audio_metadata(fields: &CosMediaFields) -> AudioMediaMetadata {
+    let audio = fields.audio.as_ref();
+    let format = fields.format.as_ref();
 
     AudioMediaMetadata {
         title: None,
@@ -212,89 +279,54 @@ fn display_dimensions(
     }
 }
 
-fn first_descendant<'a>(element: &'a Element, name: &str) -> Option<&'a Element> {
-    if xml_name_matches(&element.name, name) {
-        return Some(element);
-    }
-    element.children.iter().find_map(|child| match child {
-        XMLNode::Element(child) => first_descendant(child, name),
-        _ => None,
-    })
-}
-
-fn descendant_count(element: &Element, name: &str) -> u32 {
-    let mut count = u32::from(xml_name_matches(&element.name, name));
-    for child in &element.children {
-        if let XMLNode::Element(child) = child {
-            count = count.saturating_add(descendant_count(child, name));
-        }
-    }
-    count
-}
-
-fn child_string(element: &Element, names: &[&str]) -> Option<String> {
+fn child_string(element: &BTreeMap<String, String>, names: &[&str]) -> Option<String> {
     names.iter().find_map(|name| {
-        element
-            .children
-            .iter()
-            .filter_map(|child| match child {
-                XMLNode::Element(child) if xml_name_matches(&child.name, name) => Some(child),
-                _ => None,
-            })
-            .find_map(|child| {
-                child
-                    .get_text()
-                    .map(|value| value.trim().to_string())
-                    .filter(|value| !value.is_empty())
-            })
+        element.iter().find_map(|(field_name, value)| {
+            field_name.eq_ignore_ascii_case(name).then(|| value.clone())
+        })
     })
 }
 
-fn child_u8(element: &Element, names: &[&str]) -> Option<u8> {
+fn child_u8(element: &BTreeMap<String, String>, names: &[&str]) -> Option<u8> {
     child_string(element, names).and_then(|value| value.parse().ok())
 }
 
-fn child_u32(element: &Element, names: &[&str]) -> Option<u32> {
+fn child_u32(element: &BTreeMap<String, String>, names: &[&str]) -> Option<u32> {
     child_string(element, names).and_then(|value| value.parse().ok())
 }
 
-fn child_i32(element: &Element, names: &[&str]) -> Option<i32> {
+fn child_i32(element: &BTreeMap<String, String>, names: &[&str]) -> Option<i32> {
     child_string(element, names).and_then(|value| value.parse().ok())
 }
 
-fn child_u64(element: &Element, names: &[&str]) -> Option<u64> {
+fn child_u64(element: &BTreeMap<String, String>, names: &[&str]) -> Option<u64> {
     child_string(element, names).and_then(|value| value.parse().ok())
 }
 
-fn child_duration_ms(element: &Element, names: &[&str]) -> Option<u64> {
-    child_string(element, names).and_then(|value| {
-        let seconds = value.parse::<f64>().ok()?;
-        if !seconds.is_finite() || seconds <= 0.0 {
-            return None;
-        }
-        aster_forge_utils::numbers::f64_seconds_to_u64_millis(
-            seconds,
-            "COS native media metadata duration",
-        )
-        .ok()
-    })
+fn child_duration_ms(element: &BTreeMap<String, String>, names: &[&str]) -> Option<u64> {
+    child_string(element, names).and_then(|value| parse_duration_ms(&value))
 }
 
-fn xml_name_matches(actual: &str, expected: &str) -> bool {
-    actual
-        .rsplit_once(':')
-        .map(|(_, local)| local)
-        .unwrap_or(actual)
-        .eq_ignore_ascii_case(expected)
+fn parse_duration_ms(value: &str) -> Option<u64> {
+    let seconds = value.parse::<f64>().ok()?;
+    if !seconds.is_finite() || seconds <= 0.0 {
+        return None;
+    }
+    aster_forge_utils::numbers::f64_seconds_to_u64_millis(
+        seconds,
+        "COS native media metadata duration",
+    )
+    .ok()
 }
 
 #[cfg(test)]
 mod tests {
-    use std::io::Cursor;
+    use aster_forge_xml::{
+        DEFAULT_XML_MAX_ATTRIBUTES_PER_ELEMENT, DEFAULT_XML_MAX_DEPTH, DEFAULT_XML_MAX_TEXT_BYTES,
+    };
 
-    use super::{child_duration_ms, parse_cos_media_info_xml};
+    use super::{parse_cos_media_info_xml, parse_duration_ms};
     use crate::types::{MediaMetadataKind, MediaMetadataPayload};
-    use xmltree::Element;
 
     #[test]
     fn parses_cos_video_media_info_xml() {
@@ -383,16 +415,60 @@ mod tests {
 
     #[test]
     fn parses_cos_duration_with_checked_rounding_and_rejects_invalid_values() {
-        let rounded = Element::parse(Cursor::new(
-            br#"<Video><Duration>1.2345</Duration></Video>"#.as_slice(),
-        ))
-        .unwrap();
-        assert_eq!(child_duration_ms(&rounded, &["Duration"]), Some(1235));
+        assert_eq!(parse_duration_ms("1.2345"), Some(1235));
 
         for value in ["0", "-1", "NaN", "not-a-number"] {
-            let xml = format!("<Video><Duration>{value}</Duration></Video>");
-            let element = Element::parse(Cursor::new(xml.as_bytes())).unwrap();
-            assert_eq!(child_duration_ms(&element, &["Duration"]), None);
+            assert_eq!(parse_duration_ms(value), None);
         }
+    }
+
+    #[test]
+    fn media_info_parser_covers_xml_safety_boundaries() {
+        for xml in [
+            "<!DOCTYPE Response><Response/>",
+            "junk<Response/>",
+            "<Response/>junk",
+        ] {
+            assert!(parse_cos_media_info_xml(xml.as_bytes(), MediaMetadataKind::Video).is_err());
+        }
+
+        let comment = "x".repeat(DEFAULT_XML_MAX_TEXT_BYTES + 1);
+        assert!(
+            parse_cos_media_info_xml(
+                format!("<Response><!--{comment}--></Response>").as_bytes(),
+                MediaMetadataKind::Video,
+            )
+            .is_err()
+        );
+
+        let mut exact_depth = String::from("<Response>");
+        for _ in 1..DEFAULT_XML_MAX_DEPTH {
+            exact_depth.push_str("<x>");
+        }
+        for _ in 1..DEFAULT_XML_MAX_DEPTH {
+            exact_depth.push_str("</x>");
+        }
+        exact_depth.push_str("</Response>");
+        assert!(parse_cos_media_info_xml(exact_depth.as_bytes(), MediaMetadataKind::Video).is_ok());
+
+        let mut attributes = String::new();
+        for index in 0..DEFAULT_XML_MAX_ATTRIBUTES_PER_ELEMENT {
+            attributes.push_str(&format!("x{index}=\"value\" "));
+        }
+        assert!(
+            parse_cos_media_info_xml(
+                format!("<Response {attributes}/>").as_bytes(),
+                MediaMetadataKind::Video,
+            )
+            .is_ok()
+        );
+        attributes.push_str("overflow=\"value\" ");
+        assert!(
+            parse_cos_media_info_xml(
+                format!("<Response {attributes}/>").as_bytes(),
+                MediaMetadataKind::Video,
+            )
+            .is_err()
+        );
     }
 }

--- a/src/storage/http_body.rs
+++ b/src/storage/http_body.rs
@@ -1,0 +1,158 @@
+use futures::StreamExt;
+
+use crate::errors::{AsterError, Result};
+
+/// Reads a reqwest response without allocating beyond the caller's byte budget.
+pub(crate) async fn read_reqwest_response_body_limited<F>(
+    response: reqwest::Response,
+    context: &str,
+    max_body_bytes: usize,
+    map_error: F,
+) -> Result<Vec<u8>>
+where
+    F: Fn(String) -> AsterError + Copy,
+{
+    if response
+        .content_length()
+        .is_some_and(|length| length > u64::try_from(max_body_bytes).unwrap_or(u64::MAX))
+    {
+        return Err(map_error(format!(
+            "{context} response body exceeds {max_body_bytes} bytes limit"
+        )));
+    }
+
+    let mut body = Vec::with_capacity(max_body_bytes.min(4096));
+    let mut stream = response.bytes_stream();
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk.map_err(|error| map_error(format!("{context}: {error}")))?;
+        let next_len = body
+            .len()
+            .checked_add(chunk.len())
+            .ok_or_else(|| map_error(format!("{context} response body size overflow")))?;
+        if next_len > max_body_bytes {
+            return Err(map_error(format!(
+                "{context} response body exceeds {max_body_bytes} bytes limit"
+            )));
+        }
+        body.extend_from_slice(&chunk);
+    }
+    Ok(body)
+}
+
+#[cfg(test)]
+mod tests {
+    use tokio::io::AsyncWriteExt;
+
+    use super::read_reqwest_response_body_limited;
+    use crate::errors::AsterError;
+
+    #[tokio::test]
+    async fn rejects_declared_body_larger_than_limit() {
+        let listener = tokio::net::TcpListener::bind(("127.0.0.1", 0))
+            .await
+            .expect("test listener should bind");
+        let address = listener
+            .local_addr()
+            .expect("test listener should expose address");
+        let server = tokio::spawn(async move {
+            let (mut socket, _) = listener
+                .accept()
+                .await
+                .expect("test server should accept request");
+            socket
+                .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 5\r\n\r\n12345")
+                .await
+                .expect("test server should write response");
+        });
+
+        let response = reqwest::Client::new()
+            .get(format!("http://{address}/"))
+            .send()
+            .await
+            .expect("request should succeed");
+        let error = read_reqwest_response_body_limited(
+            response,
+            "test body",
+            4,
+            AsterError::validation_error,
+        )
+        .await
+        .expect_err("declared oversized body should be rejected");
+        assert!(error.to_string().contains("exceeds 4 bytes"));
+        server.await.expect("test server should finish");
+    }
+
+    #[tokio::test]
+    async fn rejects_chunked_body_after_accumulated_limit() {
+        let listener = tokio::net::TcpListener::bind(("127.0.0.1", 0))
+            .await
+            .expect("test listener should bind");
+        let address = listener
+            .local_addr()
+            .expect("test listener should expose address");
+        let server = tokio::spawn(async move {
+            let (mut socket, _) = listener
+                .accept()
+                .await
+                .expect("test server should accept request");
+            socket
+                .write_all(
+                    b"HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n3\r\nabc\r\n3\r\ndef\r\n0\r\n\r\n",
+                )
+                .await
+                .expect("test server should write response");
+        });
+
+        let response = reqwest::Client::new()
+            .get(format!("http://{address}/"))
+            .send()
+            .await
+            .expect("request should succeed");
+        let error = read_reqwest_response_body_limited(
+            response,
+            "test body",
+            5,
+            AsterError::validation_error,
+        )
+        .await
+        .expect_err("chunked oversized body should be rejected");
+        assert!(error.to_string().contains("exceeds 5 bytes"));
+        server.await.expect("test server should finish");
+    }
+
+    #[tokio::test]
+    async fn accepts_body_at_exact_limit() {
+        let listener = tokio::net::TcpListener::bind(("127.0.0.1", 0))
+            .await
+            .expect("test listener should bind");
+        let address = listener
+            .local_addr()
+            .expect("test listener should expose address");
+        let server = tokio::spawn(async move {
+            let (mut socket, _) = listener
+                .accept()
+                .await
+                .expect("test server should accept request");
+            socket
+                .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 4\r\n\r\n1234")
+                .await
+                .expect("test server should write response");
+        });
+
+        let response = reqwest::Client::new()
+            .get(format!("http://{address}/"))
+            .send()
+            .await
+            .expect("request should succeed");
+        let body = read_reqwest_response_body_limited(
+            response,
+            "test body",
+            4,
+            AsterError::validation_error,
+        )
+        .await
+        .expect("body at the exact limit should be accepted");
+        assert_eq!(body, b"1234");
+        server.await.expect("test server should finish");
+    }
+}

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -9,6 +9,7 @@ pub mod connectors;
 pub mod drivers;
 pub mod error;
 pub(crate) mod field_contract;
+pub(crate) mod http_body;
 mod metrics_driver;
 pub mod object_key;
 pub mod policy_snapshot;

--- a/src/webdav/dav.rs
+++ b/src/webdav/dav.rs
@@ -6,10 +6,10 @@ use std::io::SeekFrom;
 use std::pin::Pin;
 use std::time::{Duration, SystemTime};
 
+use aster_forge_xml::XmlElement as Element;
 use bytes::{Buf, Bytes};
 use futures::Stream;
 use http::StatusCode;
-use xmltree::Element;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct DavPath {

--- a/src/webdav/db_lock_system.rs
+++ b/src/webdav/db_lock_system.rs
@@ -4,9 +4,9 @@ use aster_forge_db::transaction;
 use std::collections::HashMap;
 use std::time::{Duration, SystemTime};
 
+use aster_forge_xml::XmlElement as Element;
 use chrono::Utc;
 use sea_orm::{ConnectionTrait, DatabaseConnection};
-use xmltree::Element;
 
 use crate::config::webdav;
 use crate::db::repository::{file_repo, folder_repo, lock_repo, user_repo};

--- a/src/webdav/deltav.rs
+++ b/src/webdav/deltav.rs
@@ -5,9 +5,9 @@
 
 use actix_web::HttpResponse;
 use actix_web::http::{StatusCode, Uri};
-use aster_forge_utils::xml::{XmlSafetyError, XmlSafetyPolicy, xml_root_local_name};
+use aster_forge_xml::{XmlElement as Element, XmlNode as XMLNode};
+use aster_forge_xml::{XmlSafetyError, XmlSafetyPolicy, xml_root_local_name};
 use sea_orm::DatabaseConnection;
-use xmltree::Element;
 
 use crate::db::repository::{file_repo, user_repo, version_repo};
 use crate::webdav::auth::WebdavAuthResult;
@@ -28,7 +28,13 @@ pub(crate) async fn handle_report(
         Ok(root_name) => root_name,
         Err(XmlSafetyError::ExternalEntity) => return responses::no_external_entities(),
         Err(
-            XmlSafetyError::TooDeep | XmlSafetyError::Malformed | XmlSafetyError::InvalidPolicy,
+            XmlSafetyError::TooDeep
+            | XmlSafetyError::Malformed
+            | XmlSafetyError::InvalidPolicy
+            | XmlSafetyError::InputTooLarge
+            | XmlSafetyError::TooManyEvents
+            | XmlSafetyError::TooManyAttributes
+            | XmlSafetyError::TextTooLarge,
         ) => {
             return error_response(StatusCode::BAD_REQUEST, "Invalid XML body");
         }
@@ -109,9 +115,7 @@ pub(crate) async fn handle_report(
         let href = href_for_relative(prefix, &decoded_relative);
         let response =
             build_version_response(&href, "current", blob.size, &file.updated_at, &creator);
-        multistatus
-            .children
-            .push(xmltree::XMLNode::Element(response));
+        multistatus.children.push(XMLNode::Element(response));
     }
 
     // 历史版本
@@ -136,9 +140,7 @@ pub(crate) async fn handle_report(
             &ver.created_at,
             &creator,
         );
-        multistatus
-            .children
-            .push(xmltree::XMLNode::Element(response));
+        multistatus.children.push(XMLNode::Element(response));
     }
 
     xml_response(multistatus, StatusCode::MULTI_STATUS)
@@ -184,10 +186,8 @@ fn build_version_response(
 
     // <D:href>
     let mut href_el = Element::new("D:href");
-    href_el
-        .children
-        .push(xmltree::XMLNode::Text(href.to_string()));
-    response.children.push(xmltree::XMLNode::Element(href_el));
+    href_el.children.push(XMLNode::Text(href.to_string()));
+    response.children.push(XMLNode::Element(href_el));
 
     // <D:propstat>
     let mut propstat = Element::new("D:propstat");
@@ -196,39 +196,35 @@ fn build_version_response(
 
     // <D:version-name>
     let mut vname = Element::new("D:version-name");
-    vname
-        .children
-        .push(xmltree::XMLNode::Text(version_name.to_string()));
-    prop.children.push(xmltree::XMLNode::Element(vname));
+    vname.children.push(XMLNode::Text(version_name.to_string()));
+    prop.children.push(XMLNode::Element(vname));
 
     // <D:creator-displayname>
     let mut cname = Element::new("D:creator-displayname");
-    cname
-        .children
-        .push(xmltree::XMLNode::Text(creator.to_string()));
-    prop.children.push(xmltree::XMLNode::Element(cname));
+    cname.children.push(XMLNode::Text(creator.to_string()));
+    prop.children.push(XMLNode::Element(cname));
 
     // <D:getcontentlength>
     let mut clen = Element::new("D:getcontentlength");
-    clen.children.push(xmltree::XMLNode::Text(size.to_string()));
-    prop.children.push(xmltree::XMLNode::Element(clen));
+    clen.children.push(XMLNode::Text(size.to_string()));
+    prop.children.push(XMLNode::Element(clen));
 
     // <D:getlastmodified>
     let mut lmod = Element::new("D:getlastmodified");
     let rfc2822 = modified.format("%a, %d %b %Y %H:%M:%S GMT").to_string();
-    lmod.children.push(xmltree::XMLNode::Text(rfc2822));
-    prop.children.push(xmltree::XMLNode::Element(lmod));
+    lmod.children.push(XMLNode::Text(rfc2822));
+    prop.children.push(XMLNode::Element(lmod));
 
-    propstat.children.push(xmltree::XMLNode::Element(prop));
+    propstat.children.push(XMLNode::Element(prop));
 
     // <D:status>
     let mut status = Element::new("D:status");
     status
         .children
-        .push(xmltree::XMLNode::Text("HTTP/1.1 200 OK".to_string()));
-    propstat.children.push(xmltree::XMLNode::Element(status));
+        .push(XMLNode::Text("HTTP/1.1 200 OK".to_string()));
+    propstat.children.push(XMLNode::Element(status));
 
-    response.children.push(xmltree::XMLNode::Element(propstat));
+    response.children.push(XMLNode::Element(propstat));
 
     response
 }

--- a/src/webdav/handler_tests/mod.rs
+++ b/src/webdav/handler_tests/mod.rs
@@ -18,6 +18,7 @@ use actix_web::http::{StatusCode, header};
 use actix_web::{FromRequest, web};
 use aster_forge_cache as cache;
 use aster_forge_cache::CacheConfig;
+use aster_forge_xml::{XmlElement as Element, XmlNode as XMLNode};
 use async_trait::async_trait;
 use chrono::Utc;
 use migration::Migrator;
@@ -33,7 +34,6 @@ use std::sync::{
 use std::task::{Context, Poll};
 use std::time::Duration;
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWriteExt, ReadBuf};
-use xmltree::{Element, XMLNode};
 
 async fn build_webdav_test_state(
     driver_type: DriverType,
@@ -213,7 +213,7 @@ impl DavLockSystem for NoopLockSystem {
         &self,
         _path: &crate::webdav::dav::DavPath,
         _principal: Option<&str>,
-        _owner: Option<&xmltree::Element>,
+        _owner: Option<&Element>,
         _timeout: Option<Duration>,
         _shared: bool,
         _deep: bool,
@@ -719,7 +719,7 @@ fn collect_href_text(element: &Element, hrefs: &mut Vec<String>) {
     if (element.name == "href" || element.name == "D:href")
         && let Some(text) = element.get_text()
     {
-        hrefs.push(text.into_owned());
+        hrefs.push(text);
     }
 
     for child in &element.children {

--- a/src/webdav/locks/mod.rs
+++ b/src/webdav/locks/mod.rs
@@ -4,8 +4,8 @@ use std::time::Duration;
 
 use actix_web::http::{StatusCode, header};
 use actix_web::{HttpRequest, HttpResponse};
-use aster_forge_utils::xml::XmlSafetyError;
-use xmltree::{Element, XMLNode};
+use aster_forge_xml::XmlSafetyError;
+use aster_forge_xml::{XmlElement as Element, XmlNode as XMLNode};
 
 use crate::webdav::dav::{
     DavFileSystem, DavLock, DavLockError, DavLockPreflightError, DavLockSystem, FsError,
@@ -88,7 +88,13 @@ pub(crate) async fn handle_lock(
         Ok(tree) => tree,
         Err(XmlSafetyError::ExternalEntity) => return responses::no_external_entities(),
         Err(
-            XmlSafetyError::TooDeep | XmlSafetyError::Malformed | XmlSafetyError::InvalidPolicy,
+            XmlSafetyError::TooDeep
+            | XmlSafetyError::Malformed
+            | XmlSafetyError::InvalidPolicy
+            | XmlSafetyError::InputTooLarge
+            | XmlSafetyError::TooManyEvents
+            | XmlSafetyError::TooManyAttributes
+            | XmlSafetyError::TextTooLarge,
         ) => {
             return responses::invalid_xml_body();
         }

--- a/src/webdav/mod.rs
+++ b/src/webdav/mod.rs
@@ -20,10 +20,10 @@ mod transfer;
 
 use actix_web::http::{StatusCode, header};
 use actix_web::{HttpRequest, HttpResponse, web};
-use aster_forge_utils::xml::{XmlSafetyError, XmlSafetyPolicy, validate_xml_input};
+use aster_forge_xml::{XmlElement as Element, XmlNode as XMLNode};
+use aster_forge_xml::{XmlSafetyError, XmlSafetyPolicy, validate_xml_input};
 use futures::StreamExt;
 use std::io::Cursor;
-use xmltree::{Element, XMLNode};
 
 use crate::config::{NetworkTrustConfig, RateLimitConfig, WebDavConfig};
 use crate::runtime::{PrimaryAppState, SharedRuntimeState};
@@ -536,7 +536,7 @@ mod tests {
     use super::{XmlSafetyError, parse_webdav_element};
 
     #[test]
-    fn parse_webdav_element_rejects_probe_depth_before_xmltree_parse() {
+    fn parse_webdav_element_rejects_probe_depth_before_fragment_parse() {
         const PROBE_DEPTH: usize = 30_000;
 
         let mut body = String::with_capacity(64 + PROBE_DEPTH * 7);

--- a/src/webdav/props/mod.rs
+++ b/src/webdav/props/mod.rs
@@ -7,9 +7,9 @@ use std::time::Instant;
 use actix_web::http::StatusCode;
 use actix_web::{HttpRequest, HttpResponse};
 use aster_forge_utils::http_validators::format_http_date;
-use aster_forge_utils::xml::XmlSafetyError;
+use aster_forge_xml::XmlSafetyError;
+use aster_forge_xml::{XmlElement as Element, XmlNode as XMLNode};
 use futures::{StreamExt, pin_mut};
-use xmltree::{Element, XMLNode};
 
 use crate::services::content::property;
 use crate::webdav::dav::{
@@ -355,7 +355,13 @@ fn parse_propfind_request(body: &[u8]) -> Result<PropfindKind, HttpResponse> {
         Ok(root) => root,
         Err(XmlSafetyError::ExternalEntity) => return Err(responses::no_external_entities()),
         Err(
-            XmlSafetyError::TooDeep | XmlSafetyError::Malformed | XmlSafetyError::InvalidPolicy,
+            XmlSafetyError::TooDeep
+            | XmlSafetyError::Malformed
+            | XmlSafetyError::InvalidPolicy
+            | XmlSafetyError::InputTooLarge
+            | XmlSafetyError::TooManyEvents
+            | XmlSafetyError::TooManyAttributes
+            | XmlSafetyError::TextTooLarge,
         ) => {
             return Err(responses::invalid_xml_body());
         }
@@ -420,7 +426,13 @@ fn parse_proppatch_request(body: &[u8]) -> Result<Vec<(bool, DavProp)>, HttpResp
         Ok(root) => root,
         Err(XmlSafetyError::ExternalEntity) => return Err(responses::no_external_entities()),
         Err(
-            XmlSafetyError::TooDeep | XmlSafetyError::Malformed | XmlSafetyError::InvalidPolicy,
+            XmlSafetyError::TooDeep
+            | XmlSafetyError::Malformed
+            | XmlSafetyError::InvalidPolicy
+            | XmlSafetyError::InputTooLarge
+            | XmlSafetyError::TooManyEvents
+            | XmlSafetyError::TooManyAttributes
+            | XmlSafetyError::TextTooLarge,
         ) => {
             return Err(responses::invalid_xml_body());
         }
@@ -803,6 +815,7 @@ fn standard_prop_element(
 
 fn prop_from_xml(prop: &Element, inherited_lang: Option<&str>) -> DavProp {
     let mut prop = prop.clone();
+    ensure_property_namespace_declarations(&mut prop);
     if let Some(lang) = inherited_lang
         && !lang.is_empty()
     {
@@ -816,6 +829,38 @@ fn prop_from_xml(prop: &Element, inherited_lang: Option<&str>) -> DavProp {
         prefix: prop.prefix.clone(),
         namespace: prop.namespace.clone(),
         xml: xml_bytes(&prop).ok(),
+    }
+}
+
+fn ensure_property_namespace_declarations(prop: &mut Element) {
+    let mut namespaces = Vec::new();
+    collect_property_namespaces(prop, &mut namespaces);
+    for (prefix, namespace) in namespaces {
+        let declaration = if prefix.is_empty() {
+            "xmlns".to_string()
+        } else {
+            format!("xmlns:{prefix}")
+        };
+        prop.attributes.entry(declaration).or_insert(namespace);
+    }
+}
+
+fn collect_property_namespaces(element: &Element, out: &mut Vec<(String, String)>) {
+    if let Some(namespace) = &element.namespace {
+        let prefix = element
+            .prefix
+            .clone()
+            .unwrap_or_else(|| default_prefix(Some(namespace)).to_string());
+        if !out.iter().any(|(known_prefix, known_namespace)| {
+            known_prefix == &prefix && known_namespace == namespace
+        }) {
+            out.push((prefix, namespace.clone()));
+        }
+    }
+    for child in &element.children {
+        if let XMLNode::Element(child) = child {
+            collect_property_namespaces(child, out);
+        }
     }
 }
 
@@ -871,7 +916,7 @@ fn append_stored_property_data(element: &mut Element, prop: &DavProp) {
 
 fn copy_dead_property_attributes(target: &mut Element, stored: &Element) {
     for (key, value) in &stored.attributes {
-        if key.starts_with("xmlns") {
+        if key.starts_with("xmlns") && target.attributes.contains_key(key) {
             continue;
         }
         let key = if key == "lang" {
@@ -956,7 +1001,7 @@ mod tests {
     use actix_web::body::to_bytes;
     use actix_web::http::{Method, StatusCode, header};
     use actix_web::test::TestRequest;
-    use xmltree::Element;
+    use aster_forge_xml::XmlElement as Element;
 
     use super::handle_propfind;
     use crate::types::EntityType;

--- a/src/webdav/resources/mod.rs
+++ b/src/webdav/resources/mod.rs
@@ -4,8 +4,8 @@ use std::collections::HashMap;
 
 use actix_web::http::{StatusCode, header};
 use actix_web::{HttpRequest, HttpResponse, web};
+use aster_forge_xml::XmlNode as XMLNode;
 use futures::{StreamExt, pin_mut};
-use xmltree::XMLNode;
 
 use crate::webdav::dav::{DavFileSystem, DavLockSystem, DavPath, FsError, ReadDirMeta};
 use crate::webdav::protocol::{self, Depth};

--- a/src/webdav/responses.rs
+++ b/src/webdav/responses.rs
@@ -2,7 +2,7 @@
 
 use actix_web::http::{StatusCode, header};
 use actix_web::{HttpResponse, HttpResponseBuilder};
-use xmltree::{Element, XMLNode};
+use aster_forge_xml::{XmlElement as Element, XmlNode as XMLNode};
 
 use crate::webdav::dav::{DavPath, FsError};
 use crate::webdav::{dav_element, href_for_dav_path, text_element};

--- a/tests/test_webdav.rs
+++ b/tests/test_webdav.rs
@@ -12,13 +12,13 @@ use aster_drive::runtime::{PrimaryAppState, SharedRuntimeState};
 use aster_drive::types::{AuditAction, EntityType, TeamMemberRole, UserRole, UserStatus};
 use aster_forge_config::{ConfigSource, ConfigValueType, ConfigVisibility};
 use aster_forge_db::system_config;
+use aster_forge_xml::XmlElement as Element;
 use base64::Engine;
 use chrono::Utc;
 use sea_orm::{ActiveModelTrait, ColumnTrait, EntityTrait, PaginatorTrait, QueryFilter, Set};
 use std::io::Cursor;
 use std::num::{NonZeroU32, NonZeroU64};
 use tokio::task::JoinHandle;
-use xmltree::Element;
 
 fn basic_auth_header(username: &str, password: &str) -> String {
     format!(

--- a/tests/test_webdav_file.rs
+++ b/tests/test_webdav_file.rs
@@ -237,10 +237,10 @@ async fn test_aster_dav_fs_reports_quota_and_roundtrips_custom_props() {
         .xml
         .as_deref()
         .expect("stored property should include XML content");
-    let color_prop = xmltree::Element::parse(std::io::Cursor::new(xml))
+    let color_prop = aster_forge_xml::XmlElement::parse(std::io::Cursor::new(xml))
         .expect("stored property XML should parse");
-    assert_eq!(color_prop.name, "color");
-    assert_eq!(color_prop.namespace.as_deref(), Some("urn:aster:test"));
+    assert_eq!(color_prop.name(), "color");
+    assert_eq!(color_prop.namespace(), Some("urn:aster:test"));
     assert_eq!(color_prop.get_text().as_deref(), Some("blue"));
 
     let remove_results = dav_fs

--- a/tests/test_webdav_lock_system.rs
+++ b/tests/test_webdav_lock_system.rs
@@ -22,7 +22,7 @@ async fn test_db_lock_system_deep_lock_supports_check_refresh_discover_and_delet
     use aster_drive::services::{files::file, files::folder};
     use aster_drive::webdav::dav::{DavLockSystem, DavPath};
     use aster_drive::webdav::db_lock_system::DbLockSystem;
-    use xmltree::Element;
+    use aster_forge_xml::XmlElement as Element;
 
     let state = common::setup().await;
     let user = common::create_test_account(&state, "davlocks", "davlocks@example.com", "pass1234")

--- a/tests/test_webdav_xml_depth_probe.rs
+++ b/tests/test_webdav_xml_depth_probe.rs
@@ -1,15 +1,10 @@
-//! WebDAV XML 深度探针。
-//!
-//! 这是一个故意放在 ignored 下的崩溃复现测试：
-//! - 父测试进程拉起同一个测试二进制里的子测试；
-//! - 子测试按 `xmltree::Element::parse` 直接调用，证明底层递归风险仍可复现。
-//! - 如果子进程因栈溢出中止，父测试把它视为“风险已复现”。
+//! WebDAV XML nesting-depth regression coverage.
 
 use std::io::Cursor;
-use std::process::Command;
 
-const PROBE_TEST_NAME: &str = "webdav_xml_deep_nesting_child_probe";
-const PROBE_ENV: &str = "ASTER_WEBDAV_XML_DEPTH_CRASH_PROBE_CHILD";
+use aster_forge_xml::{XmlElement as WebDavXmlFragment, XmlTreeError as WebDavXmlError};
+use aster_forge_xml::{XmlSafetyError, XmlSafetyPolicy, validate_xml_input};
+
 const XML_DEPTH: usize = 30_000;
 const XML_BODY_LIMIT: usize = 1_048_576;
 
@@ -27,43 +22,18 @@ fn nested_propfind(depth: usize) -> Vec<u8> {
 }
 
 #[test]
-#[ignore = "crash probe: spawns a child process that currently stack-overflows in xmltree; run with -- --ignored"]
-fn webdav_xml_deep_nesting_crashes_parser_process() {
-    let executable = std::env::current_exe().expect("current test executable path");
-    let output = Command::new(executable)
-        .args(["--exact", PROBE_TEST_NAME, "--ignored", "--nocapture"])
-        .env(PROBE_ENV, "1")
-        .output()
-        .expect("spawn child probe");
-
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    eprintln!("child status: {}", output.status);
-    eprintln!("child stderr:\n{stderr}");
-
-    assert!(
-        !output.status.success(),
-        "child parser process unexpectedly survived deep WebDAV XML"
-    );
-    assert!(
-        stderr.contains("overflowed its stack") || stderr.contains("stack overflow"),
-        "child process failed, but stderr did not show a stack overflow"
-    );
-}
-
-#[test]
-#[ignore = "helper test executed only by webdav_xml_deep_nesting_crashes_parser_process"]
-fn webdav_xml_deep_nesting_child_probe() {
-    if std::env::var(PROBE_ENV).as_deref() != Ok("1") {
-        eprintln!("skipping crash probe child without parent-provided gate");
-        return;
-    }
-
+fn webdav_xml_deep_nesting_is_rejected_before_fragment_construction() {
     let body = nested_propfind(XML_DEPTH);
     assert!(
         body.len() < XML_BODY_LIMIT,
-        "probe body must stay below configured WebDAV XML limit"
+        "deep XML regression fixture must remain below the WebDAV body limit"
     );
-    let root = xmltree::Element::parse(Cursor::new(body))
-        .expect("well-formed deep WebDAV XML should parse structurally");
-    assert_eq!(root.name, "propfind");
+    assert_eq!(
+        validate_xml_input(&body, XmlSafetyPolicy::untrusted()),
+        Err(XmlSafetyError::TooDeep)
+    );
+    assert_eq!(
+        WebDavXmlFragment::parse(Cursor::new(body)),
+        Err(WebDavXmlError::TooDeep)
+    );
 }


### PR DESCRIPTION
Replaced xmltree with a new aster_forge_xml wrapper around quick-xml that enforces strict safety boundaries: max depth, input size, event count, attributes per element, and text node size. All XML parsing now uses streaming SAX-style event handling to prevent stack overflow and resource exhaustion.

Changes:
- Added aster_forge_xml dependency wrapping quick-xml with safety policy
- Migrated WOPI discovery, Tencent COS CORS, COS media metadata, and WebDAV to event-based parsing
- Replaced xmltree::Element with XmlElement fragment type for dead properties and lock owner storage
- Added read_reqwest_response_body_limited helper to enforce body size limits before parsing
- Removed xmltree and quick-xml direct dependencies from main crate
- Updated all XML construction to use XmlWriter with proper namespace declarations
- Added comprehensive safety boundary tests covering depth, size, and attribute limits
- Fixed WebDAV property namespace declaration to prevent malformed output when namespaces were only in nested elements

Closed AsterCommunity/AsterDrive#433

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **安全性**
  * 增强 WOPI、腾讯 COS 与 WebDAV XML 的安全解析，拒绝危险结构、异常格式及超出大小、深度或属性限制的内容。
  * 新增响应体大小限制与 UTF-8 校验，降低异常响应带来的风险。

* **Bug 修复**
  * 改进 WOPI discovery、COS 配置及媒体元数据解析的错误处理。
  * 修复 WebDAV 属性命名空间补全及 XML 处理兼容性问题。

* **测试**
  * 新增并完善 XML 安全边界、重复密钥、字段缺失和深层嵌套等场景的测试覆盖。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->