### PR TITLE
feat(webdav): validate VERSION-CONTROL request body and extend XML li…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -793,7 +793,7 @@ dependencies = [
  "aws-smithy-types",
  "azure_core",
  "azure_storage_blob",
- "base64 0.22.1",
+ "base64 0.23.0",
  "bytes",
  "chrono",
  "chrono-tz",
@@ -864,7 +864,7 @@ dependencies = [
 [[package]]
 name = "aster_forge_actix_middleware"
 version = "0.1.0"
-source = "git+https://github.com/AsterCommunity/AsterForge#a2b9e7c037d07c24905af16478ef25e050e30d0b"
+source = "git+https://github.com/AsterCommunity/AsterForge#0b9ca96485a57053f1e132ffc20388a0a240baff"
 dependencies = [
  "actix-governor",
  "actix-web",
@@ -884,7 +884,7 @@ dependencies = [
 [[package]]
 name = "aster_forge_actix_observability"
 version = "0.1.0"
-source = "git+https://github.com/AsterCommunity/AsterForge#a2b9e7c037d07c24905af16478ef25e050e30d0b"
+source = "git+https://github.com/AsterCommunity/AsterForge#0b9ca96485a57053f1e132ffc20388a0a240baff"
 dependencies = [
  "actix-web",
  "aster_forge_metrics",
@@ -894,7 +894,7 @@ dependencies = [
 [[package]]
 name = "aster_forge_alloc"
 version = "0.1.0"
-source = "git+https://github.com/AsterCommunity/AsterForge#a2b9e7c037d07c24905af16478ef25e050e30d0b"
+source = "git+https://github.com/AsterCommunity/AsterForge#0b9ca96485a57053f1e132ffc20388a0a240baff"
 dependencies = [
  "tikv-jemalloc-ctl",
  "tracing",
@@ -903,7 +903,7 @@ dependencies = [
 [[package]]
 name = "aster_forge_api"
 version = "0.1.0"
-source = "git+https://github.com/AsterCommunity/AsterForge#a2b9e7c037d07c24905af16478ef25e050e30d0b"
+source = "git+https://github.com/AsterCommunity/AsterForge#0b9ca96485a57053f1e132ffc20388a0a240baff"
 dependencies = [
  "chrono",
  "serde",
@@ -914,7 +914,7 @@ dependencies = [
 [[package]]
 name = "aster_forge_api_docs_macros"
 version = "0.1.0"
-source = "git+https://github.com/AsterCommunity/AsterForge#a2b9e7c037d07c24905af16478ef25e050e30d0b"
+source = "git+https://github.com/AsterCommunity/AsterForge#0b9ca96485a57053f1e132ffc20388a0a240baff"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -924,7 +924,7 @@ dependencies = [
 [[package]]
 name = "aster_forge_audit"
 version = "0.1.0"
-source = "git+https://github.com/AsterCommunity/AsterForge#a2b9e7c037d07c24905af16478ef25e050e30d0b"
+source = "git+https://github.com/AsterCommunity/AsterForge#0b9ca96485a57053f1e132ffc20388a0a240baff"
 dependencies = [
  "aster_forge_db",
  "aster_forge_mail",
@@ -936,7 +936,7 @@ dependencies = [
 [[package]]
 name = "aster_forge_cache"
 version = "0.1.0"
-source = "git+https://github.com/AsterCommunity/AsterForge#a2b9e7c037d07c24905af16478ef25e050e30d0b"
+source = "git+https://github.com/AsterCommunity/AsterForge#0b9ca96485a57053f1e132ffc20388a0a240baff"
 dependencies = [
  "aster_forge_runtime",
  "aster_forge_utils",
@@ -954,7 +954,7 @@ dependencies = [
 [[package]]
 name = "aster_forge_config"
 version = "0.1.0"
-source = "git+https://github.com/AsterCommunity/AsterForge#a2b9e7c037d07c24905af16478ef25e050e30d0b"
+source = "git+https://github.com/AsterCommunity/AsterForge#0b9ca96485a57053f1e132ffc20388a0a240baff"
 dependencies = [
  "aster_forge_events",
  "aster_forge_utils",
@@ -974,7 +974,7 @@ dependencies = [
 [[package]]
 name = "aster_forge_crypto"
 version = "0.1.0"
-source = "git+https://github.com/AsterCommunity/AsterForge#a2b9e7c037d07c24905af16478ef25e050e30d0b"
+source = "git+https://github.com/AsterCommunity/AsterForge#0b9ca96485a57053f1e132ffc20388a0a240baff"
 dependencies = [
  "argon2 0.5.3",
  "hmac 0.13.0",
@@ -986,7 +986,7 @@ dependencies = [
 [[package]]
 name = "aster_forge_db"
 version = "0.1.0"
-source = "git+https://github.com/AsterCommunity/AsterForge#a2b9e7c037d07c24905af16478ef25e050e30d0b"
+source = "git+https://github.com/AsterCommunity/AsterForge#0b9ca96485a57053f1e132ffc20388a0a240baff"
 dependencies = [
  "aster_forge_api",
  "aster_forge_config",
@@ -1007,7 +1007,7 @@ dependencies = [
 [[package]]
 name = "aster_forge_db_migration"
 version = "0.1.0"
-source = "git+https://github.com/AsterCommunity/AsterForge#a2b9e7c037d07c24905af16478ef25e050e30d0b"
+source = "git+https://github.com/AsterCommunity/AsterForge#0b9ca96485a57053f1e132ffc20388a0a240baff"
 dependencies = [
  "sea-orm-migration",
  "tracing",
@@ -1016,7 +1016,7 @@ dependencies = [
 [[package]]
 name = "aster_forge_events"
 version = "0.1.0"
-source = "git+https://github.com/AsterCommunity/AsterForge#a2b9e7c037d07c24905af16478ef25e050e30d0b"
+source = "git+https://github.com/AsterCommunity/AsterForge#0b9ca96485a57053f1e132ffc20388a0a240baff"
 dependencies = [
  "aster_forge_utils",
  "async-trait",
@@ -1031,7 +1031,7 @@ dependencies = [
 [[package]]
 name = "aster_forge_external_auth"
 version = "0.1.0"
-source = "git+https://github.com/AsterCommunity/AsterForge#a2b9e7c037d07c24905af16478ef25e050e30d0b"
+source = "git+https://github.com/AsterCommunity/AsterForge#0b9ca96485a57053f1e132ffc20388a0a240baff"
 dependencies = [
  "aster_forge_crypto",
  "aster_forge_utils",
@@ -1054,7 +1054,7 @@ dependencies = [
 [[package]]
 name = "aster_forge_file_classification"
 version = "0.1.0"
-source = "git+https://github.com/AsterCommunity/AsterForge#a2b9e7c037d07c24905af16478ef25e050e30d0b"
+source = "git+https://github.com/AsterCommunity/AsterForge#0b9ca96485a57053f1e132ffc20388a0a240baff"
 dependencies = [
  "sea-orm",
  "serde",
@@ -1065,7 +1065,7 @@ dependencies = [
 [[package]]
 name = "aster_forge_logging"
 version = "0.1.0"
-source = "git+https://github.com/AsterCommunity/AsterForge#a2b9e7c037d07c24905af16478ef25e050e30d0b"
+source = "git+https://github.com/AsterCommunity/AsterForge#0b9ca96485a57053f1e132ffc20388a0a240baff"
 dependencies = [
  "serde",
  "tracing-appender",
@@ -1075,7 +1075,7 @@ dependencies = [
 [[package]]
 name = "aster_forge_mail"
 version = "0.1.0"
-source = "git+https://github.com/AsterCommunity/AsterForge#a2b9e7c037d07c24905af16478ef25e050e30d0b"
+source = "git+https://github.com/AsterCommunity/AsterForge#0b9ca96485a57053f1e132ffc20388a0a240baff"
 dependencies = [
  "aster_forge_runtime",
  "aster_forge_tasks",
@@ -1093,7 +1093,7 @@ dependencies = [
 [[package]]
 name = "aster_forge_metrics"
 version = "0.1.0"
-source = "git+https://github.com/AsterCommunity/AsterForge#a2b9e7c037d07c24905af16478ef25e050e30d0b"
+source = "git+https://github.com/AsterCommunity/AsterForge#0b9ca96485a57053f1e132ffc20388a0a240baff"
 dependencies = [
  "aster_forge_alloc",
  "aster_forge_runtime",
@@ -1108,7 +1108,7 @@ dependencies = [
 [[package]]
 name = "aster_forge_panic"
 version = "0.1.0"
-source = "git+https://github.com/AsterCommunity/AsterForge#a2b9e7c037d07c24905af16478ef25e050e30d0b"
+source = "git+https://github.com/AsterCommunity/AsterForge#0b9ca96485a57053f1e132ffc20388a0a240baff"
 dependencies = [
  "chrono",
 ]
@@ -1116,7 +1116,7 @@ dependencies = [
 [[package]]
 name = "aster_forge_runtime"
 version = "0.1.0"
-source = "git+https://github.com/AsterCommunity/AsterForge#a2b9e7c037d07c24905af16478ef25e050e30d0b"
+source = "git+https://github.com/AsterCommunity/AsterForge#0b9ca96485a57053f1e132ffc20388a0a240baff"
 dependencies = [
  "aster_forge_utils",
  "async-trait",
@@ -1133,7 +1133,7 @@ dependencies = [
 [[package]]
 name = "aster_forge_tasks"
 version = "0.1.0"
-source = "git+https://github.com/AsterCommunity/AsterForge#a2b9e7c037d07c24905af16478ef25e050e30d0b"
+source = "git+https://github.com/AsterCommunity/AsterForge#0b9ca96485a57053f1e132ffc20388a0a240baff"
 dependencies = [
  "aster_forge_runtime",
  "aster_forge_utils",
@@ -1153,7 +1153,7 @@ dependencies = [
 [[package]]
 name = "aster_forge_test"
 version = "0.1.0"
-source = "git+https://github.com/AsterCommunity/AsterForge#a2b9e7c037d07c24905af16478ef25e050e30d0b"
+source = "git+https://github.com/AsterCommunity/AsterForge#0b9ca96485a57053f1e132ffc20388a0a240baff"
 dependencies = [
  "aster_forge_utils",
  "fs2",
@@ -1169,6 +1169,7 @@ dependencies = [
 [[package]]
 name = "aster_forge_utils"
 version = "0.1.0"
+source = "git+https://github.com/AsterCommunity/AsterForge#0b9ca96485a57053f1e132ffc20388a0a240baff"
 dependencies = [
  "http 1.4.2",
  "httpdate",
@@ -1186,7 +1187,7 @@ dependencies = [
 [[package]]
 name = "aster_forge_validation"
 version = "0.1.0"
-source = "git+https://github.com/AsterCommunity/AsterForge#a2b9e7c037d07c24905af16478ef25e050e30d0b"
+source = "git+https://github.com/AsterCommunity/AsterForge#0b9ca96485a57053f1e132ffc20388a0a240baff"
 dependencies = [
  "thiserror 2.0.19",
  "unicode-normalization",
@@ -1195,6 +1196,7 @@ dependencies = [
 [[package]]
 name = "aster_forge_webdav"
 version = "0.1.0"
+source = "git+https://github.com/AsterCommunity/AsterForge#0b9ca96485a57053f1e132ffc20388a0a240baff"
 dependencies = [
  "actix-web",
  "aster_forge_utils",
@@ -1211,6 +1213,7 @@ dependencies = [
 [[package]]
 name = "aster_forge_xml"
 version = "0.1.0"
+source = "git+https://github.com/AsterCommunity/AsterForge#0b9ca96485a57053f1e132ffc20388a0a240baff"
 dependencies = [
  "aster_forge_utils",
  "quick-xml",
@@ -4472,9 +4475,9 @@ dependencies = [
 
 [[package]]
 name = "jsonwebtoken"
-version = "10.4.0"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eba32bfb4ffdeaca3e34431072faf01745c9b26d25504aa7a6cf5684334fc4fc"
+checksum = "881733cbc631fc9e472e24447ce32a64bedf2da498d6d8570b08edc87de71f65"
 dependencies = [
  "aws-lc-rs",
  "base64 0.22.1",
@@ -8055,7 +8058,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.3",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -8876,12 +8879,11 @@ dependencies = [
 
 [[package]]
 name = "validator"
-version = "0.20.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43fb22e1a008ece370ce08a3e9e4447a910e92621bb49b85d6e48a45397e7cfa"
+checksum = "c3d68c6633c483df6780cc5277a417c7c2d1bceee2649d06c8ab6b0fd2dd3c81"
 dependencies = [
  "idna",
- "once_cell",
  "regex",
  "serde",
  "serde_derive",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1169,7 +1169,6 @@ dependencies = [
 [[package]]
 name = "aster_forge_utils"
 version = "0.1.0"
-source = "git+https://github.com/AsterCommunity/AsterForge#a2b9e7c037d07c24905af16478ef25e050e30d0b"
 dependencies = [
  "http 1.4.2",
  "httpdate",
@@ -1196,7 +1195,6 @@ dependencies = [
 [[package]]
 name = "aster_forge_webdav"
 version = "0.1.0"
-source = "git+https://github.com/AsterCommunity/AsterForge#a2b9e7c037d07c24905af16478ef25e050e30d0b"
 dependencies = [
  "actix-web",
  "aster_forge_utils",
@@ -1213,7 +1211,6 @@ dependencies = [
 [[package]]
 name = "aster_forge_xml"
 version = "0.1.0"
-source = "git+https://github.com/AsterCommunity/AsterForge#a2b9e7c037d07c24905af16478ef25e050e30d0b"
 dependencies = [
  "aster_forge_utils",
  "quick-xml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -226,3 +226,8 @@ required-features = ["multi-primary-e2e"]
 [[test]]
 name = "test_multi_primary_storage_events_e2e"
 required-features = ["multi-primary-e2e"]
+
+[patch."https://github.com/AsterCommunity/AsterForge"]
+aster_forge_webdav = { path = "/private/tmp/asterforge-issue-427/crates/aster_forge_webdav" }
+aster_forge_xml = { path = "/private/tmp/asterforge-issue-427/crates/aster_forge_xml" }
+aster_forge_utils = { path = "/private/tmp/asterforge-issue-427/crates/aster_forge_utils" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -129,7 +129,7 @@ aster_forge_webdav = { git = "https://github.com/AsterCommunity/AsterForge", pac
 aster_forge_xml = { git = "https://github.com/AsterCommunity/AsterForge", package = "aster_forge_xml" }
 async-stream = "0.3"
 async-trait = "0.1"
-base64 = "0.22"
+base64 = { version = "0.23", default-features = false, features = ["std"] }
 bytes = "1"
 aws-credential-types = { version = "1.3.0", features = ["hardcoded-credentials"] }
 aws-sdk-s3 = { version = "1.140.0", default-features = false, features = ["sigv4a", "http-1x", "default-https-client", "rt-tokio"] }
@@ -155,7 +155,7 @@ http = "1"
 http-body = "1"
 image = { version = "0.25", default-features = false, features = ["bmp", "dds", "exr", "ff", "gif", "hdr", "ico", "jpeg", "png", "pnm", "qoi", "tga", "tiff", "webp"] }
 governor = "0.10"
-jsonwebtoken = { version = "10", features = ["aws_lc_rs"] }
+jsonwebtoken = { version = "11", features = ["aws_lc_rs"] }
 migration = { version = "0.1.0", path = "migration" }
 mime_guess = "2"
 moka = { version = "0.12.15", features = ["future"] }
@@ -191,7 +191,7 @@ utoipa-swagger-ui = { version = "9.0.2", features = ["actix-web"], optional = tr
 urlencoding = "2"
 url = "2"
 uuid = { version = "1", features = ["v4"] }
-validator = { version = "0.20", features = ["derive"] }
+validator = { version = "0.21", features = ["derive"] }
 webauthn-rs = { version = "0.6.1-dev", default-features = false, features = ["conditional-ui", "danger-allow-state-serialisation"] }
 webauthn-rs-proto = "0.6.1-dev"
 
@@ -226,8 +226,3 @@ required-features = ["multi-primary-e2e"]
 [[test]]
 name = "test_multi_primary_storage_events_e2e"
 required-features = ["multi-primary-e2e"]
-
-[patch."https://github.com/AsterCommunity/AsterForge"]
-aster_forge_webdav = { path = "/private/tmp/asterforge-issue-427/crates/aster_forge_webdav" }
-aster_forge_xml = { path = "/private/tmp/asterforge-issue-427/crates/aster_forge_xml" }
-aster_forge_utils = { path = "/private/tmp/asterforge-issue-427/crates/aster_forge_utils" }

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -224,7 +224,7 @@ pub struct WebDavConfig {
     /// actix payload 硬上限，改了要重启。运行时软限制从 DB 读。
     #[serde(default = "WebDavConfig::default_payload_limit")]
     pub payload_limit: u64,
-    /// XML 类 WebDAV 请求体上限，改了要重启。仅用于 REPORT/PROPFIND/PROPPATCH/LOCK。
+    /// XML 类 WebDAV 请求体上限，改了要重启。用于 REPORT/PROPFIND/PROPPATCH/LOCK/VERSION-CONTROL。
     #[serde(default = "WebDavConfig::default_xml_payload_limit")]
     pub xml_payload_limit: u64,
 }

--- a/src/webdav/handlers/deltav.rs
+++ b/src/webdav/handlers/deltav.rs
@@ -7,9 +7,9 @@ use actix_web::HttpResponse;
 use actix_web::http::StatusCode;
 use aster_forge_utils::http_validators::format_http_date;
 use aster_forge_webdav::{
-    DavRequestHead, DavResourceKind, DavVersionXml, validate_version_tree_report,
-    version_control_response, version_tree_non_file_response, version_tree_report_error_response,
-    version_tree_response,
+    DavRequestHead, DavResourceKind, DavVersionXml, validate_version_control_request,
+    validate_version_tree_report, version_control_request_error_response, version_control_response,
+    version_tree_non_file_response, version_tree_report_error_response, version_tree_response,
 };
 use sea_orm::DatabaseConnection;
 
@@ -124,9 +124,17 @@ pub(crate) async fn handle_report(
 /// 处理 VERSION-CONTROL 方法（所有文件自动版本控制，直接返回 200）
 pub(crate) async fn handle_version_control(
     request_head: &DavRequestHead,
+    body_bytes: &[u8],
     db: &DatabaseConnection,
     auth: &WebdavAuthResult,
 ) -> HttpResponse {
+    if let Err(error) = validate_version_control_request(body_bytes) {
+        return match version_control_request_error_response(error) {
+            Ok(response) => aster_forge_webdav::actix::into_response(response),
+            Err(_) => responses::empty(StatusCode::INTERNAL_SERVER_ERROR),
+        };
+    }
+
     match path_resolver::resolve_path_in_scope(
         db,
         auth.scope,

--- a/src/webdav/mod.rs
+++ b/src/webdav/mod.rs
@@ -154,6 +154,7 @@ pub async fn webdav_handler(
         DavMethod::VersionControl => {
             handlers::deltav::handle_version_control(
                 &request_head,
+                request_body.xml(),
                 state.get_ref().reader_db(),
                 &auth_result,
             )

--- a/tests/webdav/deltav.rs
+++ b/tests/webdav/deltav.rs
@@ -251,6 +251,115 @@ async fn test_deltav_version_control_file() {
     assert_eq!(resp.status(), 200);
 }
 
+#[actix_web::test]
+async fn test_deltav_version_control_accepts_rfc3253_any_extensions() {
+    let app = setup_with_webdav!();
+    let (token, _) = register_and_login!(app);
+    let auth = create_webdav_basic_auth!(app, token);
+
+    webdav_put!(app, "/webdav/vc-any.txt", auth, "content");
+
+    for body in [
+        r#"<D:version-control xmlns:D="DAV:"/>"#,
+        r#"<V:version-control xmlns:V="DAV:" xmlns:X="urn:x" X:flag="1">
+              text<X:future><V:nested/></X:future><![CDATA[more]]>
+            </V:version-control>"#,
+    ] {
+        let req = test::TestRequest::with_uri("/webdav/vc-any.txt")
+            .method(actix_web::http::Method::from_bytes(b"VERSION-CONTROL").unwrap())
+            .insert_header(("Authorization", auth.clone()))
+            .insert_header(("Content-Type", "application/xml"))
+            .set_payload(body)
+            .to_request();
+        let resp: actix_web::dev::ServiceResponse = test::call_service(&app, req).await;
+        assert_eq!(
+            resp.status(),
+            200,
+            "VERSION-CONTROL should accept a safe DAV:version-control ANY body"
+        );
+    }
+}
+
+#[actix_web::test]
+async fn test_deltav_version_control_rejects_invalid_xml_grammar_and_entities() {
+    let app = setup_with_webdav!();
+    let (token, _) = register_and_login!(app);
+    let auth = create_webdav_basic_auth!(app, token);
+
+    webdav_put!(app, "/webdav/vc-invalid.txt", auth, "content");
+
+    let cases = [
+        (
+            "wrong root namespace",
+            r#"<X:version-control xmlns:X="urn:x"/>"#,
+            actix_web::http::StatusCode::BAD_REQUEST,
+        ),
+        (
+            "whitespace-only body",
+            " \r\n\t",
+            actix_web::http::StatusCode::BAD_REQUEST,
+        ),
+        (
+            "external entity",
+            r#"<!DOCTYPE x [<!ENTITY e SYSTEM "file:///TARGET">]><D:version-control xmlns:D="DAV:">&e;</D:version-control>"#,
+            actix_web::http::StatusCode::FORBIDDEN,
+        ),
+    ];
+
+    for (label, body, expected_status) in cases {
+        let req = test::TestRequest::with_uri("/webdav/vc-invalid.txt")
+            .method(actix_web::http::Method::from_bytes(b"VERSION-CONTROL").unwrap())
+            .insert_header(("Authorization", auth.clone()))
+            .insert_header(("Content-Type", "application/xml"))
+            .set_payload(body)
+            .to_request();
+        let resp: actix_web::dev::ServiceResponse = test::call_service(&app, req).await;
+        assert_eq!(
+            resp.status(),
+            expected_status,
+            "invalid VERSION-CONTROL case should be rejected: {label}"
+        );
+    }
+}
+
+#[actix_web::test]
+async fn test_deltav_report_enforces_version_tree_prop_grammar() {
+    let app = setup_with_webdav!();
+    let (token, _) = register_and_login!(app);
+    let auth = create_webdav_basic_auth!(app, token);
+
+    webdav_put!(app, "/webdav/report-grammar.txt", auth, "content");
+
+    let valid = r#"<D:version-tree xmlns:D="DAV:" xmlns:X="urn:x">
+      <D:future><D:prop><D:not-active/></D:prop></D:future>
+      <D:prop><D:getetag><D:ignored>value</D:ignored></D:getetag></D:prop>
+      <X:future/>
+    </D:version-tree>"#;
+    let req = test::TestRequest::with_uri("/webdav/report-grammar.txt")
+        .method(actix_web::http::Method::from_bytes(b"REPORT").unwrap())
+        .insert_header(("Authorization", auth.clone()))
+        .insert_header(("Content-Type", "application/xml"))
+        .set_payload(valid)
+        .to_request();
+    let resp: actix_web::dev::ServiceResponse = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), 207);
+
+    for body in [
+        r#"<D:version-tree xmlns:D="DAV:"><D:prop/><D:prop/></D:version-tree>"#,
+        r#"<D:version-tree xmlns:D="DAV:">text</D:version-tree>"#,
+        r#"<D:version-tree xmlns:D="DAV:"><D:prop><D:getetag>value</D:getetag></D:prop></D:version-tree>"#,
+    ] {
+        let req = test::TestRequest::with_uri("/webdav/report-grammar.txt")
+            .method(actix_web::http::Method::from_bytes(b"REPORT").unwrap())
+            .insert_header(("Authorization", auth.clone()))
+            .insert_header(("Content-Type", "application/xml"))
+            .set_payload(body)
+            .to_request();
+        let resp: actix_web::dev::ServiceResponse = test::call_service(&app, req).await;
+        assert_eq!(resp.status(), 400, "invalid version-tree grammar must fail");
+    }
+}
+
 // ── VERSION-CONTROL：文件夹返回 405 ─────────────────────────
 
 #[actix_web::test]

--- a/tests/webdav/protocol.rs
+++ b/tests/webdav/protocol.rs
@@ -985,7 +985,7 @@ async fn test_webdav_xml_methods_reject_body_over_limit() {
     let auth = create_webdav_basic_auth!(app, token);
     let over_limit_xml = "<?xml version=\"1.0\"?><D:x xmlns:D=\"DAV:\">too-large</D:x>";
 
-    for method in ["REPORT", "PROPFIND", "PROPPATCH", "LOCK"] {
+    for method in ["REPORT", "PROPFIND", "PROPPATCH", "LOCK", "VERSION-CONTROL"] {
         let req = test::TestRequest::with_uri("/webdav/")
             .method(actix_web::http::Method::from_bytes(method.as_bytes()).unwrap())
             .insert_header(("Authorization", auth.clone()))
@@ -1041,6 +1041,12 @@ async fn test_webdav_small_xml_methods_still_reach_handlers() {
             "/webdav/xml-limit-small.txt",
             "<D:version-tree xmlns:D=\"DAV:\"/>",
             actix_web::http::StatusCode::MULTI_STATUS,
+        ),
+        (
+            "VERSION-CONTROL",
+            "/webdav/xml-limit-small.txt",
+            "<D:version-control xmlns:D=\"DAV:\"/>",
+            actix_web::http::StatusCode::OK,
         ),
     ];
 
@@ -5780,7 +5786,7 @@ async fn test_webdav_tagged_if_token_only_unlocks_matching_resource() {
 }
 
 #[actix_web::test]
-async fn test_webdav_lock_rejects_invalid_lockinfo_and_timeout_headers() {
+async fn test_webdav_lock_enforces_lockinfo_grammar_and_timeout_headers() {
     let app = setup_with_webdav!();
     let (token, _) = register_and_login!(app);
     let auth = create_webdav_basic_auth!(app, token);
@@ -5803,11 +5809,11 @@ async fn test_webdav_lock_rejects_invalid_lockinfo_and_timeout_headers() {
 </D:lockinfo>"#,
         ),
         (
-            "ambiguous locktype",
+            "duplicate known locktype",
             r#"<?xml version="1.0" encoding="utf-8" ?>
 <D:lockinfo xmlns:D="DAV:">
   <D:lockscope><D:exclusive/></D:lockscope>
-  <D:locktype><D:write/><D:other/></D:locktype>
+  <D:locktype><D:write/><D:write/></D:locktype>
 </D:lockinfo>"#,
         ),
     ] {
@@ -5825,6 +5831,25 @@ async fn test_webdav_lock_rejects_invalid_lockinfo_and_timeout_headers() {
             "LOCK should reject invalid lockinfo body for case: {label}"
         );
     }
+
+    let extension_lock_body = r#"<?xml version="1.0" encoding="utf-8" ?>
+<D:lockinfo xmlns:D="DAV:">
+  <D:lockscope><D:exclusive/><D:future-scope/></D:lockscope>
+  <D:locktype><D:write/><D:other/></D:locktype>
+</D:lockinfo>"#;
+    let req = test::TestRequest::with_uri("/webdav/extended-lockinfo.txt")
+        .method(actix_web::http::Method::from_bytes(b"LOCK").unwrap())
+        .insert_header(("Authorization", auth.clone()))
+        .insert_header(("Content-Type", "application/xml"))
+        .insert_header(("Depth", "0"))
+        .set_payload(extension_lock_body)
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(
+        resp.status(),
+        201,
+        "unknown DAV: lockinfo extensions must be ignored"
+    );
 
     let valid_lock_body = r#"<?xml version="1.0" encoding="utf-8" ?>
 <D:lockinfo xmlns:D="DAV:">
@@ -7901,7 +7926,7 @@ async fn test_webdav_xml_entrypoints_reject_probe_depth_without_crashing_process
     body.push_str("</D:propfind>");
     assert!(body.len() < 1_048_576);
 
-    for method in ["PROPFIND", "PROPPATCH", "LOCK", "REPORT"] {
+    for method in ["PROPFIND", "PROPPATCH", "LOCK", "REPORT", "VERSION-CONTROL"] {
         let req = test::TestRequest::with_uri("/webdav/deep-xml-target.txt")
             .method(actix_web::http::Method::from_bytes(method.as_bytes()).unwrap())
             .insert_header(("Authorization", auth.clone()))


### PR DESCRIPTION
…mit scope

- Add `validate_version_control_request` call in `handle_version_control` handler, returning 400/403 on invalid or forbidden XML
- Pass `body_bytes` (via `request_body.xml()`) into `handle_version_control` to enable body inspection
- Import `validate_version_control_request` and `version_control_request_error_response` from `aster_forge_webdav`
- Extend `xml_payload_limit` enforcement and depth-probe rejection to cover `VERSION-CONTROL` alongside existing XML methods
- Update `xml_payload_limit` doc comment to include `VERSION-CONTROL` in the list of covered methods
- Patch `aster_forge_webdav`, `aster_forge_xml`, and `aster_forge_utils` to local paths for issue-427 development
- Add tests for VERSION-CONTROL accepting valid RFC 3253 any-extension bodies
- Add tests for VERSION-CONTROL rejecting wrong root namespace, whitespace-only body, and external entity references
- Add tests for REPORT enforcing version-tree prop grammar (duplicate `<D:prop>`, text content, non-empty prop values)
- Clarify lock grammar test: rename ambiguous-locktype case to duplicate-known-locktype and add passing case for unknown DAV extension elements in lockinfo

Closed #427

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 支持更完整的 WebDAV `VERSION-CONTROL` 请求处理，包括 XML 内容解析与响应。
  - 扩展 `VERSION-CONTROL` 和 `REPORT` 的 XML 语法校验能力，兼容合法扩展内容。

- **错误修复**
  - 拒绝命名空间错误、格式无效或包含外部实体的 XML 请求。
  - 加强 XML 请求大小与深度限制，提升协议处理安全性。
  - 优化 WebDAV 锁信息校验，并正确忽略未知扩展元素。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->