### PR TITLE
feat(storage): add Alibaba Cloud OSS storage backend with native OSS V4 signing

### DIFF
--- a/developer-docs/en/api/admin.md
+++ b/developer-docs/en/api/admin.md
@@ -79,11 +79,12 @@ Create example:
 
 Current notes:
 
-- `driver_type` currently supports `local`, `s3`, `sftp`, `azure_blob`, `tencent_cos`, `remote`, and `one_drive`
+- `driver_type` currently supports `local`, `s3`, `alibaba_oss`, `sftp`, `azure_blob`, `tencent_cos`, `remote`, and `one_drive`
 - `GET /admin/policies/storage-drivers` returns `StorageConnectorDescriptor` entries. The frontend should use descriptor `capabilities`, `fields`, `upload_workflows`, `actions`, and `credential_mode` to decide forms, connection tests, upload/download strategies, and action affordances instead of maintaining a hard-coded driver capability matrix.
 - create and update both honor request `chunk_size`
 - `options` carries policy-level behavior:
-  - S3-compatible / Azure Blob / Tencent COS object-storage connectors use `object_storage_upload_strategy` / `object_storage_download_strategy` for transfer strategy. Legacy `s3_upload_strategy` / `s3_download_strategy` JSON remains accepted as a compatibility alias.
+  - S3-compatible / Alibaba OSS / Azure Blob / Tencent COS object-storage connectors use `object_storage_upload_strategy` / `object_storage_download_strategy` for transfer strategy. Legacy `s3_upload_strategy` / `s3_download_strategy` JSON remains accepted as a compatibility alias.
+  - Native Alibaba OSS fields: public `endpoint`, optional `oss_server_side_endpoint`, `oss_region`, and `oss_use_cname`. Backend I/O prefers the server-side endpoint, while presigned URLs always use the public endpoint. CNAME mode accepts a custom domain; normal mode accepts an `aliyuncs.com` OSS endpoint.
   - Remote upload and download strategies through `remote_upload_strategy` / `remote_download_strategy`
   - local `content_dedup`
   - generic S3 path-style addressing through `s3_path_style` (defaults to `true`)
@@ -101,7 +102,8 @@ Current notes:
 - `driver_type = "one_drive"` uses Microsoft Graph OAuth credentials. Save the policy and `application_config.microsoft_graph` before starting authorization.
 - `driver_type = "sftp"` uses SSH username / password credentials to connect to an SFTP server. Endpoint supports `sftp://host:port`, bare `host`, and `host:port`; the remote root belongs in `base_path`. Unknown or mismatched SSH host keys are rejected as `StorageErrorKind::Precondition` with diagnostics that include actual / expected fingerprints; the confirmed fingerprint is stored in `options.sftp_host_key_fingerprint`.
 - `driver_type = "tencent_cos"` uses the S3-compatible object path for normal reads and writes, validates Tencent COS endpoint shape, and can expose COS CI storage-native thumbnail / image-preview / media-metadata capabilities when the policy opts in
-- built-in Local, S3-compatible, SFTP, Azure Blob, OneDrive, and Remote drivers do not expose storage-native thumbnail, image-preview, or media-metadata capabilities
+- `driver_type = "alibaba_oss"` reuses AWS S3 SDK object, streaming, and multipart orchestration but applies native `OSS4-HMAC-SHA256` header/query signing; normal requests and generated presigning are validated separately
+- built-in Local, S3-compatible, Alibaba OSS, SFTP, Azure Blob, OneDrive, and Remote drivers do not expose storage-native thumbnail, image-preview, or media-metadata capabilities
 - legacy `{"presigned_upload":true}` remains compatible with object-storage presigned upload
 - `allowed_types` can be managed through REST
 - Creating a `driver_type = "remote"` policy requires both `remote_node_id` and `remote_storage_target_key`. The target must belong to that node's current binding, have no `last_error`, and satisfy `applied_revision >= desired_revision`.

--- a/developer-docs/en/design/object-storage-custom-auth.md
+++ b/developer-docs/en/design/object-storage-custom-auth.md
@@ -113,9 +113,9 @@ These transformations belong in the COS driver/signing module. They do not
 belong in services, connector common code, or the shared
 `aster_drive_storage` trait.
 
-## Boundary for a Future OSS Implementation
+## OSS Implementation Boundary
 
-OSS can follow the structure verified for COS, but its signer,
+OSS follows the auth-scheme structure verified for COS, but its signer,
 endpoint/addressing behavior, and field transformations must remain
 independent:
 
@@ -128,9 +128,17 @@ independent:
   layer.
 - Header signing and query presigning both use OSS V4 rather than AWS SigV4.
 
-Prefer two clients that share a signer, one for backend operations and one for
-browser presigning. Temporarily changing the endpoint for a single request can
-break consistency between the Host and canonical URI.
+`AlibabaOssDriver` keeps a public client for browser presigning and constructs
+a separate backend client when a server-side endpoint is configured. Without
+a server-side endpoint, both paths share one client. This avoids changing an
+endpoint on a single request and breaking consistency between the Host and
+canonical URI.
+
+The OSS signer lives in `src/storage/drivers/alibaba_oss/signing.rs`. Current
+coverage includes an official Go SDK vector, captured normal requests,
+generated presigning, the CNAME wire path, CopyObject header conversion, and
+public/server endpoint separation. Real-provider integration remains an
+external release-validation boundary.
 
 ## Boundary with Provider Option Plugins
 

--- a/developer-docs/zh-CN/api/admin.md
+++ b/developer-docs/zh-CN/api/admin.md
@@ -94,11 +94,12 @@
 
 当前实现注意点：
 
-- `driver_type` 当前支持 `local`、`s3`、`sftp`、`azure_blob`、`tencent_cos`、`remote` 和 `one_drive`
+- `driver_type` 当前支持 `local`、`s3`、`alibaba_oss`、`sftp`、`azure_blob`、`tencent_cos`、`remote` 和 `one_drive`
 - `GET /admin/policies/storage-drivers` 返回 `StorageConnectorDescriptor` 列表，前端应以 descriptor 的 `capabilities`、`fields`、`upload_workflows`、`actions` 和 `credential_mode` 决定表单、连接测试、上传/下载策略和操作入口，不要在前端维护一份 driver-type 能力矩阵
 - 创建和更新都会采用请求里的 `chunk_size`
 - `options` 当前承载策略级行为：
-  - S3-compatible / Azure Blob / Tencent COS 这类对象存储 connector 使用 `object_storage_upload_strategy` / `object_storage_download_strategy` 表达传输策略，例如 `{"object_storage_upload_strategy":"presigned","object_storage_download_strategy":"presigned"}`；旧 `s3_upload_strategy` / `s3_download_strategy` JSON 字段仍作为兼容 alias 接受
+  - S3-compatible / Alibaba OSS / Azure Blob / Tencent COS 这类对象存储 connector 使用 `object_storage_upload_strategy` / `object_storage_download_strategy` 表达传输策略，例如 `{"object_storage_upload_strategy":"presigned","object_storage_download_strategy":"presigned"}`；旧 `s3_upload_strategy` / `s3_download_strategy` JSON 字段仍作为兼容 alias 接受
+  - Alibaba OSS 原生字段：公网 `endpoint`、可选 `oss_server_side_endpoint`、`oss_region`、`oss_use_cname`。后端 I/O 优先使用服务端 endpoint；presigned URL 固定使用公网 endpoint。CNAME 模式只接受自定义域名，普通模式只接受 `aliyuncs.com` OSS endpoint
   - Remote 上传下载策略，例如 `{"remote_upload_strategy":"presigned","remote_download_strategy":"presigned"}`
   - 本地策略的内容去重开关 `content_dedup`
   - 通用 S3 path-style 访问开关：`s3_path_style`，默认 `true`
@@ -116,7 +117,8 @@
 - `driver_type = "one_drive"` 使用 Microsoft Graph OAuth 凭据，授权前需要先保存策略和 `application_config.microsoft_graph`
 - `driver_type = "sftp"` 使用 SSH 用户名 / 密码连接 SFTP 服务器；Endpoint 支持 `sftp://host:port`、裸 `host` 和 `host:port`，远程根目录放在 `base_path`。未知或不匹配的 SSH 主机密钥会以 `StorageErrorKind::Precondition` 拒绝，并通过诊断提示 actual / expected 指纹；确认后的指纹保存在 `options.sftp_host_key_fingerprint`。
 - `driver_type = "tencent_cos"` 普通读写复用 S3-compatible 对象存储路径，会校验 Tencent COS endpoint 形态；策略启用后可通过 COS CI 暴露原生缩略图、图片预览和媒体元数据能力
-- 内置 Local、S3-compatible、SFTP、Azure Blob、OneDrive 和 Remote 驱动不暴露存储原生缩略图、图片预览或媒体元数据能力
+- `driver_type = "alibaba_oss"` 复用 AWS S3 SDK 的对象、流式和 multipart 编排，但使用原生 `OSS4-HMAC-SHA256` header/query 签名；普通请求和 generated presign 分别验证
+- 内置 Local、S3-compatible、Alibaba OSS、SFTP、Azure Blob、OneDrive 和 Remote 驱动不暴露存储原生缩略图、图片预览或媒体元数据能力
 - 旧配置 `{"presigned_upload":true}` 仍兼容，等价于 S3 预签名上传策略
 - `POST /admin/policies/{id}/promote-s3-driver` 当前支持把通用 `s3` 策略提升为 `tencent_cos`。请求体必须包含目标驱动和当前 endpoint / bucket，例如 `{ "target_driver_type": "tencent_cos", "endpoint": "https://bucket-1250000000.cos.ap-guangzhou.myqcloud.com", "bucket": "bucket-1250000000" }`。提升时不允许改变 bucket；若该策略还有活动上传 session，或目标驱动不能接受当前 endpoint / bucket 组合，会直接拒绝。
 - REST 已经可以通过 `allowed_types` 管理策略允许的 MIME / 类型列表；不传时创建会使用空列表，更新会保持原值

--- a/developer-docs/zh-CN/design/object-storage-custom-auth.md
+++ b/developer-docs/zh-CN/design/object-storage-custom-auth.md
@@ -88,9 +88,9 @@ COS signer 还必须处理 AWS operation serializer 与 COS 原生字段之间�
 这些转换属于 COS driver/signing 模块，不进入 service、connector common 或共享
 `aster_drive_storage` trait。
 
-## OSS 后续实现边界
+## OSS 实现边界
 
-OSS 可以沿用 COS 验证后的结构，但 signer、endpoint/addressing 和字段转换必须独立：
+OSS 沿用 COS 验证后的 auth-scheme 结构，但 signer、endpoint/addressing 和字段转换保持独立：
 
 - backend I/O 使用 server-side endpoint（未配置时回退 public endpoint）；
 - 浏览器 presigned URL 使用 public endpoint；
@@ -99,8 +99,13 @@ OSS 可以沿用 COS 验证后的结构，但 signer、endpoint/addressing 和�
   provider-specific 分支；
 - header signing 和 query presigning 都使用 OSS V4，而不是 AWS SigV4。
 
-建议为 backend operation 和 browser presign 构造两个共享 signer 的 client，避免在
-单次请求里临时改 endpoint 后破坏 Host/canonical URI 一致性。
+`AlibabaOssDriver` 为 browser presign 保留 public client；配置 server-side endpoint
+时再构造独立 backend client。没有 server-side endpoint 时两条路径复用同一 client。
+这种结构避免在单次请求里临时改 endpoint 后破坏 Host/canonical URI 一致性。
+
+OSS signer 位于 `src/storage/drivers/alibaba_oss/signing.rs`，当前覆盖官方 Go SDK
+固定向量、普通捕获请求、generated presign、CNAME wire path、CopyObject header 转换
+和 public/server endpoint 分流。真实 provider 集成仍是发布前的外部验收边界。
 
 ## 与 provider option 插件化的边界
 

--- a/docs/astro.config.mts
+++ b/docs/astro.config.mts
@@ -104,6 +104,7 @@ const sidebar = assertUniqueSidebarLinks([
           { label: '后端总览', translations: { en: 'Backend Overview' }, link: '/admin/storage-backends/' },
           { label: '本地磁盘', translations: { en: 'Local Disk' }, link: '/admin/storage-backends/local/' },
           { label: 'S3 / MinIO / R2', translations: { en: 'S3 / MinIO / R2' }, link: '/admin/storage-backends/s3/' },
+          { label: '阿里云 OSS', translations: { en: 'Alibaba Cloud OSS' }, link: '/admin/storage-backends/alibaba-oss/' },
           {
             label: 'Azure Blob Storage',
             translations: { en: 'Azure Blob Storage' },

--- a/docs/src/content/docs/admin/storage-backends/alibaba-oss.md
+++ b/docs/src/content/docs/admin/storage-backends/alibaba-oss.md
@@ -1,0 +1,103 @@
+---
+description: 阿里云 OSS 存储策略教程，覆盖原生 OSS V4 签名、公网与服务端 endpoint、CNAME、上传下载方式、CORS 和上线验收。
+title: "阿里云 OSS 存储策略教程"
+---
+
+:::tip[这一篇覆盖什么]
+这页讲怎样把 AsterDrive 文件写入阿里云对象存储 OSS。AsterDrive 使用原生 `OSS4-HMAC-SHA256` 签名，不把 Cloudreve 或 OSS 原生策略伪装成普通 S3-compatible 配置。
+:::
+
+## 什么时候选阿里云 OSS
+
+- 已经有阿里云 OSS bucket，希望保留 OSS 原生 endpoint 和 region 语义
+- AsterDrive 服务端可以走 OSS 内网 endpoint，但浏览器直传仍要走公网 endpoint
+- bucket 绑定了自定义域名，需要 CNAME 访问
+- 需要 `relay_stream` 与 `presigned` 上传、下载和 multipart 上传
+
+只接通一个“看起来像 S3”的 endpoint 不等于原生 OSS 支持。OSS V4 的算法、credential scope、canonical URI 和 query 参数都与 AWS SigV4 不同。
+
+## 入口速查
+
+| 任务 | 位置 |
+| --- | --- |
+| 创建 bucket、AccessKey、CORS | 阿里云 OSS 控制台 |
+| 创建策略 | `管理 -> 存储策略 -> 新建策略 -> 阿里云 OSS` |
+| 分配给用户或团队 | `管理 -> 策略组` |
+| 对比 `relay_stream` / `presigned` | [存储能力矩阵](/reference/storage-matrix/) |
+
+## 1. 准备 OSS bucket
+
+1. 创建专用 bucket，记录 bucket 名称和 region，例如 `cn-hangzhou`
+2. 记录公网 endpoint，例如 `https://oss-cn-hangzhou.aliyuncs.com`
+3. 如果 AsterDrive 与 OSS 在同一云网络，记录可供服务端使用的内网 endpoint，例如 `https://oss-cn-hangzhou-internal.aliyuncs.com`
+4. 创建只允许访问该 bucket 的 AccessKey，至少授予对象读、写、删除、列举和 multipart 所需权限
+5. 如果使用 `presigned`，为 AsterDrive 站点配置 OSS CORS
+
+不要把 AccessKey 写入日志、截图或 issue。AsterDrive 会把 connector credential 加密存储，备份和迁移时必须同时保留 `[auth].storage_credential_secret_key`。
+
+## 2. 理解三个 endpoint 相关字段
+
+| 字段 | 作用 |
+| --- | --- |
+| 公网 endpoint | 生成浏览器可见的 presigned URL；没有服务端 endpoint 时也用于后端 I/O |
+| 服务端 endpoint | 可选，只用于 AsterDrive 后端请求；不会出现在浏览器 presigned URL 中 |
+| 使用 CNAME 自定义域名 | 把公网 endpoint 视为已绑定当前 bucket 的自定义域名 |
+
+普通模式的 endpoint 必须使用 `aliyuncs.com` OSS 域名。CNAME 模式的公网 endpoint 必须是自定义域名；bucket 仍参与 OSS V4 canonical URI，但不会重复出现在实际 URL path 中。
+
+:::caution[CNAME 不会替代服务端 endpoint]
+配置了服务端 endpoint 时，后端 I/O 使用服务端 endpoint，浏览器 presigned URL 仍使用公网 endpoint。先分别确认服务端和浏览器的 DNS、HTTPS 与网络可达性。
+:::
+
+## 3. 创建 AsterDrive 存储策略
+
+在 `管理 -> 存储策略` 新建 **阿里云 OSS**，填写：
+
+- 公网 endpoint
+- 可选服务端 endpoint
+- OSS region
+- bucket
+- 可选基础路径
+- 是否使用 CNAME
+- AccessKey ID / AccessKey Secret
+- 上传方式和下载方式
+
+先使用 `relay_stream` 完成连接测试和端到端验收。确认服务端读写、Range、删除、复制和 multipart 稳定后，再切 `presigned`。
+
+## 4. 为 presigned 配置 CORS
+
+浏览器直传至少需要允许 AsterDrive 站点来源执行 `GET`、`HEAD`、`PUT`、`POST` 和 `DELETE`，允许上传实际携带的请求头，并暴露 `ETag`、`Content-Length`、`Content-Range` 等响应头。具体字段以 OSS 控制台当前 CORS 配置界面为准。
+
+如果连接测试通过但浏览器直传失败，优先检查：
+
+1. 浏览器拿到的 URL 是否使用公网 endpoint 或 CNAME，而不是内网 endpoint
+2. CORS `AllowedOrigin` 是否与浏览器地址栏的 origin 完全一致
+3. multipart part 响应的 `ETag` 是否对浏览器可见
+4. 自定义域名 HTTPS 证书是否覆盖当前域名
+
+## 5. 配置策略组并验收
+
+新建测试策略组，把一个测试用户或团队绑定到 OSS 策略，然后依次验证：
+
+- 小文件上传、下载、删除和恢复
+- 大文件 multipart 上传、暂停后续传、取消
+- Range 下载、PDF / 视频 seek、图片预览
+- 文件复制、移动和覆盖冲突
+- 公开分享下载
+- `relay_stream` 与 `presigned` 两种上传和下载方式
+
+验收完成前，不要直接修改已有策略的 bucket、endpoint、region、CNAME 或基础路径；这些字段共同决定旧对象的真实位置和签名方式。
+
+## 常见问题
+
+### `SignatureDoesNotMatch`
+
+确认 region 与 bucket endpoint 匹配，AccessKey 没有多余空白，系统时间准确，并且没有把 OSS 原生策略填进通用 S3 connector。
+
+### 服务端正常，浏览器 presigned URL 访问失败
+
+服务端 endpoint 只证明 AsterDrive 后端可达。检查公网 endpoint / CNAME、HTTPS、DNS 和 CORS。
+
+### CNAME URL 里又出现了 bucket
+
+确认启用了 **使用 CNAME 自定义域名**，且公网 endpoint 填的是绑定到 bucket 的自定义域名，而不是 `aliyuncs.com` provider endpoint。

--- a/docs/src/content/docs/admin/storage-backends/index.md
+++ b/docs/src/content/docs/admin/storage-backends/index.md
@@ -1,5 +1,5 @@
 ---
-description: "AsterDrive 存储后端选择指南：七种后端的适用场景、所有后端共用的接入流程，以及切生产流量前的验证顺序。"
+description: "AsterDrive 存储后端选择指南：八种后端的适用场景、所有后端共用的接入流程，以及切生产流量前的验证顺序。"
 title: "存储后端"
 ---
 
@@ -14,6 +14,7 @@ title: "存储后端"
 | --- | --- | --- |
 | 本地磁盘 | 单机、NAS、小团队、最少依赖 | [本地磁盘](/admin/storage-backends/local/) |
 | S3 / MinIO / R2 | 对象存储、大文件、外部 bucket、云存储 | [S3 / MinIO / R2](/admin/storage-backends/s3/) |
+| 阿里云 OSS | 阿里云原生 OSS bucket、OSS V4 签名、内外网 endpoint 分流或 CNAME | [阿里云 OSS](/admin/storage-backends/alibaba-oss/) |
 | Azure Blob Storage | Azure Storage account、Blob container、Azure 托管对象存储 | [Azure Blob Storage](/admin/storage-backends/azure-blob/) |
 | 腾讯云 COS | 腾讯云对象存储、COS 数据万象、按策略启用原生处理 | [腾讯云 COS](/admin/storage-backends/tencent-cos/) |
 | OneDrive | Microsoft 365、OneDrive、SharePoint / group drive、Microsoft Graph 授权 | [OneDrive](/admin/storage-backends/onedrive/) |
@@ -48,5 +49,5 @@ flowchart TD
 5. 确认没有问题后，再把真实用户或团队迁到新策略组
 
 :::caution[已写入文件的策略，不要直接改真实落点]
-`local` 的目录、S3 的 bucket / endpoint / prefix、Azure Blob 的 endpoint / container / 基础路径、OneDrive 的 drive / root item / site 或 group 定位字段、SFTP 的 endpoint / 基础路径、远程节点绑定，这些字段决定旧文件在哪里。直接改掉，旧文件可能会找不到。正确的搬迁方式见 [存储策略与策略组](/admin/storage-policies/#迁移已有策略数据)。
+`local` 的目录、S3 / OSS 的 bucket / endpoint / prefix、Azure Blob 的 endpoint / container / 基础路径、OneDrive 的 drive / root item / site 或 group 定位字段、SFTP 的 endpoint / 基础路径、远程节点绑定，这些字段决定旧文件在哪里。直接改掉，旧文件可能会找不到。正确的搬迁方式见 [存储策略与策略组](/admin/storage-policies/#迁移已有策略数据)。
 :::

--- a/docs/src/content/docs/admin/storage-policies.md
+++ b/docs/src/content/docs/admin/storage-policies.md
@@ -29,7 +29,8 @@ title: "存储策略与策略组"
 | 类型 | 说明 | 详细教程 |
 | --- | --- | --- |
 | `local` | 文件存到本地目录 | [本地磁盘](/admin/storage-backends/local/) |
-| `s3` | 文件存到 S3 或兼容对象存储（MinIO / R2 / B2 / OSS 等） | [S3 / MinIO / R2](/admin/storage-backends/s3/) |
+| `s3` | 文件存到 S3 或明确提供 S3-compatible API 的对象存储（MinIO / R2 / B2 等） | [S3 / MinIO / R2](/admin/storage-backends/s3/) |
+| `alibaba_oss` | 使用原生 OSS V4 签名写入阿里云 OSS，支持公网 / 服务端 endpoint 分流和 CNAME | [阿里云 OSS](/admin/storage-backends/alibaba-oss/) |
 | `azure_blob` | 文件存到 Azure Blob Storage container，使用 Azure Blob SDK 和 SAS URL | [Azure Blob Storage](/admin/storage-backends/azure-blob/) |
 | `tencent_cos` | 文件存到腾讯云 COS；基础对象读写复用 S3 兼容能力，并额外暴露 COS 数据万象等腾讯云原生能力 | [腾讯云 COS](/admin/storage-backends/tencent-cos/) |
 | `one_drive` | 文件写到 Microsoft Graph 可访问的 OneDrive、SharePoint 或 Microsoft 365 group drive | [OneDrive](/admin/storage-backends/onedrive/) |
@@ -63,13 +64,13 @@ title: "存储策略与策略组"
 | 项目 | 作用 |
 | --- | --- |
 | 名称 | 后台显示名 |
-| 驱动类型 | `local`、`s3`、`azure_blob`、`tencent_cos`、`one_drive`、`sftp` 或 `remote` |
-| 连接信息 | 本地目录 / S3 endpoint、bucket、密钥 / Azure Blob endpoint、container、账号密钥 / COS endpoint、bucket、密钥 / OneDrive Microsoft Graph 目标与授权配置 / SFTP endpoint、SSH 凭据、主机密钥指纹 / 绑定的远程节点 |
+| 驱动类型 | `local`、`s3`、`alibaba_oss`、`azure_blob`、`tencent_cos`、`one_drive`、`sftp` 或 `remote` |
+| 连接信息 | 本地目录 / S3 endpoint、bucket、密钥 / OSS 公网 endpoint、可选服务端 endpoint、region、bucket、CNAME、密钥 / Azure Blob endpoint、container、账号密钥 / COS endpoint、bucket、密钥 / OneDrive Microsoft Graph 目标与授权配置 / SFTP endpoint、SSH 凭据、主机密钥指纹 / 绑定的远程节点 |
 | 基础路径 | 写入该策略时使用的目录、prefix 或远程落点相对路径 |
 | 单文件大小上限 | 允许上传的最大文件；`0` = 不限 |
 | 分片大小 | 大文件上传时每一片的大小 |
 | 默认策略 | 新建默认组或默认分流规则会优先使用 |
-| 附加选项 | 本地内容去重、S3 / Azure Blob / COS 上传下载方式、S3 path-style 访问、OneDrive 目标 drive 定位、SFTP 主机密钥指纹、远程上传下载方式、存储原生处理开关等 |
+| 附加选项 | 本地内容去重、S3 / OSS / Azure Blob / COS 上传下载方式、S3 path-style 访问、OSS CNAME、OneDrive 目标 drive 定位、SFTP 主机密钥指纹、远程上传下载方式、存储原生处理开关等 |
 
 后台的存储策略表单不是靠前端硬编码各个厂商字段。AsterDrive 会从后端的 `StorageConnector` descriptor 读取当前 driver 支持的字段、能力、上传工作流和管理动作，所以新增或调整存储后端时，管理界面会尽量跟着后端能力显示。
 
@@ -78,7 +79,7 @@ title: "存储策略与策略组"
 存储策略有两类连接测试：
 
 - **测试已保存策略**：对数据库里已经保存的策略做读写探测。
-- **测试草稿配置**：在保存前用当前表单参数做探测；S3、Azure Blob 和 Tencent COS 这类静态凭据后端，在密钥字段留空时可以复用已保存凭据。
+- **测试草稿配置**：在保存前用当前表单参数做探测；S3、阿里云 OSS、Azure Blob 和 Tencent COS 这类静态凭据后端，在密钥字段留空时可以复用已保存凭据。
 
 连接测试成功时只表示 AsterDrive 服务端能访问后端，并且凭据、bucket / container / drive / follower 远程存储目标等基础读写路径可用。它不代表浏览器一定能直连对象存储或 follower。只要用了 `presigned`，还要继续检查浏览器网络、HTTPS 证书、CORS 和暴露响应头。
 

--- a/docs/src/content/docs/en/admin/storage-backends/alibaba-oss.md
+++ b/docs/src/content/docs/en/admin/storage-backends/alibaba-oss.md
@@ -1,0 +1,103 @@
+---
+description: Alibaba Cloud OSS storage policy tutorial covering native OSS V4 signing, public and server-side endpoints, CNAME, transfer modes, CORS, and production validation.
+title: "Alibaba Cloud OSS Storage Policy Tutorial"
+---
+
+:::tip[What this page covers]
+This page explains how to store AsterDrive files in Alibaba Cloud Object Storage Service. AsterDrive uses native `OSS4-HMAC-SHA256` signing; it does not disguise a Cloudreve or native OSS policy as generic S3-compatible storage.
+:::
+
+## When to Choose Alibaba Cloud OSS
+
+- You already have an OSS bucket and need native endpoint and region semantics
+- AsterDrive backend traffic should use an OSS internal endpoint while browser direct transfers use the public endpoint
+- The bucket is bound to a custom CNAME domain
+- You need `relay_stream`, `presigned`, and multipart upload paths
+
+An endpoint that merely resembles S3 does not provide native OSS behavior. OSS V4 uses a different algorithm, credential scope, canonical URI, and query-signing contract from AWS SigV4.
+
+## Entry Points
+
+| Task | Location |
+| --- | --- |
+| Create the bucket, AccessKey, and CORS rules | Alibaba Cloud OSS console |
+| Create the policy | `Admin -> Storage Policies -> New Policy -> Alibaba Cloud OSS` |
+| Assign users or teams | `Admin -> Policy Groups` |
+| Compare `relay_stream` and `presigned` | [Storage Capability Matrix](/en/reference/storage-matrix/) |
+
+## 1. Prepare the OSS Bucket
+
+1. Create a dedicated bucket and record its region, for example `cn-hangzhou`
+2. Record the public endpoint, for example `https://oss-cn-hangzhou.aliyuncs.com`
+3. If AsterDrive and OSS share a cloud network, record a server-side internal endpoint such as `https://oss-cn-hangzhou-internal.aliyuncs.com`
+4. Create an AccessKey scoped to this bucket with the object read, write, delete, list, and multipart permissions AsterDrive needs
+5. If you plan to use `presigned`, configure OSS CORS for the AsterDrive site
+
+Do not paste the AccessKey into logs, screenshots, or issues. AsterDrive encrypts connector credentials at rest; backups and migrations must also preserve `[auth].storage_credential_secret_key`.
+
+## 2. Understand the Three Endpoint Settings
+
+| Field | Purpose |
+| --- | --- |
+| Public endpoint | Generates browser-visible presigned URLs; also handles backend I/O when no server-side endpoint is set |
+| Server-side endpoint | Optional and used only by AsterDrive backend requests; never appears in browser presigned URLs |
+| Use CNAME custom domain | Treats the public endpoint as a custom domain already bound to the current bucket |
+
+In normal mode, endpoints must use an `aliyuncs.com` OSS hostname. In CNAME mode, the public endpoint must be a custom domain. The bucket remains part of the OSS V4 canonical URI but is not repeated in the transmitted URL path.
+
+:::caution[CNAME does not replace the server-side endpoint]
+When a server-side endpoint is configured, backend I/O uses it while browser presigned URLs continue to use the public endpoint. Validate DNS, HTTPS, and reachability for the backend and browser paths separately.
+:::
+
+## 3. Create the AsterDrive Storage Policy
+
+Under `Admin -> Storage Policies`, create **Alibaba Cloud OSS** and fill in:
+
+- Public endpoint
+- Optional server-side endpoint
+- OSS region
+- Bucket
+- Optional base path
+- CNAME mode
+- AccessKey ID / AccessKey Secret
+- Upload and download modes
+
+Start with `relay_stream` for connection testing and end-to-end validation. After server-side reads, writes, Range requests, deletes, copies, and multipart operations are stable, switch to `presigned` if needed.
+
+## 4. Configure CORS for Presigned Transfers
+
+Browser direct transfers normally need the AsterDrive site origin to use `GET`, `HEAD`, `PUT`, `POST`, and `DELETE`, send the headers used by uploads, and read response headers such as `ETag`, `Content-Length`, and `Content-Range`. Use the current OSS console CORS form as the authority for exact field names.
+
+If the connection test succeeds but browser direct transfer fails, check:
+
+1. The browser URL uses the public endpoint or CNAME, not the internal endpoint
+2. CORS `AllowedOrigin` exactly matches the origin in the browser address bar
+3. Multipart part `ETag` responses are visible to browser JavaScript
+4. The custom-domain TLS certificate covers the selected hostname
+
+## 5. Configure a Policy Group and Validate
+
+Create a test policy group, bind one test user or team, then verify:
+
+- Small-file upload, download, delete, and restore
+- Large multipart upload, resume, and cancellation
+- Range download, PDF / video seeking, and image preview
+- File copy, move, and overwrite conflicts
+- Public-share download
+- Both `relay_stream` and `presigned` upload/download modes
+
+Until validation is complete, do not edit the bucket, endpoint, region, CNAME, or base path of a policy that already owns files. Together, those fields determine the real object location and signing behavior.
+
+## Troubleshooting
+
+### `SignatureDoesNotMatch`
+
+Confirm that the region matches the bucket endpoint, credentials contain no extra whitespace, system time is correct, and the native OSS policy was not entered through the generic S3 connector.
+
+### Backend Works but Browser Presigned URLs Fail
+
+The server-side endpoint only proves backend reachability. Check the public endpoint / CNAME, HTTPS, DNS, and CORS separately.
+
+### The Bucket Appears Again in a CNAME URL
+
+Enable **Use CNAME custom domain** and make sure the public endpoint is the custom domain bound to the bucket, not an `aliyuncs.com` provider endpoint.

--- a/docs/src/content/docs/en/admin/storage-backends/index.md
+++ b/docs/src/content/docs/en/admin/storage-backends/index.md
@@ -1,5 +1,5 @@
 ---
-description: "AsterDrive storage backend selection guide: when to pick each of the seven backends, the onboarding flow shared by all backends, and how to validate before switching production traffic."
+description: "AsterDrive storage backend selection guide: when to pick each of the eight backends, the onboarding flow shared by all backends, and how to validate before switching production traffic."
 title: "Storage Backends"
 ---
 
@@ -14,6 +14,7 @@ The two-layer concept of storage policies and policy groups itself lives in [Sto
 | --- | --- | --- |
 | Local Disk | Single machine, NAS, small teams, minimal dependencies | [Local Disk](/en/admin/storage-backends/local/) |
 | S3 / MinIO / R2 | Object storage, large files, external buckets, cloud storage | [S3 / MinIO / R2](/en/admin/storage-backends/s3/) |
+| Alibaba Cloud OSS | Native Alibaba OSS buckets, OSS V4 signing, public/internal endpoint split, or CNAME | [Alibaba Cloud OSS](/en/admin/storage-backends/alibaba-oss/) |
 | Azure Blob Storage | Azure Storage accounts, Blob containers, Azure-managed object storage | [Azure Blob Storage](/en/admin/storage-backends/azure-blob/) |
 | Tencent Cloud COS | Tencent Cloud object storage, COS CI, per-policy native processing | [Tencent Cloud COS](/en/admin/storage-backends/tencent-cos/) |
 | OneDrive | Microsoft 365, OneDrive, SharePoint / group drives, Microsoft Graph authorization | [OneDrive](/en/admin/storage-backends/onedrive/) |
@@ -48,5 +49,5 @@ Recommended approach:
 5. Only then migrate real users or teams to the new policy group
 
 :::caution[Do not edit the real landing location of a policy that already has files]
-The `local` directory, S3 bucket / endpoint / prefix, Azure Blob endpoint / container / base path, OneDrive drive / root item / site / group targeting fields, SFTP endpoint / base path, and the bound remote node all decide where old files live. Change them in place and old files may become unfindable. For the correct move procedure, see [Storage Policies and Policy Groups](/en/admin/storage-policies/#migrating-existing-policy-data).
+The `local` directory, S3 / OSS bucket / endpoint / prefix, Azure Blob endpoint / container / base path, OneDrive drive / root item / site / group targeting fields, SFTP endpoint / base path, and the bound remote node all decide where old files live. Change them in place and old files may become unfindable. For the correct move procedure, see [Storage Policies and Policy Groups](/en/admin/storage-policies/#migrating-existing-policy-data).
 :::

--- a/docs/src/content/docs/en/admin/storage-policies.md
+++ b/docs/src/content/docs/en/admin/storage-policies.md
@@ -29,7 +29,8 @@ When a system administrator creates a new team without specifying a policy group
 | Type | Description | Full tutorial |
 | --- | --- | --- |
 | `local` | Files on a local directory | [Local Disk](/en/admin/storage-backends/local/) |
-| `s3` | Files on S3 or compatible object storage (MinIO / R2 / B2 / OSS, etc.) | [S3 / MinIO / R2](/en/admin/storage-backends/s3/) |
+| `s3` | Files on S3 or object storage with an explicit S3-compatible API (MinIO / R2 / B2, etc.) | [S3 / MinIO / R2](/en/admin/storage-backends/s3/) |
+| `alibaba_oss` | Files on Alibaba Cloud OSS with native OSS V4 signing, public/server endpoint separation, and CNAME support | [Alibaba Cloud OSS](/en/admin/storage-backends/alibaba-oss/) |
 | `azure_blob` | Files in an Azure Blob Storage container via the Azure Blob SDK and SAS URLs | [Azure Blob Storage](/en/admin/storage-backends/azure-blob/) |
 | `tencent_cos` | Files on Tencent Cloud COS; basic object I/O reuses S3-compatible logic and additionally exposes Tencent-native capabilities like COS CI | [Tencent Cloud COS](/en/admin/storage-backends/tencent-cos/) |
 | `one_drive` | Files written to OneDrive, SharePoint, or Microsoft 365 group drives reachable via Microsoft Graph | [OneDrive](/en/admin/storage-backends/onedrive/) |
@@ -63,13 +64,13 @@ When migrating existing data, do not edit the old policy's path, bucket, endpoin
 | Item | Purpose |
 | --- | --- |
 | Name | Display name in the console |
-| Driver type | `local`, `s3`, `azure_blob`, `tencent_cos`, `one_drive`, `sftp`, or `remote` |
-| Connection info | Local directory / S3 endpoint, bucket, keys / Azure Blob endpoint, container, account keys / COS endpoint, bucket, keys / OneDrive Microsoft Graph target and authorization / SFTP endpoint, SSH credentials, host key fingerprint / bound remote node |
+| Driver type | `local`, `s3`, `alibaba_oss`, `azure_blob`, `tencent_cos`, `one_drive`, `sftp`, or `remote` |
+| Connection info | Local directory / S3 endpoint, bucket, keys / OSS public endpoint, optional server-side endpoint, region, bucket, CNAME, keys / Azure Blob endpoint, container, account keys / COS endpoint, bucket, keys / OneDrive Microsoft Graph target and authorization / SFTP endpoint, SSH credentials, host key fingerprint / bound remote node |
 | Base path | Directory, prefix, or remote relative path used when writing through this policy |
 | Max single-file size | Largest allowed upload; `0` = unlimited |
 | Chunk size | Size of each part for large-file uploads |
 | Default policy | Preferred by new default groups or default routing rules |
-| Additional options | Local content dedup, S3 / Azure Blob / COS upload and download modes, S3 path-style access, OneDrive drive targeting, SFTP host key fingerprint, remote upload/download modes, storage-native processing switch, etc. |
+| Additional options | Local content dedup, S3 / OSS / Azure Blob / COS upload and download modes, S3 path-style access, OSS CNAME, OneDrive drive targeting, SFTP host key fingerprint, remote upload/download modes, storage-native processing switch, etc. |
 
 The console's storage policy form is not hardcoded per vendor on the frontend. AsterDrive reads the fields, capabilities, upload workflows, and management actions supported by the current driver from the backend `StorageConnector` descriptor, so when storage backends are added or adjusted, the admin UI follows backend capabilities as much as possible.
 
@@ -78,7 +79,7 @@ The console's storage policy form is not hardcoded per vendor on the frontend. A
 Storage policies have two kinds of connection tests:
 
 - **Test a saved policy**: read-write probe against a policy already saved in the database.
-- **Test a draft config**: probe with current form values before saving; for static-credential backends like S3, Azure Blob, and Tencent COS, leaving the secret field empty reuses the saved credential.
+- **Test a draft config**: probe with current form values before saving; for static-credential backends like S3, Alibaba Cloud OSS, Azure Blob, and Tencent COS, leaving the secret field empty reuses the saved credential.
 
 A successful connection test only means the AsterDrive server can reach the backend and the basic read-write paths — credentials, bucket / container / drive / follower remote storage target — work. It does not mean a browser can reach the object storage or follower directly. Whenever `presigned` is used, you still need to check browser networking, HTTPS certificates, CORS, and exposed response headers.
 

--- a/docs/src/content/docs/en/reference/index.md
+++ b/docs/src/content/docs/en/reference/index.md
@@ -9,7 +9,7 @@ This section is not an operations manual. It is for looking things up and learni
 | --- | --- |
 | Look up a `config.toml` field | [Configuration Overview](./config/) |
 | Look up an admin-console system setting and when it takes effect | [System Settings](./config/runtime/) |
-| Compare the seven storage backends and their credentials at rest | [Storage Capability Matrix](./storage-matrix/) |
+| Compare the eight storage backends and their credentials at rest | [Storage Capability Matrix](./storage-matrix/) |
 | Check WebDAV protocol methods, property, lock, and versioning boundaries | [WebDAV Protocol Compatibility](./webdav-compat/) |
 | Understand primary / follower and the upload-download data flow | [Runtime Architecture](./runtime-architecture/) |
 | Look up a term | [Glossary](./glossary/) |

--- a/docs/src/content/docs/en/reference/storage-matrix.md
+++ b/docs/src/content/docs/en/reference/storage-matrix.md
@@ -1,5 +1,5 @@
 ---
-description: "Storage capability matrix for the seven backends: browser direct upload / download, capacity observation, storage-native processing, credentials at rest, and the authoritative relay_stream vs presigned comparison."
+description: "Storage capability matrix for the eight backends: browser direct upload / download, capacity observation, storage-native processing, credentials at rest, and the authoritative relay_stream vs presigned comparison."
 title: "Storage Capability Matrix"
 ---
 
@@ -13,6 +13,7 @@ Per-backend onboarding steps live in the [Storage Backends](/en/admin/storage-ba
 | --- | --- | --- | --- | --- |
 | `local` | Not supported; AsterDrive reads/writes the local disk | Supported (filesystem) | Not supported | No credentials |
 | `s3` | `presigned` upload + download | Not supported | Not supported | Plaintext |
+| `alibaba_oss` | `presigned` upload + download; browsers always use the public endpoint | Not supported | Not supported | AES-256-GCM encrypted |
 | `azure_blob` | `presigned` (SAS URL) upload + download | Not supported | Not supported | Plaintext |
 | `tencent_cos` | `presigned` upload + download | Not supported | COS CI (per-policy switch) | Plaintext |
 | `one_drive` | `frontend_direct` upload, Graph direct download | Supported (Graph quota) | Not supported | AES-256-GCM encrypted |

--- a/docs/src/content/docs/reference/index.md
+++ b/docs/src/content/docs/reference/index.md
@@ -9,7 +9,7 @@ title: "参考与项目"
 | --- | --- |
 | 查 `config.toml` 某个字段的含义 | [配置总览](./config/) |
 | 查后台系统设置某个选项的含义和生效时机 | [系统设置](./config/runtime/) |
-| 对比七种存储后端的能力和凭据落库方式 | [存储能力矩阵](./storage-matrix/) |
+| 对比八种存储后端的能力和凭据落库方式 | [存储能力矩阵](./storage-matrix/) |
 | 查 WebDAV 协议方法、属性、锁和版本控制边界 | [WebDAV 协议兼容](./webdav-compat/) |
 | 搞清楚 primary / follower、上传下载数据流怎么跑 | [运行架构](./runtime-architecture/) |
 | 查一个词是什么意思 | [术语表](./glossary/) |

--- a/docs/src/content/docs/reference/storage-matrix.md
+++ b/docs/src/content/docs/reference/storage-matrix.md
@@ -1,5 +1,5 @@
 ---
-description: "七种存储后端的能力矩阵：浏览器直传 / 直连下载、容量观测、存储原生处理、凭据落库方式，以及 relay_stream 与 presigned 的权威对比。"
+description: "八种存储后端的能力矩阵：浏览器直传 / 直连下载、容量观测、存储原生处理、凭据落库方式，以及 relay_stream 与 presigned 的权威对比。"
 title: "存储能力矩阵"
 ---
 
@@ -13,6 +13,7 @@ title: "存储能力矩阵"
 | --- | --- | --- | --- | --- |
 | `local` | 不支持，由 AsterDrive 读写本地磁盘 | 支持（文件系统） | 不支持 | 无凭据 |
 | `s3` | `presigned` 上传 + 下载 | 不支持 | 不支持 | 明文 |
+| `alibaba_oss` | `presigned` 上传 + 下载；浏览器固定走公网 endpoint | 不支持 | 不支持 | AES-256-GCM 加密 |
 | `azure_blob` | `presigned`（SAS URL）上传 + 下载 | 不支持 | 不支持 | 明文 |
 | `tencent_cos` | `presigned` 上传 + 下载 | 不支持 | COS 数据万象（按策略开关） | 明文 |
 | `one_drive` | `frontend_direct` 上传、Graph 直接下载 | 支持（Graph quota） | 不支持 | AES-256-GCM 加密 |

--- a/src/services/ops/deployment.rs
+++ b/src/services/ops/deployment.rs
@@ -218,6 +218,7 @@ mod tests {
         assert!(error.contains("instance_local"));
         for connector_id in [
             "asterdrive.storage.s3",
+            "asterdrive.storage.alibaba_oss",
             "asterdrive.storage.sftp",
             "asterdrive.storage.azure_blob",
             "asterdrive.storage.tencent_cos",

--- a/src/services/storage_policy/connector_catalog.rs
+++ b/src/services/storage_policy/connector_catalog.rs
@@ -143,8 +143,9 @@ mod tests {
         let drivers = connector_ids(&config, StorageConnectorCatalogContext::Create);
 
         assert!(drivers.contains(&ConnectorId::declared("asterdrive.storage.local")));
+        assert!(drivers.contains(&ConnectorId::declared("asterdrive.storage.alibaba_oss")));
         assert!(drivers.contains(&ConnectorId::declared("asterdrive.storage.onedrive")));
-        assert_eq!(drivers.len(), 7);
+        assert_eq!(drivers.len(), 8);
     }
 
     #[test]
@@ -155,8 +156,9 @@ mod tests {
         let drivers = connector_ids(&config, StorageConnectorCatalogContext::Create);
 
         assert!(!drivers.contains(&ConnectorId::declared("asterdrive.storage.local")));
+        assert!(drivers.contains(&ConnectorId::declared("asterdrive.storage.alibaba_oss")));
         assert!(drivers.contains(&ConnectorId::declared("asterdrive.storage.onedrive")));
-        assert_eq!(drivers.len(), 6);
+        assert_eq!(drivers.len(), 7);
     }
 
     #[test]
@@ -164,15 +166,17 @@ mod tests {
         let single = Config::default();
         let single_drivers = connector_ids(&single, StorageConnectorCatalogContext::InitialSetup);
         assert!(single_drivers.contains(&ConnectorId::declared("asterdrive.storage.local")));
+        assert!(single_drivers.contains(&ConnectorId::declared("asterdrive.storage.alibaba_oss")));
         assert!(single_drivers.contains(&ConnectorId::declared("asterdrive.storage.onedrive")));
-        assert_eq!(single_drivers.len(), 7);
+        assert_eq!(single_drivers.len(), 8);
 
         let mut cluster = Config::default();
         cluster.deployment.profile = DeploymentProfile::Cluster;
         let cluster_drivers = connector_ids(&cluster, StorageConnectorCatalogContext::InitialSetup);
         assert!(!cluster_drivers.contains(&ConnectorId::declared("asterdrive.storage.local")));
+        assert!(cluster_drivers.contains(&ConnectorId::declared("asterdrive.storage.alibaba_oss")));
         assert!(cluster_drivers.contains(&ConnectorId::declared("asterdrive.storage.onedrive")));
-        assert_eq!(cluster_drivers.len(), 6);
+        assert_eq!(cluster_drivers.len(), 7);
     }
 
     #[test]
@@ -183,8 +187,9 @@ mod tests {
         let drivers = connector_ids(&config, StorageConnectorCatalogContext::Manage);
 
         assert!(drivers.contains(&ConnectorId::declared("asterdrive.storage.local")));
+        assert!(drivers.contains(&ConnectorId::declared("asterdrive.storage.alibaba_oss")));
         assert!(drivers.contains(&ConnectorId::declared("asterdrive.storage.onedrive")));
-        assert_eq!(drivers.len(), 7);
+        assert_eq!(drivers.len(), 8);
     }
 
     #[test]
@@ -204,7 +209,7 @@ mod tests {
         .unwrap();
 
         assert_eq!(catalog.requested_locale, requested_locale);
-        assert_eq!(catalog.resources.len(), 6);
+        assert_eq!(catalog.resources.len(), 7);
         assert!(catalog.resources.iter().all(|resource| {
             resource.connector_id.as_str() != "asterdrive.storage.local"
                 && resource.resolved_locale.as_str() == "zh"

--- a/src/services/task/storage_policy_cleanup.rs
+++ b/src/services/task/storage_policy_cleanup.rs
@@ -371,6 +371,7 @@ mod tests {
 
         for connector_id in [
             "asterdrive.storage.s3",
+            "asterdrive.storage.alibaba_oss",
             "asterdrive.storage.sftp",
             "asterdrive.storage.azure_blob",
             "asterdrive.storage.tencent_cos",

--- a/src/storage/connectors/alibaba_oss.rs
+++ b/src/storage/connectors/alibaba_oss.rs
@@ -1,0 +1,289 @@
+use async_trait::async_trait;
+use std::time::Duration;
+
+use crate::errors::{AsterError, Result};
+use crate::storage::drivers::alibaba_oss::{
+    AlibabaOssDriver, AlibabaOssDriverConfig, AlibabaOssStaticCredentials,
+};
+use aster_drive_model::entities::storage_policy;
+use aster_drive_model::types::{ObjectStorageDownloadStrategy, ObjectStorageUploadStrategy};
+use aster_drive_storage::StorageDriver;
+use aster_drive_storage::connector_descriptor::{
+    ObjectStorageConnectorDescriptorInput, StorageConnectorBadgeRgb,
+    StorageConnectorDeploymentScope, StorageConnectorDescriptor, StorageConnectorFieldDisplayInput,
+    StorageConnectorFieldKind, StorageConnectorFieldScope, StorageConnectorUiDescriptorInput,
+    object_storage_connector_descriptor, storage_connector_field,
+    storage_connector_field_with_display,
+};
+use aster_drive_storage::{StorageConnectorConfigSchema, StorageConnectorFieldDefaultValue};
+
+use super::common::{StorageTransferDirection, transfer_strategy_field};
+use super::{StorageConnector, StorageConnectorCredentialInput, StorageConnectorUploadTransport};
+
+mod localization;
+
+pub struct AlibabaOssConnector;
+
+aster_drive_storage::storage_connector_schema! {
+    pub struct AlibabaOssConnectorConfigV1 {
+        config {
+        pub endpoint: String => storage_connector_field_with_display(StorageConnectorFieldDisplayInput {
+            name: "endpoint", scope: StorageConnectorFieldScope::ConnectorConfig,
+            kind: StorageConnectorFieldKind::Text, required: true, secret: false,
+            label_key: "oss_public_endpoint", placeholder: Some("https://oss-cn-hangzhou.aliyuncs.com"),
+            help_key: Some("oss_public_endpoint_desc"), required_message_key: None,
+            invalid_protocol_message_key: Some("s3_endpoint_protocol_required_error"),
+            allowed_endpoint_protocols: vec!["http:", "https:"],
+            allow_endpoint_without_protocol: false, trim_on_blur: false,
+        }),
+        pub oss_server_side_endpoint: String => {
+            let mut field = storage_connector_field_with_display(StorageConnectorFieldDisplayInput {
+                name: "oss_server_side_endpoint", scope: StorageConnectorFieldScope::ConnectorConfig,
+                kind: StorageConnectorFieldKind::Text, required: false, secret: false,
+                label_key: "oss_server_side_endpoint", placeholder: Some("https://oss-cn-hangzhou-internal.aliyuncs.com"),
+                help_key: Some("oss_server_side_endpoint_desc"), required_message_key: None,
+                invalid_protocol_message_key: Some("s3_endpoint_protocol_required_error"),
+                allowed_endpoint_protocols: vec!["http:", "https:"],
+                allow_endpoint_without_protocol: false, trim_on_blur: false,
+            });
+            field.default_value = Some(StorageConnectorFieldDefaultValue::String(String::new()));
+            field.default_mode = aster_drive_storage::StorageConnectorFieldDefaultMode::MissingOrEmptyText;
+            field
+        },
+        pub oss_region: String => {
+            let mut field = storage_connector_field_with_display(StorageConnectorFieldDisplayInput {
+                name: "oss_region", scope: StorageConnectorFieldScope::ConnectorConfig,
+                kind: StorageConnectorFieldKind::Text, required: true, secret: false,
+                label_key: "oss_region", placeholder: Some("cn-hangzhou"),
+                help_key: Some("oss_region_desc"), required_message_key: None,
+                invalid_protocol_message_key: None, allowed_endpoint_protocols: Vec::new(),
+                allow_endpoint_without_protocol: false, trim_on_blur: true,
+            });
+            field.validation.max_length = Some(128);
+            field
+        },
+        pub bucket: String => storage_connector_field(
+            "bucket", StorageConnectorFieldScope::ConnectorConfig,
+            StorageConnectorFieldKind::Text, true, false,
+        ),
+        pub base_path: String => {
+            let mut field = storage_connector_field(
+                "base_path", StorageConnectorFieldScope::ConnectorConfig,
+                StorageConnectorFieldKind::Text, false, false,
+            );
+            field.default_value = Some(StorageConnectorFieldDefaultValue::String(String::new()));
+            field.default_mode = aster_drive_storage::StorageConnectorFieldDefaultMode::MissingOrEmptyText;
+            field
+        },
+        pub oss_use_cname: bool => {
+            let mut field = storage_connector_field_with_display(StorageConnectorFieldDisplayInput {
+                name: "oss_use_cname", scope: StorageConnectorFieldScope::ConnectorConfig,
+                kind: StorageConnectorFieldKind::Boolean, required: false, secret: false,
+                label_key: "oss_use_cname", placeholder: None, help_key: Some("oss_use_cname_desc"),
+                required_message_key: None, invalid_protocol_message_key: None,
+                allowed_endpoint_protocols: Vec::new(), allow_endpoint_without_protocol: false,
+                trim_on_blur: false,
+            });
+            field.default_value = Some(StorageConnectorFieldDefaultValue::Boolean(false));
+            field
+        },
+        pub object_storage_upload_strategy: ObjectStorageUploadStrategy => transfer_strategy_field(
+            "object_storage_upload_strategy", StorageTransferDirection::Upload,
+        ),
+        pub object_storage_download_strategy: ObjectStorageDownloadStrategy => transfer_strategy_field(
+            "object_storage_download_strategy", StorageTransferDirection::Download,
+        ),
+        }
+        credentials static AlibabaOssStaticCredentialsV1 {
+            pub aliyun_oss_access_key_id: String => storage_connector_field(
+                "aliyun_oss_access_key_id", StorageConnectorFieldScope::StaticCredential,
+                StorageConnectorFieldKind::Text, true, false,
+            ),
+            pub aliyun_oss_access_key_secret: String => storage_connector_field(
+                "aliyun_oss_access_key_secret", StorageConnectorFieldScope::StaticCredential,
+                StorageConnectorFieldKind::Secret, true, true,
+            ),
+        }
+    }
+}
+
+impl AlibabaOssConnector {
+    pub const ID: &'static str = "asterdrive.storage.alibaba_oss";
+
+    fn decode_config(policy: &storage_policy::Model) -> Result<AlibabaOssConnectorConfigV1> {
+        super::common::decode_typed_policy_config(policy, Self::ID, 1).map(|(config, _)| config)
+    }
+
+    fn driver_config(config: AlibabaOssConnectorConfigV1) -> AlibabaOssDriverConfig {
+        AlibabaOssDriverConfig {
+            endpoint: config.endpoint,
+            server_side_endpoint: config.oss_server_side_endpoint,
+            region: config.oss_region,
+            bucket: config.bucket,
+            base_path: config.base_path,
+            use_cname: config.oss_use_cname,
+            connect_timeout: Duration::from_secs(5),
+            read_timeout: Duration::from_secs(30),
+            operation_timeout: Duration::from_secs(3_600),
+        }
+    }
+
+    fn driver_credentials(
+        credentials: AlibabaOssStaticCredentialsV1,
+    ) -> AlibabaOssStaticCredentials {
+        AlibabaOssStaticCredentials {
+            access_key: credentials.aliyun_oss_access_key_id,
+            secret_key: credentials.aliyun_oss_access_key_secret,
+        }
+    }
+
+    fn descriptor_definition() -> StorageConnectorDescriptor {
+        object_storage_connector_descriptor(ObjectStorageConnectorDescriptorInput {
+            connector_id: aster_drive_storage::ConnectorId::declared(Self::ID),
+            label: "Alibaba Cloud OSS",
+            description: "Alibaba Cloud Object Storage Service policy",
+            ui: StorageConnectorUiDescriptorInput {
+                label_key: "driver_type_alibaba_oss",
+                description_key: "policy_wizard_alibaba_oss_storage_desc",
+                icon_src: Some("/static/storage/aliyun-oss.svg"),
+                icon_name: None,
+                badge_rgb: StorageConnectorBadgeRgb::new(255, 106, 0),
+                helper_key: "policy_wizard_alibaba_oss_helper",
+                config_step_title_key: "policy_wizard_step_connection_title",
+                config_step_description_key: "policy_wizard_step_alibaba_oss_connection_desc",
+                edit_context_key: "policy_edit_context_object_storage_desc",
+                base_path_empty_display: "core:root",
+                base_path_placeholder: "tenant/prefix",
+            },
+            deployment_scope: StorageConnectorDeploymentScope::SharedAcrossPrimaryInstances,
+            supports_initial_setup: true,
+            credential_mode: AlibabaOssConnectorConfigV1::credential_mode(),
+            fields: AlibabaOssConnectorConfigV1::descriptor_fields(),
+            presigned_part_etag_required: true,
+            storage_native_processing: false,
+            config_schema_version: 1,
+            credential_schema_version: Some(1),
+            related_issues: vec![450],
+        })
+    }
+}
+
+#[async_trait]
+impl StorageConnector for AlibabaOssConnector {
+    fn descriptor(&self) -> StorageConnectorDescriptor {
+        Self::descriptor_definition()
+    }
+
+    fn localization(&self) -> Result<aster_drive_storage::StorageConnectorLocalization> {
+        let descriptor = Self::descriptor_definition();
+        super::localization::builtin_connector_localization(
+            Self::ID,
+            &descriptor,
+            localization::MESSAGES,
+        )
+    }
+
+    fn validate_connector_config(
+        &self,
+        input: &aster_drive_storage::ConnectorConfigEnvelope,
+    ) -> Result<aster_drive_storage::ConnectorConfigEnvelope> {
+        let normalized =
+            aster_drive_storage::connector_descriptor::normalize_storage_connector_config(
+                &self.descriptor(),
+                input,
+            )
+            .map_err(|error| AsterError::validation_error(error.to_string()))?;
+        let config: AlibabaOssConnectorConfigV1 =
+            super::common::decode_normalized_connector_config(&normalized)?;
+        let driver_config = Self::driver_config(config.clone());
+        AlibabaOssDriver::validate_connection_config(&driver_config)
+            .map_err(|error| AsterError::validation_error(error.message().to_string()))?;
+        super::common::encode_normalized_connector_config(
+            normalized.connector_id,
+            normalized.schema_version,
+            config,
+        )
+    }
+
+    fn validate_credential_input(&self, input: &StorageConnectorCredentialInput) -> Result<()> {
+        let credential: AlibabaOssStaticCredentialsV1 =
+            super::common::decode_static_credential(input, Self::ID)?;
+        super::common::validate_required_credential_field(
+            &credential.aliyun_oss_access_key_id,
+            "aliyun_oss_access_key_id",
+            Self::ID,
+        )?;
+        super::common::validate_required_credential_field(
+            &credential.aliyun_oss_access_key_secret,
+            "aliyun_oss_access_key_secret",
+            Self::ID,
+        )
+    }
+
+    async fn build_draft_driver(
+        &self,
+        context: &super::StorageConnectorContext<'_>,
+        policy: &storage_policy::Model,
+        credential: &StorageConnectorCredentialInput,
+    ) -> Result<Box<dyn StorageDriver>> {
+        let _ = context;
+        let config = Self::decode_config(policy)?;
+        let credentials = super::common::decode_static_credential(credential, Self::ID)?;
+        Ok(Box::new(AlibabaOssDriver::new(
+            Self::driver_config(config),
+            Self::driver_credentials(credentials),
+        )?))
+    }
+
+    fn build_runtime_driver(
+        &self,
+        registry: &crate::storage::DriverRegistry,
+        policy: &storage_policy::Model,
+    ) -> Result<super::StorageConnectorDriver> {
+        let config = Self::decode_config(policy)?;
+        let credentials: AlibabaOssStaticCredentialsV1 =
+            super::common::runtime_static_credential(registry, policy, Self::ID)?;
+        Ok(super::StorageConnectorDriver::multipart(
+            std::sync::Arc::new(AlibabaOssDriver::new(
+                Self::driver_config(config),
+                Self::driver_credentials(credentials),
+            )?),
+        ))
+    }
+
+    async fn build_cleanup_driver(
+        &self,
+        context: &super::StorageConnectorContext<'_>,
+        policy: &storage_policy::Model,
+        snapshots: super::StoragePolicyCleanupSnapshots<'_>,
+    ) -> Result<std::sync::Arc<dyn StorageDriver>> {
+        let config = Self::decode_config(policy)?;
+        let credentials: AlibabaOssStaticCredentialsV1 =
+            super::common::static_credential_from_cleanup_snapshot(
+                context,
+                policy,
+                snapshots,
+                Self::ID,
+                1,
+            )?;
+        Ok(std::sync::Arc::new(AlibabaOssDriver::new(
+            Self::driver_config(config),
+            Self::driver_credentials(credentials),
+        )?))
+    }
+
+    fn upload_transport(
+        &self,
+        policy: &storage_policy::Model,
+    ) -> Result<StorageConnectorUploadTransport> {
+        let config = Self::decode_config(policy)?;
+        Ok(StorageConnectorUploadTransport::ObjectStorage(
+            config.object_storage_upload_strategy,
+        ))
+    }
+
+    fn presigned_download_enabled(&self, policy: &storage_policy::Model) -> Result<bool> {
+        let config = Self::decode_config(policy)?;
+        Ok(config.object_storage_download_strategy == ObjectStorageDownloadStrategy::Presigned)
+    }
+}

--- a/src/storage/connectors/alibaba_oss/localization.rs
+++ b/src/storage/connectors/alibaba_oss/localization.rs
@@ -1,0 +1,70 @@
+use aster_drive_storage::StorageConnectorLocalizationMessage;
+
+pub(super) const MESSAGES: &[StorageConnectorLocalizationMessage<'static>] = &[
+    aster_drive_storage::storage_connector_message!(
+        "aliyun_oss_access_key_id",
+        "Alibaba Cloud AccessKey ID",
+        "阿里云 AccessKey ID",
+    ),
+    aster_drive_storage::storage_connector_message!(
+        "aliyun_oss_access_key_secret",
+        "Alibaba Cloud AccessKey Secret",
+        "阿里云 AccessKey Secret",
+    ),
+    aster_drive_storage::storage_connector_message!(
+        "driver_type_alibaba_oss",
+        "Alibaba Cloud OSS",
+        "阿里云 OSS",
+    ),
+    aster_drive_storage::storage_connector_message!(
+        "oss_public_endpoint",
+        "Public endpoint",
+        "公网 endpoint",
+    ),
+    aster_drive_storage::storage_connector_message!(
+        "oss_public_endpoint_desc",
+        "Used for browser-facing presigned URLs and for backend requests when no server-side endpoint is configured. Use an aliyuncs.com OSS endpoint, or enable CNAME mode for a custom domain.",
+        "用于浏览器可见的 presigned URL；未配置服务端 endpoint 时也用于后端请求。普通模式填写 aliyuncs.com OSS endpoint，自定义域名则启用 CNAME 模式。",
+    ),
+    aster_drive_storage::storage_connector_message!("oss_region", "OSS region", "OSS 地域",),
+    aster_drive_storage::storage_connector_message!(
+        "oss_region_desc",
+        "Region used by OSS V4 signing, such as cn-hangzhou. It must match the bucket endpoint.",
+        "用于 OSS V4 签名的地域，例如 cn-hangzhou，必须与 bucket endpoint 匹配。",
+    ),
+    aster_drive_storage::storage_connector_message!(
+        "oss_server_side_endpoint",
+        "Server-side endpoint",
+        "服务端 endpoint",
+    ),
+    aster_drive_storage::storage_connector_message!(
+        "oss_server_side_endpoint_desc",
+        "Optional OSS endpoint used only by AsterDrive backend I/O, for example an internal aliyuncs.com endpoint. Presigned URLs continue to use the public endpoint.",
+        "仅供 AsterDrive 后端 I/O 使用的可选 OSS endpoint，例如 aliyuncs.com 内网 endpoint；presigned URL 始终使用公网 endpoint。",
+    ),
+    aster_drive_storage::storage_connector_message!(
+        "oss_use_cname",
+        "Use CNAME custom domain",
+        "使用 CNAME 自定义域名",
+    ),
+    aster_drive_storage::storage_connector_message!(
+        "oss_use_cname_desc",
+        "Treat the public endpoint as a bucket-bound custom domain. The bucket remains part of the OSS V4 canonical URI but is omitted from the transmitted URL path.",
+        "将公网 endpoint 视为绑定到 bucket 的自定义域名。bucket 仍参与 OSS V4 canonical URI，但不会出现在实际 URL path 中。",
+    ),
+    aster_drive_storage::storage_connector_message!(
+        "policy_wizard_alibaba_oss_helper",
+        "Connection tests validate OSS V4 request signing. Presigned upload and download URLs always use the public endpoint.",
+        "连接测试会验证 OSS V4 请求签名；presigned 上传和下载 URL 始终使用公网 endpoint。",
+    ),
+    aster_drive_storage::storage_connector_message!(
+        "policy_wizard_alibaba_oss_storage_desc",
+        "Store files in Alibaba Cloud Object Storage Service with native OSS V4 signing.",
+        "使用原生 OSS V4 签名将文件存入阿里云对象存储 OSS。",
+    ),
+    aster_drive_storage::storage_connector_message!(
+        "policy_wizard_step_alibaba_oss_connection_desc",
+        "Set the OSS public endpoint, optional server-side endpoint, region, bucket, and credentials.",
+        "填写 OSS 公网 endpoint、可选服务端 endpoint、地域、bucket 和访问凭证。",
+    ),
+];

--- a/src/storage/connectors/mod.rs
+++ b/src/storage/connectors/mod.rs
@@ -9,6 +9,7 @@
 //! `StorageDriver` 管“policy 已经配好后怎么读写对象”。如果一段逻辑需要数据库、
 //! OAuth、表单字段、连接测试或策略动作，它通常属于 connector，而不是 driver。
 
+mod alibaba_oss;
 mod azure_blob;
 mod common;
 mod contract;
@@ -40,6 +41,7 @@ use aster_drive_storage::connector_descriptor::{
     StorageConnectorObjectNamingMode,
 };
 
+use alibaba_oss::AlibabaOssConnector;
 use azure_blob::AzureBlobConnector;
 pub use common::unsupported_multipart_error;
 use local::LocalConnector;
@@ -77,6 +79,7 @@ pub(crate) fn builtin_storage_connector_registry() -> Result<StorageConnectorReg
     StorageConnectorRegistry::new(vec![
         Arc::new(LocalConnector),
         Arc::new(S3Connector),
+        Arc::new(AlibabaOssConnector),
         Arc::new(SftpConnector),
         Arc::new(AzureBlobConnector),
         Arc::new(TencentCosConnector),

--- a/src/storage/connectors/tests.rs
+++ b/src/storage/connectors/tests.rs
@@ -14,6 +14,7 @@ use aster_drive_storage::connector_descriptor::{
 use aster_drive_storage::{ConnectorConfigEnvelope, ConnectorId, StoragePolicyBehaviorConfig};
 use sea_orm::ActiveModelTrait;
 
+use super::alibaba_oss::AlibabaOssConnectorConfigV1;
 use super::azure_blob::AzureBlobConnectorConfigV1;
 use super::local::LocalConnectorConfigV1;
 use super::onedrive::{OneDriveAccountMode, OneDriveConnectorConfigV1};
@@ -103,6 +104,19 @@ fn s3_config(upload: ObjectStorageUploadStrategy) -> S3ConnectorConfigV1 {
     }
 }
 
+fn oss_config(upload: ObjectStorageUploadStrategy) -> AlibabaOssConnectorConfigV1 {
+    AlibabaOssConnectorConfigV1 {
+        endpoint: "https://oss-cn-hangzhou.aliyuncs.com".to_string(),
+        oss_server_side_endpoint: String::new(),
+        oss_region: "cn-hangzhou".to_string(),
+        bucket: "archive-bucket".to_string(),
+        base_path: "tenant-a".to_string(),
+        oss_use_cname: false,
+        object_storage_upload_strategy: upload,
+        object_storage_download_strategy: ObjectStorageDownloadStrategy::RelayStream,
+    }
+}
+
 fn sftp_config() -> SftpConnectorConfigV1 {
     SftpConnectorConfigV1 {
         endpoint: "sftp://storage.example.test:22".to_string(),
@@ -183,6 +197,7 @@ fn registry_exposes_each_builtin_connector_once_in_stable_order() {
         vec![
             LocalConnector::ID,
             S3Connector::ID,
+            AlibabaOssConnector::ID,
             SftpConnector::ID,
             AzureBlobConnector::ID,
             TencentCosConnector::ID,
@@ -190,7 +205,7 @@ fn registry_exposes_each_builtin_connector_once_in_stable_order() {
             OneDriveConnector::ID,
         ]
     );
-    assert_eq!(actual.iter().copied().collect::<HashSet<_>>().len(), 7);
+    assert_eq!(actual.iter().copied().collect::<HashSet<_>>().len(), 8);
 }
 
 #[test]
@@ -515,6 +530,10 @@ fn descriptors_are_complete_and_keep_config_credentials_separate() {
         ),
         (S3Connector::ID, StorageConnectorBadgeRgb::new(59, 130, 246)),
         (
+            AlibabaOssConnector::ID,
+            StorageConnectorBadgeRgb::new(255, 106, 0),
+        ),
+        (
             OneDriveConnector::ID,
             StorageConnectorBadgeRgb::new(59, 130, 246),
         ),
@@ -544,6 +563,7 @@ fn descriptors_are_complete_and_keep_config_credentials_separate() {
     );
     for id in [
         S3Connector::ID,
+        AlibabaOssConnector::ID,
         SftpConnector::ID,
         AzureBlobConnector::ID,
         TencentCosConnector::ID,
@@ -569,6 +589,7 @@ fn credential_schema_version_is_independent_from_connector_config_schema() {
 fn transfer_strategy_descriptors_keep_upload_and_download_copy_distinct() {
     for connector_id in [
         S3Connector::ID,
+        AlibabaOssConnector::ID,
         AzureBlobConnector::ID,
         TencentCosConnector::ID,
     ] {
@@ -645,6 +666,7 @@ fn object_naming_and_local_default_path_are_connector_owned() {
     for id in [
         LocalConnector::ID,
         S3Connector::ID,
+        AlibabaOssConnector::ID,
         SftpConnector::ID,
         AzureBlobConnector::ID,
         TencentCosConnector::ID,
@@ -742,6 +764,7 @@ fn credential_channels_are_mutually_exclusive_by_connector_contract() {
     }
     for id in [
         S3Connector::ID,
+        AlibabaOssConnector::ID,
         SftpConnector::ID,
         AzureBlobConnector::ID,
         TencentCosConnector::ID,
@@ -807,6 +830,68 @@ fn typed_connector_config_round_trips_and_rejects_unknown_fields() {
     assert!(error.to_string().contains("unknown"));
 }
 
+#[test]
+fn alibaba_oss_connector_validates_endpoint_region_and_cname_contract() {
+    let connector = connector(AlibabaOssConnector::ID);
+    let descriptor = connector.descriptor();
+    for field_name in [
+        "endpoint",
+        "oss_server_side_endpoint",
+        "oss_region",
+        "bucket",
+        "base_path",
+        "oss_use_cname",
+        "object_storage_upload_strategy",
+        "object_storage_download_strategy",
+        "aliyun_oss_access_key_id",
+        "aliyun_oss_access_key_secret",
+    ] {
+        assert!(
+            descriptor
+                .fields
+                .iter()
+                .any(|field| field.name == field_name),
+            "missing OSS descriptor field {field_name}"
+        );
+    }
+    assert!(
+        descriptor
+            .fields
+            .iter()
+            .find(|field| field.name == "aliyun_oss_access_key_secret")
+            .is_some_and(|field| field.secret)
+    );
+
+    let mut config = oss_config(ObjectStorageUploadStrategy::Presigned);
+    config.oss_server_side_endpoint = "https://oss-cn-hangzhou-internal.aliyuncs.com".to_string();
+    connector
+        .validate_connector_config(&super::test_support::connection_config(
+            AlibabaOssConnector::ID,
+            1,
+            config.clone(),
+        ))
+        .expect("valid OSS public/internal endpoint pair");
+
+    config.endpoint = "https://files.example.test".to_string();
+    let error = connector
+        .validate_connector_config(&super::test_support::connection_config(
+            AlibabaOssConnector::ID,
+            1,
+            config.clone(),
+        ))
+        .expect_err("custom domain requires CNAME mode");
+    assert!(error.to_string().contains("CNAME"));
+
+    config.oss_use_cname = true;
+    connector
+        .validate_connector_config(&super::test_support::connection_config(
+            AlibabaOssConnector::ID,
+            1,
+            config,
+        ))
+        .expect("custom domain with CNAME mode");
+}
+
 fn assert_empty_base_path_normalizes<T>(
     connector_id: &'static str,
     config: T,
@@ -833,6 +918,10 @@ fn optional_empty_base_paths_decode_without_weakening_required_fields() {
     let mut s3 = s3_config(ObjectStorageUploadStrategy::RelayStream);
     s3.base_path.clear();
     assert_empty_base_path_normalizes(S3Connector::ID, s3.clone(), "");
+
+    let mut oss = oss_config(ObjectStorageUploadStrategy::RelayStream);
+    oss.base_path.clear();
+    assert_empty_base_path_normalizes(AlibabaOssConnector::ID, oss, "");
 
     let mut sftp = sftp_config();
     sftp.base_path.clear();
@@ -937,6 +1026,14 @@ fn upload_transport_is_resolved_by_connector_owned_typed_config() {
             policy(
                 S3Connector::ID,
                 s3_config(ObjectStorageUploadStrategy::Presigned),
+            ),
+            StorageConnectorUploadTransport::ObjectStorage(ObjectStorageUploadStrategy::Presigned),
+        ),
+        (
+            AlibabaOssConnector::ID,
+            policy(
+                AlibabaOssConnector::ID,
+                oss_config(ObjectStorageUploadStrategy::Presigned),
             ),
             StorageConnectorUploadTransport::ObjectStorage(ObjectStorageUploadStrategy::Presigned),
         ),

--- a/src/storage/drivers/alibaba_oss/mod.rs
+++ b/src/storage/drivers/alibaba_oss/mod.rs
@@ -1,0 +1,461 @@
+//! 阿里云 OSS 存储驱动。
+//!
+//! 对象读写、Range、流式上传和 multipart 编排复用 AWS S3 SDK；请求在 Smithy
+//! 鉴权阶段改写为 OSS V4。后端 I/O 可以走内网 endpoint，而所有浏览器可见的
+//! presigned URL 始终由 public endpoint client 生成。
+
+mod signing;
+#[cfg(test)]
+mod tests;
+
+use std::{sync::Arc, time::Duration};
+
+use aster_drive_storage::traits::driver::{PresignedDownloadOptions, StorageDriver};
+use aster_drive_storage::traits::extensions::{PresignedStorageDriver, StorageDriverExtensions};
+use aster_drive_storage::traits::multipart::{MultipartStorageDriver, UploadedMultipartPart};
+use aster_drive_storage::{Result, StorageCapacityInfo};
+use bytes::Bytes;
+use tokio::io::AsyncRead;
+use url::Url;
+
+use super::s3::{S3Driver, S3DriverConfig, S3DriverOptions, S3StaticCredentials};
+use super::s3_compatible::S3CompatibleDriver;
+use super::s3_config::{S3ConfigError, normalize_s3_endpoint_and_bucket};
+use aster_drive_storage::error::{StorageErrorKind, storage_driver_error};
+
+pub struct AlibabaOssDriver {
+    storage: S3CompatibleDriver,
+    public_driver: Arc<S3Driver>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AlibabaOssDriverConfig {
+    pub endpoint: String,
+    pub server_side_endpoint: String,
+    pub region: String,
+    pub bucket: String,
+    pub base_path: String,
+    pub use_cname: bool,
+    pub connect_timeout: Duration,
+    pub read_timeout: Duration,
+    pub operation_timeout: Duration,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AlibabaOssStaticCredentials {
+    pub access_key: String,
+    pub secret_key: String,
+}
+
+impl AlibabaOssDriver {
+    pub fn validate_connection_config(config: &AlibabaOssDriverConfig) -> Result<()> {
+        let public = normalize_oss_endpoint(
+            &config.endpoint,
+            &config.bucket,
+            config.use_cname,
+            "OSS public endpoint",
+        )?;
+        validate_oss_bucket(&public.bucket)?;
+        validate_oss_region(&config.region)?;
+
+        if !config.server_side_endpoint.trim().is_empty() {
+            normalize_oss_endpoint(
+                &config.server_side_endpoint,
+                &config.bucket,
+                false,
+                "OSS server-side endpoint",
+            )?;
+        }
+        Ok(())
+    }
+
+    pub fn validate_config(
+        config: &AlibabaOssDriverConfig,
+        credentials: &AlibabaOssStaticCredentials,
+    ) -> Result<()> {
+        Self::validate_connection_config(config)?;
+        if credentials.access_key.trim().is_empty() {
+            return Err(storage_driver_error(
+                StorageErrorKind::Auth,
+                "OSS access key ID cannot be empty",
+            ));
+        }
+        if credentials.secret_key.trim().is_empty() {
+            return Err(storage_driver_error(
+                StorageErrorKind::Auth,
+                "OSS access key secret cannot be empty",
+            ));
+        }
+        Ok(())
+    }
+
+    pub fn new(
+        config: AlibabaOssDriverConfig,
+        credentials: AlibabaOssStaticCredentials,
+    ) -> Result<Self> {
+        Self::validate_config(&config, &credentials)?;
+
+        let public_driver = Arc::new(build_oss_s3_driver(
+            &config.endpoint,
+            &config,
+            &credentials,
+            config.use_cname,
+        )?);
+        let backend_driver = if config.server_side_endpoint.trim().is_empty() {
+            public_driver.clone()
+        } else {
+            Arc::new(build_oss_s3_driver(
+                &config.server_side_endpoint,
+                &config,
+                &credentials,
+                false,
+            )?)
+        };
+
+        Ok(Self {
+            storage: S3CompatibleDriver::from_s3_driver(backend_driver),
+            public_driver,
+        })
+    }
+
+    pub fn backend_s3_driver(&self) -> Arc<S3Driver> {
+        self.storage.s3_driver()
+    }
+
+    pub fn public_s3_driver(&self) -> Arc<S3Driver> {
+        self.public_driver.clone()
+    }
+}
+
+fn build_oss_s3_driver(
+    endpoint: &str,
+    config: &AlibabaOssDriverConfig,
+    credentials: &AlibabaOssStaticCredentials,
+    use_cname: bool,
+) -> Result<S3Driver> {
+    let normalized = normalize_oss_endpoint(endpoint, &config.bucket, use_cname, "OSS endpoint")?;
+    let bucket = normalized.bucket.clone();
+    let signer_bucket = normalized.bucket.clone();
+    let region = config.region.trim().to_string();
+    let signer_region = region.clone();
+
+    S3Driver::new(
+        S3DriverConfig {
+            endpoint: normalized.endpoint,
+            bucket,
+            base_path: config.base_path.clone(),
+            region,
+            path_style: use_cname,
+            connect_timeout: config.connect_timeout,
+            read_timeout: config.read_timeout,
+            operation_timeout: config.operation_timeout,
+        },
+        S3StaticCredentials {
+            access_key: credentials.access_key.clone(),
+            secret_key: credentials.secret_key.clone(),
+        },
+        if use_cname {
+            S3DriverOptions::path_style()
+        } else {
+            S3DriverOptions::virtual_hosted_style()
+        },
+        move |builder| {
+            signing::configure_oss_auth(builder, signer_bucket, signer_region, use_cname)
+        },
+    )
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct NormalizedOssEndpoint {
+    endpoint: String,
+    bucket: String,
+}
+
+fn normalize_oss_endpoint(
+    endpoint: &str,
+    bucket: &str,
+    use_cname: bool,
+    label: &str,
+) -> Result<NormalizedOssEndpoint> {
+    let normalized =
+        normalize_s3_endpoint_and_bucket(endpoint, bucket).map_err(rewrap_s3_config_error)?;
+    if normalized.endpoint.is_empty() {
+        return Err(storage_driver_error(
+            StorageErrorKind::Misconfigured,
+            format!("{label} is required"),
+        ));
+    }
+
+    let mut url = Url::parse(&normalized.endpoint).map_err(|error| {
+        storage_driver_error(
+            StorageErrorKind::Misconfigured,
+            format!("invalid {label}: {error}"),
+        )
+    })?;
+    if !url.username().is_empty() || url.password().is_some() {
+        return Err(storage_driver_error(
+            StorageErrorKind::Misconfigured,
+            format!("{label} must not contain credentials"),
+        ));
+    }
+    if url.query().is_some() || url.fragment().is_some() {
+        return Err(storage_driver_error(
+            StorageErrorKind::Misconfigured,
+            format!("{label} must not contain query or fragment components"),
+        ));
+    }
+    if url.path() != "/" && !url.path().is_empty() {
+        return Err(storage_driver_error(
+            StorageErrorKind::Misconfigured,
+            format!("{label} must not contain a path"),
+        ));
+    }
+
+    let host = url
+        .host_str()
+        .ok_or_else(|| {
+            storage_driver_error(
+                StorageErrorKind::Misconfigured,
+                format!("{label} must contain a hostname"),
+            )
+        })?
+        .to_string();
+    let is_aliyun_host = host == "aliyuncs.com" || host.ends_with(".aliyuncs.com");
+    if use_cname == is_aliyun_host {
+        let message = if use_cname {
+            "OSS CNAME mode requires a custom-domain endpoint"
+        } else {
+            "OSS endpoint must use an aliyuncs.com host unless CNAME mode is enabled"
+        };
+        return Err(storage_driver_error(
+            StorageErrorKind::Misconfigured,
+            message,
+        ));
+    }
+
+    if !use_cname {
+        let bucket_prefix = format!("{}.", normalized.bucket);
+        if let Some(root_host) = host.strip_prefix(&bucket_prefix) {
+            url.set_host(Some(root_host)).map_err(|_| {
+                storage_driver_error(
+                    StorageErrorKind::Misconfigured,
+                    format!("invalid {label} hostname"),
+                )
+            })?;
+        }
+    }
+    url.set_path("");
+    url.set_query(None);
+    url.set_fragment(None);
+
+    Ok(NormalizedOssEndpoint {
+        endpoint: String::from(url).trim_end_matches('/').to_string(),
+        bucket: normalized.bucket,
+    })
+}
+
+fn validate_oss_bucket(bucket: &str) -> Result<()> {
+    let bytes = bucket.as_bytes();
+    let valid = (3..=63).contains(&bytes.len())
+        && bytes.first().is_some_and(u8::is_ascii_alphanumeric)
+        && bytes.last().is_some_and(u8::is_ascii_alphanumeric)
+        && bytes
+            .iter()
+            .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || *byte == b'-');
+    if valid {
+        Ok(())
+    } else {
+        Err(storage_driver_error(
+            StorageErrorKind::Misconfigured,
+            "OSS bucket must be 3-63 lowercase letters, digits, or hyphens and start/end with a letter or digit",
+        ))
+    }
+}
+
+fn validate_oss_region(region: &str) -> Result<()> {
+    let region = region.trim();
+    if region.is_empty() {
+        return Err(storage_driver_error(
+            StorageErrorKind::Misconfigured,
+            "OSS region is required",
+        ));
+    }
+    if region.len() > 128
+        || !region
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || byte == b'-')
+    {
+        return Err(storage_driver_error(
+            StorageErrorKind::Misconfigured,
+            "OSS region contains invalid characters",
+        ));
+    }
+    Ok(())
+}
+
+fn rewrap_s3_config_error(error: S3ConfigError) -> aster_drive_storage::StorageError {
+    let message = match error {
+        S3ConfigError::MissingBucket => "OSS bucket is required".to_string(),
+        S3ConfigError::InvalidEndpoint(message) => message.replace("S3 endpoint", "OSS endpoint"),
+    };
+    storage_driver_error(StorageErrorKind::Misconfigured, message)
+}
+
+#[async_trait::async_trait]
+impl StorageDriver for AlibabaOssDriver {
+    async fn put(&self, path: &str, data: &[u8]) -> Result<String> {
+        self.storage.put(path, data).await
+    }
+
+    async fn get(&self, path: &str) -> Result<Vec<u8>> {
+        self.storage.get(path).await
+    }
+
+    async fn get_stream(&self, path: &str) -> Result<Box<dyn AsyncRead + Unpin + Send>> {
+        self.storage.get_stream(path).await
+    }
+
+    async fn get_range(
+        &self,
+        path: &str,
+        offset: u64,
+        length: Option<u64>,
+    ) -> Result<Box<dyn AsyncRead + Unpin + Send>> {
+        self.storage.get_range(path, offset, length).await
+    }
+
+    fn supports_efficient_range(&self) -> bool {
+        self.storage.supports_efficient_range()
+    }
+
+    async fn delete(&self, path: &str) -> Result<()> {
+        self.storage.delete(path).await
+    }
+
+    async fn exists(&self, path: &str) -> Result<bool> {
+        self.storage.exists(path).await
+    }
+
+    async fn metadata(&self, path: &str) -> Result<aster_drive_storage::BlobMetadata> {
+        self.storage.metadata(path).await
+    }
+
+    async fn readiness_check(&self) -> Result<()> {
+        self.storage.readiness_check().await
+    }
+
+    async fn copy_object(&self, src_path: &str, dest_path: &str) -> Result<String> {
+        self.storage.copy_object(src_path, dest_path).await
+    }
+
+    fn extensions(&self) -> StorageDriverExtensions<'_> {
+        StorageDriverExtensions {
+            presigned: Some(self),
+            multipart: Some(self),
+            ..self.storage.extensions()
+        }
+    }
+
+    async fn capacity_info(&self) -> Result<StorageCapacityInfo> {
+        self.storage.capacity_info().await
+    }
+}
+
+#[async_trait::async_trait]
+impl PresignedStorageDriver for AlibabaOssDriver {
+    async fn presigned_url(
+        &self,
+        path: &str,
+        expires: Duration,
+        options: PresignedDownloadOptions,
+    ) -> Result<Option<String>> {
+        self.public_driver
+            .presigned_url(path, expires, options)
+            .await
+    }
+
+    async fn presigned_put_url(&self, path: &str, expires: Duration) -> Result<Option<String>> {
+        self.public_driver.presigned_put_url(path, expires).await
+    }
+}
+
+#[async_trait::async_trait]
+impl MultipartStorageDriver for AlibabaOssDriver {
+    async fn create_multipart_upload(&self, path: &str) -> Result<String> {
+        self.storage.create_multipart_upload(path).await
+    }
+
+    async fn presigned_upload_part_url(
+        &self,
+        path: &str,
+        upload_id: &str,
+        part_number: i32,
+        expires: Duration,
+    ) -> Result<String> {
+        self.public_driver
+            .presigned_upload_part_url(path, upload_id, part_number, expires)
+            .await
+    }
+
+    async fn complete_multipart_upload(
+        &self,
+        path: &str,
+        upload_id: &str,
+        parts: Vec<(i32, String)>,
+    ) -> Result<()> {
+        self.storage
+            .complete_multipart_upload(path, upload_id, parts)
+            .await
+    }
+
+    async fn upload_multipart_part(
+        &self,
+        path: &str,
+        upload_id: &str,
+        part_number: i32,
+        data: &[u8],
+    ) -> Result<String> {
+        self.storage
+            .upload_multipart_part(path, upload_id, part_number, data)
+            .await
+    }
+
+    async fn upload_multipart_part_bytes(
+        &self,
+        path: &str,
+        upload_id: &str,
+        part_number: i32,
+        data: Bytes,
+    ) -> Result<String> {
+        self.storage
+            .upload_multipart_part_bytes(path, upload_id, part_number, data)
+            .await
+    }
+
+    async fn upload_multipart_part_reader(
+        &self,
+        path: &str,
+        upload_id: &str,
+        part_number: i32,
+        reader: Box<dyn AsyncRead + Unpin + Send + Sync>,
+        size: i64,
+    ) -> Result<String> {
+        self.storage
+            .upload_multipart_part_reader(path, upload_id, part_number, reader, size)
+            .await
+    }
+
+    async fn abort_multipart_upload(&self, path: &str, upload_id: &str) -> Result<()> {
+        self.storage.abort_multipart_upload(path, upload_id).await
+    }
+
+    async fn list_uploaded_part_details(
+        &self,
+        path: &str,
+        upload_id: &str,
+    ) -> Result<Vec<UploadedMultipartPart>> {
+        self.storage
+            .list_uploaded_part_details(path, upload_id)
+            .await
+    }
+}

--- a/src/storage/drivers/alibaba_oss/signing.rs
+++ b/src/storage/drivers/alibaba_oss/signing.rs
@@ -1,0 +1,750 @@
+use std::collections::BTreeMap;
+use std::time::{Duration, UNIX_EPOCH};
+
+use aws_credential_types::Credentials;
+use aws_runtime::auth::{HttpSignatureType, SigV4OperationSigningConfig};
+use aws_smithy_runtime_api::box_error::BoxError;
+use aws_smithy_runtime_api::client::auth::{
+    AuthScheme, AuthSchemeEndpointConfig, AuthSchemeId, Sign,
+};
+use aws_smithy_runtime_api::client::identity::{Identity, SharedIdentityResolver};
+use aws_smithy_runtime_api::client::orchestrator::HttpRequest;
+use aws_smithy_runtime_api::client::runtime_components::{GetIdentityResolver, RuntimeComponents};
+use aws_smithy_types::config_bag::ConfigBag;
+use chrono::{DateTime, Utc};
+use hmac::{Hmac, KeyInit, Mac};
+use percent_encoding::percent_decode_str;
+use sha2::{Digest, Sha256};
+use url::Url;
+
+type HmacSha256 = Hmac<Sha256>;
+
+const OSS_AUTH_SCHEME_ID: AuthSchemeId = aws_runtime::auth::sigv4::SCHEME_ID;
+const OSS_SIGN_ALGORITHM: &str = "OSS4-HMAC-SHA256";
+const OSS_PRODUCT: &str = "oss";
+const OSS_TERMINATOR: &str = "aliyun_v4_request";
+const OSS_UNSIGNED_PAYLOAD: &str = "UNSIGNED-PAYLOAD";
+const DEFAULT_OSS_AUTH_TTL: Duration = Duration::from_secs(60 * 60);
+
+const OSS_HEADER_RENAMES: &[(&str, &str)] = &[
+    ("x-amz-copy-source", "x-oss-copy-source"),
+    ("x-amz-copy-source-range", "x-oss-copy-source-range"),
+    ("x-amz-copy-source-if-match", "x-oss-copy-source-if-match"),
+    (
+        "x-amz-copy-source-if-none-match",
+        "x-oss-copy-source-if-none-match",
+    ),
+    (
+        "x-amz-copy-source-if-modified-since",
+        "x-oss-copy-source-if-modified-since",
+    ),
+    (
+        "x-amz-copy-source-if-unmodified-since",
+        "x-oss-copy-source-if-unmodified-since",
+    ),
+    ("x-amz-metadata-directive", "x-oss-metadata-directive"),
+    ("x-amz-tagging-directive", "x-oss-tagging-directive"),
+    ("x-amz-storage-class", "x-oss-storage-class"),
+    ("x-amz-acl", "x-oss-object-acl"),
+    (
+        "x-amz-server-side-encryption",
+        "x-oss-server-side-encryption",
+    ),
+];
+
+pub(super) fn configure_oss_auth(
+    builder: aws_sdk_s3::config::Builder,
+    bucket: String,
+    region: String,
+    use_cname: bool,
+) -> aws_sdk_s3::config::Builder {
+    builder
+        .request_checksum_calculation(aws_sdk_s3::config::RequestChecksumCalculation::WhenRequired)
+        .response_checksum_validation(aws_sdk_s3::config::ResponseChecksumValidation::WhenRequired)
+        .push_auth_scheme(OssAuthScheme::new(bucket, region, use_cname))
+}
+
+#[derive(Debug)]
+struct OssAuthScheme {
+    signer: OssSigner,
+}
+
+impl OssAuthScheme {
+    fn new(bucket: String, region: String, use_cname: bool) -> Self {
+        Self {
+            signer: OssSigner {
+                bucket,
+                region,
+                use_cname,
+            },
+        }
+    }
+}
+
+impl AuthScheme for OssAuthScheme {
+    fn scheme_id(&self) -> AuthSchemeId {
+        OSS_AUTH_SCHEME_ID
+    }
+
+    fn identity_resolver(
+        &self,
+        identity_resolvers: &dyn GetIdentityResolver,
+    ) -> Option<SharedIdentityResolver> {
+        identity_resolvers.identity_resolver(self.scheme_id())
+    }
+
+    fn signer(&self) -> &dyn Sign {
+        &self.signer
+    }
+}
+
+#[derive(Debug)]
+struct OssSigner {
+    bucket: String,
+    region: String,
+    use_cname: bool,
+}
+
+impl Sign for OssSigner {
+    fn sign_http_request(
+        &self,
+        request: &mut HttpRequest,
+        identity: &Identity,
+        _auth_scheme_endpoint_config: AuthSchemeEndpointConfig<'_>,
+        runtime_components: &RuntimeComponents,
+        config_bag: &ConfigBag,
+    ) -> std::result::Result<(), BoxError> {
+        let credentials = identity
+            .data::<Credentials>()
+            .ok_or("OSS signer requires AWS credential identity")?;
+        let key = normalize_aws_request_for_oss(request, &self.bucket, self.use_cname)?;
+
+        let operation_config = config_bag.load::<SigV4OperationSigningConfig>();
+        let signature_type = operation_config
+            .map(|config| config.signing_options.signature_type)
+            .unwrap_or(HttpSignatureType::HttpRequestHeaders);
+        let expires = operation_config
+            .and_then(|config| config.signing_options.expires_in)
+            .unwrap_or(DEFAULT_OSS_AUTH_TTL);
+        let now = runtime_components.time_source().unwrap_or_default().now();
+        let now = now.duration_since(UNIX_EPOCH)?;
+        let now =
+            DateTime::<Utc>::from_timestamp(i64::try_from(now.as_secs())?, now.subsec_nanos())
+                .ok_or("OSS signing time is outside chrono range")?;
+
+        match signature_type {
+            HttpSignatureType::HttpRequestQueryParams => {
+                self.sign_query(request, credentials, &key, now, expires)?
+            }
+            HttpSignatureType::HttpRequestHeaders => {
+                self.sign_headers(request, credentials, &key, now)?
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl OssSigner {
+    fn sign_headers(
+        &self,
+        request: &mut HttpRequest,
+        credentials: &Credentials,
+        key: &str,
+        now: DateTime<Utc>,
+    ) -> std::result::Result<(), BoxError> {
+        let datetime = now.format("%Y%m%dT%H%M%SZ").to_string();
+        request.headers_mut().insert("x-oss-date", datetime.clone());
+        request
+            .headers_mut()
+            .insert("x-oss-content-sha256", OSS_UNSIGNED_PAYLOAD.to_string());
+        if let Some(token) = credentials.session_token() {
+            request
+                .headers_mut()
+                .insert("x-oss-security-token", token.to_string());
+        }
+
+        let date = now.format("%Y%m%d").to_string();
+        let scope = credential_scope(&date, &self.region);
+        let url = Url::parse(request.uri())?;
+        let canonical_request = canonical_request(
+            request.method(),
+            &self.bucket,
+            key,
+            url.query().unwrap_or_default(),
+            &collect_signed_headers(request),
+        );
+        let string_to_sign = string_to_sign(&datetime, &scope, &canonical_request);
+        let signature = signature(
+            credentials.secret_access_key(),
+            &date,
+            &self.region,
+            &string_to_sign,
+        )?;
+        request.headers_mut().insert(
+            "authorization",
+            format!(
+                "{OSS_SIGN_ALGORITHM} Credential={}/{scope},Signature={signature}",
+                credentials.access_key_id()
+            ),
+        );
+        Ok(())
+    }
+
+    fn sign_query(
+        &self,
+        request: &mut HttpRequest,
+        credentials: &Credentials,
+        key: &str,
+        now: DateTime<Utc>,
+        expires: Duration,
+    ) -> std::result::Result<(), BoxError> {
+        let datetime = now.format("%Y%m%dT%H%M%SZ").to_string();
+        let date = now.format("%Y%m%d").to_string();
+        let scope = credential_scope(&date, &self.region);
+        let mut url = Url::parse(request.uri())?;
+        {
+            let mut query = url.query_pairs_mut();
+            if let Some(token) = credentials.session_token() {
+                query.append_pair("x-oss-security-token", token);
+            }
+            query.append_pair("x-oss-signature-version", OSS_SIGN_ALGORITHM);
+            query.append_pair("x-oss-date", &datetime);
+            query.append_pair("x-oss-expires", &expires.as_secs().to_string());
+            query.append_pair(
+                "x-oss-credential",
+                &format!("{}/{scope}", credentials.access_key_id()),
+            );
+        }
+
+        let canonical_request = canonical_request(
+            request.method(),
+            &self.bucket,
+            key,
+            url.query().unwrap_or_default(),
+            &collect_signed_headers(request),
+        );
+        let string_to_sign = string_to_sign(&datetime, &scope, &canonical_request);
+        let signature = signature(
+            credentials.secret_access_key(),
+            &date,
+            &self.region,
+            &string_to_sign,
+        )?;
+        url.query_pairs_mut()
+            .append_pair("x-oss-signature", &signature);
+        request.set_uri(url.as_str())?;
+        Ok(())
+    }
+}
+
+fn normalize_aws_request_for_oss(
+    request: &mut HttpRequest,
+    bucket: &str,
+    use_cname: bool,
+) -> std::result::Result<String, BoxError> {
+    let metadata_headers = request
+        .headers()
+        .iter()
+        .filter_map(|(name, value)| {
+            name.strip_prefix("x-amz-meta-").map(|suffix| {
+                (
+                    name.to_string(),
+                    format!("x-oss-meta-{suffix}"),
+                    value.to_string(),
+                )
+            })
+        })
+        .collect::<Vec<_>>();
+    for (aws_name, oss_name, value) in metadata_headers {
+        request.headers_mut().remove(&aws_name);
+        request.headers_mut().insert(oss_name, value);
+    }
+
+    let mut key = None;
+    crate::storage::drivers::s3_vendor::normalize_aws_s3_vendor_request(
+        request,
+        OSS_HEADER_RENAMES,
+        |url| {
+            let decoded_path = percent_decode_str(url.path()).decode_utf8()?;
+            let decoded_path = decoded_path.trim_start_matches('/');
+            let object_key = if use_cname {
+                let prefix = format!("{bucket}/");
+                decoded_path
+                    .strip_prefix(&prefix)
+                    .ok_or("OSS CNAME request path is missing the bucket prefix")?
+                    .to_string()
+            } else {
+                decoded_path.to_string()
+            };
+            if use_cname {
+                url.set_path(&format!("/{object_key}"));
+            }
+            key = Some(object_key);
+            Ok(())
+        },
+    )?;
+
+    let aws_headers = request
+        .headers()
+        .iter()
+        .filter(|(name, _)| name.starts_with("x-amz-") || name.starts_with("amz-sdk-"))
+        .map(|(name, _)| name.to_string())
+        .collect::<Vec<_>>();
+    for name in aws_headers {
+        request.headers_mut().remove(&name);
+    }
+
+    if let Some(copy_source) = request.headers_mut().remove("x-oss-copy-source") {
+        let copy_source = if copy_source.starts_with('/') {
+            copy_source
+        } else {
+            format!("/{copy_source}")
+        };
+        request
+            .headers_mut()
+            .insert("x-oss-copy-source", copy_source);
+    }
+
+    key.ok_or_else(|| "OSS request path normalization did not produce an object key".into())
+}
+
+fn collect_signed_headers(request: &HttpRequest) -> BTreeMap<String, Vec<String>> {
+    let mut headers = BTreeMap::<String, Vec<String>>::new();
+    for (name, value) in request.headers() {
+        let name = name.to_ascii_lowercase();
+        if is_default_signed_header(&name) {
+            headers
+                .entry(name)
+                .or_default()
+                .push(value.trim().to_string());
+        }
+    }
+    headers
+}
+
+fn is_default_signed_header(name: &str) -> bool {
+    name.starts_with("x-oss-") || name == "content-type" || name == "content-md5"
+}
+
+fn canonical_request(
+    method: &str,
+    bucket: &str,
+    key: &str,
+    raw_query: &str,
+    headers: &BTreeMap<String, Vec<String>>,
+) -> String {
+    let canonical_headers = headers
+        .iter()
+        .map(|(name, values)| format!("{name}:{}\n", values.join(",")))
+        .collect::<String>();
+    let payload_hash = headers
+        .get("x-oss-content-sha256")
+        .and_then(|values| values.first())
+        .map(String::as_str)
+        .unwrap_or(OSS_UNSIGNED_PAYLOAD);
+    format!(
+        "{method}\n{}\n{}\n{canonical_headers}\n\n{payload_hash}",
+        canonical_uri(bucket, key),
+        canonical_query(raw_query),
+    )
+}
+
+fn canonical_uri(bucket: &str, key: &str) -> String {
+    oss_percent_encode(&format!("/{bucket}/{key}"), false)
+}
+
+fn canonical_query(raw_query: &str) -> String {
+    let raw_query = raw_query.replace('+', "%20");
+    let mut values = BTreeMap::<String, String>::new();
+    let mut names = Vec::<String>::new();
+    for component in raw_query
+        .split('&')
+        .filter(|component| !component.is_empty())
+    {
+        let (name, value) = component.split_once('=').unwrap_or((component, ""));
+        values.insert(name.to_string(), value.to_string());
+        names.push(name.to_string());
+    }
+    names.sort();
+    names
+        .into_iter()
+        .map(|name| match values.get(&name) {
+            Some(value) if !value.is_empty() => format!("{name}={value}"),
+            _ => name,
+        })
+        .collect::<Vec<_>>()
+        .join("&")
+}
+
+fn oss_percent_encode(value: &str, encode_slash: bool) -> String {
+    const HEX: &[u8; 16] = b"0123456789ABCDEF";
+
+    let mut encoded = String::with_capacity(value.len());
+    for byte in value.bytes() {
+        if byte.is_ascii_alphanumeric()
+            || matches!(byte, b'-' | b'.' | b'_' | b'~')
+            || (!encode_slash && byte == b'/')
+        {
+            encoded.push(char::from(byte));
+        } else {
+            encoded.push('%');
+            encoded.push(char::from(HEX[usize::from(byte >> 4)]));
+            encoded.push(char::from(HEX[usize::from(byte & 0x0f)]));
+        }
+    }
+    encoded
+}
+
+fn credential_scope(date: &str, region: &str) -> String {
+    format!("{date}/{region}/{OSS_PRODUCT}/{OSS_TERMINATOR}")
+}
+
+fn string_to_sign(datetime: &str, scope: &str, canonical_request: &str) -> String {
+    format!(
+        "{OSS_SIGN_ALGORITHM}\n{datetime}\n{scope}\n{}",
+        sha256_hex(canonical_request.as_bytes())
+    )
+}
+
+fn signature(
+    secret_key: &str,
+    date: &str,
+    region: &str,
+    string_to_sign: &str,
+) -> std::result::Result<String, BoxError> {
+    let date_key = hmac_sha256(format!("aliyun_v4{secret_key}").as_bytes(), date.as_bytes())?;
+    let region_key = hmac_sha256(&date_key, region.as_bytes())?;
+    let product_key = hmac_sha256(&region_key, OSS_PRODUCT.as_bytes())?;
+    let signing_key = hmac_sha256(&product_key, OSS_TERMINATOR.as_bytes())?;
+    Ok(hex::encode(hmac_sha256(
+        &signing_key,
+        string_to_sign.as_bytes(),
+    )?))
+}
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    hex::encode(hasher.finalize())
+}
+
+fn hmac_sha256(key: &[u8], message: &[u8]) -> std::result::Result<Vec<u8>, BoxError> {
+    let mut mac = HmacSha256::new_from_slice(key)?;
+    mac.update(message);
+    Ok(mac.finalize().into_bytes().to_vec())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aws_sdk_s3::config::{BehaviorVersion, Credentials, Region};
+    use aws_sdk_s3::presigning::PresigningConfig;
+    use aws_smithy_http_client::test_util::{CaptureRequestReceiver, capture_request};
+    use aws_smithy_types::body::SdkBody;
+
+    fn oss_sdk_client(
+        endpoint: &str,
+        bucket: &str,
+        use_cname: bool,
+        response: Option<http::Response<SdkBody>>,
+    ) -> (aws_sdk_s3::Client, CaptureRequestReceiver) {
+        let (http_client, receiver) = capture_request(response);
+        let builder = aws_sdk_s3::Config::builder()
+            .behavior_version(BehaviorVersion::latest())
+            .http_client(http_client)
+            .credentials_provider(Credentials::new("ak", "sk", None, None, "oss-auth-test"))
+            .region(Region::new("cn-hangzhou"))
+            .endpoint_url(endpoint)
+            .force_path_style(use_cname);
+        let config = configure_oss_auth(
+            builder,
+            bucket.to_string(),
+            "cn-hangzhou".to_string(),
+            use_cname,
+        )
+        .build();
+        (aws_sdk_s3::Client::from_conf(config), receiver)
+    }
+
+    fn empty_success_response() -> http::Response<SdkBody> {
+        http::Response::builder()
+            .status(200)
+            .body(SdkBody::empty())
+            .expect("mock OSS response")
+    }
+
+    fn empty_list_response() -> http::Response<SdkBody> {
+        http::Response::builder()
+            .status(200)
+            .header("content-type", "application/xml")
+            .body(SdkBody::from(
+                r#"<?xml version="1.0" encoding="UTF-8"?>
+                <ListBucketResult>
+                    <IsTruncated>false</IsTruncated>
+                </ListBucketResult>"#,
+            ))
+            .expect("mock OSS list response")
+    }
+
+    #[test]
+    fn header_signature_matches_official_go_sdk_vector() {
+        let headers = BTreeMap::from([
+            ("content-type".to_string(), vec!["text/plain".to_string()]),
+            (
+                "x-oss-content-sha256".to_string(),
+                vec![OSS_UNSIGNED_PAYLOAD.to_string()],
+            ),
+            (
+                "x-oss-date".to_string(),
+                vec!["20231216T162057Z".to_string()],
+            ),
+            ("x-oss-head1".to_string(), vec!["value".to_string()]),
+        ]);
+        let canonical = canonical_request(
+            "PUT",
+            "bucket",
+            "1234+-/123/1.txt",
+            "%2Bparam1=value3&%2Bparam2=&%7Cparam1=value4&%7Cparam2=&param1=value1&param2=",
+            &headers,
+        );
+        let scope = credential_scope("20231216", "cn-hangzhou");
+        let string_to_sign = string_to_sign("20231216T162057Z", &scope, &canonical);
+        let signature =
+            signature("sk", "20231216", "cn-hangzhou", &string_to_sign).expect("OSS signature");
+
+        assert_eq!(
+            signature,
+            "e21d18daa82167720f9b1047ae7e7f1ce7cb77a31e8203a7d5f4624fa0284afe"
+        );
+    }
+
+    #[test]
+    fn canonical_uri_includes_bucket_and_encodes_key_once() {
+        assert_eq!(
+            canonical_uri("bucket", "目录/a b+%2F.txt"),
+            "/bucket/%E7%9B%AE%E5%BD%95/a%20b%2B%252F.txt"
+        );
+    }
+
+    #[tokio::test]
+    async fn aws_sdk_normal_request_uses_oss_v4_headers() {
+        let (client, receiver) = oss_sdk_client(
+            "https://oss-cn-hangzhou.aliyuncs.com",
+            "bucket",
+            false,
+            Some(empty_success_response()),
+        );
+
+        client
+            .get_object()
+            .bucket("bucket")
+            .key("docs/report.txt")
+            .range("bytes=0-9")
+            .send()
+            .await
+            .expect("mock OSS GET should deserialize");
+
+        let request = receiver.expect_request();
+        let request_url = Url::parse(request.uri()).expect("captured OSS URL");
+        assert_eq!(
+            request_url.host_str(),
+            Some("bucket.oss-cn-hangzhou.aliyuncs.com")
+        );
+        let authorization = request
+            .headers()
+            .get("authorization")
+            .expect("OSS Authorization header");
+        assert!(authorization.starts_with("OSS4-HMAC-SHA256 Credential=ak/"));
+        assert!(authorization.contains("/cn-hangzhou/oss/aliyun_v4_request,Signature="));
+        assert_eq!(
+            request.headers().get("x-oss-content-sha256"),
+            Some(OSS_UNSIGNED_PAYLOAD)
+        );
+        assert!(request.headers().get("x-oss-date").is_some());
+        assert!(!request.uri().to_string().contains("x-id="));
+        let aws_protocol_headers = request
+            .headers()
+            .iter()
+            // The SDK adds its telemetry header after signing. It is not part
+            // of the OSS canonical request; AWS protocol/signature headers
+            // must already have been removed by the OSS signer.
+            .filter(|(name, _)| name.starts_with("x-amz-") && *name != "x-amz-user-agent")
+            .collect::<Vec<_>>();
+        assert!(
+            aws_protocol_headers.is_empty(),
+            "unexpected AWS protocol headers: {aws_protocol_headers:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn aws_sdk_presigned_request_uses_oss_v4_query() {
+        let (client, _receiver) = oss_sdk_client(
+            "https://oss-cn-hangzhou.aliyuncs.com",
+            "bucket",
+            false,
+            None,
+        );
+        let presigned = client
+            .put_object()
+            .bucket("bucket")
+            .key("docs/report 1.txt")
+            .presigned(
+                PresigningConfig::builder()
+                    .expires_in(Duration::from_secs(599))
+                    .build()
+                    .expect("presign config"),
+            )
+            .await
+            .expect("OSS presigned PUT");
+        let url = Url::parse(presigned.uri()).expect("presigned URL");
+
+        assert_eq!(url.host_str(), Some("bucket.oss-cn-hangzhou.aliyuncs.com"));
+        assert_eq!(url.path(), "/docs/report%201.txt");
+        assert_eq!(
+            url.query_pairs()
+                .find(|(name, _)| name == "x-oss-signature-version")
+                .map(|(_, value)| value.into_owned()),
+            Some(OSS_SIGN_ALGORITHM.to_string())
+        );
+        assert_eq!(
+            url.query_pairs()
+                .find(|(name, _)| name == "x-oss-expires")
+                .map(|(_, value)| value.into_owned()),
+            Some("599".to_string())
+        );
+        assert!(url.query_pairs().any(|(name, _)| name == "x-oss-signature"));
+        assert!(
+            !url.query_pairs()
+                .any(|(name, _)| name.starts_with("X-Amz-"))
+        );
+    }
+
+    #[tokio::test]
+    async fn aws_sdk_presigned_upload_part_keeps_multipart_query() {
+        let (client, receiver) = oss_sdk_client(
+            "https://oss-cn-hangzhou.aliyuncs.com",
+            "bucket",
+            false,
+            None,
+        );
+        let presigned = client
+            .upload_part()
+            .bucket("bucket")
+            .key("video.bin")
+            .upload_id("upload-id")
+            .part_number(7)
+            .presigned(
+                PresigningConfig::builder()
+                    .expires_in(Duration::from_secs(300))
+                    .build()
+                    .expect("presign config"),
+            )
+            .await
+            .expect("OSS presigned upload part");
+
+        receiver.expect_no_request();
+        let url = Url::parse(presigned.uri()).expect("OSS presigned part URL");
+        let query = url
+            .query_pairs()
+            .collect::<std::collections::HashMap<_, _>>();
+        assert_eq!(query.get("partNumber").map(AsRef::as_ref), Some("7"));
+        assert_eq!(query.get("uploadId").map(AsRef::as_ref), Some("upload-id"));
+        assert_eq!(
+            query.get("x-oss-signature-version").map(AsRef::as_ref),
+            Some(OSS_SIGN_ALGORITHM)
+        );
+        assert!(query.contains_key("x-oss-signature"));
+        assert!(!query.keys().any(|name| name.starts_with("X-Amz-")));
+    }
+
+    #[tokio::test]
+    async fn cname_request_removes_bucket_from_wire_path_but_signs_it() {
+        let (client, receiver) = oss_sdk_client(
+            "https://files.example.test",
+            "bucket",
+            true,
+            Some(empty_success_response()),
+        );
+
+        client
+            .head_object()
+            .bucket("bucket")
+            .key("docs/report.txt")
+            .send()
+            .await
+            .expect("mock OSS CNAME HEAD should deserialize");
+
+        let request = receiver.expect_request();
+        let request_url = Url::parse(request.uri()).expect("captured OSS CNAME URL");
+        assert_eq!(request_url.path(), "/docs/report.txt");
+        assert_eq!(request_url.host_str(), Some("files.example.test"));
+        assert!(
+            request
+                .headers()
+                .get("authorization")
+                .is_some_and(|value| value.starts_with(OSS_SIGN_ALGORITHM))
+        );
+    }
+
+    #[tokio::test]
+    async fn cname_bucket_root_request_uses_root_wire_path() {
+        let (client, receiver) = oss_sdk_client(
+            "https://files.example.test",
+            "bucket",
+            true,
+            Some(empty_list_response()),
+        );
+
+        client
+            .list_objects_v2()
+            .bucket("bucket")
+            .send()
+            .await
+            .expect("mock OSS CNAME list should deserialize");
+
+        let request = receiver.expect_request();
+        let request_url = Url::parse(request.uri()).expect("captured OSS CNAME list URL");
+        assert_eq!(request_url.path(), "/");
+        assert_eq!(request_url.host_str(), Some("files.example.test"));
+        assert_eq!(
+            request_url
+                .query_pairs()
+                .find(|(name, _)| name == "list-type")
+                .map(|(_, value)| value.into_owned()),
+            Some("2".to_string())
+        );
+        assert!(
+            request
+                .headers()
+                .get("authorization")
+                .is_some_and(|value| value.starts_with(OSS_SIGN_ALGORITHM))
+        );
+    }
+
+    #[tokio::test]
+    async fn copy_object_translates_copy_source_header() {
+        let (client, receiver) = oss_sdk_client(
+            "https://oss-cn-hangzhou.aliyuncs.com",
+            "bucket",
+            false,
+            Some(empty_success_response()),
+        );
+
+        client
+            .copy_object()
+            .bucket("bucket")
+            .key("dest.txt")
+            .copy_source("bucket/source.txt")
+            .send()
+            .await
+            .expect("mock OSS copy should deserialize");
+
+        let request = receiver.expect_request();
+        assert_eq!(
+            request.headers().get("x-oss-copy-source"),
+            Some("/bucket/source.txt")
+        );
+        assert!(request.headers().get("x-amz-copy-source").is_none());
+    }
+}

--- a/src/storage/drivers/alibaba_oss/tests.rs
+++ b/src/storage/drivers/alibaba_oss/tests.rs
@@ -1,0 +1,153 @@
+use std::time::Duration;
+
+use aster_drive_storage::StorageDriver;
+
+use super::*;
+
+fn sample_config() -> AlibabaOssDriverConfig {
+    AlibabaOssDriverConfig {
+        endpoint: "https://oss-cn-hangzhou.aliyuncs.com".to_string(),
+        server_side_endpoint: String::new(),
+        region: "cn-hangzhou".to_string(),
+        bucket: "asterdrive-test".to_string(),
+        base_path: "tenant/prefix".to_string(),
+        use_cname: false,
+        connect_timeout: Duration::from_secs(5),
+        read_timeout: Duration::from_secs(30),
+        operation_timeout: Duration::from_secs(3_600),
+    }
+}
+
+fn sample_credentials() -> AlibabaOssStaticCredentials {
+    AlibabaOssStaticCredentials {
+        access_key: "ak".to_string(),
+        secret_key: "sk".to_string(),
+    }
+}
+
+#[test]
+fn validate_config_accepts_public_oss_endpoint() {
+    AlibabaOssDriver::validate_config(&sample_config(), &sample_credentials())
+        .expect("valid OSS config");
+}
+
+#[test]
+fn validate_config_accepts_bucket_qualified_endpoint() {
+    let mut config = sample_config();
+    config.endpoint = "https://asterdrive-test.oss-cn-hangzhou.aliyuncs.com".to_string();
+
+    AlibabaOssDriver::validate_config(&config, &sample_credentials())
+        .expect("bucket-qualified OSS endpoint");
+}
+
+#[test]
+fn validate_config_accepts_custom_domain_only_in_cname_mode() {
+    let mut config = sample_config();
+    config.endpoint = "https://files.example.test".to_string();
+    let err = AlibabaOssDriver::validate_config(&config, &sample_credentials())
+        .expect_err("custom domain without CNAME mode should fail");
+    assert_eq!(err.kind(), StorageErrorKind::Misconfigured);
+    assert!(err.message().contains("CNAME"));
+
+    config.use_cname = true;
+    AlibabaOssDriver::validate_config(&config, &sample_credentials())
+        .expect("custom domain in CNAME mode");
+}
+
+#[test]
+fn validate_config_rejects_oss_host_in_cname_mode() {
+    let mut config = sample_config();
+    config.use_cname = true;
+
+    let err = AlibabaOssDriver::validate_config(&config, &sample_credentials())
+        .expect_err("provider endpoint is not a CNAME domain");
+    assert_eq!(err.kind(), StorageErrorKind::Misconfigured);
+    assert!(err.message().contains("custom-domain"));
+}
+
+#[test]
+fn validate_config_checks_server_side_endpoint_as_provider_endpoint() {
+    let mut config = sample_config();
+    config.server_side_endpoint = "https://oss-cn-hangzhou-internal.aliyuncs.com".to_string();
+    AlibabaOssDriver::validate_config(&config, &sample_credentials())
+        .expect("valid internal OSS endpoint");
+
+    config.server_side_endpoint = "https://internal.example.test".to_string();
+    let err = AlibabaOssDriver::validate_config(&config, &sample_credentials())
+        .expect_err("non-provider server endpoint should fail");
+    assert_eq!(err.kind(), StorageErrorKind::Misconfigured);
+}
+
+#[test]
+fn validate_config_rejects_invalid_bucket_and_region() {
+    let mut config = sample_config();
+    config.bucket = "Invalid_Bucket".to_string();
+    let err = AlibabaOssDriver::validate_config(&config, &sample_credentials())
+        .expect_err("invalid bucket should fail");
+    assert!(err.message().contains("OSS bucket"));
+
+    config = sample_config();
+    config.region = "".to_string();
+    let err = AlibabaOssDriver::validate_config(&config, &sample_credentials())
+        .expect_err("missing region should fail");
+    assert!(err.message().contains("OSS region is required"));
+}
+
+#[test]
+fn driver_exposes_s3_compatible_capabilities_with_public_presigning() {
+    let driver = AlibabaOssDriver::new(sample_config(), sample_credentials())
+        .expect("OSS driver should build");
+    let extensions = driver.extensions();
+
+    assert!(driver.supports_efficient_range());
+    assert!(extensions.presigned.is_some());
+    assert!(extensions.list.is_some());
+    assert!(extensions.stream_upload.is_some());
+    assert!(extensions.multipart.is_some());
+}
+
+#[tokio::test]
+async fn public_presigned_url_ignores_server_side_endpoint() {
+    let mut config = sample_config();
+    config.server_side_endpoint = "https://oss-cn-hangzhou-internal.aliyuncs.com".to_string();
+    let driver =
+        AlibabaOssDriver::new(config, sample_credentials()).expect("OSS driver should build");
+
+    let url = driver
+        .extensions()
+        .presigned
+        .expect("presigned extension")
+        .presigned_put_url("docs/report.txt", Duration::from_secs(60))
+        .await
+        .expect("presigned PUT")
+        .expect("presigned URL");
+
+    assert!(url.starts_with(
+        "https://asterdrive-test.oss-cn-hangzhou.aliyuncs.com/tenant/prefix/docs/report.txt"
+    ));
+    assert!(url.contains("x-oss-signature="));
+    assert!(!url.contains("internal"));
+}
+
+#[tokio::test]
+async fn public_presigned_url_uses_cname_without_bucket_wire_path() {
+    let mut config = sample_config();
+    config.endpoint = "https://files.example.test".to_string();
+    config.use_cname = true;
+    config.server_side_endpoint = "https://oss-cn-hangzhou-internal.aliyuncs.com".to_string();
+    let driver =
+        AlibabaOssDriver::new(config, sample_credentials()).expect("OSS CNAME driver should build");
+
+    let url = driver
+        .extensions()
+        .presigned
+        .expect("presigned extension")
+        .presigned_put_url("docs/report.txt", Duration::from_secs(60))
+        .await
+        .expect("presigned PUT")
+        .expect("presigned URL");
+
+    assert!(url.starts_with("https://files.example.test/tenant/prefix/docs/report.txt"));
+    assert!(!url.contains("/asterdrive-test/"));
+    assert!(url.contains("x-oss-signature="));
+}

--- a/src/storage/drivers/mod.rs
+++ b/src/storage/drivers/mod.rs
@@ -2,6 +2,7 @@
 //!
 //! 存放具体存储后端驱动，不参与 trait 定义。
 
+pub mod alibaba_oss;
 pub mod azure_blob;
 pub mod local;
 pub mod onedrive;

--- a/tests/storage/policies.rs
+++ b/tests/storage/policies.rs
@@ -301,7 +301,7 @@ async fn test_admin_storage_driver_descriptors_expose_capability_matrix() {
     let body: Value = test::read_body_json(resp).await;
     let descriptors = body["data"].as_array().expect("descriptor list");
 
-    assert_eq!(descriptors.len(), 7);
+    assert_eq!(descriptors.len(), 8);
 
     let descriptor = |connector_id: &str| {
         descriptors
@@ -415,6 +415,47 @@ async fn test_admin_storage_driver_descriptors_expose_capability_matrix() {
     );
     assert_eq!(s3["capabilities"]["storage_native_thumbnail"], false);
 
+    let alibaba_oss = descriptor("asterdrive.storage.alibaba_oss");
+    assert_eq!(alibaba_oss["credential_mode"], "static_secret");
+    assert_eq!(alibaba_oss["ui"]["label_key"], "driver_type_alibaba_oss");
+    assert_eq!(
+        alibaba_oss["ui"]["icon_src"],
+        "/static/storage/aliyun-oss.svg"
+    );
+    assert_eq!(
+        alibaba_oss["upload_workflows"]["object_multipart_upload"],
+        true
+    );
+    assert_eq!(
+        alibaba_oss["upload_workflows"]["object_multipart_upload_capabilities"]["presigned_part_upload"],
+        true
+    );
+    assert_eq!(
+        alibaba_oss["upload_workflows"]["object_multipart_upload_capabilities"]["presigned_part_etag_required"],
+        true
+    );
+    for field in [
+        "endpoint",
+        "oss_server_side_endpoint",
+        "oss_region",
+        "bucket",
+        "base_path",
+        "oss_use_cname",
+        "object_storage_upload_strategy",
+        "object_storage_download_strategy",
+        "aliyun_oss_access_key_id",
+        "aliyun_oss_access_key_secret",
+    ] {
+        assert!(
+            alibaba_oss["fields"]
+                .as_array()
+                .expect("OSS fields")
+                .iter()
+                .any(|candidate| candidate["name"] == field),
+            "missing OSS descriptor field {field}"
+        );
+    }
+
     let azure_blob = descriptor("asterdrive.storage.azure_blob");
     assert_eq!(
         azure_blob["upload_workflows"]["object_multipart_upload"],
@@ -504,9 +545,9 @@ async fn test_storage_driver_catalog_contexts_are_backend_authoritative_in_singl
     let create = list_storage_driver_descriptors_via_admin(&app, &token, Some("create")).await;
     let setup = list_storage_driver_descriptors_via_admin(&app, &token, Some("setup")).await;
 
-    assert_eq!(manage.len(), 7);
-    assert_eq!(create.len(), 7);
-    assert_eq!(setup.len(), 7);
+    assert_eq!(manage.len(), 8);
+    assert_eq!(create.len(), 8);
+    assert_eq!(setup.len(), 8);
     assert!(
         setup
             .iter()
@@ -532,13 +573,13 @@ async fn test_cluster_storage_driver_catalog_hides_local_only_from_new_policy_fl
     let create = list_storage_driver_descriptors_via_admin(&app, &token, Some("create")).await;
     let setup = list_storage_driver_descriptors_via_admin(&app, &token, Some("setup")).await;
 
-    assert_eq!(manage.len(), 7);
+    assert_eq!(manage.len(), 8);
     assert!(
         manage
             .iter()
             .any(|item| item["connector_id"] == "asterdrive.storage.local")
     );
-    assert_eq!(create.len(), 6);
+    assert_eq!(create.len(), 7);
     assert!(
         !create
             .iter()
@@ -549,7 +590,7 @@ async fn test_cluster_storage_driver_catalog_hides_local_only_from_new_policy_fl
             .iter()
             .any(|item| item["connector_id"] == "asterdrive.storage.onedrive")
     );
-    assert_eq!(setup.len(), 6);
+    assert_eq!(setup.len(), 7);
     assert!(
         !setup
             .iter()
@@ -610,7 +651,7 @@ async fn test_storage_driver_localizations_are_admin_only_and_cacheable() {
     let resources = body["data"]["resources"]
         .as_array()
         .expect("connector localization resources");
-    assert_eq!(resources.len(), 7);
+    assert_eq!(resources.len(), 8);
     let local = resources
         .iter()
         .find(|resource| resource["connector_id"] == "asterdrive.storage.local")
@@ -618,6 +659,12 @@ async fn test_storage_driver_localizations_are_admin_only_and_cacheable() {
     assert_eq!(local["namespace"], "asterdrive.storage.local");
     assert_eq!(local["resolved_locale"], "zh");
     assert_eq!(local["messages"]["driver_type_local"], "本机");
+    let oss = resources
+        .iter()
+        .find(|resource| resource["connector_id"] == "asterdrive.storage.alibaba_oss")
+        .expect("Alibaba OSS connector localization");
+    assert_eq!(oss["resolved_locale"], "zh");
+    assert_eq!(oss["messages"]["driver_type_alibaba_oss"], "阿里云 OSS");
 
     let req = test::TestRequest::get()
         .uri(uri)


### PR DESCRIPTION
## Summary

- add first-class `asterdrive.storage.alibaba_oss` driver and connector
- reuse the locked AWS S3 SDK operation lifecycle while replacing AWS SigV4 with native `OSS4-HMAC-SHA256` header and query signing
- support public endpoint + optional server-side endpoint separation, explicit OSS region, base path, multipart, Range/list/stream/copy operations, and CNAME custom domains
- keep browser presigned GET/PUT/UploadPart URLs on the public client while backend I/O uses the optional server-side client
- expose descriptor-driven fields, credentials, transfer strategies, localization, cluster compatibility, cleanup behavior, and admin catalog integration
- add bilingual OSS setup/tutorial documentation and focused provider/auth design notes

## OSS V4 contract

The signer follows Alibaba Cloud official `aliyun/alibabacloud-oss-go-sdk-v2` behavior:

- algorithm: `OSS4-HMAC-SHA256`
- scope: `DATE/REGION/oss/aliyun_v4_request`
- key chain starts with `aliyun_v4`
- header signing uses `x-oss-date` and `x-oss-content-sha256: UNSIGNED-PAYLOAD`
- query presigning uses `x-oss-signature-version`, `x-oss-date`, `x-oss-expires`, `x-oss-credential`, and `x-oss-signature`
- canonical URI retains `/bucket/key` even when a CNAME wire URL omits the bucket

Normal SDK requests and generated presigned requests are tested separately. UploadPart presigning verifies `uploadId` and `partNumber`; CNAME list capture verifies a root wire path while retaining OSS signing.

## Validation

- `cargo fmt --all -- --check`
- `cargo test --lib storage::drivers::alibaba_oss --no-fail-fast` — 17 passed
- `cargo test --lib storage::connectors --no-fail-fast` — 35 passed
- `cargo test --lib services::storage_policy::connector_catalog::tests --no-fail-fast` — 6 passed
- `cargo test --test storage --no-fail-fast` — 182 passed
- `cargo test --lib --no-fail-fast` — 1543 passed, 1 ignored
- `cargo check -p aster_drive`
- `cargo clippy -p aster_drive --all-targets -- -D warnings`
- `cd frontend-panel && bun run check`
- `cd docs && bun run docs:build` — 163 pages, internal links valid
- `cd docs && bun run developer-docs:build` — 412 pages, internal links valid
- `git diff --check`

Official SDK vectors and local mock/capture tests prove canonicalization, header signing, query presigning, multipart query retention, CNAME URL shape, CopyObject translation, and public/server endpoint routing. A live Alibaba Cloud OSS account integration was not run.

## Documentation follow-up

Repeated backend lists were deliberately kept out of this PR after review. #473 tracks centralizing/generated validation for storage backend capability facts so future connectors do not require repository-wide manual list edits.

Closes #450

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 新增阿里云 OSS 存储后端，支持对象上传、下载、分片上传、范围读取、流式传输和预签名访问。
  - 支持 OSS V4 签名、公共端点与服务端端点、自定义域名及 CNAME 配置。
  - 管理后台新增阿里云 OSS 配置入口、中文及英文界面文案和配置校验。

- **文档**
  - 新增阿里云 OSS 配置教程、能力说明、权限要求、CORS 设置及常见问题排查指南。
  - 存储后端列表和能力矩阵更新为支持八种后端。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->