### PR TITLE
perf(bench): establish WebDAV provider Range performance baselines

### DIFF
--- a/.github/workflows/webdav-provider-range.yml
+++ b/.github/workflows/webdav-provider-range.yml
@@ -1,0 +1,111 @@
+name: WebDAV Provider Range Baselines
+
+on:
+  schedule:
+    - cron: "23 3 * * 2"
+  workflow_dispatch:
+    inputs:
+      provider:
+        description: Storage provider fixture to benchmark
+        required: true
+        type: choice
+        default: local
+        options:
+          - local
+          - s3
+          - onedrive
+          - sftp
+          - remote
+      payload_bytes:
+        description: Fixture payload size in bytes
+        required: true
+        default: "5242880"
+      range_bytes:
+        description: Selected bytes for each single-range sample
+        required: true
+        default: "262144"
+      warmups:
+        description: Warmup samples discarded before reporting
+        required: true
+        default: "3"
+      samples:
+        description: Repeated samples used for percentiles
+        required: true
+        default: "20"
+      baseline_profile:
+        description: Versioned machine/provider baseline profile
+        required: true
+        default: github-actions-ubuntu-local-v1
+      require_provider:
+        description: Fail after writing a skip artifact when fixture credentials are missing
+        required: true
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+
+concurrency:
+  group: webdav-provider-range-${{ github.workflow }}-${{ github.ref }}-${{ inputs.provider || 'local' }}
+  cancel-in-progress: false
+
+jobs:
+  benchmark:
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    env:
+      ASTER_BENCH_RANGE_PROVIDER: ${{ inputs.provider || 'local' }}
+      ASTER_BENCH_RANGE_PROVIDER_REQUIRED: ${{ github.event_name == 'schedule' || inputs.require_provider }}
+      ASTER_BENCH_RANGE_PAYLOAD_BYTES: ${{ inputs.payload_bytes || '5242880' }}
+      ASTER_BENCH_RANGE_BYTES: ${{ inputs.range_bytes || '262144' }}
+      ASTER_BENCH_RANGE_WARMUPS: ${{ inputs.warmups || '3' }}
+      ASTER_BENCH_RANGE_SAMPLES: ${{ inputs.samples || '20' }}
+      ASTER_BENCH_RANGE_BASELINE_PROFILE: ${{ inputs.baseline_profile || 'github-actions-ubuntu-local-v1' }}
+      ASTER_BENCH_RANGE_BASELINE: tests/performance/baselines/webdav-provider-range-v1.json
+      ASTER_BENCH_RANGE_OUTPUT: tests/performance/results/webdav-provider-range/artifact.json
+      ASTER_BENCH_RANGE_FAIL_ON_REGRESSION: "false"
+      ASTER_BENCH_S3_ENDPOINT: ${{ secrets.ASTER_BENCH_S3_ENDPOINT }}
+      ASTER_BENCH_S3_BUCKET: ${{ secrets.ASTER_BENCH_S3_BUCKET }}
+      ASTER_BENCH_S3_REGION: ${{ secrets.ASTER_BENCH_S3_REGION }}
+      ASTER_BENCH_S3_BASE_PATH: ${{ secrets.ASTER_BENCH_S3_BASE_PATH }}
+      ASTER_BENCH_S3_ACCESS_KEY: ${{ secrets.ASTER_BENCH_S3_ACCESS_KEY }}
+      ASTER_BENCH_S3_SECRET_KEY: ${{ secrets.ASTER_BENCH_S3_SECRET_KEY }}
+      ASTER_BENCH_ONEDRIVE_GRAPH_BASE_URL: ${{ secrets.ASTER_BENCH_ONEDRIVE_GRAPH_BASE_URL }}
+      ASTER_BENCH_ONEDRIVE_ACCESS_TOKEN: ${{ secrets.ASTER_BENCH_ONEDRIVE_ACCESS_TOKEN }}
+      ASTER_BENCH_ONEDRIVE_DRIVE_ID: ${{ secrets.ASTER_BENCH_ONEDRIVE_DRIVE_ID }}
+      ASTER_BENCH_ONEDRIVE_ROOT_ITEM_ID: ${{ secrets.ASTER_BENCH_ONEDRIVE_ROOT_ITEM_ID }}
+      ASTER_BENCH_ONEDRIVE_BASE_PATH: ${{ secrets.ASTER_BENCH_ONEDRIVE_BASE_PATH }}
+      ASTER_BENCH_SFTP_ENDPOINT: ${{ secrets.ASTER_BENCH_SFTP_ENDPOINT }}
+      ASTER_BENCH_SFTP_USERNAME: ${{ secrets.ASTER_BENCH_SFTP_USERNAME }}
+      ASTER_BENCH_SFTP_PASSWORD: ${{ secrets.ASTER_BENCH_SFTP_PASSWORD }}
+      ASTER_BENCH_SFTP_HOST_KEY_FINGERPRINT: ${{ secrets.ASTER_BENCH_SFTP_HOST_KEY_FINGERPRINT }}
+      ASTER_BENCH_SFTP_BASE_PATH: ${{ secrets.ASTER_BENCH_SFTP_BASE_PATH }}
+      ASTER_BENCH_REMOTE_BASE_URL: ${{ secrets.ASTER_BENCH_REMOTE_BASE_URL }}
+      ASTER_BENCH_REMOTE_ACCESS_KEY: ${{ secrets.ASTER_BENCH_REMOTE_ACCESS_KEY }}
+      ASTER_BENCH_REMOTE_SECRET_KEY: ${{ secrets.ASTER_BENCH_REMOTE_SECRET_KEY }}
+      ASTER_BENCH_REMOTE_BASE_PATH: ${{ secrets.ASTER_BENCH_REMOTE_BASE_PATH }}
+      ASTER_BENCH_REMOTE_STORAGE_TARGET_KEY: ${{ secrets.ASTER_BENCH_REMOTE_STORAGE_TARGET_KEY }}
+      ASTER_BENCH_REMOTE_CAPABILITIES_JSON: ${{ secrets.ASTER_BENCH_REMOTE_CAPABILITIES_JSON }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust build artifacts
+        uses: Swatinem/rust-cache@v2
+
+      - name: Run provider Range benchmark
+        run: |
+          mkdir -p tests/performance/results/webdav-provider-range
+          set -o pipefail
+          cargo bench --bench webdav_provider_range --features benchmarks 2>&1 \
+            | tee tests/performance/results/webdav-provider-range/runner.log
+
+      - name: Upload provider artifact
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: webdav-provider-range-${{ inputs.provider || 'local' }}-${{ github.run_id }}
+          if-no-files-found: error
+          path: tests/performance/results/webdav-provider-range

--- a/.github/workflows/webdav-provider-range.yml
+++ b/.github/workflows/webdav-provider-range.yml
@@ -64,28 +64,6 @@ jobs:
       ASTER_BENCH_RANGE_BASELINE: tests/performance/baselines/webdav-provider-range-v1.json
       ASTER_BENCH_RANGE_OUTPUT: tests/performance/results/webdav-provider-range/artifact.json
       ASTER_BENCH_RANGE_FAIL_ON_REGRESSION: "false"
-      ASTER_BENCH_S3_ENDPOINT: ${{ secrets.ASTER_BENCH_S3_ENDPOINT }}
-      ASTER_BENCH_S3_BUCKET: ${{ secrets.ASTER_BENCH_S3_BUCKET }}
-      ASTER_BENCH_S3_REGION: ${{ secrets.ASTER_BENCH_S3_REGION }}
-      ASTER_BENCH_S3_BASE_PATH: ${{ secrets.ASTER_BENCH_S3_BASE_PATH }}
-      ASTER_BENCH_S3_ACCESS_KEY: ${{ secrets.ASTER_BENCH_S3_ACCESS_KEY }}
-      ASTER_BENCH_S3_SECRET_KEY: ${{ secrets.ASTER_BENCH_S3_SECRET_KEY }}
-      ASTER_BENCH_ONEDRIVE_GRAPH_BASE_URL: ${{ secrets.ASTER_BENCH_ONEDRIVE_GRAPH_BASE_URL }}
-      ASTER_BENCH_ONEDRIVE_ACCESS_TOKEN: ${{ secrets.ASTER_BENCH_ONEDRIVE_ACCESS_TOKEN }}
-      ASTER_BENCH_ONEDRIVE_DRIVE_ID: ${{ secrets.ASTER_BENCH_ONEDRIVE_DRIVE_ID }}
-      ASTER_BENCH_ONEDRIVE_ROOT_ITEM_ID: ${{ secrets.ASTER_BENCH_ONEDRIVE_ROOT_ITEM_ID }}
-      ASTER_BENCH_ONEDRIVE_BASE_PATH: ${{ secrets.ASTER_BENCH_ONEDRIVE_BASE_PATH }}
-      ASTER_BENCH_SFTP_ENDPOINT: ${{ secrets.ASTER_BENCH_SFTP_ENDPOINT }}
-      ASTER_BENCH_SFTP_USERNAME: ${{ secrets.ASTER_BENCH_SFTP_USERNAME }}
-      ASTER_BENCH_SFTP_PASSWORD: ${{ secrets.ASTER_BENCH_SFTP_PASSWORD }}
-      ASTER_BENCH_SFTP_HOST_KEY_FINGERPRINT: ${{ secrets.ASTER_BENCH_SFTP_HOST_KEY_FINGERPRINT }}
-      ASTER_BENCH_SFTP_BASE_PATH: ${{ secrets.ASTER_BENCH_SFTP_BASE_PATH }}
-      ASTER_BENCH_REMOTE_BASE_URL: ${{ secrets.ASTER_BENCH_REMOTE_BASE_URL }}
-      ASTER_BENCH_REMOTE_ACCESS_KEY: ${{ secrets.ASTER_BENCH_REMOTE_ACCESS_KEY }}
-      ASTER_BENCH_REMOTE_SECRET_KEY: ${{ secrets.ASTER_BENCH_REMOTE_SECRET_KEY }}
-      ASTER_BENCH_REMOTE_BASE_PATH: ${{ secrets.ASTER_BENCH_REMOTE_BASE_PATH }}
-      ASTER_BENCH_REMOTE_STORAGE_TARGET_KEY: ${{ secrets.ASTER_BENCH_REMOTE_STORAGE_TARGET_KEY }}
-      ASTER_BENCH_REMOTE_CAPABILITIES_JSON: ${{ secrets.ASTER_BENCH_REMOTE_CAPABILITIES_JSON }}
     steps:
       - uses: actions/checkout@v6
 
@@ -95,7 +73,67 @@ jobs:
       - name: Cache Rust build artifacts
         uses: Swatinem/rust-cache@v2
 
-      - name: Run provider Range benchmark
+      - name: Run local provider Range benchmark
+        if: env.ASTER_BENCH_RANGE_PROVIDER == 'local'
+        run: |
+          mkdir -p tests/performance/results/webdav-provider-range
+          set -o pipefail
+          cargo bench --bench webdav_provider_range --features benchmarks 2>&1 \
+            | tee tests/performance/results/webdav-provider-range/runner.log
+
+      - name: Run S3 provider Range benchmark
+        if: env.ASTER_BENCH_RANGE_PROVIDER == 's3'
+        env:
+          ASTER_BENCH_S3_ENDPOINT: ${{ secrets.ASTER_BENCH_S3_ENDPOINT }}
+          ASTER_BENCH_S3_BUCKET: ${{ secrets.ASTER_BENCH_S3_BUCKET }}
+          ASTER_BENCH_S3_REGION: ${{ secrets.ASTER_BENCH_S3_REGION }}
+          ASTER_BENCH_S3_BASE_PATH: ${{ secrets.ASTER_BENCH_S3_BASE_PATH }}
+          ASTER_BENCH_S3_PATH_STYLE: ${{ secrets.ASTER_BENCH_S3_PATH_STYLE }}
+          ASTER_BENCH_S3_ACCESS_KEY: ${{ secrets.ASTER_BENCH_S3_ACCESS_KEY }}
+          ASTER_BENCH_S3_SECRET_KEY: ${{ secrets.ASTER_BENCH_S3_SECRET_KEY }}
+        run: |
+          mkdir -p tests/performance/results/webdav-provider-range
+          set -o pipefail
+          cargo bench --bench webdav_provider_range --features benchmarks 2>&1 \
+            | tee tests/performance/results/webdav-provider-range/runner.log
+
+      - name: Run OneDrive provider Range benchmark
+        if: env.ASTER_BENCH_RANGE_PROVIDER == 'onedrive'
+        env:
+          ASTER_BENCH_ONEDRIVE_GRAPH_BASE_URL: ${{ secrets.ASTER_BENCH_ONEDRIVE_GRAPH_BASE_URL }}
+          ASTER_BENCH_ONEDRIVE_ACCESS_TOKEN: ${{ secrets.ASTER_BENCH_ONEDRIVE_ACCESS_TOKEN }}
+          ASTER_BENCH_ONEDRIVE_DRIVE_ID: ${{ secrets.ASTER_BENCH_ONEDRIVE_DRIVE_ID }}
+          ASTER_BENCH_ONEDRIVE_ROOT_ITEM_ID: ${{ secrets.ASTER_BENCH_ONEDRIVE_ROOT_ITEM_ID }}
+          ASTER_BENCH_ONEDRIVE_BASE_PATH: ${{ secrets.ASTER_BENCH_ONEDRIVE_BASE_PATH }}
+        run: |
+          mkdir -p tests/performance/results/webdav-provider-range
+          set -o pipefail
+          cargo bench --bench webdav_provider_range --features benchmarks 2>&1 \
+            | tee tests/performance/results/webdav-provider-range/runner.log
+
+      - name: Run SFTP provider Range benchmark
+        if: env.ASTER_BENCH_RANGE_PROVIDER == 'sftp'
+        env:
+          ASTER_BENCH_SFTP_ENDPOINT: ${{ secrets.ASTER_BENCH_SFTP_ENDPOINT }}
+          ASTER_BENCH_SFTP_USERNAME: ${{ secrets.ASTER_BENCH_SFTP_USERNAME }}
+          ASTER_BENCH_SFTP_PASSWORD: ${{ secrets.ASTER_BENCH_SFTP_PASSWORD }}
+          ASTER_BENCH_SFTP_HOST_KEY_FINGERPRINT: ${{ secrets.ASTER_BENCH_SFTP_HOST_KEY_FINGERPRINT }}
+          ASTER_BENCH_SFTP_BASE_PATH: ${{ secrets.ASTER_BENCH_SFTP_BASE_PATH }}
+        run: |
+          mkdir -p tests/performance/results/webdav-provider-range
+          set -o pipefail
+          cargo bench --bench webdav_provider_range --features benchmarks 2>&1 \
+            | tee tests/performance/results/webdav-provider-range/runner.log
+
+      - name: Run remote provider Range benchmark
+        if: env.ASTER_BENCH_RANGE_PROVIDER == 'remote'
+        env:
+          ASTER_BENCH_REMOTE_BASE_URL: ${{ secrets.ASTER_BENCH_REMOTE_BASE_URL }}
+          ASTER_BENCH_REMOTE_ACCESS_KEY: ${{ secrets.ASTER_BENCH_REMOTE_ACCESS_KEY }}
+          ASTER_BENCH_REMOTE_SECRET_KEY: ${{ secrets.ASTER_BENCH_REMOTE_SECRET_KEY }}
+          ASTER_BENCH_REMOTE_BASE_PATH: ${{ secrets.ASTER_BENCH_REMOTE_BASE_PATH }}
+          ASTER_BENCH_REMOTE_STORAGE_TARGET_KEY: ${{ secrets.ASTER_BENCH_REMOTE_STORAGE_TARGET_KEY }}
+          ASTER_BENCH_REMOTE_CAPABILITIES_JSON: ${{ secrets.ASTER_BENCH_REMOTE_CAPABILITIES_JSON }}
         run: |
           mkdir -p tests/performance/results/webdav-provider-range
           set -o pipefail

--- a/.github/workflows/webdav-provider-range.yml
+++ b/.github/workflows/webdav-provider-range.yml
@@ -67,6 +67,9 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+
       - name: Setup Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
@@ -77,9 +80,14 @@ jobs:
         if: env.ASTER_BENCH_RANGE_PROVIDER == 'local'
         run: |
           mkdir -p tests/performance/results/webdav-provider-range
+          log=tests/performance/results/webdav-provider-range/runner.log
+          redacted=tests/performance/results/webdav-provider-range/runner.redacted.log
+          status=0
           set -o pipefail
           cargo bench --bench webdav_provider_range --features benchmarks 2>&1 \
-            | tee tests/performance/results/webdav-provider-range/runner.log
+            | tee "$log" || status=$?
+          bun tests/performance/redact-webdav-provider-range-log.mjs "$log" "$redacted"
+          exit "$status"
 
       - name: Run S3 provider Range benchmark
         if: env.ASTER_BENCH_RANGE_PROVIDER == 's3'
@@ -93,9 +101,18 @@ jobs:
           ASTER_BENCH_S3_SECRET_KEY: ${{ secrets.ASTER_BENCH_S3_SECRET_KEY }}
         run: |
           mkdir -p tests/performance/results/webdav-provider-range
+          log=tests/performance/results/webdav-provider-range/runner.log
+          redacted=tests/performance/results/webdav-provider-range/runner.redacted.log
+          status=0
           set -o pipefail
           cargo bench --bench webdav_provider_range --features benchmarks 2>&1 \
-            | tee tests/performance/results/webdav-provider-range/runner.log
+            | tee "$log" || status=$?
+          bun tests/performance/redact-webdav-provider-range-log.mjs \
+            "$log" "$redacted" \
+            ASTER_BENCH_S3_ENDPOINT ASTER_BENCH_S3_BUCKET ASTER_BENCH_S3_REGION \
+            ASTER_BENCH_S3_BASE_PATH ASTER_BENCH_S3_PATH_STYLE \
+            ASTER_BENCH_S3_ACCESS_KEY ASTER_BENCH_S3_SECRET_KEY
+          exit "$status"
 
       - name: Run OneDrive provider Range benchmark
         if: env.ASTER_BENCH_RANGE_PROVIDER == 'onedrive'
@@ -107,9 +124,18 @@ jobs:
           ASTER_BENCH_ONEDRIVE_BASE_PATH: ${{ secrets.ASTER_BENCH_ONEDRIVE_BASE_PATH }}
         run: |
           mkdir -p tests/performance/results/webdav-provider-range
+          log=tests/performance/results/webdav-provider-range/runner.log
+          redacted=tests/performance/results/webdav-provider-range/runner.redacted.log
+          status=0
           set -o pipefail
           cargo bench --bench webdav_provider_range --features benchmarks 2>&1 \
-            | tee tests/performance/results/webdav-provider-range/runner.log
+            | tee "$log" || status=$?
+          bun tests/performance/redact-webdav-provider-range-log.mjs \
+            "$log" "$redacted" \
+            ASTER_BENCH_ONEDRIVE_GRAPH_BASE_URL ASTER_BENCH_ONEDRIVE_ACCESS_TOKEN \
+            ASTER_BENCH_ONEDRIVE_DRIVE_ID ASTER_BENCH_ONEDRIVE_ROOT_ITEM_ID \
+            ASTER_BENCH_ONEDRIVE_BASE_PATH
+          exit "$status"
 
       - name: Run SFTP provider Range benchmark
         if: env.ASTER_BENCH_RANGE_PROVIDER == 'sftp'
@@ -121,9 +147,18 @@ jobs:
           ASTER_BENCH_SFTP_BASE_PATH: ${{ secrets.ASTER_BENCH_SFTP_BASE_PATH }}
         run: |
           mkdir -p tests/performance/results/webdav-provider-range
+          log=tests/performance/results/webdav-provider-range/runner.log
+          redacted=tests/performance/results/webdav-provider-range/runner.redacted.log
+          status=0
           set -o pipefail
           cargo bench --bench webdav_provider_range --features benchmarks 2>&1 \
-            | tee tests/performance/results/webdav-provider-range/runner.log
+            | tee "$log" || status=$?
+          bun tests/performance/redact-webdav-provider-range-log.mjs \
+            "$log" "$redacted" \
+            ASTER_BENCH_SFTP_ENDPOINT ASTER_BENCH_SFTP_USERNAME \
+            ASTER_BENCH_SFTP_PASSWORD ASTER_BENCH_SFTP_HOST_KEY_FINGERPRINT \
+            ASTER_BENCH_SFTP_BASE_PATH
+          exit "$status"
 
       - name: Run remote provider Range benchmark
         if: env.ASTER_BENCH_RANGE_PROVIDER == 'remote'
@@ -136,22 +171,51 @@ jobs:
           ASTER_BENCH_REMOTE_CAPABILITIES_JSON: ${{ secrets.ASTER_BENCH_REMOTE_CAPABILITIES_JSON }}
         run: |
           mkdir -p tests/performance/results/webdav-provider-range
+          log=tests/performance/results/webdav-provider-range/runner.log
+          redacted=tests/performance/results/webdav-provider-range/runner.redacted.log
+          status=0
           set -o pipefail
           cargo bench --bench webdav_provider_range --features benchmarks 2>&1 \
-            | tee tests/performance/results/webdav-provider-range/runner.log
+            | tee "$log" || status=$?
+          bun tests/performance/redact-webdav-provider-range-log.mjs \
+            "$log" "$redacted" \
+            ASTER_BENCH_REMOTE_BASE_URL ASTER_BENCH_REMOTE_ACCESS_KEY \
+            ASTER_BENCH_REMOTE_SECRET_KEY ASTER_BENCH_REMOTE_BASE_PATH \
+            ASTER_BENCH_REMOTE_STORAGE_TARGET_KEY ASTER_BENCH_REMOTE_CAPABILITIES_JSON
+          exit "$status"
 
       - name: Verify structured provider artifact
         id: structured-artifact
         if: always()
         run: |
           artifact=tests/performance/results/webdav-provider-range/artifact.json
-          if test -s "$artifact"; then
-            echo "available=true" >> "$GITHUB_OUTPUT"
-          else
+          if ! test -s "$artifact"; then
             echo "available=false" >> "$GITHUB_OUTPUT"
+            echo "state=missing" >> "$GITHUB_OUTPUT"
             echo "::error file=$artifact::Provider benchmark did not produce a non-empty structured artifact"
             exit 1
           fi
+          if ! state="$(bun tests/performance/validate-webdav-provider-range-artifact.mjs "$artifact")"; then
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            echo "state=invalid" >> "$GITHUB_OUTPUT"
+            echo "::error file=$artifact::Provider benchmark produced an invalid structured artifact"
+            exit 1
+          fi
+          echo "state=$state" >> "$GITHUB_OUTPUT"
+          case "$state" in
+            completed)
+              echo "available=true" >> "$GITHUB_OUTPUT"
+              ;;
+            skipped)
+              echo "available=false" >> "$GITHUB_OUTPUT"
+              echo "::notice file=$artifact::Provider benchmark was skipped; retaining diagnostics only"
+              ;;
+            *)
+              echo "available=false" >> "$GITHUB_OUTPUT"
+              echo "::error file=$artifact::Unexpected provider artifact state: $state"
+              exit 1
+              ;;
+          esac
 
       - name: Upload provider artifact
         if: always() && steps.structured-artifact.outputs.available == 'true'
@@ -161,7 +225,7 @@ jobs:
           if-no-files-found: error
           path: |
             tests/performance/results/webdav-provider-range/artifact.json
-            tests/performance/results/webdav-provider-range/runner.log
+            tests/performance/results/webdav-provider-range/runner.redacted.log
 
       - name: Upload provider diagnostics
         if: always() && steps.structured-artifact.outputs.available != 'true'
@@ -169,4 +233,6 @@ jobs:
         with:
           name: webdav-provider-range-diagnostics-${{ inputs.provider || 'local' }}-${{ github.run_id }}
           if-no-files-found: warn
-          path: tests/performance/results/webdav-provider-range/runner.log
+          path: |
+            tests/performance/results/webdav-provider-range/artifact.json
+            tests/performance/results/webdav-provider-range/runner.redacted.log

--- a/.github/workflows/webdav-provider-range.yml
+++ b/.github/workflows/webdav-provider-range.yml
@@ -140,10 +140,33 @@ jobs:
           cargo bench --bench webdav_provider_range --features benchmarks 2>&1 \
             | tee tests/performance/results/webdav-provider-range/runner.log
 
-      - name: Upload provider artifact
+      - name: Verify structured provider artifact
+        id: structured-artifact
         if: always()
+        run: |
+          artifact=tests/performance/results/webdav-provider-range/artifact.json
+          if test -s "$artifact"; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            echo "::error file=$artifact::Provider benchmark did not produce a non-empty structured artifact"
+            exit 1
+          fi
+
+      - name: Upload provider artifact
+        if: always() && steps.structured-artifact.outputs.available == 'true'
         uses: actions/upload-artifact@v7
         with:
           name: webdav-provider-range-${{ inputs.provider || 'local' }}-${{ github.run_id }}
           if-no-files-found: error
-          path: tests/performance/results/webdav-provider-range
+          path: |
+            tests/performance/results/webdav-provider-range/artifact.json
+            tests/performance/results/webdav-provider-range/runner.log
+
+      - name: Upload provider diagnostics
+        if: always() && steps.structured-artifact.outputs.available != 'true'
+        uses: actions/upload-artifact@v7
+        with:
+          name: webdav-provider-range-diagnostics-${{ inputs.provider || 'local' }}-${{ github.run_id }}
+          if-no-files-found: warn
+          path: tests/performance/results/webdav-provider-range/runner.log

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -301,6 +301,11 @@ harness = false
 required-features = ["benchmarks"]
 
 [[test]]
+name = "webdav_provider_range_contract"
+path = "tests/webdav_provider_range_contract.rs"
+required-features = ["benchmarks"]
+
+[[test]]
 name = "multi_primary"
 path = "tests/multi_primary/main.rs"
 required-features = ["multi-primary-e2e"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -295,6 +295,11 @@ name = "path_hotspots"
 harness = false
 required-features = ["benchmarks"]
 
+[[bench]]
+name = "webdav_provider_range"
+harness = false
+required-features = ["benchmarks"]
+
 [[test]]
 name = "multi_primary"
 path = "tests/multi_primary/main.rs"

--- a/benches/webdav_provider_range.rs
+++ b/benches/webdav_provider_range.rs
@@ -1,0 +1,1254 @@
+use std::collections::BTreeMap;
+use std::error::Error;
+use std::path::{Path, PathBuf};
+use std::pin::Pin;
+use std::process::Command;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
+use std::task::{Context, Poll};
+use std::time::{Duration, Instant};
+
+use aster_drive::storage::drivers::local::LocalDriver;
+use aster_drive::storage::drivers::onedrive::{
+    MicrosoftGraphClient, MicrosoftGraphClientConfig, OneDriveDriver,
+};
+use aster_drive::storage::drivers::remote::{RemoteDriver, RemoteDriverConfig};
+use aster_drive::storage::drivers::s3::{
+    S3Driver, S3DriverConfig, S3DriverOptions, S3StaticCredentials,
+};
+use aster_drive::storage::drivers::sftp::{SftpDriver, SftpDriverConfig, SftpStaticCredentials};
+use aster_drive::storage::remote_protocol::RemoteStorageCapabilities;
+use aster_drive_model::entities::managed_follower;
+use aster_drive_model::types::RemoteNodeTransportMode;
+use aster_drive_storage::{BlobMetadata, StorageDriver};
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+use tokio::io::{AsyncRead, AsyncReadExt, ReadBuf};
+
+type AnyError = Box<dyn Error + Send + Sync>;
+type BenchResult<T> = Result<T, AnyError>;
+
+const ARTIFACT_SCHEMA_VERSION: u32 = 1;
+const DEFAULT_PAYLOAD_BYTES: u64 = 5 * 1024 * 1024;
+const DEFAULT_RANGE_BYTES: u64 = 256 * 1024;
+const MAX_PAYLOAD_BYTES: u64 = 1024 * 1024 * 1024;
+const DEFAULT_WARMUPS: usize = 3;
+const DEFAULT_SAMPLES: usize = 20;
+const DEFAULT_OBJECT_PATH: &str = "webdav-provider-range-v1.bin";
+const READ_BUFFER_BYTES: usize = 64 * 1024;
+
+#[derive(Debug, Clone)]
+struct BenchConfig {
+    provider: String,
+    provider_required: bool,
+    payload_bytes: u64,
+    range_bytes: u64,
+    warmups: usize,
+    samples: usize,
+    object_path: String,
+    output_path: PathBuf,
+    cleanup_fixture: bool,
+    baseline_path: Option<PathBuf>,
+    baseline_profile: Option<String>,
+    fail_on_regression: bool,
+}
+
+impl BenchConfig {
+    fn from_env() -> BenchResult<Self> {
+        let payload_bytes = env_u64("ASTER_BENCH_RANGE_PAYLOAD_BYTES", DEFAULT_PAYLOAD_BYTES)?;
+        let range_bytes = env_u64("ASTER_BENCH_RANGE_BYTES", DEFAULT_RANGE_BYTES)?;
+        if range_bytes == 0 {
+            return Err("ASTER_BENCH_RANGE_BYTES must be positive".into());
+        }
+        if payload_bytes > MAX_PAYLOAD_BYTES {
+            return Err(format!(
+                "ASTER_BENCH_RANGE_PAYLOAD_BYTES exceeds the bounded benchmark fixture limit of {MAX_PAYLOAD_BYTES} bytes"
+            )
+            .into());
+        }
+        if payload_bytes < range_bytes.saturating_mul(6) {
+            return Err(format!(
+                "ASTER_BENCH_RANGE_PAYLOAD_BYTES must be at least six times ASTER_BENCH_RANGE_BYTES (payload={payload_bytes}, range={range_bytes})"
+            )
+            .into());
+        }
+
+        Ok(Self {
+            provider: env_string("ASTER_BENCH_RANGE_PROVIDER", "local").to_ascii_lowercase(),
+            provider_required: env_bool("ASTER_BENCH_RANGE_PROVIDER_REQUIRED", false)?,
+            payload_bytes,
+            range_bytes,
+            warmups: env_usize("ASTER_BENCH_RANGE_WARMUPS", DEFAULT_WARMUPS)?,
+            samples: env_usize("ASTER_BENCH_RANGE_SAMPLES", DEFAULT_SAMPLES)?.max(1),
+            object_path: env_string("ASTER_BENCH_RANGE_OBJECT_PATH", DEFAULT_OBJECT_PATH),
+            output_path: PathBuf::from(env_string(
+                "ASTER_BENCH_RANGE_OUTPUT",
+                "tests/performance/results/webdav-provider-range/artifact.json",
+            )),
+            cleanup_fixture: env_bool("ASTER_BENCH_RANGE_CLEANUP", true)?,
+            baseline_path: env_optional("ASTER_BENCH_RANGE_BASELINE").map(PathBuf::from),
+            baseline_profile: env_optional("ASTER_BENCH_RANGE_BASELINE_PROFILE"),
+            fail_on_regression: env_bool("ASTER_BENCH_RANGE_FAIL_ON_REGRESSION", false)?,
+        })
+    }
+
+    fn scenario_specs(&self) -> BTreeMap<String, ScenarioSpec> {
+        let half = self.range_bytes / 2;
+        let mut scenarios = BTreeMap::new();
+        scenarios.insert(
+            "full_get".to_string(),
+            ScenarioSpec::Full {
+                selected_bytes: self.payload_bytes,
+            },
+        );
+        scenarios.insert(
+            "single_range_early".to_string(),
+            ScenarioSpec::Single {
+                offset: 0,
+                length: self.range_bytes,
+            },
+        );
+        scenarios.insert(
+            "single_range_late".to_string(),
+            ScenarioSpec::Single {
+                offset: self.payload_bytes - self.range_bytes,
+                length: self.range_bytes,
+            },
+        );
+        scenarios.insert(
+            "multi_range_disjoint".to_string(),
+            ScenarioSpec::Multi {
+                ranges: [
+                    ByteWindow {
+                        offset: self.range_bytes.saturating_mul(2),
+                        length: half,
+                    },
+                    ByteWindow {
+                        offset: self.payload_bytes - self.range_bytes.saturating_mul(3),
+                        length: half,
+                    },
+                ],
+            },
+        );
+        scenarios
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct ByteWindow {
+    offset: u64,
+    length: u64,
+}
+
+#[derive(Debug, Clone)]
+enum ScenarioSpec {
+    Full { selected_bytes: u64 },
+    Single { offset: u64, length: u64 },
+    Multi { ranges: [ByteWindow; 2] },
+}
+
+enum ProviderBuild {
+    Ready(ProviderFixture),
+    Skipped {
+        provider: String,
+        reason: String,
+        prerequisites: Vec<String>,
+        config_summary: Value,
+    },
+}
+
+struct ProviderFixture {
+    provider: String,
+    driver: Box<dyn StorageDriver>,
+    requests_per_backend_call: u64,
+    config_summary: Value,
+    cleanup_root: Option<PathBuf>,
+}
+
+#[derive(Debug, Serialize)]
+struct BenchmarkArtifact {
+    schema_version: u32,
+    generated_at: String,
+    git_revision: Option<String>,
+    git_dirty: Option<bool>,
+    status: &'static str,
+    provider: String,
+    skip_reason: Option<String>,
+    prerequisites: Vec<String>,
+    fixture: FixtureSummary,
+    sampling: SamplingSummary,
+    machine: MachineSummary,
+    provider_config: Value,
+    scenarios: BTreeMap<String, ScenarioReport>,
+    fallback: Option<ScenarioReport>,
+    baseline: BaselineComparison,
+}
+
+#[derive(Debug, Serialize)]
+struct FixtureSummary {
+    object_path: String,
+    payload_bytes: u64,
+    range_bytes: u64,
+    content_pattern: &'static str,
+    cleanup_requested: bool,
+}
+
+#[derive(Debug, Serialize)]
+struct SamplingSummary {
+    warmups: usize,
+    samples: usize,
+    read_buffer_bytes: usize,
+}
+
+#[derive(Debug, Serialize, Clone)]
+struct MachineSummary {
+    profile: Option<String>,
+    build_profile: &'static str,
+    os: String,
+    architecture: String,
+    cpu_model: Option<String>,
+    logical_cpus: usize,
+    rustc: Option<String>,
+    kernel: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct ScenarioReport {
+    selected_bytes: u64,
+    expected_backend_calls: u64,
+    expected_backend_requests: u64,
+    expected_prefix_skip_bytes: u64,
+    samples: Vec<Sample>,
+    summary: ScenarioStatistics,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct Sample {
+    open_ms: f64,
+    ttfb_ms: f64,
+    read_ms: f64,
+    total_ms: f64,
+    throughput_bytes_per_second: f64,
+    backend_call_count: u64,
+    backend_request_count: u64,
+    actual_read_bytes: u64,
+    prefix_skip_bytes: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct ScenarioStatistics {
+    open_ms: Distribution,
+    ttfb_ms: Distribution,
+    read_ms: Distribution,
+    total_ms: Distribution,
+    throughput_bytes_per_second: Distribution,
+    backend_call_count: Distribution,
+    backend_request_count: Distribution,
+    actual_read_bytes: Distribution,
+    prefix_skip_bytes: Distribution,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct Distribution {
+    min: f64,
+    p50: f64,
+    p95: f64,
+    p99: f64,
+    max: f64,
+}
+
+#[derive(Debug, Serialize)]
+struct BaselineComparison {
+    baseline_path: Option<String>,
+    profile: Option<String>,
+    status: &'static str,
+    reason: Option<String>,
+    policy: Option<RegressionPolicy>,
+    scenarios: BTreeMap<String, ScenarioComparison>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct RegressionPolicy {
+    ttfb_p95_max_ratio: f64,
+    throughput_p50_min_ratio: f64,
+}
+
+#[derive(Debug, Serialize)]
+struct ScenarioComparison {
+    ttfb_p95_ratio: f64,
+    throughput_p50_ratio: f64,
+    regressed: bool,
+}
+
+#[derive(Debug, Deserialize)]
+struct BaselineFile {
+    schema_version: u32,
+    regression_policy: RegressionPolicy,
+    profiles: Vec<BaselineProfile>,
+}
+
+#[derive(Debug, Deserialize)]
+struct BaselineProfile {
+    profile: String,
+    provider: String,
+    payload_bytes: u64,
+    range_bytes: u64,
+    sampling: BaselineSampling,
+    machine: BaselineMachine,
+    scenarios: BTreeMap<String, BaselineScenario>,
+}
+
+#[derive(Debug, Deserialize)]
+struct BaselineSampling {
+    warmups: usize,
+    samples: usize,
+    read_buffer_bytes: usize,
+}
+
+#[derive(Debug, Deserialize)]
+struct BaselineMachine {
+    build_profile: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct BaselineScenario {
+    ttfb_p95_ms: f64,
+    throughput_p50_bytes_per_second: f64,
+}
+
+#[tokio::main]
+async fn main() -> BenchResult<()> {
+    let config = BenchConfig::from_env()?;
+    let machine = machine_summary(config.baseline_profile.clone());
+    let fixture_summary = FixtureSummary {
+        object_path: config.object_path.clone(),
+        payload_bytes: config.payload_bytes,
+        range_bytes: config.range_bytes,
+        content_pattern: "byte[index % 251]",
+        cleanup_requested: config.cleanup_fixture,
+    };
+    let sampling = SamplingSummary {
+        warmups: config.warmups,
+        samples: config.samples,
+        read_buffer_bytes: READ_BUFFER_BYTES,
+    };
+
+    let provider_fixture = match build_provider(&config).await? {
+        ProviderBuild::Ready(provider_fixture) => provider_fixture,
+        ProviderBuild::Skipped {
+            provider,
+            reason,
+            prerequisites,
+            config_summary,
+        } => {
+            let artifact = BenchmarkArtifact {
+                schema_version: ARTIFACT_SCHEMA_VERSION,
+                generated_at: chrono::Utc::now().to_rfc3339(),
+                git_revision: command_output("git", &["rev-parse", "HEAD"]),
+                git_dirty: git_dirty(),
+                status: "skipped",
+                provider,
+                skip_reason: Some(reason.clone()),
+                prerequisites,
+                fixture: fixture_summary,
+                sampling,
+                machine,
+                provider_config: config_summary,
+                scenarios: BTreeMap::new(),
+                fallback: None,
+                baseline: baseline_not_compared(&config, "provider benchmark was skipped"),
+            };
+            write_artifact(&config.output_path, &artifact).await?;
+            if config.provider_required {
+                return Err(reason.into());
+            }
+            return Ok(());
+        }
+    };
+
+    let payload = deterministic_payload(config.payload_bytes)?;
+    provider_fixture
+        .driver
+        .put(&config.object_path, &payload)
+        .await?;
+
+    let scenario_specs = config.scenario_specs();
+    let mut scenarios = BTreeMap::new();
+    for (name, scenario) in &scenario_specs {
+        for _ in 0..config.warmups {
+            let _ = run_provider_scenario(
+                provider_fixture.driver.as_ref(),
+                provider_fixture.requests_per_backend_call,
+                &config.object_path,
+                scenario,
+            )
+            .await?;
+        }
+        let mut samples = Vec::with_capacity(config.samples);
+        for _ in 0..config.samples {
+            samples.push(
+                run_provider_scenario(
+                    provider_fixture.driver.as_ref(),
+                    provider_fixture.requests_per_backend_call,
+                    &config.object_path,
+                    scenario,
+                )
+                .await?,
+            );
+        }
+        scenarios.insert(name.clone(), report_for_scenario(scenario, samples));
+    }
+
+    let fallback = run_fallback_benchmark(&config, &payload).await?;
+    let baseline = compare_baseline(&config, &scenarios).await?;
+    let baseline_regressed = baseline
+        .scenarios
+        .values()
+        .any(|scenario| scenario.regressed);
+
+    let artifact = BenchmarkArtifact {
+        schema_version: ARTIFACT_SCHEMA_VERSION,
+        generated_at: chrono::Utc::now().to_rfc3339(),
+        git_revision: command_output("git", &["rev-parse", "HEAD"]),
+        git_dirty: git_dirty(),
+        status: "completed",
+        provider: provider_fixture.provider.clone(),
+        skip_reason: None,
+        prerequisites: Vec::new(),
+        fixture: fixture_summary,
+        sampling,
+        machine,
+        provider_config: provider_fixture.config_summary.clone(),
+        scenarios,
+        fallback: Some(fallback),
+        baseline,
+    };
+    write_artifact(&config.output_path, &artifact).await?;
+
+    if config.cleanup_fixture {
+        provider_fixture.driver.delete(&config.object_path).await?;
+        if let Some(root) = provider_fixture.cleanup_root {
+            tokio::fs::remove_dir_all(root).await?;
+        }
+    }
+
+    if config.fail_on_regression && baseline_regressed {
+        return Err(
+            "provider Range benchmark exceeded the selected versioned baseline policy".into(),
+        );
+    }
+    Ok(())
+}
+
+async fn build_provider(config: &BenchConfig) -> BenchResult<ProviderBuild> {
+    match config.provider.as_str() {
+        "local" => build_local_provider().await,
+        "s3" | "s3-compatible" | "s3_compatible" => build_s3_provider(),
+        "onedrive" | "one-drive" => build_onedrive_provider(),
+        "sftp" => build_sftp_provider(),
+        "remote" => build_remote_provider(),
+        provider => Ok(ProviderBuild::Skipped {
+            provider: provider.to_string(),
+            reason: format!(
+                "unknown provider '{provider}'; expected local, s3, onedrive, sftp, or remote"
+            ),
+            prerequisites: vec![
+                "ASTER_BENCH_RANGE_PROVIDER=local|s3|onedrive|sftp|remote".to_string(),
+            ],
+            config_summary: json!({}),
+        }),
+    }
+}
+
+async fn build_local_provider() -> BenchResult<ProviderBuild> {
+    let root = std::env::temp_dir().join(format!(
+        "asterdrive-webdav-provider-range-{}",
+        uuid::Uuid::new_v4()
+    ));
+    tokio::fs::create_dir_all(&root).await?;
+    let root_string = root.to_string_lossy().into_owned();
+    let driver = LocalDriver::new(&root_string)?;
+    Ok(ProviderBuild::Ready(ProviderFixture {
+        provider: "local".to_string(),
+        driver: Box::new(driver),
+        requests_per_backend_call: 1,
+        config_summary: json!({
+            "storage_root_kind": "temporary_directory",
+            "request_count_contract": "one local file open per backend call",
+        }),
+        cleanup_root: Some(root),
+    }))
+}
+
+fn build_s3_provider() -> BenchResult<ProviderBuild> {
+    let required = [
+        "ASTER_BENCH_S3_ENDPOINT",
+        "ASTER_BENCH_S3_BUCKET",
+        "ASTER_BENCH_S3_ACCESS_KEY",
+        "ASTER_BENCH_S3_SECRET_KEY",
+    ];
+    if let Some(skipped) = missing_provider_env("s3", &required) {
+        return Ok(skipped);
+    }
+    let endpoint = env_required("ASTER_BENCH_S3_ENDPOINT")?;
+    let bucket = env_required("ASTER_BENCH_S3_BUCKET")?;
+    let region = env_string("ASTER_BENCH_S3_REGION", "us-east-1");
+    let base_path = env_string("ASTER_BENCH_S3_BASE_PATH", "asterdrive-range-benchmark");
+    let path_style = env_bool("ASTER_BENCH_S3_PATH_STYLE", true)?;
+    let driver = S3Driver::new(
+        S3DriverConfig {
+            endpoint: endpoint.clone(),
+            bucket: bucket.clone(),
+            base_path: base_path.clone(),
+            region: region.clone(),
+            path_style,
+            connect_timeout: Duration::from_secs(10),
+            read_timeout: Duration::from_secs(120),
+            operation_timeout: Duration::from_secs(180),
+        },
+        S3StaticCredentials {
+            access_key: env_required("ASTER_BENCH_S3_ACCESS_KEY")?,
+            secret_key: env_required("ASTER_BENCH_S3_SECRET_KEY")?,
+        },
+        S3DriverOptions::default(),
+        |builder| builder,
+    )?;
+    Ok(ProviderBuild::Ready(ProviderFixture {
+        provider: "s3".to_string(),
+        driver: Box::new(driver),
+        requests_per_backend_call: 1,
+        config_summary: json!({
+            "endpoint_kind": "configured_s3_compatible",
+            "bucket_configured": !bucket.is_empty(),
+            "region": region,
+            "base_path_kind": "benchmark_fixture",
+            "path_style": path_style,
+            "fixture_identifiers_redacted": true,
+            "request_count_contract": "one successful no-retry GetObject request per backend call",
+        }),
+        cleanup_root: None,
+    }))
+}
+
+fn build_onedrive_provider() -> BenchResult<ProviderBuild> {
+    let required = [
+        "ASTER_BENCH_ONEDRIVE_ACCESS_TOKEN",
+        "ASTER_BENCH_ONEDRIVE_DRIVE_ID",
+        "ASTER_BENCH_ONEDRIVE_ROOT_ITEM_ID",
+    ];
+    if let Some(skipped) = missing_provider_env("onedrive", &required) {
+        return Ok(skipped);
+    }
+    let graph_base_url = env_string(
+        "ASTER_BENCH_ONEDRIVE_GRAPH_BASE_URL",
+        "https://graph.microsoft.com",
+    );
+    let drive_id = env_required("ASTER_BENCH_ONEDRIVE_DRIVE_ID")?;
+    let root_item_id = env_required("ASTER_BENCH_ONEDRIVE_ROOT_ITEM_ID")?;
+    let base_path = env_string(
+        "ASTER_BENCH_ONEDRIVE_BASE_PATH",
+        "asterdrive-range-benchmark",
+    );
+    let client = MicrosoftGraphClient::new(MicrosoftGraphClientConfig::new(
+        graph_base_url.clone(),
+        env_required("ASTER_BENCH_ONEDRIVE_ACCESS_TOKEN")?,
+    ))?;
+    let driver = OneDriveDriver::new(
+        client,
+        drive_id.clone(),
+        root_item_id.clone(),
+        base_path.clone(),
+        10 * 1024 * 1024,
+    );
+    Ok(ProviderBuild::Ready(ProviderFixture {
+        provider: "onedrive".to_string(),
+        driver: Box::new(driver),
+        requests_per_backend_call: 2,
+        config_summary: json!({
+            "graph_endpoint_kind": if graph_base_url == "https://graph.microsoft.com" { "microsoft_graph" } else { "custom_graph_compatible" },
+            "drive_id_configured": !drive_id.is_empty(),
+            "root_item_id_configured": !root_item_id.is_empty(),
+            "base_path_kind": "benchmark_fixture",
+            "fixture_identifiers_redacted": true,
+            "request_count_contract": "one Graph /content request plus one download redirect request per backend call",
+        }),
+        cleanup_root: None,
+    }))
+}
+
+fn build_sftp_provider() -> BenchResult<ProviderBuild> {
+    let required = [
+        "ASTER_BENCH_SFTP_ENDPOINT",
+        "ASTER_BENCH_SFTP_USERNAME",
+        "ASTER_BENCH_SFTP_PASSWORD",
+        "ASTER_BENCH_SFTP_HOST_KEY_FINGERPRINT",
+    ];
+    if let Some(skipped) = missing_provider_env("sftp", &required) {
+        return Ok(skipped);
+    }
+    let endpoint = env_required("ASTER_BENCH_SFTP_ENDPOINT")?;
+    let base_path = env_string("ASTER_BENCH_SFTP_BASE_PATH", "asterdrive-range-benchmark");
+    let host_key_fingerprint = env_required("ASTER_BENCH_SFTP_HOST_KEY_FINGERPRINT")?;
+    let driver = SftpDriver::new(
+        SftpDriverConfig {
+            endpoint: endpoint.clone(),
+            base_path: base_path.clone(),
+            host_key_fingerprint: Some(host_key_fingerprint.clone()),
+        },
+        SftpStaticCredentials {
+            username: env_required("ASTER_BENCH_SFTP_USERNAME")?,
+            password: env_required("ASTER_BENCH_SFTP_PASSWORD")?,
+        },
+    )?;
+    Ok(ProviderBuild::Ready(ProviderFixture {
+        provider: "sftp".to_string(),
+        driver: Box::new(driver),
+        requests_per_backend_call: 1,
+        config_summary: json!({
+            "endpoint_configured": !endpoint.is_empty(),
+            "base_path_kind": "benchmark_fixture",
+            "host_key_pinning": !host_key_fingerprint.is_empty(),
+            "fixture_identifiers_redacted": true,
+            "request_count_contract": "one SFTP file open per backend call after connection warmup",
+        }),
+        cleanup_root: None,
+    }))
+}
+
+fn build_remote_provider() -> BenchResult<ProviderBuild> {
+    let required = [
+        "ASTER_BENCH_REMOTE_BASE_URL",
+        "ASTER_BENCH_REMOTE_ACCESS_KEY",
+        "ASTER_BENCH_REMOTE_SECRET_KEY",
+    ];
+    if let Some(skipped) = missing_provider_env("remote", &required) {
+        return Ok(skipped);
+    }
+    let base_url = env_required("ASTER_BENCH_REMOTE_BASE_URL")?;
+    let base_path = env_string("ASTER_BENCH_REMOTE_BASE_PATH", "asterdrive-range-benchmark");
+    let target_key = env_optional("ASTER_BENCH_REMOTE_STORAGE_TARGET_KEY");
+    let capabilities = match env_optional("ASTER_BENCH_REMOTE_CAPABILITIES_JSON") {
+        Some(raw) => serde_json::from_str::<RemoteStorageCapabilities>(&raw)?,
+        None => RemoteStorageCapabilities::current(),
+    };
+    let stored_capabilities = serde_json::to_string(&capabilities)?;
+    let now = chrono::Utc::now();
+    let follower = managed_follower::Model {
+        id: 1,
+        name: "provider-range-benchmark".to_string(),
+        base_url: base_url.clone(),
+        access_key: env_required("ASTER_BENCH_REMOTE_ACCESS_KEY")?,
+        secret_key: env_required("ASTER_BENCH_REMOTE_SECRET_KEY")?,
+        is_enabled: true,
+        transport_mode: RemoteNodeTransportMode::Direct,
+        last_capabilities: stored_capabilities,
+        last_error: String::new(),
+        last_checked_at: None,
+        tunnel_last_error: String::new(),
+        tunnel_last_seen_at: None,
+        created_at: now,
+        updated_at: now,
+    };
+    let driver = RemoteDriver::new(
+        &RemoteDriverConfig {
+            base_path: base_path.clone(),
+            remote_storage_target_key: target_key.clone(),
+            max_file_size: 0,
+        },
+        &follower,
+    )?;
+    Ok(ProviderBuild::Ready(ProviderFixture {
+        provider: "remote".to_string(),
+        driver: Box::new(driver),
+        requests_per_backend_call: 1,
+        config_summary: json!({
+            "base_url_configured": !base_url.is_empty(),
+            "base_path_kind": "benchmark_fixture",
+            "storage_target_selection": if target_key.is_some() { "explicit" } else { "default" },
+            "protocol_version": capabilities.protocol_version,
+            "min_supported_protocol_version": capabilities.min_supported_protocol_version,
+            "server_version": capabilities.server_version,
+            "fixture_identifiers_redacted": true,
+            "request_count_contract": "one signed internal-storage GET per backend call",
+        }),
+        cleanup_root: None,
+    }))
+}
+
+fn missing_provider_env(provider: &str, required: &[&str]) -> Option<ProviderBuild> {
+    let missing = required
+        .iter()
+        .filter(|name| env_optional(name).is_none())
+        .map(|name| (*name).to_string())
+        .collect::<Vec<_>>();
+    (!missing.is_empty()).then(|| ProviderBuild::Skipped {
+        provider: provider.to_string(),
+        reason: format!(
+            "provider fixture is not configured; missing {}",
+            missing.join(", ")
+        ),
+        prerequisites: required.iter().map(|name| (*name).to_string()).collect(),
+        config_summary: json!({ "missing_environment": missing }),
+    })
+}
+
+async fn run_provider_scenario(
+    driver: &dyn StorageDriver,
+    requests_per_backend_call: u64,
+    object_path: &str,
+    scenario: &ScenarioSpec,
+) -> BenchResult<Sample> {
+    match scenario {
+        ScenarioSpec::Full { selected_bytes } => {
+            let expected = ByteWindow {
+                offset: 0,
+                length: *selected_bytes,
+            };
+            let sample = read_one(driver, object_path, None, expected).await?;
+            let actual_read_bytes = sample.bytes_read;
+            Ok(sample.into_sample(1, requests_per_backend_call, actual_read_bytes, 0))
+        }
+        ScenarioSpec::Single { offset, length } => {
+            let expected = ByteWindow {
+                offset: *offset,
+                length: *length,
+            };
+            let sample = read_one(driver, object_path, Some(expected), expected).await?;
+            let actual_read_bytes = sample.bytes_read;
+            Ok(sample.into_sample(1, requests_per_backend_call, actual_read_bytes, 0))
+        }
+        ScenarioSpec::Multi { ranges } => {
+            read_multi(driver, requests_per_backend_call, object_path, *ranges).await
+        }
+    }
+}
+
+struct ReadSample {
+    open_duration: Duration,
+    first_byte_duration: Duration,
+    read_duration: Duration,
+    total_duration: Duration,
+    bytes_read: u64,
+}
+
+impl ReadSample {
+    fn into_sample(
+        self,
+        backend_call_count: u64,
+        backend_request_count: u64,
+        actual_read_bytes: u64,
+        prefix_skip_bytes: u64,
+    ) -> Sample {
+        let read_seconds = self.read_duration.as_secs_f64().max(f64::EPSILON);
+        Sample {
+            open_ms: duration_ms(self.open_duration),
+            ttfb_ms: duration_ms(self.first_byte_duration),
+            read_ms: duration_ms(self.read_duration),
+            total_ms: duration_ms(self.total_duration),
+            throughput_bytes_per_second: self.bytes_read as f64 / read_seconds,
+            backend_call_count,
+            backend_request_count,
+            actual_read_bytes,
+            prefix_skip_bytes,
+        }
+    }
+}
+
+async fn read_one(
+    driver: &dyn StorageDriver,
+    object_path: &str,
+    range: Option<ByteWindow>,
+    expected: ByteWindow,
+) -> BenchResult<ReadSample> {
+    let started = Instant::now();
+    let mut reader = match range {
+        Some(range) => {
+            driver
+                .get_range(object_path, range.offset, Some(range.length))
+                .await?
+        }
+        None => driver.get_stream(object_path).await?,
+    };
+    let opened = Instant::now();
+    let mut buffer = vec![0_u8; READ_BUFFER_BYTES];
+    let mut first_byte_at = None;
+    let mut bytes_read = 0_u64;
+    loop {
+        let read = reader.read(&mut buffer).await?;
+        if read == 0 {
+            break;
+        }
+        if first_byte_at.is_none() {
+            first_byte_at = Some(Instant::now());
+        }
+        let read = u64::try_from(read)?;
+        let remaining = expected.length.saturating_sub(bytes_read);
+        if read > remaining {
+            return Err(format!(
+                "provider returned more bytes than the selected window: expected={}, received_at_least={}",
+                expected.length,
+                bytes_read.saturating_add(read)
+            )
+            .into());
+        }
+        validate_pattern(
+            &buffer[..usize::try_from(read)?],
+            expected.offset.saturating_add(bytes_read),
+        )?;
+        bytes_read = bytes_read.saturating_add(read);
+    }
+    let finished = Instant::now();
+    let first_byte_at = first_byte_at.ok_or("provider returned an empty stream")?;
+    if bytes_read != expected.length {
+        return Err(format!(
+            "provider returned a short byte window: expected={}, actual={bytes_read}",
+            expected.length
+        )
+        .into());
+    }
+    Ok(ReadSample {
+        open_duration: opened.duration_since(started),
+        first_byte_duration: first_byte_at.duration_since(started),
+        read_duration: finished.duration_since(opened),
+        total_duration: finished.duration_since(started),
+        bytes_read,
+    })
+}
+
+async fn read_multi(
+    driver: &dyn StorageDriver,
+    requests_per_backend_call: u64,
+    object_path: &str,
+    ranges: [ByteWindow; 2],
+) -> BenchResult<Sample> {
+    let started = Instant::now();
+    let first = read_one(driver, object_path, Some(ranges[0]), ranges[0]).await?;
+    let second = read_one(driver, object_path, Some(ranges[1]), ranges[1]).await?;
+    let total_duration = started.elapsed();
+    let read_duration = first.read_duration.saturating_add(second.read_duration);
+    let selected = first.bytes_read.saturating_add(second.bytes_read);
+    Ok(Sample {
+        open_ms: duration_ms(first.open_duration.saturating_add(second.open_duration)),
+        ttfb_ms: duration_ms(first.first_byte_duration),
+        read_ms: duration_ms(read_duration),
+        total_ms: duration_ms(total_duration),
+        throughput_bytes_per_second: selected as f64
+            / read_duration.as_secs_f64().max(f64::EPSILON),
+        backend_call_count: 2,
+        backend_request_count: requests_per_backend_call.saturating_mul(2),
+        actual_read_bytes: selected,
+        prefix_skip_bytes: 0,
+    })
+}
+
+fn validate_pattern(bytes: &[u8], absolute_offset: u64) -> BenchResult<()> {
+    for (index, actual) in bytes.iter().copied().enumerate() {
+        let index = u64::try_from(index)?;
+        let expected = u8::try_from(absolute_offset.saturating_add(index) % 251)?;
+        if actual != expected {
+            return Err(format!(
+                "provider returned unexpected content at byte {}: expected={expected}, actual={actual}",
+                absolute_offset.saturating_add(index)
+            )
+            .into());
+        }
+    }
+    Ok(())
+}
+
+fn report_for_scenario(scenario: &ScenarioSpec, samples: Vec<Sample>) -> ScenarioReport {
+    let (selected_bytes, expected_backend_calls) = match scenario {
+        ScenarioSpec::Full { selected_bytes } => (*selected_bytes, 1),
+        ScenarioSpec::Single { length, .. } => (*length, 1),
+        ScenarioSpec::Multi { ranges } => (ranges[0].length + ranges[1].length, 2),
+    };
+    ScenarioReport {
+        selected_bytes,
+        expected_backend_calls,
+        expected_backend_requests: samples
+            .first()
+            .map_or(0, |sample| sample.backend_request_count),
+        expected_prefix_skip_bytes: 0,
+        summary: summarize_samples(&samples),
+        samples,
+    }
+}
+
+async fn run_fallback_benchmark(
+    config: &BenchConfig,
+    payload: &[u8],
+) -> BenchResult<ScenarioReport> {
+    let offset = config.payload_bytes - config.range_bytes;
+    let driver = FallbackDriver::new(payload);
+    for _ in 0..config.warmups {
+        let _ = run_fallback_sample(&driver, offset, config.range_bytes).await?;
+    }
+    let mut samples = Vec::with_capacity(config.samples);
+    for _ in 0..config.samples {
+        samples.push(run_fallback_sample(&driver, offset, config.range_bytes).await?);
+    }
+    Ok(ScenarioReport {
+        selected_bytes: config.range_bytes,
+        expected_backend_calls: 1,
+        expected_backend_requests: 1,
+        expected_prefix_skip_bytes: offset,
+        summary: summarize_samples(&samples),
+        samples,
+    })
+}
+
+async fn run_fallback_sample(
+    driver: &FallbackDriver,
+    offset: u64,
+    length: u64,
+) -> BenchResult<Sample> {
+    let before_bytes = driver.bytes_read.load(Ordering::SeqCst);
+    let before_opens = driver.stream_opens.load(Ordering::SeqCst);
+    let window = ByteWindow { offset, length };
+    let sample = read_one(driver, "fallback.bin", Some(window), window).await?;
+    let actual_read_bytes = driver
+        .bytes_read
+        .load(Ordering::SeqCst)
+        .saturating_sub(before_bytes);
+    let backend_calls = driver
+        .stream_opens
+        .load(Ordering::SeqCst)
+        .saturating_sub(before_opens);
+    Ok(sample.into_sample(
+        u64::try_from(backend_calls)?,
+        u64::try_from(backend_calls)?,
+        actual_read_bytes,
+        offset,
+    ))
+}
+
+struct CountingReader {
+    inner: std::io::Cursor<Vec<u8>>,
+    bytes_read: Arc<AtomicU64>,
+}
+
+impl AsyncRead for CountingReader {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        _context: &mut Context<'_>,
+        buffer: &mut ReadBuf<'_>,
+    ) -> Poll<std::io::Result<()>> {
+        let result = std::io::Read::read(&mut self.inner, buffer.initialize_unfilled());
+        if let Ok(read) = result {
+            buffer.advance(read);
+            self.bytes_read
+                .fetch_add(u64::try_from(read).unwrap_or(u64::MAX), Ordering::SeqCst);
+        }
+        Poll::Ready(result.map(|_| ()))
+    }
+}
+
+struct FallbackDriver {
+    data: Vec<u8>,
+    stream_opens: AtomicUsize,
+    bytes_read: Arc<AtomicU64>,
+}
+
+impl FallbackDriver {
+    fn new(data: &[u8]) -> Self {
+        Self {
+            data: data.to_vec(),
+            stream_opens: AtomicUsize::new(0),
+            bytes_read: Arc::new(AtomicU64::new(0)),
+        }
+    }
+}
+
+#[async_trait]
+impl StorageDriver for FallbackDriver {
+    async fn put(&self, path: &str, _data: &[u8]) -> aster_drive_storage::Result<String> {
+        Ok(path.to_string())
+    }
+
+    async fn get(&self, _path: &str) -> aster_drive_storage::Result<Vec<u8>> {
+        Ok(self.data.clone())
+    }
+
+    async fn get_stream(
+        &self,
+        _path: &str,
+    ) -> aster_drive_storage::Result<Box<dyn AsyncRead + Unpin + Send>> {
+        self.stream_opens.fetch_add(1, Ordering::SeqCst);
+        Ok(Box::new(CountingReader {
+            inner: std::io::Cursor::new(self.data.clone()),
+            bytes_read: Arc::clone(&self.bytes_read),
+        }))
+    }
+
+    async fn delete(&self, _path: &str) -> aster_drive_storage::Result<()> {
+        Ok(())
+    }
+
+    async fn exists(&self, _path: &str) -> aster_drive_storage::Result<bool> {
+        Ok(true)
+    }
+
+    async fn metadata(&self, _path: &str) -> aster_drive_storage::Result<BlobMetadata> {
+        Ok(BlobMetadata {
+            size: u64::try_from(self.data.len()).unwrap_or(u64::MAX),
+            content_type: Some("application/octet-stream".to_string()),
+        })
+    }
+}
+
+fn summarize_samples(samples: &[Sample]) -> ScenarioStatistics {
+    ScenarioStatistics {
+        open_ms: distribution(samples.iter().map(|sample| sample.open_ms)),
+        ttfb_ms: distribution(samples.iter().map(|sample| sample.ttfb_ms)),
+        read_ms: distribution(samples.iter().map(|sample| sample.read_ms)),
+        total_ms: distribution(samples.iter().map(|sample| sample.total_ms)),
+        throughput_bytes_per_second: distribution(
+            samples
+                .iter()
+                .map(|sample| sample.throughput_bytes_per_second),
+        ),
+        backend_call_count: distribution(
+            samples
+                .iter()
+                .map(|sample| sample.backend_call_count as f64),
+        ),
+        backend_request_count: distribution(
+            samples
+                .iter()
+                .map(|sample| sample.backend_request_count as f64),
+        ),
+        actual_read_bytes: distribution(
+            samples.iter().map(|sample| sample.actual_read_bytes as f64),
+        ),
+        prefix_skip_bytes: distribution(
+            samples.iter().map(|sample| sample.prefix_skip_bytes as f64),
+        ),
+    }
+}
+
+fn distribution(values: impl Iterator<Item = f64>) -> Distribution {
+    let mut values = values.collect::<Vec<_>>();
+    values.sort_by(f64::total_cmp);
+    Distribution {
+        min: values[0],
+        p50: percentile(&values, 0.50),
+        p95: percentile(&values, 0.95),
+        p99: percentile(&values, 0.99),
+        max: values[values.len() - 1],
+    }
+}
+
+#[expect(
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss,
+    reason = "The interpolated percentile index is bounded by the non-empty slice length."
+)]
+fn percentile(values: &[f64], percentile: f64) -> f64 {
+    if values.len() == 1 {
+        return values[0];
+    }
+    let position = percentile * (values.len() - 1) as f64;
+    let lower = position.floor() as usize;
+    let upper = position.ceil() as usize;
+    if lower == upper {
+        return values[lower];
+    }
+    let weight = position - lower as f64;
+    values[lower] + (values[upper] - values[lower]) * weight
+}
+
+async fn compare_baseline(
+    config: &BenchConfig,
+    scenarios: &BTreeMap<String, ScenarioReport>,
+) -> BenchResult<BaselineComparison> {
+    let Some(path) = config.baseline_path.as_deref() else {
+        return Ok(baseline_not_compared(config, "no baseline path configured"));
+    };
+    let Some(profile) = config.baseline_profile.as_deref() else {
+        return Ok(baseline_not_compared(
+            config,
+            "no baseline profile configured",
+        ));
+    };
+    let bytes = tokio::fs::read(path).await?;
+    let baseline: BaselineFile = serde_json::from_slice(&bytes)?;
+    if baseline.schema_version != ARTIFACT_SCHEMA_VERSION {
+        return Ok(baseline_not_compared(
+            config,
+            "baseline schema version does not match artifact schema",
+        ));
+    }
+    let Some(selected) = baseline.profiles.iter().find(|candidate| {
+        candidate.profile == profile
+            && candidate.provider == config.provider
+            && candidate.payload_bytes == config.payload_bytes
+            && candidate.range_bytes == config.range_bytes
+            && candidate.sampling.warmups == config.warmups
+            && candidate.sampling.samples == config.samples
+            && candidate.sampling.read_buffer_bytes == READ_BUFFER_BYTES
+            && candidate.machine.build_profile == current_build_profile()
+    }) else {
+        return Ok(BaselineComparison {
+            baseline_path: Some(path.display().to_string()),
+            profile: Some(profile.to_string()),
+            status: "not_compared",
+            reason: Some("no matching provider, fixture, and machine profile".to_string()),
+            policy: Some(baseline.regression_policy),
+            scenarios: BTreeMap::new(),
+        });
+    };
+
+    let mut comparisons = BTreeMap::new();
+    for (name, current) in scenarios {
+        let Some(reference) = selected.scenarios.get(name) else {
+            continue;
+        };
+        let ttfb_ratio = ratio(current.summary.ttfb_ms.p95, reference.ttfb_p95_ms);
+        let throughput_ratio = ratio(
+            current.summary.throughput_bytes_per_second.p50,
+            reference.throughput_p50_bytes_per_second,
+        );
+        comparisons.insert(
+            name.clone(),
+            ScenarioComparison {
+                ttfb_p95_ratio: ttfb_ratio,
+                throughput_p50_ratio: throughput_ratio,
+                regressed: ttfb_ratio > baseline.regression_policy.ttfb_p95_max_ratio
+                    || throughput_ratio < baseline.regression_policy.throughput_p50_min_ratio,
+            },
+        );
+    }
+    Ok(BaselineComparison {
+        baseline_path: Some(path.display().to_string()),
+        profile: Some(profile.to_string()),
+        status: "compared",
+        reason: None,
+        policy: Some(baseline.regression_policy),
+        scenarios: comparisons,
+    })
+}
+
+fn baseline_not_compared(config: &BenchConfig, reason: &str) -> BaselineComparison {
+    BaselineComparison {
+        baseline_path: config
+            .baseline_path
+            .as_ref()
+            .map(|path| path.display().to_string()),
+        profile: config.baseline_profile.clone(),
+        status: "not_compared",
+        reason: Some(reason.to_string()),
+        policy: None,
+        scenarios: BTreeMap::new(),
+    }
+}
+
+fn ratio(current: f64, baseline: f64) -> f64 {
+    if baseline <= f64::EPSILON {
+        f64::INFINITY
+    } else {
+        current / baseline
+    }
+}
+
+async fn write_artifact(path: &Path, artifact: &BenchmarkArtifact) -> BenchResult<()> {
+    if let Some(parent) = path.parent() {
+        tokio::fs::create_dir_all(parent).await?;
+    }
+    let body = serde_json::to_vec_pretty(artifact)?;
+    tokio::fs::write(path, body).await?;
+    println!("WebDAV provider Range artifact: {}", path.display());
+    Ok(())
+}
+
+fn deterministic_payload(size: u64) -> BenchResult<Vec<u8>> {
+    let size = usize::try_from(size)?;
+    (0..size)
+        .map(|index| u8::try_from(index % 251).map_err(Into::into))
+        .collect()
+}
+
+fn machine_summary(profile: Option<String>) -> MachineSummary {
+    MachineSummary {
+        profile,
+        build_profile: current_build_profile(),
+        os: std::env::consts::OS.to_string(),
+        architecture: std::env::consts::ARCH.to_string(),
+        cpu_model: cpu_model(),
+        logical_cpus: std::thread::available_parallelism().map_or(1, usize::from),
+        rustc: command_output("rustc", &["--version"]),
+        kernel: command_output("uname", &["-srmo"]),
+    }
+}
+
+const fn current_build_profile() -> &'static str {
+    if cfg!(debug_assertions) {
+        "debug"
+    } else {
+        "optimized"
+    }
+}
+
+fn cpu_model() -> Option<String> {
+    let contents = std::fs::read_to_string("/proc/cpuinfo").ok()?;
+    contents.lines().find_map(|line| {
+        line.split_once(':')
+            .and_then(|(key, value)| (key.trim() == "model name").then(|| value.trim().to_string()))
+    })
+}
+
+fn command_output(command: &str, args: &[&str]) -> Option<String> {
+    let output = Command::new(command).args(args).output().ok()?;
+    output
+        .status
+        .success()
+        .then(|| String::from_utf8_lossy(&output.stdout).trim().to_string())
+}
+
+fn git_dirty() -> Option<bool> {
+    command_output("git", &["status", "--porcelain"]).map(|output| !output.is_empty())
+}
+
+fn duration_ms(duration: Duration) -> f64 {
+    duration.as_secs_f64() * 1000.0
+}
+
+fn env_optional(name: &str) -> Option<String> {
+    std::env::var(name)
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+}
+
+fn env_required(name: &str) -> BenchResult<String> {
+    env_optional(name).ok_or_else(|| format!("missing required environment variable {name}").into())
+}
+
+fn env_string(name: &str, fallback: &str) -> String {
+    env_optional(name).unwrap_or_else(|| fallback.to_string())
+}
+
+fn env_bool(name: &str, fallback: bool) -> BenchResult<bool> {
+    let Some(value) = env_optional(name) else {
+        return Ok(fallback);
+    };
+    match value.to_ascii_lowercase().as_str() {
+        "1" | "true" | "yes" | "on" => Ok(true),
+        "0" | "false" | "no" | "off" => Ok(false),
+        _ => Err(format!("invalid boolean environment variable {name}={value}").into()),
+    }
+}
+
+fn env_u64(name: &str, fallback: u64) -> BenchResult<u64> {
+    match env_optional(name) {
+        Some(value) => Ok(value.parse()?),
+        None => Ok(fallback),
+    }
+}
+
+fn env_usize(name: &str, fallback: usize) -> BenchResult<usize> {
+    match env_optional(name) {
+        Some(value) => Ok(value.parse()?),
+        None => Ok(fallback),
+    }
+}

--- a/benches/webdav_provider_range.rs
+++ b/benches/webdav_provider_range.rs
@@ -58,8 +58,11 @@ impl BenchConfig {
     fn from_env() -> BenchResult<Self> {
         let payload_bytes = env_u64("ASTER_BENCH_RANGE_PAYLOAD_BYTES", DEFAULT_PAYLOAD_BYTES)?;
         let range_bytes = env_u64("ASTER_BENCH_RANGE_BYTES", DEFAULT_RANGE_BYTES)?;
-        if range_bytes == 0 {
-            return Err("ASTER_BENCH_RANGE_BYTES must be positive".into());
+        if range_bytes < 2 {
+            return Err(
+                "ASTER_BENCH_RANGE_BYTES must be at least 2 so multi-range windows stay non-empty"
+                    .into(),
+            );
         }
         if payload_bytes > MAX_PAYLOAD_BYTES {
             return Err(format!(
@@ -400,7 +403,7 @@ async fn main() -> BenchResult<()> {
         scenarios.insert(name.clone(), report_for_scenario(scenario, samples));
     }
 
-    let fallback = run_fallback_benchmark(&config, &payload).await?;
+    let fallback = run_fallback_benchmark(&config, Arc::<[u8]>::from(payload)).await?;
     let baseline = compare_baseline(&config, &scenarios).await?;
     let baseline_regressed = baseline
         .scenarios
@@ -877,7 +880,7 @@ fn report_for_scenario(scenario: &ScenarioSpec, samples: Vec<Sample>) -> Scenari
 
 async fn run_fallback_benchmark(
     config: &BenchConfig,
-    payload: &[u8],
+    payload: Arc<[u8]>,
 ) -> BenchResult<ScenarioReport> {
     let offset = config.payload_bytes - config.range_bytes;
     let driver = FallbackDriver::new(payload);
@@ -924,7 +927,7 @@ async fn run_fallback_sample(
 }
 
 struct CountingReader {
-    inner: std::io::Cursor<Vec<u8>>,
+    inner: std::io::Cursor<Arc<[u8]>>,
     bytes_read: Arc<AtomicU64>,
 }
 
@@ -945,15 +948,15 @@ impl AsyncRead for CountingReader {
 }
 
 struct FallbackDriver {
-    data: Vec<u8>,
+    data: Arc<[u8]>,
     stream_opens: AtomicUsize,
     bytes_read: Arc<AtomicU64>,
 }
 
 impl FallbackDriver {
-    fn new(data: &[u8]) -> Self {
+    fn new(data: Arc<[u8]>) -> Self {
         Self {
-            data: data.to_vec(),
+            data,
             stream_opens: AtomicUsize::new(0),
             bytes_read: Arc::new(AtomicU64::new(0)),
         }
@@ -967,7 +970,7 @@ impl StorageDriver for FallbackDriver {
     }
 
     async fn get(&self, _path: &str) -> aster_drive_storage::Result<Vec<u8>> {
-        Ok(self.data.clone())
+        Ok(self.data.as_ref().to_vec())
     }
 
     async fn get_stream(
@@ -976,7 +979,7 @@ impl StorageDriver for FallbackDriver {
     ) -> aster_drive_storage::Result<Box<dyn AsyncRead + Unpin + Send>> {
         self.stream_opens.fetch_add(1, Ordering::SeqCst);
         Ok(Box::new(CountingReader {
-            inner: std::io::Cursor::new(self.data.clone()),
+            inner: std::io::Cursor::new(Arc::clone(&self.data)),
             bytes_read: Arc::clone(&self.bytes_read),
         }))
     }
@@ -995,6 +998,54 @@ impl StorageDriver for FallbackDriver {
             content_type: Some("application/octet-stream".to_string()),
         })
     }
+}
+
+#[cfg(test)]
+pub async fn contract_multi_range_accounting() {
+    let root = std::env::temp_dir().join(format!(
+        "asterdrive-webdav-provider-range-contract-{}",
+        uuid::Uuid::new_v4()
+    ));
+    tokio::fs::create_dir_all(&root).await.unwrap();
+    let root_string = root.to_string_lossy().into_owned();
+    let driver = LocalDriver::new(&root_string).unwrap();
+    let payload = deterministic_payload(1024).unwrap();
+    driver.put("contract.bin", &payload).await.unwrap();
+    let ranges = [
+        ByteWindow {
+            offset: 10,
+            length: 8,
+        },
+        ByteWindow {
+            offset: 900,
+            length: 8,
+        },
+    ];
+
+    let sample = run_provider_scenario(&driver, 1, "contract.bin", &ScenarioSpec::Multi { ranges })
+        .await
+        .unwrap();
+
+    assert_eq!(sample.backend_call_count, 2);
+    assert_eq!(sample.backend_request_count, 2);
+    assert_eq!(sample.actual_read_bytes, 16);
+    driver.delete("contract.bin").await.unwrap();
+    tokio::fs::remove_dir_all(root).await.unwrap();
+}
+
+#[cfg(test)]
+pub async fn contract_fallback_read_accounting() {
+    let payload = Arc::<[u8]>::from(deterministic_payload(1024).unwrap());
+    let driver = FallbackDriver::new(payload);
+    let offset = 900;
+    let length = 16;
+
+    let sample = run_fallback_sample(&driver, offset, length).await.unwrap();
+
+    assert_eq!(sample.backend_call_count, 1);
+    assert_eq!(sample.backend_request_count, 1);
+    assert_eq!(sample.actual_read_bytes, offset + length);
+    assert_eq!(sample.prefix_skip_bytes, offset);
 }
 
 fn summarize_samples(samples: &[Sample]) -> ScenarioStatistics {

--- a/benches/webdav_provider_range.rs
+++ b/benches/webdav_provider_range.rs
@@ -129,7 +129,7 @@ impl BenchConfig {
                     },
                     ByteWindow {
                         offset: self.payload_bytes - self.range_bytes.saturating_mul(3),
-                        length: half,
+                        length: self.range_bytes - half,
                     },
                 ],
             },
@@ -370,78 +370,122 @@ async fn main() -> BenchResult<()> {
         }
     };
 
-    let payload = deterministic_payload(config.payload_bytes)?;
-    provider_fixture
-        .driver
-        .put(&config.object_path, &payload)
-        .await?;
-
-    let scenario_specs = config.scenario_specs();
-    let mut scenarios = BTreeMap::new();
-    for (name, scenario) in &scenario_specs {
-        for _ in 0..config.warmups {
-            let _ = run_provider_scenario(
-                provider_fixture.driver.as_ref(),
-                provider_fixture.requests_per_backend_call,
-                &config.object_path,
-                scenario,
-            )
+    let benchmark_result = async {
+        let payload = deterministic_payload(config.payload_bytes)?;
+        provider_fixture
+            .driver
+            .put(&config.object_path, &payload)
             .await?;
-        }
-        let mut samples = Vec::with_capacity(config.samples);
-        for _ in 0..config.samples {
-            samples.push(
-                run_provider_scenario(
+
+        let scenario_specs = config.scenario_specs();
+        let mut scenarios = BTreeMap::new();
+        for (name, scenario) in &scenario_specs {
+            for _ in 0..config.warmups {
+                let _ = run_provider_scenario(
                     provider_fixture.driver.as_ref(),
                     provider_fixture.requests_per_backend_call,
                     &config.object_path,
                     scenario,
                 )
-                .await?,
+                .await?;
+            }
+            let mut samples = Vec::with_capacity(config.samples);
+            for _ in 0..config.samples {
+                samples.push(
+                    run_provider_scenario(
+                        provider_fixture.driver.as_ref(),
+                        provider_fixture.requests_per_backend_call,
+                        &config.object_path,
+                        scenario,
+                    )
+                    .await?,
+                );
+            }
+            scenarios.insert(name.clone(), report_for_scenario(scenario, samples));
+        }
+
+        let fallback = run_fallback_benchmark(&config, Arc::<[u8]>::from(payload)).await?;
+        let baseline = compare_baseline(&config, &scenarios).await?;
+        let baseline_regressed = baseline
+            .scenarios
+            .values()
+            .any(|scenario| scenario.regressed);
+
+        let artifact = BenchmarkArtifact {
+            schema_version: ARTIFACT_SCHEMA_VERSION,
+            generated_at: chrono::Utc::now().to_rfc3339(),
+            git_revision: command_output("git", &["rev-parse", "HEAD"]),
+            git_dirty: git_dirty(),
+            status: "completed",
+            provider: provider_fixture.provider.clone(),
+            skip_reason: None,
+            prerequisites: Vec::new(),
+            fixture: fixture_summary,
+            sampling,
+            machine,
+            provider_config: provider_fixture.config_summary.clone(),
+            scenarios,
+            fallback: Some(fallback),
+            baseline,
+        };
+        write_artifact(&config.output_path, &artifact).await?;
+
+        if config.fail_on_regression && baseline_regressed {
+            return Err(
+                "provider Range benchmark exceeded the selected versioned baseline policy".into(),
             );
         }
-        scenarios.insert(name.clone(), report_for_scenario(scenario, samples));
+        Ok(())
+    }
+    .await;
+
+    let cleanup_result = if config.cleanup_fixture {
+        cleanup_provider_fixture(&provider_fixture, &config.object_path).await
+    } else {
+        Ok(())
+    };
+    finish_benchmark(benchmark_result, cleanup_result)
+}
+
+async fn cleanup_provider_fixture(
+    provider_fixture: &ProviderFixture,
+    object_path: &str,
+) -> BenchResult<()> {
+    let mut cleanup_errors = Vec::new();
+    if let Err(error) = provider_fixture.driver.delete(object_path).await {
+        cleanup_errors.push(format!(
+            "failed to delete provider fixture '{object_path}': {error}"
+        ));
+    }
+    if let Some(root) = &provider_fixture.cleanup_root
+        && let Err(error) = tokio::fs::remove_dir_all(root).await
+    {
+        cleanup_errors.push(format!(
+            "failed to remove local provider fixture root '{}': {error}",
+            root.display()
+        ));
     }
 
-    let fallback = run_fallback_benchmark(&config, Arc::<[u8]>::from(payload)).await?;
-    let baseline = compare_baseline(&config, &scenarios).await?;
-    let baseline_regressed = baseline
-        .scenarios
-        .values()
-        .any(|scenario| scenario.regressed);
+    if cleanup_errors.is_empty() {
+        Ok(())
+    } else {
+        Err(cleanup_errors.join("; ").into())
+    }
+}
 
-    let artifact = BenchmarkArtifact {
-        schema_version: ARTIFACT_SCHEMA_VERSION,
-        generated_at: chrono::Utc::now().to_rfc3339(),
-        git_revision: command_output("git", &["rev-parse", "HEAD"]),
-        git_dirty: git_dirty(),
-        status: "completed",
-        provider: provider_fixture.provider.clone(),
-        skip_reason: None,
-        prerequisites: Vec::new(),
-        fixture: fixture_summary,
-        sampling,
-        machine,
-        provider_config: provider_fixture.config_summary.clone(),
-        scenarios,
-        fallback: Some(fallback),
-        baseline,
-    };
-    write_artifact(&config.output_path, &artifact).await?;
-
-    if config.cleanup_fixture {
-        provider_fixture.driver.delete(&config.object_path).await?;
-        if let Some(root) = provider_fixture.cleanup_root {
-            tokio::fs::remove_dir_all(root).await?;
+fn finish_benchmark<T>(
+    benchmark_result: BenchResult<T>,
+    cleanup_result: BenchResult<()>,
+) -> BenchResult<T> {
+    match (benchmark_result, cleanup_result) {
+        (Ok(value), Ok(())) => Ok(value),
+        (Ok(_), Err(cleanup_error)) => Err(cleanup_error),
+        (Err(benchmark_error), Ok(())) => Err(benchmark_error),
+        (Err(benchmark_error), Err(cleanup_error)) => {
+            eprintln!("WebDAV provider Range fixture cleanup failed: {cleanup_error}");
+            Err(benchmark_error)
         }
     }
-
-    if config.fail_on_regression && baseline_regressed {
-        return Err(
-            "provider Range benchmark exceeded the selected versioned baseline policy".into(),
-        );
-    }
-    Ok(())
 }
 
 async fn build_provider(config: &BenchConfig) -> BenchResult<ProviderBuild> {
@@ -1022,15 +1066,70 @@ pub async fn contract_multi_range_accounting() {
         },
     ];
 
-    let sample = run_provider_scenario(&driver, 1, "contract.bin", &ScenarioSpec::Multi { ranges })
+    let sample = run_provider_scenario(&driver, 3, "contract.bin", &ScenarioSpec::Multi { ranges })
         .await
         .unwrap();
 
     assert_eq!(sample.backend_call_count, 2);
-    assert_eq!(sample.backend_request_count, 2);
+    assert_eq!(sample.backend_request_count, 6);
     assert_eq!(sample.actual_read_bytes, 16);
     driver.delete("contract.bin").await.unwrap();
     tokio::fs::remove_dir_all(root).await.unwrap();
+}
+
+#[cfg(test)]
+pub fn contract_odd_multi_range_accounting() {
+    let config = BenchConfig {
+        provider: "local".to_string(),
+        provider_required: false,
+        payload_bytes: 18,
+        range_bytes: 3,
+        warmups: 0,
+        samples: 1,
+        object_path: "contract.bin".to_string(),
+        output_path: PathBuf::from("artifact.json"),
+        cleanup_fixture: true,
+        baseline_path: None,
+        baseline_profile: None,
+        fail_on_regression: false,
+    };
+    let ScenarioSpec::Multi { ranges } = config
+        .scenario_specs()
+        .remove("multi_range_disjoint")
+        .unwrap()
+    else {
+        panic!("multi_range_disjoint must remain a multi-range scenario");
+    };
+
+    assert!(ranges.iter().all(|range| range.length > 0));
+    assert_eq!(ranges[0].length + ranges[1].length, config.range_bytes);
+}
+
+#[cfg(test)]
+pub async fn contract_failed_benchmark_cleans_fixture() {
+    let root = std::env::temp_dir().join(format!(
+        "asterdrive-webdav-provider-range-cleanup-contract-{}",
+        uuid::Uuid::new_v4()
+    ));
+    tokio::fs::create_dir_all(&root).await.unwrap();
+    let root_string = root.to_string_lossy().into_owned();
+    let driver = LocalDriver::new(&root_string).unwrap();
+    let payload = deterministic_payload(32).unwrap();
+    driver.put("contract.bin", &payload).await.unwrap();
+    let provider_fixture = ProviderFixture {
+        provider: "local".to_string(),
+        driver: Box::new(driver),
+        requests_per_backend_call: 1,
+        config_summary: json!({}),
+        cleanup_root: Some(root.clone()),
+    };
+    let benchmark_result: BenchResult<()> = Err("synthetic benchmark failure".into());
+    let cleanup_result = cleanup_provider_fixture(&provider_fixture, "contract.bin").await;
+
+    let error = finish_benchmark(benchmark_result, cleanup_result).unwrap_err();
+
+    assert_eq!(error.to_string(), "synthetic benchmark failure");
+    assert!(!root.exists());
 }
 
 #[cfg(test)]

--- a/frontend-panel/bun.lock
+++ b/frontend-panel/bun.lock
@@ -75,7 +75,7 @@
     "form-data": "4.0.6",
     "hono": "4.12.25",
     "ip-address": "10.3.1",
-    "js-yaml": "4.3.0",
+    "js-yaml": "4.3.1",
     "picomatch": "4.0.4",
     "react": "^19.2.8",
     "undici": "7.29.0",
@@ -1261,7 +1261,7 @@
 
     "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
-    "js-yaml": ["js-yaml@4.3.0", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q=="],
+    "js-yaml": ["js-yaml@4.3.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ=="],
 
     "jsdom": ["jsdom@30.0.1", "", { "dependencies": { "@asamuzakjp/css-color": "^6.0.5", "@asamuzakjp/dom-selector": "^8.3.0", "@bramus/specificity": "^2.4.2", "@csstools/css-syntax-patches-for-csstree": "^1.1.7", "@exodus/bytes": "^1.15.1", "css-tree": "^3.2.1", "data-urls": "^7.0.0", "decimal.js": "^10.6.0", "html-encoding-sniffer": "^6.0.0", "is-potential-custom-element-name": "^1.0.1", "lru-cache": "^11.5.2", "parse5": "^8.0.1", "saxes": "^6.0.0", "symbol-tree": "^3.2.4", "tough-cookie": "^6.0.2", "undici": "^8.9.0", "w3c-xmlserializer": "^5.0.0", "webidl-conversions": "^8.0.1", "whatwg-mimetype": "^5.0.0", "whatwg-url": "^17.1.0", "xml-name-validator": "^5.0.0" }, "peerDependencies": { "canvas": "^3.2.3" }, "optionalPeers": ["canvas"] }, "sha512-52v7mUVUfNQVYYqE1lcdaymWL0njO7lTLUog6ZvW2U5KsbiLk/GnZlVJ+qx0xfNJZ6Gn+KSpPNE52vurbxZwrA=="],
 

--- a/frontend-panel/package.json
+++ b/frontend-panel/package.json
@@ -94,7 +94,7 @@
 		"form-data": "4.0.6",
 		"hono": "4.12.25",
 		"ip-address": "10.3.1",
-		"js-yaml": "4.3.0",
+		"js-yaml": "4.3.1",
 		"picomatch": "4.0.4",
 		"react": "^19.2.8",
 		"undici": "7.29.0"

--- a/tests/files/upload.rs
+++ b/tests/files/upload.rs
@@ -2370,9 +2370,68 @@ async fn test_retry_with_existing_receipt_keeps_committed_staging_range() {
 
 #[actix_web::test]
 async fn test_offset_staging_rejects_corrupted_receipt_on_retry_and_complete() {
-    use aster_drive::db::repository::upload_session_part_repo;
+    use aster_drive::db::repository::{upload_session_part_repo, upload_session_repo};
     use aster_drive::services::files::upload;
     use sea_orm::{ActiveModelTrait, IntoActiveModel, Set};
+
+    async fn create_corrupted_upload(
+        state: &aster_drive::runtime::PrimaryAppState,
+        user_id: i64,
+        filename: &str,
+        etag: &str,
+        size: i64,
+    ) -> (String, Vec<u8>) {
+        let init = upload::init_upload(state, user_id, filename, 10_485_760, None, None)
+            .await
+            .unwrap();
+        let upload_id = init.upload_id.unwrap();
+        let chunk0 = vec![b'A'; TEST_CHUNK_SIZE];
+        let chunk1 = vec![b'B'; TEST_CHUNK_SIZE];
+        upload::upload_chunk(state, &upload_id, 0, user_id, &chunk0)
+            .await
+            .unwrap();
+        upload::upload_chunk(state, &upload_id, 1, user_id, &chunk1)
+            .await
+            .unwrap();
+
+        let mut receipt =
+            upload_session_part_repo::find_by_upload_and_part(state.writer_db(), &upload_id, 1)
+                .await
+                .unwrap()
+                .unwrap()
+                .into_active_model();
+        receipt.etag = Set(etag.to_string());
+        receipt.size = Set(size);
+        receipt.update(state.writer_db()).await.unwrap();
+        (upload_id, chunk0)
+    }
+
+    async fn assert_upload_stage_terminal_cleanup(
+        state: &aster_drive::runtime::PrimaryAppState,
+        upload_id: &str,
+        operation: &str,
+    ) {
+        let session = upload_session_repo::find_by_id(state.writer_db(), upload_id).await;
+        assert!(
+            session.is_err(),
+            "terminal receipt corruption during {operation} must remove the upload session; found {session:?}"
+        );
+        assert!(
+            upload_session_part_repo::list_by_upload(state.writer_db(), upload_id)
+                .await
+                .unwrap()
+                .is_empty(),
+            "terminal receipt corruption must remove persisted chunk receipts"
+        );
+        let staging_dir = aster_forge_utils::paths::upload_temp_dir(
+            &state.config.server.upload_temp_dir,
+            upload_id,
+        );
+        assert!(
+            !tokio::fs::try_exists(staging_dir).await.unwrap(),
+            "terminal receipt corruption must remove the local staging directory"
+        );
+    }
 
     let state = common::setup().await;
     let user = common::create_test_account(
@@ -2383,61 +2442,85 @@ async fn test_offset_staging_rejects_corrupted_receipt_on_retry_and_complete() {
     )
     .await
     .unwrap();
-    let init = upload::init_upload(
+
+    let (retry_upload_id, retry_chunk) = create_corrupted_upload(
         &state,
         user.id,
-        "corrupt-receipt.bin",
-        10_485_760,
-        None,
-        None,
+        "corrupt-retry.bin",
+        "corrupted-receipt",
+        TEST_CHUNK_SIZE as i64,
     )
-    .await
-    .unwrap();
-    let upload_id = init.upload_id.unwrap();
-    let chunk0 = vec![b'A'; TEST_CHUNK_SIZE];
-    let chunk1 = vec![b'B'; TEST_CHUNK_SIZE];
-    upload::upload_chunk(&state, &upload_id, 0, user.id, &chunk0)
-        .await
-        .unwrap();
-    upload::upload_chunk(&state, &upload_id, 1, user.id, &chunk1)
-        .await
-        .unwrap();
-
-    let mut receipt =
-        upload_session_part_repo::find_by_upload_and_part(state.writer_db(), &upload_id, 1)
-            .await
-            .unwrap()
-            .unwrap()
-            .into_active_model();
-    receipt.etag = Set("corrupted-receipt".to_string());
-    receipt.update(state.writer_db()).await.unwrap();
-
-    let retry_error = match upload::upload_chunk(&state, &upload_id, 0, user.id, &chunk0).await {
-        Ok(_) => panic!("corrupted local receipt must reject a retry"),
-        Err(error) => error,
-    };
+    .await;
+    let retry_error =
+        match upload::upload_chunk(&state, &retry_upload_id, 0, user.id, &retry_chunk).await {
+            Ok(_) => panic!("corrupted local receipt must reject a retry"),
+            Err(error) => error,
+        };
     assert!(retry_error.message().contains("receipt is corrupted"));
+    assert_upload_stage_terminal_cleanup(&state, &retry_upload_id, "retry").await;
 
-    let mut receipt =
-        upload_session_part_repo::find_by_upload_and_part(state.writer_db(), &upload_id, 1)
-            .await
-            .unwrap()
-            .unwrap()
-            .into_active_model();
-    receipt.etag = Set(upload::test_support::offset_staging_receipt_etag().to_string());
-    receipt.size = Set(1);
-    receipt.update(state.writer_db()).await.unwrap();
-
-    let progress_error = match upload::get_progress(&state, &upload_id, user.id).await {
+    let (progress_upload_id, _) = create_corrupted_upload(
+        &state,
+        user.id,
+        "corrupt-progress.bin",
+        upload::test_support::offset_staging_receipt_etag(),
+        1,
+    )
+    .await;
+    let progress_error = match upload::get_progress(&state, &progress_upload_id, user.id).await {
         Ok(_) => panic!("corrupted local receipt size must reject progress recovery"),
         Err(error) => error,
     };
     assert!(progress_error.message().contains("receipt is corrupted"));
+    let progress_session = upload_session_repo::find_by_id(state.writer_db(), &progress_upload_id)
+        .await
+        .expect("read-only progress failure must preserve the upload session");
+    assert_eq!(
+        progress_session.status,
+        aster_drive_model::types::UploadSessionStatus::Uploading
+    );
+    assert_eq!(
+        upload_session_part_repo::list_by_upload(state.writer_db(), &progress_upload_id)
+            .await
+            .unwrap()
+            .len(),
+        2,
+        "read-only progress validation must not mutate chunk receipts"
+    );
 
-    let complete_error = upload::complete_upload(&state, &upload_id, user.id, None)
+    let (complete_upload_id, _) = create_corrupted_upload(
+        &state,
+        user.id,
+        "corrupt-complete.bin",
+        upload::test_support::offset_staging_receipt_etag(),
+        1,
+    )
+    .await;
+    let complete_error = upload::complete_upload(&state, &complete_upload_id, user.id, None)
         .await
         .unwrap_err();
     assert!(complete_error.message().contains("receipt is invalid"));
+    let failed_session = upload_session_repo::find_by_id(state.writer_db(), &complete_upload_id)
+        .await
+        .expect("completion-stage failure should retain the session for cleanup");
+    assert_eq!(
+        failed_session.status,
+        aster_drive_model::types::UploadSessionStatus::Failed
+    );
+    assert!(
+        upload_session_repo::find_recoverable_by_owner(
+            state.writer_db(),
+            user.id,
+            None,
+            None,
+            100,
+        )
+        .await
+        .unwrap()
+        .iter()
+        .all(|session| session.id != complete_upload_id),
+        "failed completion must not remain recoverable"
+    );
 }
 
 #[actix_web::test]
@@ -5693,10 +5776,20 @@ async fn test_relay_stream_chunked_upload_s3_e2e() {
             .is_empty(),
         "oversized relay chunk must release the claimed part row"
     );
-    let oversized_progress = upload::get_progress(&state, &oversized_upload_id, user.id)
-        .await
-        .unwrap();
-    assert!(oversized_progress.chunks_on_disk.is_empty());
+    assert!(
+        upload_session_repo::find_by_id(state.writer_db(), &oversized_upload_id)
+            .await
+            .is_err(),
+        "oversized relay chunk must terminate and remove its upload session"
+    );
+    assert!(
+        upload::list_recoverable_sessions(&state, user.id, None)
+            .await
+            .unwrap()
+            .iter()
+            .all(|session| session.upload_id != oversized_upload_id),
+        "oversized relay chunk must not remain recoverable"
+    );
     let oversized_relay_temp_dir = aster_forge_utils::paths::upload_temp_dir(
         &state.config.server.upload_temp_dir,
         &oversized_upload_id,

--- a/tests/files/upload.rs
+++ b/tests/files/upload.rs
@@ -2411,10 +2411,15 @@ async fn test_offset_staging_rejects_corrupted_receipt_on_retry_and_complete() {
         upload_id: &str,
         operation: &str,
     ) {
-        let session = upload_session_repo::find_by_id(state.writer_db(), upload_id).await;
+        let error = upload_session_repo::find_by_id(state.writer_db(), upload_id)
+            .await
+            .expect_err("terminal receipt corruption must remove the upload session");
         assert!(
-            session.is_err(),
-            "terminal receipt corruption during {operation} must remove the upload session; found {session:?}"
+            matches!(
+                error,
+                aster_drive::errors::AsterError::UploadSessionNotFound(_)
+            ),
+            "terminal receipt corruption during {operation} returned the wrong lookup error: {error:?}"
         );
         assert!(
             upload_session_part_repo::list_by_upload(state.writer_db(), upload_id)
@@ -5776,11 +5781,15 @@ async fn test_relay_stream_chunked_upload_s3_e2e() {
             .is_empty(),
         "oversized relay chunk must release the claimed part row"
     );
+    let lookup_error = upload_session_repo::find_by_id(state.writer_db(), &oversized_upload_id)
+        .await
+        .expect_err("oversized relay chunk must remove its upload session");
     assert!(
-        upload_session_repo::find_by_id(state.writer_db(), &oversized_upload_id)
-            .await
-            .is_err(),
-        "oversized relay chunk must terminate and remove its upload session"
+        matches!(
+            lookup_error,
+            aster_drive::errors::AsterError::UploadSessionNotFound(_)
+        ),
+        "oversized relay chunk returned the wrong lookup error: {lookup_error:?}"
     );
     assert!(
         upload::list_recoverable_sessions(&state, user.id, None)

--- a/tests/performance/README.md
+++ b/tests/performance/README.md
@@ -342,8 +342,9 @@ policy reports a regression when p95 TTFB exceeds `1.5x` or p50 throughput
 drops below `0.7x`; scheduled runs report the comparison in the artifact and do
 not turn network variance into a protocol-test failure.
 
-Update a profile only from a reviewed artifact captured on the same machine and
-provider fixture:
+Update a profile only from a reviewed artifact captured from a clean Git
+worktree on the same machine and provider fixture. The updater rejects dirty,
+incomplete, empty, or non-finite artifacts before touching the baseline file:
 
 ```bash
 bun tests/performance/update-webdav-provider-range-baseline.mjs \

--- a/tests/performance/README.md
+++ b/tests/performance/README.md
@@ -215,6 +215,148 @@ in path and naming helpers used by file, upload, and WebDAV flows.
 cargo bench --bench path_hotspots
 ```
 
+## WebDAV Provider Range Baselines
+
+Issue `#449` uses a separate Rust runner for provider efficiency. It calls the
+same `StorageDriver::get_stream()` / `get_range()` operations selected by the
+WebDAV download adapter, without putting wall-clock assertions into ordinary
+unit tests.
+
+The fixed scenario set is:
+
+- full GET;
+- an early single range;
+- a late single range;
+- two disjoint ranges, with one backend open per final segment;
+- the default `get_stream + prefix skip` fallback, measured against an
+  instrumented in-memory fixture.
+
+Each artifact contains raw samples plus p50/p95/p99 summaries for open time,
+TTFB, read time, total time, and payload throughput. It also records selected
+bytes, logical backend call count, bytes actually pulled through the returned
+reader, and fallback prefix bytes. `backend_call_count` follows the existing
+WebDAV observation contract: it counts `get_stream` / `get_range` opens. SDK
+retries and a provider's internal redirect hop remain transport details and
+must be called out in the provider fixture summary when they change.
+
+Machine metadata distinguishes debug from optimized binaries. Baseline lookup
+also matches warmup count, sample count, and read-buffer size, so results from a
+quick debug smoke run cannot be compared with the optimized `cargo bench`
+workflow by accident.
+
+Provider summaries record behavior-relevant configuration such as path style,
+protocol versions, host-key pinning, and whether explicit target selection is
+enabled. Credentials and fixture identifiers such as endpoints, bucket names,
+drive/item IDs, remote target keys, and SFTP fingerprints are deliberately
+redacted from artifacts.
+
+The fixture is explicitly bounded to at most 1 GiB. Download samples validate
+the deterministic byte pattern incrementally with a 64 KiB buffer rather than
+buffering a complete response or writing a temporary download.
+
+Local run:
+
+```bash
+ASTER_BENCH_RANGE_PROVIDER=local \
+ASTER_BENCH_RANGE_BASELINE_PROFILE="$(uname -s)-$(uname -m)-local-v1" \
+ASTER_BENCH_RANGE_BASELINE=tests/performance/baselines/webdav-provider-range-v1.json \
+cargo bench --bench webdav_provider_range --features benchmarks
+```
+
+The default artifact path is:
+
+```text
+tests/performance/results/webdav-provider-range/artifact.json
+```
+
+External fixtures are opt-in. Missing variables produce a structured `skipped`
+artifact with the exact prerequisite list; set
+`ASTER_BENCH_RANGE_PROVIDER_REQUIRED=true` when a selected fixture must exist.
+
+### S3-compatible
+
+Required:
+
+```text
+ASTER_BENCH_S3_ENDPOINT
+ASTER_BENCH_S3_BUCKET
+ASTER_BENCH_S3_ACCESS_KEY
+ASTER_BENCH_S3_SECRET_KEY
+```
+
+Optional: `ASTER_BENCH_S3_REGION`, `ASTER_BENCH_S3_BASE_PATH`, and
+`ASTER_BENCH_S3_PATH_STYLE`.
+
+### OneDrive
+
+Required:
+
+```text
+ASTER_BENCH_ONEDRIVE_ACCESS_TOKEN
+ASTER_BENCH_ONEDRIVE_DRIVE_ID
+ASTER_BENCH_ONEDRIVE_ROOT_ITEM_ID
+```
+
+Optional: `ASTER_BENCH_ONEDRIVE_GRAPH_BASE_URL` and
+`ASTER_BENCH_ONEDRIVE_BASE_PATH`. Use a benchmark-only folder because the
+runner overwrites and normally deletes its fixture object. The configured base
+folder must already exist; the benchmark does not mutate OneDrive folder
+topology just to time object reads.
+
+### SFTP
+
+Required:
+
+```text
+ASTER_BENCH_SFTP_ENDPOINT
+ASTER_BENCH_SFTP_USERNAME
+ASTER_BENCH_SFTP_PASSWORD
+ASTER_BENCH_SFTP_HOST_KEY_FINGERPRINT
+```
+
+Optional: `ASTER_BENCH_SFTP_BASE_PATH`. The host key pin is deliberately
+mandatory; a timing run is not an excuse to weaken the connector contract.
+
+### Remote driver
+
+Required:
+
+```text
+ASTER_BENCH_REMOTE_BASE_URL
+ASTER_BENCH_REMOTE_ACCESS_KEY
+ASTER_BENCH_REMOTE_SECRET_KEY
+```
+
+Optional: `ASTER_BENCH_REMOTE_BASE_PATH` and
+`ASTER_BENCH_REMOTE_STORAGE_TARGET_KEY`. Set
+`ASTER_BENCH_REMOTE_CAPABILITIES_JSON` to the follower's stored discovery
+document when benchmarking an older compatible protocol revision; otherwise
+the runner uses the current protocol capability model.
+
+### Versioned baselines
+
+Baseline profiles live in
+`tests/performance/baselines/webdav-provider-range-v1.json`. A profile is
+matched by profile name, provider, payload size, and range size. The default
+policy reports a regression when p95 TTFB exceeds `1.5x` or p50 throughput
+drops below `0.7x`; scheduled runs report the comparison in the artifact and do
+not turn network variance into a protocol-test failure.
+
+Update a profile only from a reviewed artifact captured on the same machine and
+provider fixture:
+
+```bash
+bun tests/performance/update-webdav-provider-range-baseline.mjs \
+  tests/performance/results/webdav-provider-range/artifact.json \
+  tests/performance/baselines/webdav-provider-range-v1.json \
+  PROFILE_NAME
+```
+
+The dedicated `WebDAV Provider Range Baselines` workflow runs local storage on
+a weekly schedule and exposes manual provider selection. It always uploads the
+artifact, including skip artifacts, so fixture drift is visible instead of
+silently disappearing.
+
 ## Collecting Summaries
 
 If `ASTER_BENCH_SUMMARY_DIR` is set, each script writes a compact JSON summary:

--- a/tests/performance/baselines/webdav-provider-range-v1.json
+++ b/tests/performance/baselines/webdav-provider-range-v1.json
@@ -26,25 +26,25 @@
         "rustc": "rustc 1.97.1 (8bab26f4f 2026-07-14)",
         "kernel": "Linux 6.12.85+deb13-amd64 x86_64 GNU/Linux"
       },
-      "generated_at": "2026-08-06T14:01:58.641544227+00:00",
-      "git_revision": "24956a066214a11a9aac18500f718b08fa046ade",
-      "git_dirty": true,
+      "generated_at": "2026-08-06T17:34:07.503493741+00:00",
+      "git_revision": "aaa2b5a641c2d7e688b15d718c6672390b13c3be",
+      "git_dirty": false,
       "scenarios": {
         "full_get": {
-          "ttfb_p95_ms": 0.14698414999999998,
-          "throughput_p50_bytes_per_second": 344646281.3163978
+          "ttfb_p95_ms": 0.13965960000000002,
+          "throughput_p50_bytes_per_second": 373698030.4126808
         },
         "multi_range_disjoint": {
-          "ttfb_p95_ms": 0.17379370000000002,
-          "throughput_p50_bytes_per_second": 384897521.5236765
+          "ttfb_p95_ms": 0.17509150000000007,
+          "throughput_p50_bytes_per_second": 388062253.79542506
         },
         "single_range_early": {
-          "ttfb_p95_ms": 0.12170115000000001,
-          "throughput_p50_bytes_per_second": 379712515.58565885
+          "ttfb_p95_ms": 0.12910165000000026,
+          "throughput_p50_bytes_per_second": 390046383.03697467
         },
         "single_range_late": {
-          "ttfb_p95_ms": 0.22887285000000013,
-          "throughput_p50_bytes_per_second": 381381585.1004468
+          "ttfb_p95_ms": 0.9772120500000002,
+          "throughput_p50_bytes_per_second": 376915149.4909163
         }
       }
     }

--- a/tests/performance/baselines/webdav-provider-range-v1.json
+++ b/tests/performance/baselines/webdav-provider-range-v1.json
@@ -1,0 +1,52 @@
+{
+  "schema_version": 1,
+  "baseline_version": "webdav-provider-range-v1",
+  "regression_policy": {
+    "ttfb_p95_max_ratio": 1.5,
+    "throughput_p50_min_ratio": 0.7
+  },
+  "profiles": [
+    {
+      "profile": "debian-epyc-local-v1",
+      "provider": "local",
+      "payload_bytes": 5242880,
+      "range_bytes": 262144,
+      "sampling": {
+        "warmups": 3,
+        "samples": 20,
+        "read_buffer_bytes": 65536
+      },
+      "machine": {
+        "profile": "debian-epyc-local-v1",
+        "build_profile": "optimized",
+        "os": "linux",
+        "architecture": "x86_64",
+        "cpu_model": "AMD EPYC-Genoa Processor",
+        "logical_cpus": 64,
+        "rustc": "rustc 1.97.1 (8bab26f4f 2026-07-14)",
+        "kernel": "Linux 6.12.85+deb13-amd64 x86_64 GNU/Linux"
+      },
+      "generated_at": "2026-08-06T14:01:58.641544227+00:00",
+      "git_revision": "24956a066214a11a9aac18500f718b08fa046ade",
+      "git_dirty": true,
+      "scenarios": {
+        "full_get": {
+          "ttfb_p95_ms": 0.14698414999999998,
+          "throughput_p50_bytes_per_second": 344646281.3163978
+        },
+        "multi_range_disjoint": {
+          "ttfb_p95_ms": 0.17379370000000002,
+          "throughput_p50_bytes_per_second": 384897521.5236765
+        },
+        "single_range_early": {
+          "ttfb_p95_ms": 0.12170115000000001,
+          "throughput_p50_bytes_per_second": 379712515.58565885
+        },
+        "single_range_late": {
+          "ttfb_p95_ms": 0.22887285000000013,
+          "throughput_p50_bytes_per_second": 381381585.1004468
+        }
+      }
+    }
+  ]
+}

--- a/tests/performance/redact-webdav-provider-range-log.mjs
+++ b/tests/performance/redact-webdav-provider-range-log.mjs
@@ -1,0 +1,27 @@
+import { readFile, writeFile } from "node:fs/promises";
+
+export function redactProviderLog(log, secretValues) {
+	const values = [...new Set(secretValues.filter((value) => value !== ""))].sort(
+		(left, right) => right.length - left.length,
+	);
+	return values.reduce(
+		(redacted, value) => redacted.replaceAll(value, "[REDACTED]"),
+		log,
+	);
+}
+
+export async function redactProviderLogFile(inputPath, outputPath, secretNames) {
+	const log = await readFile(inputPath, "utf8");
+	const secretValues = secretNames.map((name) => process.env[name] ?? "");
+	await writeFile(outputPath, redactProviderLog(log, secretValues));
+}
+
+if (import.meta.main) {
+	const [, , inputPath, outputPath, ...secretNames] = process.argv;
+	if (!inputPath || !outputPath) {
+		throw new Error(
+			"usage: bun tests/performance/redact-webdav-provider-range-log.mjs <input.log> <output.log> [SECRET_ENV_NAME...]",
+		);
+	}
+	await redactProviderLogFile(inputPath, outputPath, secretNames);
+}

--- a/tests/performance/update-webdav-provider-range-baseline.mjs
+++ b/tests/performance/update-webdav-provider-range-baseline.mjs
@@ -1,5 +1,12 @@
 import { execFile } from "node:child_process";
-import { mkdir, readFile, rename, unlink, writeFile } from "node:fs/promises";
+import {
+	access,
+	mkdir,
+	readFile,
+	rename,
+	unlink,
+	writeFile,
+} from "node:fs/promises";
 import { dirname, resolve } from "node:path";
 import { promisify } from "node:util";
 
@@ -30,10 +37,10 @@ function requireFiniteNumber(value, name, minimum) {
 	}
 }
 
-export function validateArtifact(artifact) {
+export function validateArtifactMetadata(artifact) {
 	requireRecord(artifact, "artifact");
-	if (artifact.schema_version !== 1 || artifact.status !== "completed") {
-		throw new Error("baseline input must be a completed schema-v1 artifact");
+	if (artifact.schema_version !== 1) {
+		throw new Error("artifact must use schema v1");
 	}
 	requireNonEmptyString(artifact.provider, "artifact.provider");
 	requireNonEmptyString(artifact.generated_at, "artifact.generated_at");
@@ -62,6 +69,14 @@ export function validateArtifact(artifact) {
 	);
 	requireNonEmptyString(machine.os, "artifact.machine.os");
 	requireNonEmptyString(machine.architecture, "artifact.machine.architecture");
+	return artifact;
+}
+
+export function validateArtifact(artifact) {
+	validateArtifactMetadata(artifact);
+	if (artifact.status !== "completed") {
+		throw new Error("baseline input must be a completed schema-v1 artifact");
+	}
 
 	const scenarioEntries = Object.entries(
 		requireRecord(artifact.scenarios, "artifact.scenarios"),
@@ -101,7 +116,25 @@ export function validateArtifact(artifact) {
 }
 
 async function assertCleanBaselineWorktree(baselinePath) {
-	const baselineDirectory = dirname(resolve(baselinePath));
+	let baselineDirectory = dirname(resolve(baselinePath));
+	while (true) {
+		try {
+			await access(baselineDirectory);
+			break;
+		} catch (error) {
+			if (error?.code !== "ENOENT") {
+				throw error;
+			}
+			const parent = dirname(baselineDirectory);
+			if (parent === baselineDirectory) {
+				throw new Error(
+					`baseline path must belong to a Git worktree: ${baselinePath}`,
+					{ cause: error },
+				);
+			}
+			baselineDirectory = parent;
+		}
+	}
 	let worktreeRoot;
 	try {
 		({ stdout: worktreeRoot } = await execFileAsync(

--- a/tests/performance/update-webdav-provider-range-baseline.mjs
+++ b/tests/performance/update-webdav-provider-range-baseline.mjs
@@ -1,0 +1,94 @@
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { dirname } from "node:path";
+
+const [, , artifactPath, baselinePath, profile] = process.argv;
+
+if (!artifactPath || !baselinePath || !profile) {
+	throw new Error(
+		"usage: bun tests/performance/update-webdav-provider-range-baseline.mjs <artifact.json> <baseline.json> <profile>",
+	);
+}
+
+const artifact = JSON.parse(await readFile(artifactPath, "utf8"));
+if (artifact.schema_version !== 1 || artifact.status !== "completed") {
+	throw new Error("baseline input must be a completed schema-v1 artifact");
+}
+
+let baseline;
+try {
+	baseline = JSON.parse(await readFile(baselinePath, "utf8"));
+} catch (error) {
+	if (error?.code !== "ENOENT") {
+		throw error;
+	}
+	baseline = {
+		schema_version: 1,
+		baseline_version: "webdav-provider-range-v1",
+		regression_policy: {
+			ttfb_p95_max_ratio: 1.5,
+			throughput_p50_min_ratio: 0.7,
+		},
+		profiles: [],
+	};
+}
+
+if (baseline.schema_version !== 1 || !Array.isArray(baseline.profiles)) {
+	throw new Error("baseline file must use the webdav-provider-range schema v1");
+}
+
+const scenarios = Object.fromEntries(
+	Object.entries(artifact.scenarios).map(([name, scenario]) => [
+		name,
+		{
+			ttfb_p95_ms: scenario.summary.ttfb_ms.p95,
+			throughput_p50_bytes_per_second:
+				scenario.summary.throughput_bytes_per_second.p50,
+		},
+	]),
+);
+
+const nextProfile = {
+	profile,
+	provider: artifact.provider,
+	payload_bytes: artifact.fixture.payload_bytes,
+	range_bytes: artifact.fixture.range_bytes,
+	sampling: artifact.sampling,
+	machine: artifact.machine,
+	generated_at: artifact.generated_at,
+	git_revision: artifact.git_revision,
+	git_dirty: artifact.git_dirty,
+	scenarios,
+};
+
+baseline.profiles = baseline.profiles
+	.filter(
+		(candidate) =>
+			candidate.profile !== profile ||
+			candidate.provider !== artifact.provider ||
+			candidate.payload_bytes !== artifact.fixture.payload_bytes ||
+			candidate.range_bytes !== artifact.fixture.range_bytes,
+	)
+	.concat(nextProfile)
+	.sort((left, right) =>
+		[
+			left.profile,
+			left.provider,
+			left.payload_bytes,
+			left.range_bytes,
+		]
+			.join(":")
+			.localeCompare(
+				[
+					right.profile,
+					right.provider,
+					right.payload_bytes,
+					right.range_bytes,
+				].join(":"),
+			),
+	);
+
+await mkdir(dirname(baselinePath), { recursive: true });
+await writeFile(baselinePath, `${JSON.stringify(baseline, null, 2)}\n`);
+console.log(
+	`updated ${baselinePath}: ${profile}/${artifact.provider}/${artifact.fixture.payload_bytes}/${artifact.fixture.range_bytes}`,
+);

--- a/tests/performance/update-webdav-provider-range-baseline.mjs
+++ b/tests/performance/update-webdav-provider-range-baseline.mjs
@@ -1,94 +1,211 @@
-import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { mkdir, readFile, rename, unlink, writeFile } from "node:fs/promises";
 import { dirname } from "node:path";
 
-const [, , artifactPath, baselinePath, profile] = process.argv;
+function requireRecord(value, name) {
+	if (typeof value !== "object" || value === null || Array.isArray(value)) {
+		throw new Error(`${name} must be an object`);
+	}
+	return value;
+}
 
-if (!artifactPath || !baselinePath || !profile) {
-	throw new Error(
-		"usage: bun tests/performance/update-webdav-provider-range-baseline.mjs <artifact.json> <baseline.json> <profile>",
+function requireNonEmptyString(value, name) {
+	if (typeof value !== "string" || value.trim() === "") {
+		throw new Error(`${name} must be a non-empty string`);
+	}
+}
+
+function requireInteger(value, name, minimum) {
+	if (!Number.isInteger(value) || value < minimum) {
+		throw new Error(`${name} must be an integer greater than or equal to ${minimum}`);
+	}
+}
+
+function requireFiniteNumber(value, name, minimum) {
+	if (!Number.isFinite(value) || value < minimum) {
+		throw new Error(`${name} must be a finite number greater than or equal to ${minimum}`);
+	}
+}
+
+export function validateArtifact(artifact) {
+	requireRecord(artifact, "artifact");
+	if (artifact.schema_version !== 1 || artifact.status !== "completed") {
+		throw new Error("baseline input must be a completed schema-v1 artifact");
+	}
+	requireNonEmptyString(artifact.provider, "artifact.provider");
+	requireNonEmptyString(artifact.generated_at, "artifact.generated_at");
+	requireNonEmptyString(artifact.git_revision, "artifact.git_revision");
+	if (artifact.git_dirty !== false) {
+		throw new Error("baseline input must come from a clean Git worktree");
+	}
+
+	const fixture = requireRecord(artifact.fixture, "artifact.fixture");
+	requireInteger(fixture.payload_bytes, "artifact.fixture.payload_bytes", 1);
+	requireInteger(fixture.range_bytes, "artifact.fixture.range_bytes", 2);
+
+	const sampling = requireRecord(artifact.sampling, "artifact.sampling");
+	requireInteger(sampling.warmups, "artifact.sampling.warmups", 0);
+	requireInteger(sampling.samples, "artifact.sampling.samples", 1);
+	requireInteger(
+		sampling.read_buffer_bytes,
+		"artifact.sampling.read_buffer_bytes",
+		1,
 	);
+
+	const machine = requireRecord(artifact.machine, "artifact.machine");
+	requireNonEmptyString(
+		machine.build_profile,
+		"artifact.machine.build_profile",
+	);
+	requireNonEmptyString(machine.os, "artifact.machine.os");
+	requireNonEmptyString(machine.architecture, "artifact.machine.architecture");
+
+	const scenarioEntries = Object.entries(
+		requireRecord(artifact.scenarios, "artifact.scenarios"),
+	);
+	if (scenarioEntries.length === 0) {
+		throw new Error("artifact.scenarios must contain at least one scenario");
+	}
+	for (const [name, scenarioValue] of scenarioEntries) {
+		const scenario = requireRecord(
+			scenarioValue,
+			`artifact.scenarios.${name}`,
+		);
+		const summary = requireRecord(
+			scenario.summary,
+			`artifact.scenarios.${name}.summary`,
+		);
+		const ttfb = requireRecord(
+			summary.ttfb_ms,
+			`artifact.scenarios.${name}.summary.ttfb_ms`,
+		);
+		const throughput = requireRecord(
+			summary.throughput_bytes_per_second,
+			`artifact.scenarios.${name}.summary.throughput_bytes_per_second`,
+		);
+		requireFiniteNumber(
+			ttfb.p95,
+			`artifact.scenarios.${name}.summary.ttfb_ms.p95`,
+			0,
+		);
+		requireFiniteNumber(
+			throughput.p50,
+			`artifact.scenarios.${name}.summary.throughput_bytes_per_second.p50`,
+			Number.MIN_VALUE,
+		);
+	}
+	return artifact;
 }
 
-const artifact = JSON.parse(await readFile(artifactPath, "utf8"));
-if (artifact.schema_version !== 1 || artifact.status !== "completed") {
-	throw new Error("baseline input must be a completed schema-v1 artifact");
-}
+async function updateBaseline(artifactPath, baselinePath, profile) {
+	const artifact = validateArtifact(
+		JSON.parse(await readFile(artifactPath, "utf8")),
+	);
 
-let baseline;
-try {
-	baseline = JSON.parse(await readFile(baselinePath, "utf8"));
-} catch (error) {
-	if (error?.code !== "ENOENT") {
+	let baseline;
+	try {
+		baseline = JSON.parse(await readFile(baselinePath, "utf8"));
+	} catch (error) {
+		if (error?.code !== "ENOENT") {
+			throw error;
+		}
+		baseline = {
+			schema_version: 1,
+			baseline_version: "webdav-provider-range-v1",
+			regression_policy: {
+				ttfb_p95_max_ratio: 1.5,
+				throughput_p50_min_ratio: 0.7,
+			},
+			profiles: [],
+		};
+	}
+
+	if (baseline.schema_version !== 1 || !Array.isArray(baseline.profiles)) {
+		throw new Error("baseline file must use the webdav-provider-range schema v1");
+	}
+
+	const scenarios = Object.fromEntries(
+		Object.entries(artifact.scenarios).map(([name, scenario]) => [
+			name,
+			{
+				ttfb_p95_ms: scenario.summary.ttfb_ms.p95,
+				throughput_p50_bytes_per_second:
+					scenario.summary.throughput_bytes_per_second.p50,
+			},
+		]),
+	);
+
+	const nextProfile = {
+		profile,
+		provider: artifact.provider,
+		payload_bytes: artifact.fixture.payload_bytes,
+		range_bytes: artifact.fixture.range_bytes,
+		sampling: artifact.sampling,
+		machine: artifact.machine,
+		generated_at: artifact.generated_at,
+		git_revision: artifact.git_revision,
+		git_dirty: artifact.git_dirty,
+		scenarios,
+	};
+
+	baseline.profiles = baseline.profiles
+		.filter(
+			(candidate) =>
+				candidate.profile !== profile ||
+				candidate.provider !== artifact.provider ||
+				candidate.payload_bytes !== artifact.fixture.payload_bytes ||
+				candidate.range_bytes !== artifact.fixture.range_bytes,
+		)
+		.concat(nextProfile)
+		.sort((left, right) =>
+			[
+				left.profile,
+				left.provider,
+				left.payload_bytes,
+				left.range_bytes,
+			]
+				.join(":")
+				.localeCompare(
+					[
+						right.profile,
+						right.provider,
+						right.payload_bytes,
+						right.range_bytes,
+					].join(":"),
+				),
+		);
+
+	await mkdir(dirname(baselinePath), { recursive: true });
+	const temporaryBaselinePath = `${baselinePath}.${process.pid}.tmp`;
+	try {
+		await writeFile(
+			temporaryBaselinePath,
+			`${JSON.stringify(baseline, null, 2)}\n`,
+		);
+		await rename(temporaryBaselinePath, baselinePath);
+	} catch (error) {
+		try {
+			await unlink(temporaryBaselinePath);
+		} catch (cleanupError) {
+			if (cleanupError?.code !== "ENOENT") {
+				throw new AggregateError(
+					[error, cleanupError],
+					"baseline update and temporary-file cleanup both failed",
+				);
+			}
+		}
 		throw error;
 	}
-	baseline = {
-		schema_version: 1,
-		baseline_version: "webdav-provider-range-v1",
-		regression_policy: {
-			ttfb_p95_max_ratio: 1.5,
-			throughput_p50_min_ratio: 0.7,
-		},
-		profiles: [],
-	};
-}
-
-if (baseline.schema_version !== 1 || !Array.isArray(baseline.profiles)) {
-	throw new Error("baseline file must use the webdav-provider-range schema v1");
-}
-
-const scenarios = Object.fromEntries(
-	Object.entries(artifact.scenarios).map(([name, scenario]) => [
-		name,
-		{
-			ttfb_p95_ms: scenario.summary.ttfb_ms.p95,
-			throughput_p50_bytes_per_second:
-				scenario.summary.throughput_bytes_per_second.p50,
-		},
-	]),
-);
-
-const nextProfile = {
-	profile,
-	provider: artifact.provider,
-	payload_bytes: artifact.fixture.payload_bytes,
-	range_bytes: artifact.fixture.range_bytes,
-	sampling: artifact.sampling,
-	machine: artifact.machine,
-	generated_at: artifact.generated_at,
-	git_revision: artifact.git_revision,
-	git_dirty: artifact.git_dirty,
-	scenarios,
-};
-
-baseline.profiles = baseline.profiles
-	.filter(
-		(candidate) =>
-			candidate.profile !== profile ||
-			candidate.provider !== artifact.provider ||
-			candidate.payload_bytes !== artifact.fixture.payload_bytes ||
-			candidate.range_bytes !== artifact.fixture.range_bytes,
-	)
-	.concat(nextProfile)
-	.sort((left, right) =>
-		[
-			left.profile,
-			left.provider,
-			left.payload_bytes,
-			left.range_bytes,
-		]
-			.join(":")
-			.localeCompare(
-				[
-					right.profile,
-					right.provider,
-					right.payload_bytes,
-					right.range_bytes,
-				].join(":"),
-			),
+	console.log(
+		`updated ${baselinePath}: ${profile}/${artifact.provider}/${artifact.fixture.payload_bytes}/${artifact.fixture.range_bytes}`,
 	);
+}
 
-await mkdir(dirname(baselinePath), { recursive: true });
-await writeFile(baselinePath, `${JSON.stringify(baseline, null, 2)}\n`);
-console.log(
-	`updated ${baselinePath}: ${profile}/${artifact.provider}/${artifact.fixture.payload_bytes}/${artifact.fixture.range_bytes}`,
-);
+if (import.meta.main) {
+	const [, , artifactPath, baselinePath, profile] = process.argv;
+	if (!artifactPath || !baselinePath || !profile) {
+		throw new Error(
+			"usage: bun tests/performance/update-webdav-provider-range-baseline.mjs <artifact.json> <baseline.json> <profile>",
+		);
+	}
+	await updateBaseline(artifactPath, baselinePath, profile);
+}

--- a/tests/performance/update-webdav-provider-range-baseline.mjs
+++ b/tests/performance/update-webdav-provider-range-baseline.mjs
@@ -1,5 +1,9 @@
+import { execFile } from "node:child_process";
 import { mkdir, readFile, rename, unlink, writeFile } from "node:fs/promises";
-import { dirname } from "node:path";
+import { dirname, resolve } from "node:path";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
 
 function requireRecord(value, name) {
 	if (typeof value !== "object" || value === null || Array.isArray(value)) {
@@ -96,10 +100,45 @@ export function validateArtifact(artifact) {
 	return artifact;
 }
 
-async function updateBaseline(artifactPath, baselinePath, profile) {
+async function assertCleanBaselineWorktree(baselinePath) {
+	const baselineDirectory = dirname(resolve(baselinePath));
+	let worktreeRoot;
+	try {
+		({ stdout: worktreeRoot } = await execFileAsync(
+			"git",
+			["-C", baselineDirectory, "rev-parse", "--show-toplevel"],
+			{ encoding: "utf8" },
+		));
+	} catch (error) {
+		throw new Error(
+			`baseline path must belong to a Git worktree: ${baselinePath}`,
+			{ cause: error },
+		);
+	}
+
+	const { stdout: status } = await execFileAsync(
+		"git",
+		[
+			"-C",
+			worktreeRoot.trim(),
+			"status",
+			"--porcelain",
+			"--untracked-files=normal",
+		],
+		{ encoding: "utf8" },
+	);
+	if (status !== "") {
+		throw new Error(
+			`baseline target worktree must be clean before update: ${worktreeRoot.trim()}`,
+		);
+	}
+}
+
+export async function updateBaseline(artifactPath, baselinePath, profile) {
 	const artifact = validateArtifact(
 		JSON.parse(await readFile(artifactPath, "utf8")),
 	);
+	await assertCleanBaselineWorktree(baselinePath);
 
 	let baseline;
 	try {

--- a/tests/performance/update-webdav-provider-range-baseline.test.mjs
+++ b/tests/performance/update-webdav-provider-range-baseline.test.mjs
@@ -90,7 +90,7 @@ describe("validateArtifact", () => {
 	});
 });
 
-async function createBaselineRepository() {
+async function createBaselineRepository({ createBaseline = true } = {}) {
 	const root = await mkdtemp(join(tmpdir(), "asterdrive-range-baseline-test-"));
 	const repository = join(root, "repository");
 	const baselinePath = join(
@@ -98,9 +98,7 @@ async function createBaselineRepository() {
 		"tests/performance/baselines/webdav-provider-range-v1.json",
 	);
 	const artifactPath = join(root, "artifact.json");
-	await mkdir(join(repository, "tests/performance/baselines"), {
-		recursive: true,
-	});
+	await mkdir(repository, { recursive: true });
 	const originalBaseline = `${JSON.stringify(
 		{
 			schema_version: 1,
@@ -114,7 +112,12 @@ async function createBaselineRepository() {
 		null,
 		2,
 	)}\n`;
-	await writeFile(baselinePath, originalBaseline);
+	if (createBaseline) {
+		await mkdir(join(repository, "tests/performance/baselines"), {
+			recursive: true,
+		});
+		await writeFile(baselinePath, originalBaseline);
+	}
 	await writeFile(artifactPath, `${JSON.stringify(validArtifact())}\n`);
 	await execFileAsync("git", ["init", "--quiet", repository]);
 	await execFileAsync("git", [
@@ -137,6 +140,7 @@ async function createBaselineRepository() {
 		repository,
 		"commit",
 		"--quiet",
+		"--allow-empty",
 		"-m",
 		"test baseline fixture",
 	]);
@@ -175,6 +179,26 @@ describe("updateBaseline", () => {
 			expect(await readFile(fixture.baselinePath, "utf8")).toBe(
 				fixture.originalBaseline,
 			);
+		} finally {
+			await rm(fixture.root, { recursive: true, force: true });
+		}
+	});
+
+	test("creates a baseline when its target parent directories do not exist", async () => {
+		const fixture = await createBaselineRepository({ createBaseline: false });
+		const baselinePath = join(
+			fixture.repository,
+			"new/performance/baselines/webdav-provider-range-v1.json",
+		);
+		try {
+			await updateBaseline(
+				fixture.artifactPath,
+				baselinePath,
+				"test-profile",
+			);
+			const baseline = JSON.parse(await readFile(baselinePath, "utf8"));
+			expect(baseline.profiles).toHaveLength(1);
+			expect(baseline.profiles[0].profile).toBe("test-profile");
 		} finally {
 			await rm(fixture.root, { recursive: true, force: true });
 		}

--- a/tests/performance/update-webdav-provider-range-baseline.test.mjs
+++ b/tests/performance/update-webdav-provider-range-baseline.test.mjs
@@ -1,6 +1,16 @@
 import { describe, expect, test } from "bun:test";
+import { execFile } from "node:child_process";
+import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
 
-import { validateArtifact } from "./update-webdav-provider-range-baseline.mjs";
+import {
+	updateBaseline,
+	validateArtifact,
+} from "./update-webdav-provider-range-baseline.mjs";
+
+const execFileAsync = promisify(execFile);
 
 function validArtifact() {
 	return {
@@ -77,5 +87,96 @@ describe("validateArtifact", () => {
 		expect(() => validateArtifact(artifact)).toThrow(
 			"baseline input must come from a clean Git worktree",
 		);
+	});
+});
+
+async function createBaselineRepository() {
+	const root = await mkdtemp(join(tmpdir(), "asterdrive-range-baseline-test-"));
+	const repository = join(root, "repository");
+	const baselinePath = join(
+		repository,
+		"tests/performance/baselines/webdav-provider-range-v1.json",
+	);
+	const artifactPath = join(root, "artifact.json");
+	await mkdir(join(repository, "tests/performance/baselines"), {
+		recursive: true,
+	});
+	const originalBaseline = `${JSON.stringify(
+		{
+			schema_version: 1,
+			baseline_version: "webdav-provider-range-v1",
+			regression_policy: {
+				ttfb_p95_max_ratio: 1.5,
+				throughput_p50_min_ratio: 0.7,
+			},
+			profiles: [],
+		},
+		null,
+		2,
+	)}\n`;
+	await writeFile(baselinePath, originalBaseline);
+	await writeFile(artifactPath, `${JSON.stringify(validArtifact())}\n`);
+	await execFileAsync("git", ["init", "--quiet", repository]);
+	await execFileAsync("git", [
+		"-C",
+		repository,
+		"config",
+		"user.email",
+		"benchmark-test@asterdrive.invalid",
+	]);
+	await execFileAsync("git", [
+		"-C",
+		repository,
+		"config",
+		"user.name",
+		"AsterDrive Benchmark Test",
+	]);
+	await execFileAsync("git", ["-C", repository, "add", "."]);
+	await execFileAsync("git", [
+		"-C",
+		repository,
+		"commit",
+		"--quiet",
+		"-m",
+		"test baseline fixture",
+	]);
+	return { root, repository, artifactPath, baselinePath, originalBaseline };
+}
+
+describe("updateBaseline", () => {
+	test("updates a baseline in a clean target worktree", async () => {
+		const fixture = await createBaselineRepository();
+		try {
+			await updateBaseline(
+				fixture.artifactPath,
+				fixture.baselinePath,
+				"test-profile",
+			);
+			const baseline = JSON.parse(await readFile(fixture.baselinePath, "utf8"));
+			expect(baseline.profiles).toHaveLength(1);
+			expect(baseline.profiles[0].profile).toBe("test-profile");
+		} finally {
+			await rm(fixture.root, { recursive: true, force: true });
+		}
+	});
+
+	test("rejects a dirty target worktree without changing the baseline", async () => {
+		const fixture = await createBaselineRepository();
+		try {
+			await writeFile(join(fixture.repository, "uncommitted.txt"), "dirty\n");
+
+			await expect(
+				updateBaseline(
+					fixture.artifactPath,
+					fixture.baselinePath,
+					"test-profile",
+				),
+			).rejects.toThrow("baseline target worktree must be clean before update");
+			expect(await readFile(fixture.baselinePath, "utf8")).toBe(
+				fixture.originalBaseline,
+			);
+		} finally {
+			await rm(fixture.root, { recursive: true, force: true });
+		}
 	});
 });

--- a/tests/performance/update-webdav-provider-range-baseline.test.mjs
+++ b/tests/performance/update-webdav-provider-range-baseline.test.mjs
@@ -1,0 +1,81 @@
+import { describe, expect, test } from "bun:test";
+
+import { validateArtifact } from "./update-webdav-provider-range-baseline.mjs";
+
+function validArtifact() {
+	return {
+		schema_version: 1,
+		status: "completed",
+		provider: "local",
+		generated_at: "2026-08-07T00:00:00Z",
+		git_revision: "0123456789abcdef",
+		git_dirty: false,
+		fixture: {
+			payload_bytes: 1024,
+			range_bytes: 16,
+		},
+		sampling: {
+			warmups: 1,
+			samples: 2,
+			read_buffer_bytes: 64,
+		},
+		machine: {
+			build_profile: "optimized",
+			os: "linux",
+			architecture: "x86_64",
+		},
+		scenarios: {
+			full_get: {
+				summary: {
+					ttfb_ms: { p95: 0.5 },
+					throughput_bytes_per_second: { p50: 1024 },
+				},
+			},
+		},
+	};
+}
+
+describe("validateArtifact", () => {
+	test("accepts a complete clean artifact", () => {
+		expect(validateArtifact(validArtifact())).toEqual(validArtifact());
+	});
+
+	test("rejects missing fixture metadata", () => {
+		const artifact = validArtifact();
+		delete artifact.fixture;
+		expect(() => validateArtifact(artifact)).toThrow("artifact.fixture");
+	});
+
+	test("rejects an empty scenario collection", () => {
+		const artifact = validArtifact();
+		artifact.scenarios = {};
+		expect(() => validateArtifact(artifact)).toThrow(
+			"artifact.scenarios must contain at least one scenario",
+		);
+	});
+
+	test("rejects null metrics", () => {
+		const artifact = validArtifact();
+		artifact.scenarios.full_get.summary.ttfb_ms.p95 = null;
+		expect(() => validateArtifact(artifact)).toThrow(
+			"artifact.scenarios.full_get.summary.ttfb_ms.p95",
+		);
+	});
+
+	test("rejects non-finite metrics", () => {
+		const artifact = validArtifact();
+		artifact.scenarios.full_get.summary.throughput_bytes_per_second.p50 =
+			Number.POSITIVE_INFINITY;
+		expect(() => validateArtifact(artifact)).toThrow(
+			"artifact.scenarios.full_get.summary.throughput_bytes_per_second.p50",
+		);
+	});
+
+	test("rejects dirty baseline provenance", () => {
+		const artifact = validArtifact();
+		artifact.git_dirty = true;
+		expect(() => validateArtifact(artifact)).toThrow(
+			"baseline input must come from a clean Git worktree",
+		);
+	});
+});

--- a/tests/performance/validate-webdav-provider-range-artifact.mjs
+++ b/tests/performance/validate-webdav-provider-range-artifact.mjs
@@ -1,0 +1,56 @@
+import { readFile } from "node:fs/promises";
+
+import {
+	validateArtifact,
+	validateArtifactMetadata,
+} from "./update-webdav-provider-range-baseline.mjs";
+
+function requireRecord(value, name) {
+	if (typeof value !== "object" || value === null || Array.isArray(value)) {
+		throw new Error(`${name} must be an object`);
+	}
+	return value;
+}
+
+function requireNonEmptyString(value, name) {
+	if (typeof value !== "string" || value.trim() === "") {
+		throw new Error(`${name} must be a non-empty string`);
+	}
+}
+
+function validateSkippedArtifact(artifact) {
+	validateArtifactMetadata(artifact);
+	if (artifact.status !== "skipped") {
+		throw new Error("skipped input must be a schema-v1 artifact");
+	}
+	requireNonEmptyString(artifact.skip_reason, "artifact.skip_reason");
+	const scenarios = requireRecord(artifact.scenarios, "artifact.scenarios");
+	if (Object.keys(scenarios).length !== 0) {
+		throw new Error("skipped artifact.scenarios must be empty");
+	}
+	return artifact;
+}
+
+export function classifyProviderArtifact(artifact) {
+	requireRecord(artifact, "artifact");
+	if (artifact.status === "completed") {
+		validateArtifact(artifact);
+		return "completed";
+	}
+	if (artifact.status === "skipped") {
+		validateSkippedArtifact(artifact);
+		return "skipped";
+	}
+	throw new Error(`unsupported provider artifact status: ${artifact.status}`);
+}
+
+if (import.meta.main) {
+	const [, , artifactPath] = process.argv;
+	if (!artifactPath) {
+		throw new Error(
+			"usage: bun tests/performance/validate-webdav-provider-range-artifact.mjs <artifact.json>",
+		);
+	}
+	const artifact = JSON.parse(await readFile(artifactPath, "utf8"));
+	console.log(classifyProviderArtifact(artifact));
+}

--- a/tests/performance/webdav-provider-range-artifact-tools.test.mjs
+++ b/tests/performance/webdav-provider-range-artifact-tools.test.mjs
@@ -1,0 +1,78 @@
+import { describe, expect, test } from "bun:test";
+
+import { redactProviderLog } from "./redact-webdav-provider-range-log.mjs";
+import { classifyProviderArtifact } from "./validate-webdav-provider-range-artifact.mjs";
+
+function completedArtifact() {
+	return {
+		schema_version: 1,
+		status: "completed",
+		provider: "local",
+		generated_at: "2026-08-07T00:00:00Z",
+		git_revision: "0123456789abcdef",
+		git_dirty: false,
+		fixture: { payload_bytes: 1024, range_bytes: 16 },
+		sampling: { warmups: 1, samples: 2, read_buffer_bytes: 64 },
+		machine: {
+			build_profile: "optimized",
+			os: "linux",
+			architecture: "x86_64",
+		},
+		scenarios: {
+			full_get: {
+				summary: {
+					ttfb_ms: { p95: 0.5 },
+					throughput_bytes_per_second: { p50: 1024 },
+				},
+			},
+		},
+	};
+}
+
+function skippedArtifact() {
+	return {
+		...completedArtifact(),
+		status: "skipped",
+		skip_reason: "provider fixture is not configured",
+		scenarios: {},
+	};
+}
+
+describe("classifyProviderArtifact", () => {
+	test("accepts completed artifacts through the baseline validator", () => {
+		expect(classifyProviderArtifact(completedArtifact())).toBe("completed");
+	});
+
+	test("keeps valid skipped artifacts out of the completed path", () => {
+		expect(classifyProviderArtifact(skippedArtifact())).toBe("skipped");
+	});
+
+	test("rejects malformed and unsupported artifacts", () => {
+		const malformedSkip = skippedArtifact();
+		malformedSkip.scenarios.full_get = completedArtifact().scenarios.full_get;
+		expect(() => classifyProviderArtifact(malformedSkip)).toThrow(
+			"skipped artifact.scenarios must be empty",
+		);
+		expect(() =>
+			classifyProviderArtifact({ schema_version: 1, status: "partial" }),
+		).toThrow("unsupported provider artifact status");
+	});
+});
+
+describe("redactProviderLog", () => {
+	test("redacts each configured value without treating it as a pattern", () => {
+		const log = [
+			"authorization: Bearer token.with[regex]",
+			"password=s3cr3t",
+			"token.with[regex] appears twice: token.with[regex]",
+		].join("\n");
+		const redacted = redactProviderLog(log, [
+			"token.with[regex]",
+			"s3cr3t",
+			"",
+		]);
+		expect(redacted).not.toContain("token.with[regex]");
+		expect(redacted).not.toContain("s3cr3t");
+		expect(redacted.match(/\[REDACTED\]/g)).toHaveLength(4);
+	});
+});

--- a/tests/storage/remote_storage.rs
+++ b/tests/storage/remote_storage.rs
@@ -6690,10 +6690,20 @@ async fn test_remote_relay_stream_chunked_upload_e2e() {
             .is_empty(),
         "oversized remote relay chunk must release the claimed part row"
     );
-    let oversized_progress = upload::get_progress(&consumer_state, &oversized_upload_id, user.id)
-        .await
-        .expect("remote relay oversized progress should be queryable");
-    assert!(oversized_progress.chunks_on_disk.is_empty());
+    assert!(
+        upload_session_repo::find_by_id(consumer_state.writer_db(), &oversized_upload_id)
+            .await
+            .is_err(),
+        "oversized remote relay chunk must terminate and remove its upload session"
+    );
+    assert!(
+        upload::list_recoverable_sessions(&consumer_state, user.id, None)
+            .await
+            .expect("recoverable remote relay sessions should be queryable")
+            .iter()
+            .all(|session| session.upload_id != oversized_upload_id),
+        "oversized remote relay chunk must not remain recoverable"
+    );
 
     let first_chunk_end = std::cmp::min(chunk_size, body.len());
     let first_chunk = body[..first_chunk_end].to_vec();

--- a/tests/storage/remote_storage.rs
+++ b/tests/storage/remote_storage.rs
@@ -6690,11 +6690,16 @@ async fn test_remote_relay_stream_chunked_upload_e2e() {
             .is_empty(),
         "oversized remote relay chunk must release the claimed part row"
     );
-    assert!(
+    let lookup_error =
         upload_session_repo::find_by_id(consumer_state.writer_db(), &oversized_upload_id)
             .await
-            .is_err(),
-        "oversized remote relay chunk must terminate and remove its upload session"
+            .expect_err("oversized remote relay chunk must remove its upload session");
+    assert!(
+        matches!(
+            lookup_error,
+            aster_drive::errors::AsterError::UploadSessionNotFound(_)
+        ),
+        "oversized remote relay chunk returned the wrong lookup error: {lookup_error:?}"
     );
     assert!(
         upload::list_recoverable_sessions(&consumer_state, user.id, None)

--- a/tests/webdav_provider_range_contract.rs
+++ b/tests/webdav_provider_range_contract.rs
@@ -14,3 +14,13 @@ async fn multi_range_accounting_is_deterministic() {
 async fn fallback_read_accounting_is_deterministic() {
     benchmark::contract_fallback_read_accounting().await;
 }
+
+#[test]
+fn odd_multi_range_preserves_configured_total() {
+    benchmark::contract_odd_multi_range_accounting();
+}
+
+#[tokio::test]
+async fn failed_benchmark_cleans_provider_fixture() {
+    benchmark::contract_failed_benchmark_cleans_fixture().await;
+}

--- a/tests/webdav_provider_range_contract.rs
+++ b/tests/webdav_provider_range_contract.rs
@@ -1,0 +1,16 @@
+#[expect(
+    dead_code,
+    reason = "the contract test includes the complete benchmark module but exercises only its accounting helpers"
+)]
+#[path = "../benches/webdav_provider_range.rs"]
+mod benchmark;
+
+#[tokio::test]
+async fn multi_range_accounting_is_deterministic() {
+    benchmark::contract_multi_range_accounting().await;
+}
+
+#[tokio::test]
+async fn fallback_read_accounting_is_deterministic() {
+    benchmark::contract_fallback_read_accounting().await;
+}


### PR DESCRIPTION
## Summary

- Add an independent Rust benchmark runner for WebDAV provider Range efficiency across local, S3-compatible, OneDrive, SFTP, and remote drivers.
- Cover full GET, early/late single-range, disjoint multi-range, and the default `get_stream + prefix skip` fallback path.
- Record structured samples, percentile summaries, backend call/request counts, actual reader bytes, fallback prefix cost, machine/build metadata, and redacted provider configuration.
- Add versioned baseline comparison/update tooling and a weekly/manual GitHub Actions workflow with explicit external fixture skip gates.

Closes #449

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --bench webdav_provider_range --features benchmarks -- -D warnings`
- [x] `cargo bench --bench webdav_provider_range --features benchmarks` with the local optimized fixture
- [x] Focused deterministic Range/fallback tests (7 targets, all passed)
- [x] `bun install --frozen-lockfile && bun run build` in `frontend-panel/` for the release benchmark prerequisite
- [x] `actionlint .github/workflows/webdav-provider-range.yml`
- [x] `git diff --check`

External S3, OneDrive, SFTP, and remote live fixtures were not injected in this checkout; their structured skip and required-provider gates were exercised.

## Notes for reviewers

- No production WebDAV or storage-driver behavior was changed.
- The checked-in local baseline records its machine/build profile and provenance; scheduled/manual runs upload artifacts even when an external fixture is skipped.
- Provider fixture identifiers and credentials are redacted from artifacts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 新增 WebDAV Provider Range 性能基准测试，支持本地、S3、OneDrive、SFTP 和远程驱动。
  * 支持完整读取、单范围读取、多范围读取及回退路径，并生成性能结果与测试产物。
  * 支持按计划或手动运行自动化测试流程。

* **文档**
  * 新增运行配置、凭据保护、基线比较及更新说明。

* **测试**
  * 新增版本化性能基线、回归阈值、结果校验和基线更新工具。
  * 增强损坏或超大分片上传场景的清理与不可恢复状态验证。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->