### PR TITLE
docs(storage): generate connector docs from runtime descriptor catalog

### DIFF
--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -6,12 +6,20 @@ on:
     paths:
       - 'docs/**'
       - 'developer-docs/**'
+      - 'crates/aster_drive_storage/src/connector_descriptor.rs'
+      - 'src/storage/connectors/**'
+      - 'tests/storage_connector_docs.rs'
+      - 'Makefile'
       - 'src/api/api_error_code.rs'
       - '.github/workflows/docs-check.yml'
   pull_request:
     paths:
       - 'docs/**'
       - 'developer-docs/**'
+      - 'crates/aster_drive_storage/src/connector_descriptor.rs'
+      - 'src/storage/connectors/**'
+      - 'tests/storage_connector_docs.rs'
+      - 'Makefile'
       - 'src/api/api_error_code.rs'
       - '.github/workflows/docs-check.yml'
 
@@ -19,6 +27,23 @@ permissions:
   contents: read
 
 jobs:
+  storage-connectors:
+    name: Storage connector docs in sync
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust build artifacts
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: storage-connector-docs-v1
+
+      - name: Check generated connector manifest and documentation blocks
+        run: make storage-docs-check
+
   error-codes:
     name: Error code docs in sync
     runs-on: ubuntu-latest

--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -32,6 +32,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Setup Rust toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ TEST_ENV = $(if $(strip $(BACKEND)),ASTER_TEST_DATABASE_BACKEND=$(BACKEND),)
 	test test-backend test-frontend test-lib test-integration test-e2e \
 	coverage coverage-backend coverage-frontend \
 	openapi openapi-check \
-	docs-dev docs-build docs-preview \
+	storage-docs storage-docs-check docs-dev docs-build docs-preview \
 	docker-build docker-up docker-down docker-logs \
 	ci
 
@@ -136,6 +136,12 @@ openapi-check: openapi ## Verify generated OpenAPI and SDK files have no drift
 	git diff --exit-code -- \
 		$(FRONTEND_DIR)/generated/openapi.json \
 		$(FRONTEND_DIR)/src/services/api.generated.ts
+
+storage-docs: ## Regenerate the built-in storage connector manifest and documentation blocks
+	ASTER_UPDATE_STORAGE_CONNECTOR_DOCS=1 $(CARGO) test --test storage_connector_docs generated_storage_connector_docs_are_current -- --exact
+
+storage-docs-check: ## Verify storage connector documentation has no descriptor drift
+	$(CARGO) test --test storage_connector_docs generated_storage_connector_docs_are_current -- --exact
 
 docs-dev: ## Run the documentation development server
 	cd $(DOCS_DIR) && $(BUN) run docs:dev

--- a/Makefile
+++ b/Makefile
@@ -141,7 +141,7 @@ storage-docs: ## Regenerate the built-in storage connector manifest and document
 	ASTER_UPDATE_STORAGE_CONNECTOR_DOCS=1 $(CARGO) test --test storage_connector_docs generated_storage_connector_docs_are_current -- --exact
 
 storage-docs-check: ## Verify storage connector documentation has no descriptor drift
-	$(CARGO) test --test storage_connector_docs generated_storage_connector_docs_are_current -- --exact
+	env -u ASTER_UPDATE_STORAGE_CONNECTOR_DOCS $(CARGO) test --test storage_connector_docs generated_storage_connector_docs_are_current -- --exact
 
 docs-dev: ## Run the documentation development server
 	cd $(DOCS_DIR) && $(BUN) run docs:dev

--- a/crates/aster_drive_storage/src/connector_descriptor.rs
+++ b/crates/aster_drive_storage/src/connector_descriptor.rs
@@ -1951,7 +1951,10 @@ pub fn object_storage_connector_descriptor(
         credential_management: None,
         capabilities: StorageConnectorCapabilities {
             efficient_range: true,
-            capacity: true,
+            // S3-compatible, OSS, COS, and Azure Blob data-plane APIs do not
+            // expose one portable remaining-capacity contract. Policy capacity
+            // probes therefore return `unsupported` for this shared family.
+            capacity: false,
             list: true,
             presigned_download: true,
             storage_native_thumbnail: input.storage_native_processing,

--- a/developer-docs/en/contributing/documentation.md
+++ b/developer-docs/en/contributing/documentation.md
@@ -30,11 +30,22 @@ When unsure, ask first: **what task did the reader open this page to complete?**
 
 Storage backend tutorials belong under `admin/storage-backends/` in the user documentation. Keep each page focused on one backend and follow the flow "prepare the backend service -> create a storage policy -> configure policy groups -> bind a test user or team -> validate".
 
-When adding or renaming a storage backend page, at least check these entry points:
+For built-in connectors, runtime `StorageConnector` descriptors and connector localization are authoritative for identity, display name, deployment scope, credential mode, and transfer capabilities. `tests/storage_connector_docs.rs` reads that catalog through the admin APIs and generates:
 
-- `docs/src/content/docs/admin/storage-backends/index.md` (backend selection table)
-- `docs/src/content/docs/reference/storage-matrix.md` (capability matrix)
-- the sidebar in `docs/astro.config.mts`
+- `docs/generated/storage-connectors.json`, the machine-readable manifest reviewed with each PR
+- the backend selection table in `docs/src/content/docs/admin/storage-backends/index.md`
+- the connector catalog in `docs/src/content/docs/admin/storage-policies.md`
+- the capability matrix in `docs/src/content/docs/reference/storage-matrix.md`
+- the corresponding blocks in all three English pages
+
+`docs/astro.config.mts` builds the storage-backend sidebar directly from the manifest instead of maintaining another backend list. When adding or renaming a built-in connector:
+
+1. Update its descriptor and localization plus the provider-owned tutorial slug / best-for summary in `tests/storage_connector_docs.rs`.
+2. Add the Chinese and English provider tutorials.
+3. Run `make storage-docs` and review the generated manifest and Markdown diff.
+4. Run `make storage-docs-check`; CI runs the same drift check.
+
+Generated blocks are bounded by `storage-connectors:*:start/end` markers and are not edited by hand. The backend overview, policy catalog, and capability matrix are exhaustive entry points. Provider names in READMEs, deployment explanations, troubleshooting, and tutorials are contextual examples and must say “for example”, “such as”, or “etc.” rather than implying a complete list. Contextual examples stay unchanged when a new connector is added.
 
 If you only change details for one backend, do not copy large sections from another tutorial. Link common concepts to the storage policy and policy group page (`/admin/storage-policies/`) or the capability matrix (`/reference/storage-matrix/`).
 

--- a/developer-docs/en/design/storage-descriptor-normalization-contract.md
+++ b/developer-docs/en/design/storage-descriptor-normalization-contract.md
@@ -25,6 +25,14 @@ Shared field meanings and pure normalization helpers live in `src/storage/field_
 - Structured action `output` is presented transiently only through descriptor-declared `output_fields`. Undeclared fields, type mismatches, and results belonging to another action are ignored. Output is never copied into policy config or retained across actions or dialog sessions.
 - Delegated-credential status copy, semantic tone, description, attention guidance, sanitized-reason mapping, lifecycle labels, reauthorization wording, and redirect-URI help belong to `credential_management`. The shared panel must not branch on OneDrive, Microsoft Graph, or another provider ID, and must not render the wire `status_reason` directly.
 
+## Documentation Fact Projection
+
+- Built-in connector identity, display names, `deployment_scope`, `credential_mode`, `capabilities`, and `upload_workflows` remain owned by runtime descriptors and localization. The documentation layer does not define a parallel capability type.
+- `tests/storage_connector_docs.rs` reads the same catalog APIs used by administrators, generates `docs/generated/storage-connectors.json`, and updates marked blocks in the backend index, policy catalog, and capability matrix. Generated outputs are committed and reviewed with code.
+- Tutorial slugs and “best for” summaries are provider-owned documentation metadata, not runtime capabilities. Every new built-in connector must add both fields and Chinese/English tutorials; the test rejects missing metadata and tutorial paths.
+- The capability matrix shows each connector's static ceiling. Policy settings, remote-node transport, and deployment networking may narrow actual availability; provider tutorials explain those conditions.
+- Provider names in READMEs, deployment pages, and tutorials are explicitly non-exhaustive examples rather than backend catalogs. Adding a connector does not require global replacement of every contextual example.
+
 ## Normalization Rules
 
 Field normalization belongs in backend use cases or connector/driver-specific pure helpers. It must not be scattered in handlers or frontend components.
@@ -56,5 +64,6 @@ When descriptor or normalization behavior changes, add focused unit tests:
 - Normalization tests must cover trimming, blank values, path escapes, prefix slash trimming, negative storage-policy `max_file_size`, same-driver secret preservation, explicit secret replacement, and driver-change field reset.
 - SFTP coverage must include bare host, `host:port`, `sftp://host:port`, wrong schemes, host key fingerprint format, unknown-host-key rejection, and accepted pinned fingerprints.
 - For storage policy descriptor behavior, run `cargo test --lib storage::connectors` or a narrower filter.
+- When built-in connector identity, localization, or projected documentation facts change, run `make storage-docs`, review the generated diff, then run `make storage-docs-check`.
 - For remote storage target normalization, run `cargo test --lib remote::storage_target::tests::<filter>`.
 - OpenAPI schema changes require OpenAPI export, frontend SDK regeneration, and review of the generated diff.

--- a/developer-docs/zh-CN/contributing/documentation.md
+++ b/developer-docs/zh-CN/contributing/documentation.md
@@ -30,11 +30,22 @@
 
 存储后端教程放在用户文档 `admin/storage-backends/`，一页只讲一种后端，按“准备后端服务 -> 创建存储策略 -> 配置策略组 -> 绑定测试用户或团队 -> 验收”的流程写。
 
-新增或改名存储后端页面时，至少同步检查这些入口：
+内置 connector 的身份、展示名称、部署范围、凭据模式和传输能力以运行时 `StorageConnector` descriptor 与 connector localization 为准。`tests/storage_connector_docs.rs` 通过管理 API 读取这份 catalog，并生成：
 
-- `docs/src/content/docs/admin/storage-backends/index.md`（后端选择表）
-- `docs/src/content/docs/reference/storage-matrix.md`（能力矩阵）
-- `docs/astro.config.mts` 里的侧边栏
+- `docs/generated/storage-connectors.json`：机器可读、随 PR 审查的 manifest
+- `docs/src/content/docs/admin/storage-backends/index.md` 中的后端选择表
+- `docs/src/content/docs/admin/storage-policies.md` 中的 connector catalog
+- `docs/src/content/docs/reference/storage-matrix.md` 中的能力矩阵
+- 上述三处英文页面的对应 block
+
+`docs/astro.config.mts` 直接从 manifest 构造存储后端侧边栏，不再维护第二份 backend 列表。新增或改名内置 connector 时：
+
+1. 修改 connector descriptor、本地化资源和 `tests/storage_connector_docs.rs` 中 provider-owned 的教程 slug / 适用场景摘要。
+2. 新增中英文 provider 教程。
+3. 运行 `make storage-docs`，审查 manifest 和 Markdown 生成 diff。
+4. 运行 `make storage-docs-check`；CI 也会执行同一漂移检查。
+
+生成 block 由 `storage-connectors:*:start/end` 标记包围，不手动编辑。后端总览、策略 catalog 和能力矩阵是穷举入口；README、部署说明、故障排查和教程里的 provider 名称只作上下文示例，必须写成“例如 / 等”而不是暗示完整清单。上下文示例不随每个新 connector 机械扩写。
 
 如果只改某个后端的细节，不要复制另一篇教程的大段内容；把共通模型链接到存储策略与策略组页（`/admin/storage-policies/`）或能力矩阵（`/reference/storage-matrix/`）。
 

--- a/developer-docs/zh-CN/contributing/task-routing.md
+++ b/developer-docs/zh-CN/contributing/task-routing.md
@@ -30,7 +30,7 @@
 
 | 任务 | 先读 | 代码入口 | 最低验证 |
 | --- | --- | --- | --- |
-| Storage connector / descriptor / 表单字段 | [Descriptor 规范化](../design/storage-descriptor-normalization-contract.md)、[后端服务所有权](../architecture/backend-service-ownership.md) | `crates/aster_drive_storage/`、`src/storage/connectors/`、admin storage policy frontend | validation、descriptor、payload、连接测试、OpenAPI 和前端 focused tests |
+| Storage connector / descriptor / 表单字段 | [Descriptor 规范化](../design/storage-descriptor-normalization-contract.md)、[后端服务所有权](../architecture/backend-service-ownership.md) | `crates/aster_drive_storage/`、`src/storage/connectors/`、admin storage policy frontend | validation、descriptor、payload、连接测试、`make storage-docs-check`、OpenAPI 和前端 focused tests |
 | Storage driver / SDK 行为 | [项目契约](../architecture/project-contract.md) | `src/storage/drivers/`、connector runtime construction | 普通请求、错误映射、range、upload/download/delete；presigned 与普通请求分别证明 |
 | 对象命名和 OneDrive | [对象命名与 OneDrive](../design/storage-object-naming-and-onedrive-direct-download.md) | storage object key、OneDrive driver/connector | 编码、特殊字符、直链、缓存和回退边界 |
 | 远端节点 / storage target / policy ownership | [远端存储目标归属](../design/remote-storage-target-policy-ownership.md) | `src/services/remote/`、storage policy、remote protocol | direct/reverse tunnel/auto、binding、capability、target selection 和失败映射 |

--- a/developer-docs/zh-CN/design/storage-descriptor-normalization-contract.md
+++ b/developer-docs/zh-CN/design/storage-descriptor-normalization-contract.md
@@ -25,6 +25,14 @@
 - action 返回的结构化 `output` 只允许按 descriptor 的 `output_fields` 临时展示；未声明字段、类型不匹配字段和其他 action 的结果一律忽略。输出不写回 policy config，也不跨 action 或对话框会话保存。
 - delegated credential 的状态文案、语义色、说明、需要管理员关注的提示、净化后的原因映射、生命周期标签、重新授权文案和 redirect URI 辅助信息都由 `credential_management` 描述。共享面板不得按 OneDrive、Microsoft Graph 或其他 provider ID 分支，也不得直接展示 wire `status_reason`。
 
+## 文档事实投影
+
+- 内置 connector 的身份、展示名称、`deployment_scope`、`credential_mode`、`capabilities` 和 `upload_workflows` 仍由运行时 descriptor/localization 唯一拥有，文档层不建立平行 capability 类型。
+- `tests/storage_connector_docs.rs` 通过管理员实际消费的 catalog API 生成 `docs/generated/storage-connectors.json`，并更新后端索引、策略 catalog 和能力矩阵中的 marker block。生成产物提交到仓库，和代码一起审查。
+- 教程 slug 和“适合场景”是 provider-owned 文档元数据，不属于 runtime capability。新增内置 connector 时必须显式补齐这两个字段和中英文教程；测试会拒绝缺项或不存在的教程路径。
+- capability matrix 展示 connector 的静态能力上限。策略选项、远端节点 transport 和部署网络仍可能收窄实际能力，provider 教程负责解释这些条件。
+- README、部署文档和教程中的 provider 名称是明确标注的非穷举示例，不作为 backend catalog；新增 connector 不要求替换所有上下文示例。
+
 ## 字段规范化规则
 
 字段规范化属于 backend use case 或 connector/driver-specific pure helper，不能散落在 handler 或前端组件里。
@@ -55,4 +63,5 @@
 - normalization 必须覆盖 trim、空值、逃逸路径、prefix 首尾斜杠、storage policy 负数 `max_file_size`、同 driver secret preserve、显式 secret replace、driver 切换字段重置。
 - SFTP 必须覆盖裸 host、`host:port`、`sftp://host:port`、错误协议、host key 指纹格式、未知 host key 拒绝和已确认指纹通过。
 - storage policy descriptor 行为改变时，跑 `cargo test --lib storage::connectors` 或更小过滤；remote storage target 归一化改变时，跑 `cargo test --lib remote::storage_target::tests::<filter>`。
+- 内置 connector 身份、localization 或上述文档事实改变时，运行 `make storage-docs` 更新生成产物，再运行 `make storage-docs-check` 验证无漂移。
 - 改 OpenAPI schema 后必须重新导出 OpenAPI、生成前端 SDK 并审查生成差异。

--- a/docs/astro.config.mts
+++ b/docs/astro.config.mts
@@ -7,6 +7,7 @@ import starlightCopyButton from 'starlight-copy-button'
 import starlightLinksValidator from 'starlight-links-validator'
 import starlightLlmsTxt from 'starlight-llms-txt'
 import starlightScrollToTop from 'starlight-scroll-to-top'
+import storageConnectorManifest from './generated/storage-connectors.json'
 
 const SITE_URL = 'https://drive.astercosm.com'
 const ZH_SITE_DESCRIPTION =
@@ -19,6 +20,12 @@ type SidebarItem = {
   collapsed?: boolean
   items?: SidebarItem[]
 }
+
+const storageBackendSidebarItems: SidebarItem[] = storageConnectorManifest.connectors.map((connector) => ({
+  label: connector.display_name.zh,
+  translations: { en: connector.display_name.en },
+  link: `/admin/storage-backends/${connector.documentation.tutorial_slug}/`
+}))
 
 function assertUniqueSidebarLinks<T extends SidebarItem[]>(sidebar: T): T {
   const seen = new Map<string, string>()
@@ -102,22 +109,7 @@ const sidebar = assertUniqueSidebarLinks([
         collapsed: true,
         items: [
           { label: '后端总览', translations: { en: 'Backend Overview' }, link: '/admin/storage-backends/' },
-          { label: '本地磁盘', translations: { en: 'Local Disk' }, link: '/admin/storage-backends/local/' },
-          { label: 'S3 / MinIO / R2', translations: { en: 'S3 / MinIO / R2' }, link: '/admin/storage-backends/s3/' },
-          { label: '阿里云 OSS', translations: { en: 'Alibaba Cloud OSS' }, link: '/admin/storage-backends/alibaba-oss/' },
-          {
-            label: 'Azure Blob Storage',
-            translations: { en: 'Azure Blob Storage' },
-            link: '/admin/storage-backends/azure-blob/'
-          },
-          { label: '腾讯云 COS', translations: { en: 'Tencent COS' }, link: '/admin/storage-backends/tencent-cos/' },
-          { label: 'OneDrive', translations: { en: 'OneDrive' }, link: '/admin/storage-backends/onedrive/' },
-          { label: 'SFTP', translations: { en: 'SFTP' }, link: '/admin/storage-backends/sftp/' },
-          {
-            label: '远程节点存储策略',
-            translations: { en: 'Follower Node Storage Policy' },
-            link: '/admin/storage-backends/remote-follower/'
-          }
+          ...storageBackendSidebarItems
         ]
       },
       { label: '远程节点', translations: { en: 'Remote Nodes' }, link: '/admin/follower-nodes/' },

--- a/docs/generated/storage-connectors.json
+++ b/docs/generated/storage-connectors.json
@@ -1,0 +1,390 @@
+{
+  "schema_version": 1,
+  "generated_from": "authenticated built-in StorageConnector descriptor and localization catalogs",
+  "connectors": [
+    {
+      "connector_id": "asterdrive.storage.local",
+      "display_name": {
+        "en": "Local",
+        "zh": "本机"
+      },
+      "documentation": {
+        "tutorial_slug": "local",
+        "best_for": {
+          "en": "Single machine, NAS, small teams, minimal dependencies",
+          "zh": "单机、NAS、小团队、最少依赖"
+        }
+      },
+      "deployment_scope": "instance_local",
+      "supports_initial_setup": true,
+      "credential_mode": "none",
+      "capabilities": {
+        "efficient_range": true,
+        "capacity": true,
+        "list": true,
+        "presigned_download": false,
+        "storage_native_thumbnail": false,
+        "storage_native_media_metadata": false,
+        "remote_node_binding": false,
+        "object_storage_transfer_strategy": false,
+        "object_naming": "opaque_uuid"
+      },
+      "upload_workflows": {
+        "simple_upload": true,
+        "simple_upload_capabilities": {
+          "server_side_relay": true,
+          "policy_limited": true
+        },
+        "stream_upload": true,
+        "object_multipart_upload": false,
+        "provider_resumable_upload": false,
+        "presigned_upload": false,
+        "frontend_direct_provider_resumable_upload": false
+      }
+    },
+    {
+      "connector_id": "asterdrive.storage.s3",
+      "display_name": {
+        "en": "S3",
+        "zh": "S3"
+      },
+      "documentation": {
+        "tutorial_slug": "s3",
+        "best_for": {
+          "en": "S3-compatible object storage, external buckets, and large files",
+          "zh": "S3 兼容对象存储、外部 bucket 和大文件"
+        }
+      },
+      "deployment_scope": "shared_across_primary_instances",
+      "supports_initial_setup": true,
+      "credential_mode": "static_secret",
+      "capabilities": {
+        "efficient_range": true,
+        "capacity": false,
+        "list": true,
+        "presigned_download": true,
+        "storage_native_thumbnail": false,
+        "storage_native_media_metadata": false,
+        "remote_node_binding": false,
+        "object_storage_transfer_strategy": true,
+        "object_naming": "opaque_uuid"
+      },
+      "upload_workflows": {
+        "simple_upload": true,
+        "simple_upload_capabilities": {
+          "server_side_relay": true,
+          "policy_limited": true
+        },
+        "stream_upload": true,
+        "object_multipart_upload": true,
+        "object_multipart_upload_capabilities": {
+          "min_part_size": 5242880,
+          "policy_limited_part_size": true,
+          "relay_part_upload": true,
+          "presigned_part_upload": true,
+          "presigned_part_etag_required": true,
+          "explicit_complete_required": true,
+          "abort_supported": true,
+          "list_parts_supported": true
+        },
+        "provider_resumable_upload": false,
+        "presigned_upload": true,
+        "frontend_direct_provider_resumable_upload": false
+      }
+    },
+    {
+      "connector_id": "asterdrive.storage.alibaba_oss",
+      "display_name": {
+        "en": "Alibaba Cloud OSS",
+        "zh": "阿里云 OSS"
+      },
+      "documentation": {
+        "tutorial_slug": "alibaba-oss",
+        "best_for": {
+          "en": "Alibaba Cloud OSS with native V4 signing, split endpoints, or CNAME",
+          "zh": "阿里云 OSS 原生 V4 签名、内外网 endpoint 分流或 CNAME"
+        }
+      },
+      "deployment_scope": "shared_across_primary_instances",
+      "supports_initial_setup": true,
+      "credential_mode": "static_secret",
+      "capabilities": {
+        "efficient_range": true,
+        "capacity": false,
+        "list": true,
+        "presigned_download": true,
+        "storage_native_thumbnail": false,
+        "storage_native_media_metadata": false,
+        "remote_node_binding": false,
+        "object_storage_transfer_strategy": true,
+        "object_naming": "opaque_uuid"
+      },
+      "upload_workflows": {
+        "simple_upload": true,
+        "simple_upload_capabilities": {
+          "server_side_relay": true,
+          "policy_limited": true
+        },
+        "stream_upload": true,
+        "object_multipart_upload": true,
+        "object_multipart_upload_capabilities": {
+          "min_part_size": 5242880,
+          "policy_limited_part_size": true,
+          "relay_part_upload": true,
+          "presigned_part_upload": true,
+          "presigned_part_etag_required": true,
+          "explicit_complete_required": true,
+          "abort_supported": true,
+          "list_parts_supported": true
+        },
+        "provider_resumable_upload": false,
+        "presigned_upload": true,
+        "frontend_direct_provider_resumable_upload": false
+      }
+    },
+    {
+      "connector_id": "asterdrive.storage.sftp",
+      "display_name": {
+        "en": "SFTP",
+        "zh": "SFTP"
+      },
+      "documentation": {
+        "tutorial_slug": "sftp",
+        "best_for": {
+          "en": "SSH/SFTP file servers and server-side streaming",
+          "zh": "SSH/SFTP 文件服务器和服务端流式读写"
+        }
+      },
+      "deployment_scope": "shared_across_primary_instances",
+      "supports_initial_setup": true,
+      "credential_mode": "static_secret",
+      "capabilities": {
+        "efficient_range": true,
+        "capacity": false,
+        "list": false,
+        "presigned_download": false,
+        "storage_native_thumbnail": false,
+        "storage_native_media_metadata": false,
+        "remote_node_binding": false,
+        "object_storage_transfer_strategy": false,
+        "object_naming": "opaque_uuid"
+      },
+      "upload_workflows": {
+        "simple_upload": true,
+        "simple_upload_capabilities": {
+          "server_side_relay": true,
+          "policy_limited": true
+        },
+        "stream_upload": true,
+        "object_multipart_upload": false,
+        "provider_resumable_upload": false,
+        "presigned_upload": false,
+        "frontend_direct_provider_resumable_upload": false
+      }
+    },
+    {
+      "connector_id": "asterdrive.storage.azure_blob",
+      "display_name": {
+        "en": "Azure Blob",
+        "zh": "Azure Blob"
+      },
+      "documentation": {
+        "tutorial_slug": "azure-blob",
+        "best_for": {
+          "en": "Azure Storage accounts and Blob containers",
+          "zh": "Azure Storage account 和 Blob container"
+        }
+      },
+      "deployment_scope": "shared_across_primary_instances",
+      "supports_initial_setup": true,
+      "credential_mode": "static_secret",
+      "capabilities": {
+        "efficient_range": true,
+        "capacity": false,
+        "list": true,
+        "presigned_download": true,
+        "storage_native_thumbnail": false,
+        "storage_native_media_metadata": false,
+        "remote_node_binding": false,
+        "object_storage_transfer_strategy": true,
+        "object_naming": "opaque_uuid"
+      },
+      "upload_workflows": {
+        "simple_upload": true,
+        "simple_upload_capabilities": {
+          "server_side_relay": true,
+          "policy_limited": true
+        },
+        "stream_upload": true,
+        "object_multipart_upload": true,
+        "object_multipart_upload_capabilities": {
+          "min_part_size": 5242880,
+          "policy_limited_part_size": true,
+          "relay_part_upload": true,
+          "presigned_part_upload": true,
+          "presigned_part_etag_required": false,
+          "explicit_complete_required": true,
+          "abort_supported": true,
+          "list_parts_supported": true
+        },
+        "provider_resumable_upload": false,
+        "presigned_upload": true,
+        "frontend_direct_provider_resumable_upload": false
+      }
+    },
+    {
+      "connector_id": "asterdrive.storage.tencent_cos",
+      "display_name": {
+        "en": "Tencent COS",
+        "zh": "腾讯云 COS"
+      },
+      "documentation": {
+        "tutorial_slug": "tencent-cos",
+        "best_for": {
+          "en": "Tencent COS and per-policy COS CI processing",
+          "zh": "腾讯云 COS 和按策略启用的 COS 数据万象"
+        }
+      },
+      "deployment_scope": "shared_across_primary_instances",
+      "supports_initial_setup": true,
+      "credential_mode": "static_secret",
+      "capabilities": {
+        "efficient_range": true,
+        "capacity": false,
+        "list": true,
+        "presigned_download": true,
+        "storage_native_thumbnail": true,
+        "storage_native_media_metadata": true,
+        "remote_node_binding": false,
+        "object_storage_transfer_strategy": true,
+        "object_naming": "opaque_uuid"
+      },
+      "upload_workflows": {
+        "simple_upload": true,
+        "simple_upload_capabilities": {
+          "server_side_relay": true,
+          "policy_limited": true
+        },
+        "stream_upload": true,
+        "object_multipart_upload": true,
+        "object_multipart_upload_capabilities": {
+          "min_part_size": 5242880,
+          "policy_limited_part_size": true,
+          "relay_part_upload": true,
+          "presigned_part_upload": true,
+          "presigned_part_etag_required": true,
+          "explicit_complete_required": true,
+          "abort_supported": true,
+          "list_parts_supported": true
+        },
+        "provider_resumable_upload": false,
+        "presigned_upload": true,
+        "frontend_direct_provider_resumable_upload": false
+      }
+    },
+    {
+      "connector_id": "asterdrive.storage.remote",
+      "display_name": {
+        "en": "Remote",
+        "zh": "远程节点"
+      },
+      "documentation": {
+        "tutorial_slug": "remote-follower",
+        "best_for": {
+          "en": "Objects stored by another AsterDrive follower node",
+          "zh": "由另一台 AsterDrive follower 节点保存对象"
+        }
+      },
+      "deployment_scope": "shared_across_primary_instances",
+      "supports_initial_setup": true,
+      "credential_mode": "none",
+      "capabilities": {
+        "efficient_range": true,
+        "capacity": true,
+        "list": true,
+        "presigned_download": true,
+        "storage_native_thumbnail": false,
+        "storage_native_media_metadata": false,
+        "remote_node_binding": true,
+        "object_storage_transfer_strategy": false,
+        "object_naming": "opaque_uuid"
+      },
+      "upload_workflows": {
+        "simple_upload": true,
+        "simple_upload_capabilities": {
+          "server_side_relay": true,
+          "policy_limited": true
+        },
+        "stream_upload": true,
+        "object_multipart_upload": true,
+        "object_multipart_upload_capabilities": {
+          "min_part_size": 5242880,
+          "policy_limited_part_size": true,
+          "relay_part_upload": true,
+          "presigned_part_upload": true,
+          "presigned_part_etag_required": true,
+          "explicit_complete_required": true,
+          "abort_supported": true,
+          "list_parts_supported": true
+        },
+        "provider_resumable_upload": false,
+        "presigned_upload": true,
+        "frontend_direct_provider_resumable_upload": false
+      }
+    },
+    {
+      "connector_id": "asterdrive.storage.onedrive",
+      "display_name": {
+        "en": "OneDrive",
+        "zh": "OneDrive"
+      },
+      "documentation": {
+        "tutorial_slug": "onedrive",
+        "best_for": {
+          "en": "Microsoft 365, OneDrive, SharePoint, and group drives",
+          "zh": "Microsoft 365、OneDrive、SharePoint 和 group drive"
+        }
+      },
+      "deployment_scope": "shared_across_primary_instances",
+      "supports_initial_setup": false,
+      "credential_mode": "oauth_delegated",
+      "capabilities": {
+        "efficient_range": true,
+        "capacity": true,
+        "list": false,
+        "presigned_download": true,
+        "storage_native_thumbnail": false,
+        "storage_native_media_metadata": false,
+        "remote_node_binding": false,
+        "object_storage_transfer_strategy": false,
+        "object_naming": "original_filename"
+      },
+      "upload_workflows": {
+        "simple_upload": true,
+        "simple_upload_capabilities": {
+          "server_side_relay": true,
+          "policy_limited": true,
+          "max_provider_single_request_size": 250000000
+        },
+        "stream_upload": true,
+        "object_multipart_upload": false,
+        "provider_resumable_upload": true,
+        "presigned_upload": false,
+        "frontend_direct_provider_resumable_upload": true,
+        "provider_resumable_upload_capabilities": {
+          "provider": "microsoft_graph",
+          "session_label": "Microsoft Graph upload session",
+          "min_fragment_size": 327680,
+          "default_fragment_size": 10485760,
+          "max_fragment_size": 52428800,
+          "fragment_alignment": 327680,
+          "max_simple_upload_size": 250000000,
+          "frontend_direct_upload": true,
+          "implicit_completion": true,
+          "abort_supported": true,
+          "status_query_supported": true
+        }
+      }
+    }
+  ]
+}

--- a/docs/src/content/docs/admin/storage-backends/index.md
+++ b/docs/src/content/docs/admin/storage-backends/index.md
@@ -1,5 +1,5 @@
 ---
-description: "AsterDrive 存储后端选择指南：八种后端的适用场景、所有后端共用的接入流程，以及切生产流量前的验证顺序。"
+description: "AsterDrive 内置存储后端选择指南：适用场景、所有后端共用的接入流程，以及切生产流量前的验证顺序。"
 title: "存储后端"
 ---
 
@@ -10,20 +10,22 @@ title: "存储后端"
 
 ## 后端怎么选
 
-| 后端 | 适合场景 | 教程 |
-| --- | --- | --- |
-| 本地磁盘 | 单机、NAS、小团队、最少依赖 | [本地磁盘](/admin/storage-backends/local/) |
-| S3 / MinIO / R2 | 对象存储、大文件、外部 bucket、云存储 | [S3 / MinIO / R2](/admin/storage-backends/s3/) |
-| 阿里云 OSS | 阿里云原生 OSS bucket、OSS V4 签名、内外网 endpoint 分流或 CNAME | [阿里云 OSS](/admin/storage-backends/alibaba-oss/) |
-| Azure Blob Storage | Azure Storage account、Blob container、Azure 托管对象存储 | [Azure Blob Storage](/admin/storage-backends/azure-blob/) |
-| 腾讯云 COS | 腾讯云对象存储、COS 数据万象、按策略启用原生处理 | [腾讯云 COS](/admin/storage-backends/tencent-cos/) |
-| OneDrive | Microsoft 365、OneDrive、SharePoint / group drive、Microsoft Graph 授权 | [OneDrive](/admin/storage-backends/onedrive/) |
-| SFTP | SSH/SFTP 文件服务器、NAS、传统服务器目录、服务端流式读写 | [SFTP](/admin/storage-backends/sftp/) |
-| 远程节点 | 控制面在主控，真实对象写到另一台 AsterDrive | [远程节点存储策略](/admin/storage-backends/remote-follower/) |
+<!-- storage-connectors:index:start -->
+| 后端 | Connector ID | 部署范围 | 适合场景 | 教程 |
+| --- | --- | --- | --- | --- |
+| 本机 | `asterdrive.storage.local` | 单实例本地 | 单机、NAS、小团队、最少依赖 | [本机](/admin/storage-backends/local/) |
+| S3 | `asterdrive.storage.s3` | Primary 间共享 | S3 兼容对象存储、外部 bucket 和大文件 | [S3](/admin/storage-backends/s3/) |
+| 阿里云 OSS | `asterdrive.storage.alibaba_oss` | Primary 间共享 | 阿里云 OSS 原生 V4 签名、内外网 endpoint 分流或 CNAME | [阿里云 OSS](/admin/storage-backends/alibaba-oss/) |
+| SFTP | `asterdrive.storage.sftp` | Primary 间共享 | SSH/SFTP 文件服务器和服务端流式读写 | [SFTP](/admin/storage-backends/sftp/) |
+| Azure Blob | `asterdrive.storage.azure_blob` | Primary 间共享 | Azure Storage account 和 Blob container | [Azure Blob](/admin/storage-backends/azure-blob/) |
+| 腾讯云 COS | `asterdrive.storage.tencent_cos` | Primary 间共享 | 腾讯云 COS 和按策略启用的 COS 数据万象 | [腾讯云 COS](/admin/storage-backends/tencent-cos/) |
+| 远程节点 | `asterdrive.storage.remote` | Primary 间共享 | 由另一台 AsterDrive follower 节点保存对象 | [远程节点](/admin/storage-backends/remote-follower/) |
+| OneDrive | `asterdrive.storage.onedrive` | Primary 间共享 | Microsoft 365、OneDrive、SharePoint 和 group drive | [OneDrive](/admin/storage-backends/onedrive/) |
+<!-- storage-connectors:index:end -->
 
 多 Primary（cluster profile）的默认策略必须由所有 Primary 访问，`local` 不能作为默认策略；详见 [存储策略与策略组](/admin/storage-policies/#第一次启动后默认会有什么)。
 
-各后端的直传能力、容量观测、原生处理和凭据落库对比，以及 `relay_stream` 与 `presigned` 怎么选，见 [存储能力矩阵](/reference/storage-matrix/)。
+各后端的直传能力、容量观测、原生处理和凭据模式对比，以及 `relay_stream` 与 `presigned` 怎么选，见 [存储能力矩阵](/reference/storage-matrix/)。
 
 ## 通用配置流程
 

--- a/docs/src/content/docs/admin/storage-policies.md
+++ b/docs/src/content/docs/admin/storage-policies.md
@@ -26,16 +26,18 @@ title: "存储策略与策略组"
 
 ## 当前支持的存储类型
 
-| 类型 | 说明 | 详细教程 |
-| --- | --- | --- |
-| `local` | 文件存到本地目录 | [本地磁盘](/admin/storage-backends/local/) |
-| `s3` | 文件存到 S3 或明确提供 S3-compatible API 的对象存储（MinIO / R2 / B2 等） | [S3 / MinIO / R2](/admin/storage-backends/s3/) |
-| `alibaba_oss` | 使用原生 OSS V4 签名写入阿里云 OSS，支持公网 / 服务端 endpoint 分流和 CNAME | [阿里云 OSS](/admin/storage-backends/alibaba-oss/) |
-| `azure_blob` | 文件存到 Azure Blob Storage container，使用 Azure Blob SDK 和 SAS URL | [Azure Blob Storage](/admin/storage-backends/azure-blob/) |
-| `tencent_cos` | 文件存到腾讯云 COS；基础对象读写复用 S3 兼容能力，并额外暴露 COS 数据万象等腾讯云原生能力 | [腾讯云 COS](/admin/storage-backends/tencent-cos/) |
-| `one_drive` | 文件写到 Microsoft Graph 可访问的 OneDrive、SharePoint 或 Microsoft 365 group drive | [OneDrive](/admin/storage-backends/onedrive/) |
-| `sftp` | 文件通过 AsterDrive 服务端流式读写到 SSH/SFTP 文件服务器 | [SFTP](/admin/storage-backends/sftp/) |
-| `remote` | 文件通过内部远程存储协议写到另一台 AsterDrive 从节点 | [远程节点存储策略](/admin/storage-backends/remote-follower/) |
+<!-- storage-connectors:policy-catalog:start -->
+| Connector ID | 后端 | 凭据模式 | 详细教程 |
+| --- | --- | --- | --- |
+| `asterdrive.storage.local` | 本机 | 无 connector 凭据 | [本机](/admin/storage-backends/local/) |
+| `asterdrive.storage.s3` | S3 | 静态密钥 | [S3](/admin/storage-backends/s3/) |
+| `asterdrive.storage.alibaba_oss` | 阿里云 OSS | 静态密钥 | [阿里云 OSS](/admin/storage-backends/alibaba-oss/) |
+| `asterdrive.storage.sftp` | SFTP | 静态密钥 | [SFTP](/admin/storage-backends/sftp/) |
+| `asterdrive.storage.azure_blob` | Azure Blob | 静态密钥 | [Azure Blob](/admin/storage-backends/azure-blob/) |
+| `asterdrive.storage.tencent_cos` | 腾讯云 COS | 静态密钥 | [腾讯云 COS](/admin/storage-backends/tencent-cos/) |
+| `asterdrive.storage.remote` | 远程节点 | 无 connector 凭据 | [远程节点](/admin/storage-backends/remote-follower/) |
+| `asterdrive.storage.onedrive` | OneDrive | 委托 OAuth | [OneDrive](/admin/storage-backends/onedrive/) |
+<!-- storage-connectors:policy-catalog:end -->
 
 ## 存储策略 vs 策略组
 

--- a/docs/src/content/docs/en/admin/storage-backends/index.md
+++ b/docs/src/content/docs/en/admin/storage-backends/index.md
@@ -1,5 +1,5 @@
 ---
-description: "AsterDrive storage backend selection guide: when to pick each of the eight backends, the onboarding flow shared by all backends, and how to validate before switching production traffic."
+description: "AsterDrive built-in storage backend selection guide: when to pick each backend, the shared onboarding flow, and how to validate before switching production traffic."
 title: "Storage Backends"
 ---
 
@@ -10,20 +10,22 @@ The two-layer concept of storage policies and policy groups itself lives in [Sto
 
 ## Choosing a Backend
 
-| Backend | Best for | Tutorial |
-| --- | --- | --- |
-| Local Disk | Single machine, NAS, small teams, minimal dependencies | [Local Disk](/en/admin/storage-backends/local/) |
-| S3 / MinIO / R2 | Object storage, large files, external buckets, cloud storage | [S3 / MinIO / R2](/en/admin/storage-backends/s3/) |
-| Alibaba Cloud OSS | Native Alibaba OSS buckets, OSS V4 signing, public/internal endpoint split, or CNAME | [Alibaba Cloud OSS](/en/admin/storage-backends/alibaba-oss/) |
-| Azure Blob Storage | Azure Storage accounts, Blob containers, Azure-managed object storage | [Azure Blob Storage](/en/admin/storage-backends/azure-blob/) |
-| Tencent Cloud COS | Tencent Cloud object storage, COS CI, per-policy native processing | [Tencent Cloud COS](/en/admin/storage-backends/tencent-cos/) |
-| OneDrive | Microsoft 365, OneDrive, SharePoint / group drives, Microsoft Graph authorization | [OneDrive](/en/admin/storage-backends/onedrive/) |
-| SFTP | SSH/SFTP file servers, NAS, traditional server directories, server-side streaming | [SFTP](/en/admin/storage-backends/sftp/) |
-| Remote Node | Control plane on the primary, real objects written to another AsterDrive | [Follower Node Storage Policy](/en/admin/storage-backends/remote-follower/) |
+<!-- storage-connectors:index:start -->
+| Backend | Connector ID | Deployment scope | Best for | Tutorial |
+| --- | --- | --- | --- | --- |
+| Local | `asterdrive.storage.local` | Instance-local | Single machine, NAS, small teams, minimal dependencies | [Local](/en/admin/storage-backends/local/) |
+| S3 | `asterdrive.storage.s3` | Shared across Primary instances | S3-compatible object storage, external buckets, and large files | [S3](/en/admin/storage-backends/s3/) |
+| Alibaba Cloud OSS | `asterdrive.storage.alibaba_oss` | Shared across Primary instances | Alibaba Cloud OSS with native V4 signing, split endpoints, or CNAME | [Alibaba Cloud OSS](/en/admin/storage-backends/alibaba-oss/) |
+| SFTP | `asterdrive.storage.sftp` | Shared across Primary instances | SSH/SFTP file servers and server-side streaming | [SFTP](/en/admin/storage-backends/sftp/) |
+| Azure Blob | `asterdrive.storage.azure_blob` | Shared across Primary instances | Azure Storage accounts and Blob containers | [Azure Blob](/en/admin/storage-backends/azure-blob/) |
+| Tencent COS | `asterdrive.storage.tencent_cos` | Shared across Primary instances | Tencent COS and per-policy COS CI processing | [Tencent COS](/en/admin/storage-backends/tencent-cos/) |
+| Remote | `asterdrive.storage.remote` | Shared across Primary instances | Objects stored by another AsterDrive follower node | [Remote](/en/admin/storage-backends/remote-follower/) |
+| OneDrive | `asterdrive.storage.onedrive` | Shared across Primary instances | Microsoft 365, OneDrive, SharePoint, and group drives | [OneDrive](/en/admin/storage-backends/onedrive/) |
+<!-- storage-connectors:index:end -->
 
 For multi-Primary (cluster profile) deployments, the default policy must be reachable by every Primary, and `local` cannot be the default policy; see [Storage Policies and Policy Groups](/en/admin/storage-policies/#what-exists-after-first-start).
 
-For each backend's direct-upload capability, capacity observation, native processing, and credentials at rest — plus how to choose between `relay_stream` and `presigned` — see the [Storage Capability Matrix](/en/reference/storage-matrix/).
+For each backend's direct-upload capability, capacity observation, native processing, and credential mode — plus how to choose between `relay_stream` and `presigned` — see the [Storage Capability Matrix](/en/reference/storage-matrix/).
 
 ## Shared Onboarding Flow
 

--- a/docs/src/content/docs/en/admin/storage-policies.md
+++ b/docs/src/content/docs/en/admin/storage-policies.md
@@ -26,16 +26,18 @@ When a system administrator creates a new team without specifying a policy group
 
 ## Currently Supported Storage Types
 
-| Type | Description | Full tutorial |
-| --- | --- | --- |
-| `local` | Files on a local directory | [Local Disk](/en/admin/storage-backends/local/) |
-| `s3` | Files on S3 or object storage with an explicit S3-compatible API (MinIO / R2 / B2, etc.) | [S3 / MinIO / R2](/en/admin/storage-backends/s3/) |
-| `alibaba_oss` | Files on Alibaba Cloud OSS with native OSS V4 signing, public/server endpoint separation, and CNAME support | [Alibaba Cloud OSS](/en/admin/storage-backends/alibaba-oss/) |
-| `azure_blob` | Files in an Azure Blob Storage container via the Azure Blob SDK and SAS URLs | [Azure Blob Storage](/en/admin/storage-backends/azure-blob/) |
-| `tencent_cos` | Files on Tencent Cloud COS; basic object I/O reuses S3-compatible logic and additionally exposes Tencent-native capabilities like COS CI | [Tencent Cloud COS](/en/admin/storage-backends/tencent-cos/) |
-| `one_drive` | Files written to OneDrive, SharePoint, or Microsoft 365 group drives reachable via Microsoft Graph | [OneDrive](/en/admin/storage-backends/onedrive/) |
-| `sftp` | Files streamed by the AsterDrive server to an SSH/SFTP file server | [SFTP](/en/admin/storage-backends/sftp/) |
-| `remote` | Files written through the internal remote storage protocol to another AsterDrive follower node | [Follower Node Storage Policy](/en/admin/storage-backends/remote-follower/) |
+<!-- storage-connectors:policy-catalog:start -->
+| Connector ID | Backend | Credential mode | Full tutorial |
+| --- | --- | --- | --- |
+| `asterdrive.storage.local` | Local | None | [Local](/en/admin/storage-backends/local/) |
+| `asterdrive.storage.s3` | S3 | Static secret | [S3](/en/admin/storage-backends/s3/) |
+| `asterdrive.storage.alibaba_oss` | Alibaba Cloud OSS | Static secret | [Alibaba Cloud OSS](/en/admin/storage-backends/alibaba-oss/) |
+| `asterdrive.storage.sftp` | SFTP | Static secret | [SFTP](/en/admin/storage-backends/sftp/) |
+| `asterdrive.storage.azure_blob` | Azure Blob | Static secret | [Azure Blob](/en/admin/storage-backends/azure-blob/) |
+| `asterdrive.storage.tencent_cos` | Tencent COS | Static secret | [Tencent COS](/en/admin/storage-backends/tencent-cos/) |
+| `asterdrive.storage.remote` | Remote | None | [Remote](/en/admin/storage-backends/remote-follower/) |
+| `asterdrive.storage.onedrive` | OneDrive | Delegated OAuth | [OneDrive](/en/admin/storage-backends/onedrive/) |
+<!-- storage-connectors:policy-catalog:end -->
 
 ## Storage Policies vs Policy Groups
 

--- a/docs/src/content/docs/en/reference/config/auth.md
+++ b/docs/src/content/docs/en/reference/config/auth.md
@@ -54,18 +54,18 @@ Once changed, existing authenticator secrets can no longer be decrypted, and use
 
 ### `storage_credential_secret_key`
 
-This is the server-side encryption master key for the Microsoft Graph credentials (Client Secret, access token, refresh token) used by OneDrive storage policies. When the configuration is generated for the first time, the service automatically writes a random value; a key derived from it encrypts the credentials at rest with AES-256-GCM, and API responses and audit logs expose only boolean state such as `client_secret_configured`.
+This is the server-side encryption master key for storage connector credentials. The service writes a random value when configuration is first generated; a derived key encrypts static secrets, authorization-application secrets, and OAuth tokens with AES-256-GCM. API responses and audit logs do not echo plaintext credentials.
 
-:::tip[This key currently only covers OneDrive]
-It protects `storage_connector_application_configs.client_secret_ciphertext` and the access / refresh token ciphertext in the `storage_policy_credentials` table.
+:::tip[Credentials covered by this key]
+It protects connector-owned, versioned payloads in `storage_policy_connector_credentials.ciphertext`: static secrets for S3, Alibaba Cloud OSS, Azure Blob, Tencent COS, and SFTP, plus Microsoft Graph Client Secrets, access tokens, and refresh tokens for OneDrive.
 
-The `access_key` / `secret_key` for S3, Azure Blob, and Tencent COS, as well as remote node (follower) credentials, **are currently stored in plaintext** and do not depend on this key — rotating it does not affect those drivers.
+The Local and Remote Node connectors declare `credential_mode = none` and create no payload in this connector-credential table. Internal-protocol credentials between nodes belong to the separate remote-node management boundary.
 :::
 
 :::caution[Preserve it during backup and migration]
-As long as any OneDrive policy has completed Microsoft Graph authorization, do not casually replace it while migrating, restoring, or rebuilding `config.toml`.
+As long as any storage policy has saved connector credentials, do not replace this key while migrating, restoring, or rebuilding `config.toml`.
 
-Once changed or lost, the encrypted Client Secret and OAuth tokens can no longer be decrypted, and every OneDrive policy enters a requires-reauthorization state. Old refresh tokens cannot be recovered; an administrator must re-run the authorization flow for each policy from `Admin -> Storage Policies -> target OneDrive policy -> Authorize`.
+Once changed or lost, saved static secrets and OAuth credentials can no longer be decrypted. Static-credential backends need their secrets entered again; old OneDrive refresh tokens cannot be recovered, so an administrator must re-run authorization for each affected policy from `Admin -> Storage Policies -> target OneDrive policy -> Authorize`.
 
 Back up the entire `[auth]` section together with this key before upgrading or moving hosts.
 :::

--- a/docs/src/content/docs/en/reference/index.md
+++ b/docs/src/content/docs/en/reference/index.md
@@ -9,7 +9,7 @@ This section is not an operations manual. It is for looking things up and learni
 | --- | --- |
 | Look up a `config.toml` field | [Configuration Overview](./config/) |
 | Look up an admin-console system setting and when it takes effect | [System Settings](./config/runtime/) |
-| Compare the eight storage backends and their credentials at rest | [Storage Capability Matrix](./storage-matrix/) |
+| Compare built-in storage backends and their credential modes | [Storage Capability Matrix](./storage-matrix/) |
 | Check WebDAV protocol methods, property, lock, and versioning boundaries | [WebDAV Protocol Compatibility](./webdav-compat/) |
 | Understand primary / follower and the upload-download data flow | [Runtime Architecture](./runtime-architecture/) |
 | Look up a term | [Glossary](./glossary/) |

--- a/docs/src/content/docs/en/reference/storage-matrix.md
+++ b/docs/src/content/docs/en/reference/storage-matrix.md
@@ -1,5 +1,5 @@
 ---
-description: "Storage capability matrix for the eight backends: browser direct upload / download, capacity observation, storage-native processing, credentials at rest, and the authoritative relay_stream vs presigned comparison."
+description: "Capability matrix for built-in storage backends: deployment scope, browser direct upload / download, capacity, storage-native processing, credential mode, and relay_stream vs presigned."
 title: "Storage Capability Matrix"
 ---
 
@@ -9,18 +9,22 @@ Per-backend onboarding steps live in the [Storage Backends](/en/admin/storage-ba
 
 ## Capability Quick Reference
 
-| Backend | Browser direct upload / download | Capacity observation | Storage-native processing | Credentials at rest |
-| --- | --- | --- | --- | --- |
-| `local` | Not supported; AsterDrive reads/writes the local disk | Supported (filesystem) | Not supported | No credentials |
-| `s3` | `presigned` upload + download | Not supported | Not supported | Plaintext |
-| `alibaba_oss` | `presigned` upload + download; browsers always use the public endpoint | Not supported | Not supported | AES-256-GCM encrypted |
-| `azure_blob` | `presigned` (SAS URL) upload + download | Not supported | Not supported | Plaintext |
-| `tencent_cos` | `presigned` upload + download | Not supported | COS CI (per-policy switch) | Plaintext |
-| `one_drive` | `frontend_direct` upload, Graph direct download | Supported (Graph quota) | Not supported | AES-256-GCM encrypted |
-| `sftp` | Not supported; server-side streaming | Not supported | Not supported | Plaintext |
-| `remote` | `presigned` requires direct mode plus a browser-reachable follower `base_url` | Follows the remote storage target | Not supported | Plaintext |
+<!-- storage-connectors:matrix:start -->
+| Backend | Deployment scope | Browser direct upload | Direct download | Capacity | Storage-native processing | Credential mode |
+| --- | --- | --- | --- | --- | --- | --- |
+| [Local](/en/admin/storage-backends/local/) | Instance-local | No | No | Yes | No | None |
+| [S3](/en/admin/storage-backends/s3/) | Shared across Primary instances | Presigned | Yes | No | No | Static secret |
+| [Alibaba Cloud OSS](/en/admin/storage-backends/alibaba-oss/) | Shared across Primary instances | Presigned | Yes | No | No | Static secret |
+| [SFTP](/en/admin/storage-backends/sftp/) | Shared across Primary instances | No | No | No | No | Static secret |
+| [Azure Blob](/en/admin/storage-backends/azure-blob/) | Shared across Primary instances | Presigned | Yes | No | No | Static secret |
+| [Tencent COS](/en/admin/storage-backends/tencent-cos/) | Shared across Primary instances | Presigned | Yes | No | Thumbnail + media metadata | Static secret |
+| [Remote](/en/admin/storage-backends/remote-follower/) | Shared across Primary instances | Presigned | Yes | Yes | No | None |
+| [OneDrive](/en/admin/storage-backends/onedrive/) | Shared across Primary instances | Provider-direct | Yes | Yes | No | Delegated OAuth |
+<!-- storage-connectors:matrix:end -->
 
-The encryption master key for OneDrive credentials is `[auth].storage_credential_secret_key` in `config.toml`; keep it safe across migrations and restores. See [Login and Sessions](/en/reference/config/auth/#storage_credential_secret_key).
+The table shows each connector's static capability ceiling; policy settings and deployment topology can narrow the usable paths. For example, remote-node `presigned` transfer requires direct mode and a browser-reachable follower `base_url`, while its capacity result depends on the remote storage target.
+
+`Static secret` and `Delegated OAuth` describe how credentials are acquired, not a plaintext database format. Every connector-managed static secret, authorization-application secret, and OAuth token is encrypted at rest with AES-256-GCM using `[auth].storage_credential_secret_key`. Preserve that key across backups and migrations. See [Authentication and Sessions](/en/reference/config/auth/#storage_credential_secret_key).
 
 ## `relay_stream` vs `presigned`
 

--- a/docs/src/content/docs/reference/config/auth.md
+++ b/docs/src/content/docs/reference/config/auth.md
@@ -54,18 +54,18 @@ bootstrap_insecure_cookies = false
 
 ### `storage_credential_secret_key`
 
-这是 OneDrive 存储策略的 Microsoft Graph 凭据（Client Secret、access token、refresh token）的服务端加密主密钥。首次生成配置时，服务会自动写入一段随机值；派生出的密钥用 AES-256-GCM 把凭据加密后落库，API 与审计只暴露 `client_secret_configured` 这类布尔状态。
+这是 storage connector 凭据的服务端加密主密钥。首次生成配置时，服务会自动写入一段随机值；派生出的密钥使用 AES-256-GCM 加密静态密钥、授权应用 secret 和 OAuth token，API 与审计不会回显明文。
 
-:::tip[这把密钥目前只覆盖 OneDrive]
-它保护的是 `storage_connector_application_configs.client_secret_ciphertext` 和 `storage_policy_credentials` 表里的 access / refresh token 密文。
+:::tip[覆盖哪些凭据]
+它保护 `storage_policy_connector_credentials.ciphertext` 中 connector 自己管理的版本化 payload，包括 S3、阿里云 OSS、Azure Blob、腾讯云 COS、SFTP 的静态密钥，以及 OneDrive 的 Microsoft Graph Client Secret、access token 和 refresh token。
 
-S3、Azure Blob、腾讯云 COS 的 `access_key` / `secret_key`，以及远程节点（follower）凭据，**目前是明文落库**，不依赖这把密钥——换掉它不会影响这些驱动。
+本机和远程节点 connector 的 `credential_mode` 是 `none`，不会在这张 connector credential 表里创建 payload。远程节点之间的内部协议凭据属于节点管理边界，不要和存储策略 connector 凭据混为一谈。
 :::
 
 :::caution[备份和迁移时必须保留]
-只要有一条 OneDrive 策略完成过 Microsoft Graph 授权，就不要在迁移、恢复或重建 `config.toml` 时换掉它。
+只要有任意存储策略保存过 connector 凭据，就不要在迁移、恢复或重建 `config.toml` 时换掉它。
 
-一旦修改或丢失，已加密落库的 Client Secret 和 OAuth token 都无法解密，所有 OneDrive 策略会进入需要重新授权状态。旧 refresh token 无法恢复，管理员只能逐条回到 `管理 -> 存储策略 -> 目标 OneDrive 策略 -> 授权` 重新走一遍授权流程。
+一旦修改或丢失，已加密落库的静态密钥和 OAuth 凭据都无法解密。静态凭据后端需要重新填写密钥；OneDrive 的旧 refresh token 无从恢复，需要逐条回到 `管理 -> 存储策略 -> 目标 OneDrive 策略 -> 授权` 重新走授权流程。
 
 升级或换机前，把整个 `[auth]` 段连同这把密钥一起备份。
 :::

--- a/docs/src/content/docs/reference/index.md
+++ b/docs/src/content/docs/reference/index.md
@@ -9,7 +9,7 @@ title: "参考与项目"
 | --- | --- |
 | 查 `config.toml` 某个字段的含义 | [配置总览](./config/) |
 | 查后台系统设置某个选项的含义和生效时机 | [系统设置](./config/runtime/) |
-| 对比八种存储后端的能力和凭据落库方式 | [存储能力矩阵](./storage-matrix/) |
+| 对比内置存储后端的能力和凭据模式 | [存储能力矩阵](./storage-matrix/) |
 | 查 WebDAV 协议方法、属性、锁和版本控制边界 | [WebDAV 协议兼容](./webdav-compat/) |
 | 搞清楚 primary / follower、上传下载数据流怎么跑 | [运行架构](./runtime-architecture/) |
 | 查一个词是什么意思 | [术语表](./glossary/) |

--- a/docs/src/content/docs/reference/storage-matrix.md
+++ b/docs/src/content/docs/reference/storage-matrix.md
@@ -1,5 +1,5 @@
 ---
-description: "八种存储后端的能力矩阵：浏览器直传 / 直连下载、容量观测、存储原生处理、凭据落库方式，以及 relay_stream 与 presigned 的权威对比。"
+description: "内置存储后端的能力矩阵：部署范围、浏览器直传 / 直连下载、容量观测、存储原生处理、凭据模式，以及 relay_stream 与 presigned 的权威对比。"
 title: "存储能力矩阵"
 ---
 
@@ -9,18 +9,22 @@ title: "存储能力矩阵"
 
 ## 能力速查
 
-| 后端 | 浏览器直传 / 直连下载 | 容量观测 | 存储原生处理 | 凭据落库 |
-| --- | --- | --- | --- | --- |
-| `local` | 不支持，由 AsterDrive 读写本地磁盘 | 支持（文件系统） | 不支持 | 无凭据 |
-| `s3` | `presigned` 上传 + 下载 | 不支持 | 不支持 | 明文 |
-| `alibaba_oss` | `presigned` 上传 + 下载；浏览器固定走公网 endpoint | 不支持 | 不支持 | AES-256-GCM 加密 |
-| `azure_blob` | `presigned`（SAS URL）上传 + 下载 | 不支持 | 不支持 | 明文 |
-| `tencent_cos` | `presigned` 上传 + 下载 | 不支持 | COS 数据万象（按策略开关） | 明文 |
-| `one_drive` | `frontend_direct` 上传、Graph 直接下载 | 支持（Graph quota） | 不支持 | AES-256-GCM 加密 |
-| `sftp` | 不支持，服务端流式读写 | 不支持 | 不支持 | 明文 |
-| `remote` | `presigned` 需直连 + 浏览器可达的 follower `base_url` | 跟随远程存储目标 | 不支持 | 明文 |
+<!-- storage-connectors:matrix:start -->
+| 后端 | 部署范围 | 浏览器直传 | 直连下载 | 容量观测 | 存储原生处理 | 凭据模式 |
+| --- | --- | --- | --- | --- | --- | --- |
+| [本机](/admin/storage-backends/local/) | 单实例本地 | 不支持 | 不支持 | 支持 | 不支持 | 无 connector 凭据 |
+| [S3](/admin/storage-backends/s3/) | Primary 间共享 | Presigned | 支持 | 不支持 | 不支持 | 静态密钥 |
+| [阿里云 OSS](/admin/storage-backends/alibaba-oss/) | Primary 间共享 | Presigned | 支持 | 不支持 | 不支持 | 静态密钥 |
+| [SFTP](/admin/storage-backends/sftp/) | Primary 间共享 | 不支持 | 不支持 | 不支持 | 不支持 | 静态密钥 |
+| [Azure Blob](/admin/storage-backends/azure-blob/) | Primary 间共享 | Presigned | 支持 | 不支持 | 不支持 | 静态密钥 |
+| [腾讯云 COS](/admin/storage-backends/tencent-cos/) | Primary 间共享 | Presigned | 支持 | 不支持 | 缩略图 + 媒体元数据 | 静态密钥 |
+| [远程节点](/admin/storage-backends/remote-follower/) | Primary 间共享 | Presigned | 支持 | 支持 | 不支持 | 无 connector 凭据 |
+| [OneDrive](/admin/storage-backends/onedrive/) | Primary 间共享 | Provider direct | 支持 | 支持 | 不支持 | 委托 OAuth |
+<!-- storage-connectors:matrix:end -->
 
-OneDrive 凭据的加密主密钥是 `config.toml` 里的 `[auth].storage_credential_secret_key`，迁移备份时必须保留；见 [登录与会话](/reference/config/auth/#storage_credential_secret_key)。
+表格展示的是 connector 的静态能力上限；具体策略选项和部署拓扑可以进一步收窄可用路径。例如远程节点的 `presigned` 要求直连模式和浏览器可达的 follower `base_url`，容量观测结果则取决于远程存储目标。
+
+`静态密钥` 和 `委托 OAuth` 描述凭据取得方式，不表示数据库明文格式。所有 connector 自己管理的静态密钥、授权应用 secret 和 OAuth token 都由 `[auth].storage_credential_secret_key` 使用 AES-256-GCM 加密后落库；备份或迁移时必须保留该密钥。详见 [登录与会话](/reference/config/auth/#storage_credential_secret_key)。
 
 ## `relay_stream` vs `presigned`
 

--- a/src/storage/connectors/tests.rs
+++ b/src/storage/connectors/tests.rs
@@ -625,23 +625,40 @@ fn descriptors_are_complete_and_keep_config_credentials_separate() {
 
 #[test]
 fn built_in_connector_capacity_claims_match_runtime_probe_support() {
-    for connector_id in [
+    let capacity_supported = [
         LocalConnector::ID,
         OneDriveConnector::ID,
         RemoteConnector::ID,
-    ] {
-        assert!(
-            connector(connector_id).descriptor().capabilities.capacity,
-            "{connector_id} should advertise capacity probing"
-        );
-    }
-    for connector_id in [
+    ];
+    let capacity_unsupported = [
         S3Connector::ID,
         AlibabaOssConnector::ID,
         AzureBlobConnector::ID,
         TencentCosConnector::ID,
         SftpConnector::ID,
-    ] {
+    ];
+    let descriptors = registry().descriptors();
+    assert_eq!(
+        descriptors.len(),
+        capacity_supported.len() + capacity_unsupported.len(),
+        "capacity expectations must cover every built-in connector exactly once"
+    );
+    for descriptor in descriptors {
+        let connector_id = descriptor.connector_id.as_str();
+        assert_ne!(
+            capacity_supported.contains(&connector_id),
+            capacity_unsupported.contains(&connector_id),
+            "{connector_id} must appear in exactly one capacity expectation list"
+        );
+    }
+
+    for connector_id in capacity_supported {
+        assert!(
+            connector(connector_id).descriptor().capabilities.capacity,
+            "{connector_id} should advertise capacity probing"
+        );
+    }
+    for connector_id in capacity_unsupported {
         assert!(
             !connector(connector_id).descriptor().capabilities.capacity,
             "{connector_id} should not advertise a portable capacity probe"

--- a/src/storage/connectors/tests.rs
+++ b/src/storage/connectors/tests.rs
@@ -624,6 +624,32 @@ fn descriptors_are_complete_and_keep_config_credentials_separate() {
 }
 
 #[test]
+fn built_in_connector_capacity_claims_match_runtime_probe_support() {
+    for connector_id in [
+        LocalConnector::ID,
+        OneDriveConnector::ID,
+        RemoteConnector::ID,
+    ] {
+        assert!(
+            connector(connector_id).descriptor().capabilities.capacity,
+            "{connector_id} should advertise capacity probing"
+        );
+    }
+    for connector_id in [
+        S3Connector::ID,
+        AlibabaOssConnector::ID,
+        AzureBlobConnector::ID,
+        TencentCosConnector::ID,
+        SftpConnector::ID,
+    ] {
+        assert!(
+            !connector(connector_id).descriptor().capabilities.capacity,
+            "{connector_id} should not advertise a portable capacity probe"
+        );
+    }
+}
+
+#[test]
 fn credential_schema_version_is_independent_from_connector_config_schema() {
     let mut descriptor = descriptor(S3Connector::ID);
     assert_eq!(descriptor.credential_schema_version, Some(1));

--- a/tests/storage_connector_docs.rs
+++ b/tests/storage_connector_docs.rs
@@ -556,11 +556,16 @@ fn replace_generated_block(
         .find(end_marker)
         .unwrap_or_else(|| panic!("{} is missing marker {end_marker}", path.display()));
     let end = content_start + end_offset;
-    assert!(
-        current[end + end_marker.len()..]
-            .find(start_marker)
-            .is_none(),
-        "{} contains duplicate marker {start_marker}",
+    assert_eq!(
+        current.matches(start_marker).count(),
+        1,
+        "{} must contain exactly one {start_marker}",
+        path.display()
+    );
+    assert_eq!(
+        current.matches(end_marker).count(),
+        1,
+        "{} must contain exactly one {end_marker}",
         path.display()
     );
     format!(

--- a/tests/storage_connector_docs.rs
+++ b/tests/storage_connector_docs.rs
@@ -1,0 +1,592 @@
+//! Reviewable documentation projection for the built-in connector catalog.
+//!
+//! This test reads the same authenticated descriptor and localization APIs used
+//! by the admin frontend, then projects those facts into a committed JSON
+//! manifest and generated documentation blocks. Provider tutorials remain
+//! curated prose and contribute only their route and short use-case summary.
+
+#[macro_use]
+#[path = "common/mod.rs"]
+mod common;
+
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use actix_web::test;
+use aster_drive_storage::{
+    StorageConnectorCapabilities, StorageConnectorCredentialMode, StorageConnectorDeploymentScope,
+    StorageConnectorDescriptor, StorageConnectorLocalizationCatalog,
+    StorageConnectorUploadWorkflows,
+};
+use serde::Serialize;
+
+const UPDATE_ENV: &str = "ASTER_UPDATE_STORAGE_CONNECTOR_DOCS";
+const MANIFEST_PATH: &str = "docs/generated/storage-connectors.json";
+const GENERATED_SOURCE: &str =
+    "authenticated built-in StorageConnector descriptor and localization catalogs";
+
+const INDEX_START: &str = "<!-- storage-connectors:index:start -->";
+const INDEX_END: &str = "<!-- storage-connectors:index:end -->";
+const MATRIX_START: &str = "<!-- storage-connectors:matrix:start -->";
+const MATRIX_END: &str = "<!-- storage-connectors:matrix:end -->";
+const POLICY_START: &str = "<!-- storage-connectors:policy-catalog:start -->";
+const POLICY_END: &str = "<!-- storage-connectors:policy-catalog:end -->";
+
+const GENERATED_PAGES: &[GeneratedPage] = &[
+    GeneratedPage {
+        path: "docs/src/content/docs/admin/storage-backends/index.md",
+        locale: DocumentationLocale::Zh,
+        block: GeneratedBlock::Index,
+    },
+    GeneratedPage {
+        path: "docs/src/content/docs/en/admin/storage-backends/index.md",
+        locale: DocumentationLocale::En,
+        block: GeneratedBlock::Index,
+    },
+    GeneratedPage {
+        path: "docs/src/content/docs/reference/storage-matrix.md",
+        locale: DocumentationLocale::Zh,
+        block: GeneratedBlock::Matrix,
+    },
+    GeneratedPage {
+        path: "docs/src/content/docs/en/reference/storage-matrix.md",
+        locale: DocumentationLocale::En,
+        block: GeneratedBlock::Matrix,
+    },
+    GeneratedPage {
+        path: "docs/src/content/docs/admin/storage-policies.md",
+        locale: DocumentationLocale::Zh,
+        block: GeneratedBlock::PolicyCatalog,
+    },
+    GeneratedPage {
+        path: "docs/src/content/docs/en/admin/storage-policies.md",
+        locale: DocumentationLocale::En,
+        block: GeneratedBlock::PolicyCatalog,
+    },
+];
+
+const PRESENTATIONS: &[ConnectorDocumentationPresentation] = &[
+    ConnectorDocumentationPresentation {
+        connector_id: "asterdrive.storage.local",
+        tutorial_slug: "local",
+        best_for_en: "Single machine, NAS, small teams, minimal dependencies",
+        best_for_zh: "单机、NAS、小团队、最少依赖",
+    },
+    ConnectorDocumentationPresentation {
+        connector_id: "asterdrive.storage.s3",
+        tutorial_slug: "s3",
+        best_for_en: "S3-compatible object storage, external buckets, and large files",
+        best_for_zh: "S3 兼容对象存储、外部 bucket 和大文件",
+    },
+    ConnectorDocumentationPresentation {
+        connector_id: "asterdrive.storage.alibaba_oss",
+        tutorial_slug: "alibaba-oss",
+        best_for_en: "Alibaba Cloud OSS with native V4 signing, split endpoints, or CNAME",
+        best_for_zh: "阿里云 OSS 原生 V4 签名、内外网 endpoint 分流或 CNAME",
+    },
+    ConnectorDocumentationPresentation {
+        connector_id: "asterdrive.storage.azure_blob",
+        tutorial_slug: "azure-blob",
+        best_for_en: "Azure Storage accounts and Blob containers",
+        best_for_zh: "Azure Storage account 和 Blob container",
+    },
+    ConnectorDocumentationPresentation {
+        connector_id: "asterdrive.storage.tencent_cos",
+        tutorial_slug: "tencent-cos",
+        best_for_en: "Tencent COS and per-policy COS CI processing",
+        best_for_zh: "腾讯云 COS 和按策略启用的 COS 数据万象",
+    },
+    ConnectorDocumentationPresentation {
+        connector_id: "asterdrive.storage.onedrive",
+        tutorial_slug: "onedrive",
+        best_for_en: "Microsoft 365, OneDrive, SharePoint, and group drives",
+        best_for_zh: "Microsoft 365、OneDrive、SharePoint 和 group drive",
+    },
+    ConnectorDocumentationPresentation {
+        connector_id: "asterdrive.storage.sftp",
+        tutorial_slug: "sftp",
+        best_for_en: "SSH/SFTP file servers and server-side streaming",
+        best_for_zh: "SSH/SFTP 文件服务器和服务端流式读写",
+    },
+    ConnectorDocumentationPresentation {
+        connector_id: "asterdrive.storage.remote",
+        tutorial_slug: "remote-follower",
+        best_for_en: "Objects stored by another AsterDrive follower node",
+        best_for_zh: "由另一台 AsterDrive follower 节点保存对象",
+    },
+];
+
+#[derive(Clone, Copy)]
+enum DocumentationLocale {
+    En,
+    Zh,
+}
+
+impl DocumentationLocale {
+    const fn path_prefix(self) -> &'static str {
+        match self {
+            Self::En => "/en",
+            Self::Zh => "",
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+enum GeneratedBlock {
+    Index,
+    Matrix,
+    PolicyCatalog,
+}
+
+struct GeneratedPage {
+    path: &'static str,
+    locale: DocumentationLocale,
+    block: GeneratedBlock,
+}
+
+struct ConnectorDocumentationPresentation {
+    connector_id: &'static str,
+    tutorial_slug: &'static str,
+    best_for_en: &'static str,
+    best_for_zh: &'static str,
+}
+
+#[derive(Serialize)]
+struct StorageConnectorDocumentationManifest {
+    schema_version: u8,
+    generated_from: &'static str,
+    connectors: Vec<StorageConnectorDocumentationEntry>,
+}
+
+#[derive(Serialize)]
+struct StorageConnectorDocumentationEntry {
+    connector_id: String,
+    display_name: LocalizedText,
+    documentation: ConnectorDocumentation,
+    deployment_scope: StorageConnectorDeploymentScope,
+    supports_initial_setup: bool,
+    credential_mode: StorageConnectorCredentialMode,
+    capabilities: StorageConnectorCapabilities,
+    upload_workflows: StorageConnectorUploadWorkflows,
+}
+
+#[derive(Serialize)]
+struct LocalizedText {
+    en: String,
+    zh: String,
+}
+
+#[derive(Serialize)]
+struct ConnectorDocumentation {
+    tutorial_slug: String,
+    best_for: LocalizedText,
+}
+
+#[actix_web::test]
+async fn generated_storage_connector_docs_are_current() {
+    let repository_root = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let state = common::setup().await;
+    let app = create_test_app!(state);
+    let (admin_token, _) = register_and_login!(app);
+
+    let request = test::TestRequest::get()
+        .uri("/api/v1/admin/policies/storage-drivers?context=manage")
+        .insert_header(("Cookie", common::access_cookie_header(&admin_token)))
+        .to_request();
+    let response = test::call_service(&app, request).await;
+    assert_eq!(response.status(), 200);
+    let body: serde_json::Value = test::read_body_json(response).await;
+    let descriptors =
+        serde_json::from_value::<Vec<StorageConnectorDescriptor>>(body["data"].clone())
+            .expect("storage connector descriptor response");
+    let en_localizations = fetch_localizations(&app, &admin_token, "en").await;
+    let zh_localizations = fetch_localizations(&app, &admin_token, "zh-CN").await;
+    let manifest = build_manifest(descriptors, &en_localizations, &zh_localizations);
+    validate_tutorials_exist(repository_root, &manifest);
+
+    let manifest_json = format!(
+        "{}\n",
+        serde_json::to_string_pretty(&manifest).expect("serialize storage connector docs manifest")
+    );
+    assert_or_update(repository_root.join(MANIFEST_PATH), manifest_json);
+
+    for page in GENERATED_PAGES {
+        let path = repository_root.join(page.path);
+        let current = fs::read_to_string(&path)
+            .unwrap_or_else(|error| panic!("read {}: {error}", path.display()));
+        let (start, end, generated) = match page.block {
+            GeneratedBlock::Index => (INDEX_START, INDEX_END, render_index(&manifest, page.locale)),
+            GeneratedBlock::Matrix => (
+                MATRIX_START,
+                MATRIX_END,
+                render_matrix(&manifest, page.locale),
+            ),
+            GeneratedBlock::PolicyCatalog => (
+                POLICY_START,
+                POLICY_END,
+                render_policy_catalog(&manifest, page.locale),
+            ),
+        };
+        let expected = replace_generated_block(&current, start, end, &generated, &path);
+        assert_or_update(path, expected);
+    }
+}
+
+async fn fetch_localizations<S, B>(
+    app: &S,
+    admin_token: &str,
+    locale: &str,
+) -> StorageConnectorLocalizationCatalog
+where
+    S: actix_web::dev::Service<
+            actix_http::Request,
+            Response = actix_web::dev::ServiceResponse<B>,
+            Error = actix_web::Error,
+        >,
+    B: actix_web::body::MessageBody + 'static,
+{
+    let request = test::TestRequest::get()
+        .uri(&format!(
+            "/api/v1/admin/policies/storage-drivers/localizations?context=manage&locale={locale}"
+        ))
+        .insert_header(("Cookie", common::access_cookie_header(admin_token)))
+        .to_request();
+    let response = test::call_service(app, request).await;
+    assert_eq!(response.status(), 200);
+    let body: serde_json::Value = test::read_body_json(response).await;
+    serde_json::from_value(body["data"].clone()).expect("storage connector localization response")
+}
+
+fn build_manifest(
+    descriptors: Vec<StorageConnectorDescriptor>,
+    en_localizations: &StorageConnectorLocalizationCatalog,
+    zh_localizations: &StorageConnectorLocalizationCatalog,
+) -> StorageConnectorDocumentationManifest {
+    let presentations = PRESENTATIONS
+        .iter()
+        .map(|presentation| (presentation.connector_id, presentation))
+        .collect::<BTreeMap<_, _>>();
+    let connectors = descriptors
+        .into_iter()
+        .map(|descriptor| {
+            let connector_id = descriptor.connector_id.as_str();
+            let presentation = presentations.get(connector_id).unwrap_or_else(|| {
+                panic!(
+                    "built-in connector '{connector_id}' needs one provider-owned documentation presentation"
+                )
+            });
+            let display_name = LocalizedText {
+                en: localized_label(en_localizations, &descriptor),
+                zh: localized_label(zh_localizations, &descriptor),
+            };
+            StorageConnectorDocumentationEntry {
+                connector_id: connector_id.to_string(),
+                display_name,
+                documentation: ConnectorDocumentation {
+                    tutorial_slug: presentation.tutorial_slug.to_string(),
+                    best_for: LocalizedText {
+                        en: presentation.best_for_en.to_string(),
+                        zh: presentation.best_for_zh.to_string(),
+                    },
+                },
+                deployment_scope: descriptor.deployment_scope,
+                supports_initial_setup: descriptor.supports_initial_setup,
+                credential_mode: descriptor.credential_mode,
+                capabilities: descriptor.capabilities,
+                upload_workflows: descriptor.upload_workflows,
+            }
+        })
+        .collect::<Vec<_>>();
+
+    assert_eq!(
+        connectors.len(),
+        presentations.len(),
+        "documentation presentations contain an unavailable connector"
+    );
+    StorageConnectorDocumentationManifest {
+        schema_version: 1,
+        generated_from: GENERATED_SOURCE,
+        connectors,
+    }
+}
+
+fn localized_label(
+    catalog: &StorageConnectorLocalizationCatalog,
+    descriptor: &StorageConnectorDescriptor,
+) -> String {
+    catalog
+        .resources
+        .iter()
+        .find(|resource| resource.connector_id == descriptor.connector_id)
+        .unwrap_or_else(|| {
+            panic!(
+                "connector '{}' has no localization resource",
+                descriptor.connector_id
+            )
+        })
+        .messages
+        .get(&descriptor.ui.label_key)
+        .unwrap_or_else(|| {
+            panic!(
+                "connector '{}' localization is missing UI label '{}'",
+                descriptor.connector_id, descriptor.ui.label_key
+            )
+        })
+        .clone()
+}
+
+fn validate_tutorials_exist(
+    repository_root: &Path,
+    manifest: &StorageConnectorDocumentationManifest,
+) {
+    for connector in &manifest.connectors {
+        for locale_path in ["", "en/"] {
+            let path = repository_root.join(format!(
+                "docs/src/content/docs/{locale_path}admin/storage-backends/{}.md",
+                connector.documentation.tutorial_slug
+            ));
+            assert!(
+                path.is_file(),
+                "connector '{}' tutorial does not exist: {}",
+                connector.connector_id,
+                path.display()
+            );
+        }
+    }
+}
+
+fn render_index(
+    manifest: &StorageConnectorDocumentationManifest,
+    locale: DocumentationLocale,
+) -> String {
+    let mut output = match locale {
+        DocumentationLocale::Zh => {
+            "| 后端 | Connector ID | 部署范围 | 适合场景 | 教程 |\n| --- | --- | --- | --- | --- |\n"
+                .to_string()
+        }
+        DocumentationLocale::En => {
+            "| Backend | Connector ID | Deployment scope | Best for | Tutorial |\n| --- | --- | --- | --- | --- |\n"
+                .to_string()
+        }
+    };
+    for connector in &manifest.connectors {
+        let name = localized(&connector.display_name, locale);
+        let best_for = localized(&connector.documentation.best_for, locale);
+        let deployment = deployment_scope(connector.deployment_scope, locale);
+        let tutorial = tutorial_link(connector, locale);
+        output.push_str(&format!(
+            "| {name} | `{}` | {deployment} | {best_for} | [{name}]({tutorial}) |\n",
+            connector.connector_id
+        ));
+    }
+    output
+}
+
+fn render_policy_catalog(
+    manifest: &StorageConnectorDocumentationManifest,
+    locale: DocumentationLocale,
+) -> String {
+    let mut output = match locale {
+        DocumentationLocale::Zh => {
+            "| Connector ID | 后端 | 凭据模式 | 详细教程 |\n| --- | --- | --- | --- |\n"
+                .to_string()
+        }
+        DocumentationLocale::En => {
+            "| Connector ID | Backend | Credential mode | Full tutorial |\n| --- | --- | --- | --- |\n"
+                .to_string()
+        }
+    };
+    for connector in &manifest.connectors {
+        let name = localized(&connector.display_name, locale);
+        let credential = credential_mode(connector.credential_mode, locale);
+        output.push_str(&format!(
+            "| `{}` | {name} | {credential} | [{name}]({}) |\n",
+            connector.connector_id,
+            tutorial_link(connector, locale)
+        ));
+    }
+    output
+}
+
+fn render_matrix(
+    manifest: &StorageConnectorDocumentationManifest,
+    locale: DocumentationLocale,
+) -> String {
+    let mut output = match locale {
+        DocumentationLocale::Zh => "| 后端 | 部署范围 | 浏览器直传 | 直连下载 | 容量观测 | 存储原生处理 | 凭据模式 |\n| --- | --- | --- | --- | --- | --- | --- |\n".to_string(),
+        DocumentationLocale::En => "| Backend | Deployment scope | Browser direct upload | Direct download | Capacity | Storage-native processing | Credential mode |\n| --- | --- | --- | --- | --- | --- | --- |\n".to_string(),
+    };
+    for connector in &manifest.connectors {
+        let name = localized(&connector.display_name, locale);
+        output.push_str(&format!(
+            "| [{name}]({}) | {} | {} | {} | {} | {} | {} |\n",
+            tutorial_link(connector, locale),
+            deployment_scope(connector.deployment_scope, locale),
+            direct_upload(connector, locale),
+            yes_no(connector.capabilities.presigned_download, locale),
+            yes_no(connector.capabilities.capacity, locale),
+            native_processing(&connector.capabilities, locale),
+            credential_mode(connector.credential_mode, locale),
+        ));
+    }
+    output
+}
+
+fn localized(text: &LocalizedText, locale: DocumentationLocale) -> &str {
+    match locale {
+        DocumentationLocale::En => &text.en,
+        DocumentationLocale::Zh => &text.zh,
+    }
+}
+
+fn tutorial_link(
+    connector: &StorageConnectorDocumentationEntry,
+    locale: DocumentationLocale,
+) -> String {
+    format!(
+        "{}/admin/storage-backends/{}/",
+        locale.path_prefix(),
+        connector.documentation.tutorial_slug
+    )
+}
+
+fn deployment_scope(
+    scope: StorageConnectorDeploymentScope,
+    locale: DocumentationLocale,
+) -> &'static str {
+    match (scope, locale) {
+        (StorageConnectorDeploymentScope::InstanceLocal, DocumentationLocale::En) => {
+            "Instance-local"
+        }
+        (StorageConnectorDeploymentScope::InstanceLocal, DocumentationLocale::Zh) => "单实例本地",
+        (
+            StorageConnectorDeploymentScope::SharedAcrossPrimaryInstances,
+            DocumentationLocale::En,
+        ) => "Shared across Primary instances",
+        (
+            StorageConnectorDeploymentScope::SharedAcrossPrimaryInstances,
+            DocumentationLocale::Zh,
+        ) => "Primary 间共享",
+    }
+}
+
+fn credential_mode(
+    mode: StorageConnectorCredentialMode,
+    locale: DocumentationLocale,
+) -> &'static str {
+    match (mode, locale) {
+        (StorageConnectorCredentialMode::None, DocumentationLocale::En) => "None",
+        (StorageConnectorCredentialMode::None, DocumentationLocale::Zh) => "无 connector 凭据",
+        (StorageConnectorCredentialMode::StaticSecret, DocumentationLocale::En) => "Static secret",
+        (StorageConnectorCredentialMode::StaticSecret, DocumentationLocale::Zh) => "静态密钥",
+        (StorageConnectorCredentialMode::RemoteNode, DocumentationLocale::En) => {
+            "Remote-node binding"
+        }
+        (StorageConnectorCredentialMode::RemoteNode, DocumentationLocale::Zh) => "远程节点绑定",
+        (StorageConnectorCredentialMode::OauthDelegated, DocumentationLocale::En) => {
+            "Delegated OAuth"
+        }
+        (StorageConnectorCredentialMode::OauthDelegated, DocumentationLocale::Zh) => "委托 OAuth",
+    }
+}
+
+fn direct_upload(
+    connector: &StorageConnectorDocumentationEntry,
+    locale: DocumentationLocale,
+) -> &'static str {
+    match (
+        connector.upload_workflows.presigned_upload,
+        connector
+            .upload_workflows
+            .frontend_direct_provider_resumable_upload,
+        locale,
+    ) {
+        (true, true, DocumentationLocale::En) => "Presigned + provider-direct",
+        (true, true, DocumentationLocale::Zh) => "Presigned + provider direct",
+        (true, false, _) => "Presigned",
+        (false, true, DocumentationLocale::En) => "Provider-direct",
+        (false, true, DocumentationLocale::Zh) => "Provider direct",
+        (false, false, DocumentationLocale::En) => "No",
+        (false, false, DocumentationLocale::Zh) => "不支持",
+    }
+}
+
+fn yes_no(value: bool, locale: DocumentationLocale) -> &'static str {
+    match (value, locale) {
+        (true, DocumentationLocale::En) => "Yes",
+        (true, DocumentationLocale::Zh) => "支持",
+        (false, DocumentationLocale::En) => "No",
+        (false, DocumentationLocale::Zh) => "不支持",
+    }
+}
+
+fn native_processing(
+    capabilities: &StorageConnectorCapabilities,
+    locale: DocumentationLocale,
+) -> &'static str {
+    match (
+        capabilities.storage_native_thumbnail,
+        capabilities.storage_native_media_metadata,
+        locale,
+    ) {
+        (true, true, DocumentationLocale::En) => "Thumbnail + media metadata",
+        (true, true, DocumentationLocale::Zh) => "缩略图 + 媒体元数据",
+        (true, false, DocumentationLocale::En) => "Thumbnail",
+        (true, false, DocumentationLocale::Zh) => "缩略图",
+        (false, true, DocumentationLocale::En) => "Media metadata",
+        (false, true, DocumentationLocale::Zh) => "媒体元数据",
+        (false, false, DocumentationLocale::En) => "No",
+        (false, false, DocumentationLocale::Zh) => "不支持",
+    }
+}
+
+fn replace_generated_block(
+    current: &str,
+    start_marker: &str,
+    end_marker: &str,
+    generated: &str,
+    path: &Path,
+) -> String {
+    let start = current
+        .find(start_marker)
+        .unwrap_or_else(|| panic!("{} is missing marker {start_marker}", path.display()));
+    let content_start = start + start_marker.len();
+    let end_offset = current[content_start..]
+        .find(end_marker)
+        .unwrap_or_else(|| panic!("{} is missing marker {end_marker}", path.display()));
+    let end = content_start + end_offset;
+    assert!(
+        current[end + end_marker.len()..]
+            .find(start_marker)
+            .is_none(),
+        "{} contains duplicate marker {start_marker}",
+        path.display()
+    );
+    format!(
+        "{}\n{}{}",
+        &current[..content_start],
+        generated,
+        &current[end..]
+    )
+}
+
+fn assert_or_update(path: PathBuf, expected: String) {
+    if std::env::var_os(UPDATE_ENV).is_some() {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)
+                .unwrap_or_else(|error| panic!("create {}: {error}", parent.display()));
+        }
+        fs::write(&path, expected)
+            .unwrap_or_else(|error| panic!("write {}: {error}", path.display()));
+        return;
+    }
+
+    let actual = fs::read_to_string(&path).unwrap_or_default();
+    assert_eq!(
+        actual,
+        expected,
+        "{} is stale; run `make storage-docs` and review the generated diff",
+        path.display()
+    );
+}


### PR DESCRIPTION
## Summary

- treat the authenticated built-in `StorageConnector` descriptor and localization catalog as the canonical connector facts
- add `tests/storage_connector_docs.rs` as an integration-test projection tool, keeping documentation generation out of production modules
- commit a machine-readable connector manifest and generate the backend index, policy catalog, and capability matrix from it in both locales
- build the documentation sidebar from the manifest instead of another hand-maintained backend list
- document canonical exhaustive entry points versus stable contextual examples
- add `make storage-docs`, `make storage-docs-check`, and a docs CI drift check
- correct the shared object-storage capacity claim exposed by the generated matrix and cover the built-in capacity split with a unit test
- update credential-at-rest documentation for the connector credential migration

## Boundary

The generator calls the same authenticated admin descriptor/localization APIs used by the frontend. It does not expose the private registry, add a production documentation module, or define a parallel runtime capability type. Only tutorial slugs and short provider-owned “best for” summaries remain curated in the test projection.

## Validation

- `ASTER_UPDATE_STORAGE_CONNECTOR_DOCS=1 cargo test --test storage_connector_docs generated_storage_connector_docs_are_current -- --exact --nocapture`
- `make storage-docs-check`
- `cargo test --lib storage::connectors` (38 passed)
- `cargo fmt --all -- --check`
- `cd docs && bun run docs:build` (163 pages, links valid)
- `cd docs && bun run developer-docs:build` (414 pages, links valid)
- `git diff --check`

Closes #473


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 存储后端目录、侧边栏、策略目录和能力矩阵现由连接器信息自动生成，内容更完整。
  - 新增 SFTP 与远程节点的文档入口，并展示连接器 ID、部署范围、凭据模式及适用场景。
  - 明确各存储后端的容量探测支持范围。

- **文档**
  - 更新中英文存储配置、凭据加密、密钥变更影响及教程说明。
  - 新增文档生成与一致性检查流程，减少页面信息不同步。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->