### PR TITLE
fix(storage): stream Reader uploads through reverse tunnel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,7 @@ WebDAV 迁移到 AsterForge WebDAV 0.2 协议引擎，加入多 Range 下载、R
 - **存储原生处理语义** — 缩略图与媒体元数据分别使用显式 enabled flag 和 extension list；关闭开关时保留扩展名作为 dormant configuration，空扩展列表即使在开启时也不匹配任何文件。
 - **Presigned 请求所有权** — URL 与签名所需 headers 由同一个 storage driver 生成完整 request descriptor；S3、Azure Blob、Alibaba OSS、Tencent COS、Remote 以及 multipart refresh 统一走该契约，前端不再硬编码 `Content-Type: application/octet-stream`。
 - **异步 Future 体积** — 归档预览与解压 copy loop 的 64 KiB 栈内 buffer 改为每次操作一次有界分配，把相关 Future 压到 16 KiB 以下；上传与 WebDAV 热路径未引入额外 boxing 或每请求动态分配。
+- **反向隧道上传内存边界** — Reader 上传在 stream lane 可用时直接流式传输，消费后失败由上层重新打开数据源重试；polling 仅承载符合 follower 1 MiB control-plane envelope 预算的小型 body，并移除请求 body 与完整 base64 字符串的额外副本。
 - **Local 默认存储路径** — Local connector、driver、首次配置和测试统一使用 `./data/uploads`；缺失或空 base path 由 connector default 补全，不再散落多套 fallback。
 - **S3-compatible driver 复用** — 提取 AWS request vendor normalization，并用 storage / multipart delegation macro 收敛 S3-compatible 与 Tencent COS 重复实现；S3 driver 构造改为显式 options + SDK config hook，供 provider auth 和 signing customization 使用。
 - **资源锁权威模型** — 删除 `files.is_locked` / `folders.is_locked` 持久化布尔值；新增 workspace-scoped `resource_lock_namespaces`、generation counter 和结构化 lock root，写入路径通过同一事务中的 namespace lock 与 `SELECT FOR UPDATE` 重新校验。

--- a/src/storage/remote_protocol/transport.rs
+++ b/src/storage/remote_protocol/transport.rs
@@ -764,12 +764,9 @@ mod tests {
         ) -> Result<RemoteTunnelStreamHttpResponse> {
             self.stream_calls.fetch_add(1, Ordering::SeqCst);
             let mut sink = Vec::new();
-            body.read_to_end(&mut sink).await.map_err(|error| {
-                crate::errors::storage_driver_error(
-                    StorageErrorKind::Transient,
-                    format!("read boundary stream body: {error}"),
-                )
-            })?;
+            body.read_to_end(&mut sink)
+                .await
+                .expect("boundary stream body should read");
             Ok(RemoteTunnelStreamHttpResponse {
                 status: StatusCode::OK,
                 headers: http::HeaderMap::new(),
@@ -813,12 +810,10 @@ mod tests {
             self.stream_calls.fetch_add(1, Ordering::SeqCst);
             let mut buffer = [0u8; 8192];
             loop {
-                let read = body.read(&mut buffer).await.map_err(|error| {
-                    crate::errors::storage_driver_error(
-                        StorageErrorKind::Transient,
-                        format!("read allocation test stream body: {error}"),
-                    )
-                })?;
+                let read = body
+                    .read(&mut buffer)
+                    .await
+                    .expect("allocation test stream body should read");
                 if read == 0 {
                     break;
                 }
@@ -1348,6 +1343,49 @@ mod tests {
             Some(StorageErrorKind::Precondition)
         );
         assert!(error.message().contains("expected 9, got 8"));
+        assert_eq!(broker.request_calls.load(Ordering::SeqCst), 0);
+        assert_eq!(broker.stream_calls.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn reverse_tunnel_poll_fallback_propagates_reader_io_failure() {
+        struct ErrorReader;
+
+        impl AsyncRead for ErrorReader {
+            fn poll_read(
+                self: std::pin::Pin<&mut Self>,
+                _cx: &mut std::task::Context<'_>,
+                _buf: &mut tokio::io::ReadBuf<'_>,
+            ) -> std::task::Poll<std::io::Result<()>> {
+                std::task::Poll::Ready(Err(std::io::Error::other(
+                    "synthetic polling reader failure",
+                )))
+            }
+        }
+
+        let broker = Arc::new(BoundaryTunnelBroker::new(false));
+        let transport = ReverseTunnelTransport::new(&build_remote_node(), broker.clone());
+        let result = transport
+            .send(RemoteTransportRequest {
+                method: Method::PUT,
+                path_and_query: "/api/v1/internal/storage/objects/read-error.bin".to_string(),
+                content_type: Some("application/octet-stream"),
+                body: RemoteRequestBody::Reader {
+                    reader: Box::new(ErrorReader),
+                    size: 1,
+                },
+            })
+            .await;
+        let error = match result {
+            Ok(_) => panic!("polling reader I/O failure should be returned"),
+            Err(error) => error,
+        };
+
+        assert_eq!(
+            error.storage_error_kind(),
+            Some(StorageErrorKind::Transient)
+        );
+        assert!(error.message().contains("synthetic polling reader failure"));
         assert_eq!(broker.request_calls.load(Ordering::SeqCst), 0);
         assert_eq!(broker.stream_calls.load(Ordering::SeqCst), 0);
     }

--- a/src/storage/remote_protocol/transport.rs
+++ b/src/storage/remote_protocol/transport.rs
@@ -877,6 +877,10 @@ mod tests {
         ) -> Result<RemoteTunnelStreamHttpResponse> {
             self.stream_calls.fetch_add(1, Ordering::SeqCst);
             if self.fail_stream_with_lane_closed.load(Ordering::SeqCst) {
+                let mut first_byte = [0_u8; 1];
+                body.read_exact(&mut first_byte)
+                    .await
+                    .expect("failure-path stream body should be consumed");
                 return Err(crate::errors::storage_driver_error(
                     StorageErrorKind::Transient,
                     "reverse tunnel streaming lane closed",

--- a/src/storage/remote_protocol/transport.rs
+++ b/src/storage/remote_protocol/transport.rs
@@ -74,16 +74,16 @@ impl RemoteRequestBody {
         match self {
             Self::Empty => Ok(Bytes::new()),
             Self::Bytes(body) => Ok(body),
-            Self::Reader { mut reader, size } => {
+            Self::Reader { reader, size } => {
                 if size
-                    > u64::try_from(super::tunnel::server::REMOTE_TUNNEL_BODY_LIMIT)
+                    > u64::try_from(super::tunnel::server::REMOTE_TUNNEL_POLL_BODY_LIMIT)
                         .unwrap_or(u64::MAX)
                 {
                     return Err(crate::errors::storage_driver_error(
                         StorageErrorKind::Unsupported,
                         format!(
-                            "reverse tunnel streaming upload exceeds {} bytes; use direct transport or a streaming tunnel",
-                            super::tunnel::server::REMOTE_TUNNEL_BODY_LIMIT
+                            "reverse tunnel polling upload exceeds {} bytes; use direct transport or a streaming tunnel",
+                            super::tunnel::server::REMOTE_TUNNEL_POLL_BODY_LIMIT
                         ),
                     ));
                 }
@@ -92,12 +92,16 @@ impl RemoteRequestBody {
                     "reverse tunnel buffered upload size",
                 )?;
                 let mut data = Vec::with_capacity(capacity);
-                reader.read_to_end(&mut data).await.map_err(|error| {
-                    crate::errors::storage_driver_error(
-                        StorageErrorKind::Transient,
-                        format!("read reverse tunnel buffered upload: {error}"),
-                    )
-                })?;
+                let mut limited_reader = reader.take(size.saturating_add(1));
+                limited_reader
+                    .read_to_end(&mut data)
+                    .await
+                    .map_err(|error| {
+                        crate::errors::storage_driver_error(
+                            StorageErrorKind::Transient,
+                            format!("read reverse tunnel buffered upload: {error}"),
+                        )
+                    })?;
                 let actual_len = u64::try_from(data.len()).map_err(|_| {
                     crate::errors::storage_driver_error(
                         StorageErrorKind::Precondition,
@@ -114,14 +118,6 @@ impl RemoteRequestBody {
                 }
                 Ok(Bytes::from(data))
             }
-        }
-    }
-
-    fn clone_for_stream_attempt(&self) -> Option<Self> {
-        match self {
-            Self::Empty => Some(Self::Empty),
-            Self::Bytes(body) => Some(Self::Bytes(body.clone())),
-            Self::Reader { .. } => None,
         }
     }
 }
@@ -304,9 +300,24 @@ impl RemoteTransport for ReverseTunnelTransport {
             .into_iter()
             .collect::<Vec<_>>();
 
-        if self.broker.has_tunnel_stream_lane(&self.remote_node)
-            && let Some(stream_body) = request.body.clone_for_stream_attempt()
-        {
+        let mut polling_body = Some(request.body);
+        if self.broker.has_tunnel_stream_lane(&self.remote_node) {
+            let Some(body) = polling_body.take() else {
+                return Err(crate::errors::storage_driver_error(
+                    StorageErrorKind::Precondition,
+                    "reverse tunnel request body was consumed before dispatch",
+                ));
+            };
+            let (stream_body, fallback_body) = match body {
+                RemoteRequestBody::Empty => {
+                    (RemoteRequestBody::Empty, Some(RemoteRequestBody::Empty))
+                }
+                RemoteRequestBody::Bytes(body) => (
+                    RemoteRequestBody::Bytes(body.clone()),
+                    Some(RemoteRequestBody::Bytes(body)),
+                ),
+                reader @ RemoteRequestBody::Reader { .. } => (reader, None),
+            };
             match self
                 .broker
                 .clone()
@@ -322,6 +333,10 @@ impl RemoteTransport for ReverseTunnelTransport {
             {
                 Ok(response) => return Ok(RemoteTransportResponse::TunnelStream(response)),
                 Err(error) if should_fallback_stream_error_to_poll(error.message()) => {
+                    let Some(fallback_body) = fallback_body else {
+                        return Err(error);
+                    };
+                    polling_body = Some(fallback_body);
                     tracing::warn!(
                         remote_node_id = self.remote_node.id,
                         error = %error,
@@ -332,7 +347,13 @@ impl RemoteTransport for ReverseTunnelTransport {
             }
         }
 
-        let body = request.body.into_buffered_bytes().await?;
+        let Some(body) = polling_body else {
+            return Err(crate::errors::storage_driver_error(
+                StorageErrorKind::Precondition,
+                "reverse tunnel polling body was consumed before dispatch",
+            ));
+        };
+        let body = body.into_buffered_bytes().await?;
         self.broker
             .clone()
             .send_tunnel_request(
@@ -651,7 +672,7 @@ fn presigned_expires_at(expires: Duration) -> Result<i64> {
 mod tests {
     use super::*;
     use crate::storage::remote_protocol::tunnel::server::{
-        REMOTE_TUNNEL_BODY_LIMIT, RemoteTunnelHttpResponse, RemoteTunnelStreamHttpResponse,
+        REMOTE_TUNNEL_POLL_BODY_LIMIT, RemoteTunnelHttpResponse, RemoteTunnelStreamHttpResponse,
     };
     use aster_drive_model::types::RemoteNodeTransportMode;
     use async_trait::async_trait;
@@ -682,6 +703,136 @@ mod tests {
                 request_headers: Mutex::new(Vec::new()),
                 stream_headers: Mutex::new(Vec::new()),
             }
+        }
+    }
+
+    struct StreamingAllocationBroker {
+        stream_calls: AtomicUsize,
+        request_calls: AtomicUsize,
+        bytes_read: AtomicUsize,
+    }
+
+    struct BoundaryTunnelBroker {
+        stream_available: bool,
+        request_calls: AtomicUsize,
+        stream_calls: AtomicUsize,
+        request_body: Mutex<Option<Bytes>>,
+    }
+
+    impl BoundaryTunnelBroker {
+        fn new(stream_available: bool) -> Self {
+            Self {
+                stream_available,
+                request_calls: AtomicUsize::new(0),
+                stream_calls: AtomicUsize::new(0),
+                request_body: Mutex::new(None),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl RemoteTunnelBroker for BoundaryTunnelBroker {
+        async fn send_tunnel_request(
+            self: Arc<Self>,
+            _remote_node: &managed_follower::Model,
+            _method: HttpMethod,
+            _path_and_query: String,
+            _content_length: Option<u64>,
+            _extra_headers: Vec<(String, String)>,
+            body: Bytes,
+        ) -> Result<RemoteTunnelHttpResponse> {
+            self.request_calls.fetch_add(1, Ordering::SeqCst);
+            *self
+                .request_body
+                .lock()
+                .expect("boundary request body lock should not be poisoned") = Some(body);
+            Ok(RemoteTunnelHttpResponse {
+                status: StatusCode::OK,
+                headers: http::HeaderMap::new(),
+                body: Bytes::new(),
+            })
+        }
+
+        async fn send_tunnel_stream(
+            self: Arc<Self>,
+            _remote_node: &managed_follower::Model,
+            _method: HttpMethod,
+            _path_and_query: String,
+            _content_length: Option<u64>,
+            _extra_headers: Vec<(String, String)>,
+            mut body: Box<dyn AsyncRead + Unpin + Send>,
+        ) -> Result<RemoteTunnelStreamHttpResponse> {
+            self.stream_calls.fetch_add(1, Ordering::SeqCst);
+            let mut sink = Vec::new();
+            body.read_to_end(&mut sink).await.map_err(|error| {
+                crate::errors::storage_driver_error(
+                    StorageErrorKind::Transient,
+                    format!("read boundary stream body: {error}"),
+                )
+            })?;
+            Ok(RemoteTunnelStreamHttpResponse {
+                status: StatusCode::OK,
+                headers: http::HeaderMap::new(),
+                body: Box::new(std::io::Cursor::new(Bytes::new())),
+            })
+        }
+
+        fn has_tunnel_stream_lane(&self, _remote_node: &managed_follower::Model) -> bool {
+            self.stream_available
+        }
+    }
+
+    #[async_trait]
+    impl RemoteTunnelBroker for StreamingAllocationBroker {
+        async fn send_tunnel_request(
+            self: Arc<Self>,
+            _remote_node: &managed_follower::Model,
+            _method: HttpMethod,
+            _path_and_query: String,
+            _content_length: Option<u64>,
+            _extra_headers: Vec<(String, String)>,
+            _body: Bytes,
+        ) -> Result<RemoteTunnelHttpResponse> {
+            self.request_calls.fetch_add(1, Ordering::SeqCst);
+            Ok(RemoteTunnelHttpResponse {
+                status: StatusCode::OK,
+                headers: http::HeaderMap::new(),
+                body: Bytes::new(),
+            })
+        }
+
+        async fn send_tunnel_stream(
+            self: Arc<Self>,
+            _remote_node: &managed_follower::Model,
+            _method: HttpMethod,
+            _path_and_query: String,
+            _content_length: Option<u64>,
+            _extra_headers: Vec<(String, String)>,
+            mut body: Box<dyn AsyncRead + Unpin + Send>,
+        ) -> Result<RemoteTunnelStreamHttpResponse> {
+            self.stream_calls.fetch_add(1, Ordering::SeqCst);
+            let mut buffer = [0u8; 8192];
+            loop {
+                let read = body.read(&mut buffer).await.map_err(|error| {
+                    crate::errors::storage_driver_error(
+                        StorageErrorKind::Transient,
+                        format!("read allocation test stream body: {error}"),
+                    )
+                })?;
+                if read == 0 {
+                    break;
+                }
+                self.bytes_read.fetch_add(read, Ordering::SeqCst);
+            }
+            Ok(RemoteTunnelStreamHttpResponse {
+                status: StatusCode::OK,
+                headers: http::HeaderMap::new(),
+                body: Box::new(std::io::Cursor::new(Bytes::new())),
+            })
+        }
+
+        fn has_tunnel_stream_lane(&self, _remote_node: &managed_follower::Model) -> bool {
+            true
         }
     }
 
@@ -781,6 +932,38 @@ mod tests {
         }
     }
 
+    async fn measure_streaming_reader_allocations(
+        size: usize,
+    ) -> (
+        crate::test_support::allocations::AllocationMeasurement,
+        Arc<StreamingAllocationBroker>,
+    ) {
+        let broker = Arc::new(StreamingAllocationBroker {
+            stream_calls: AtomicUsize::new(0),
+            request_calls: AtomicUsize::new(0),
+            bytes_read: AtomicUsize::new(0),
+        });
+        let transport = ReverseTunnelTransport::new(&build_remote_node(), broker.clone());
+        let size_u64 = u64::try_from(size).expect("allocation test size should fit u64");
+        let (response, allocations) = crate::test_support::allocations::measure_future(
+            transport.send(RemoteTransportRequest {
+                method: Method::PUT,
+                path_and_query: "/api/v1/internal/storage/objects/stream-reader.bin".to_string(),
+                content_type: Some("application/octet-stream"),
+                body: RemoteRequestBody::Reader {
+                    reader: Box::new(tokio::io::repeat(0).take(size_u64)),
+                    size: size_u64,
+                },
+            }),
+        )
+        .await;
+        assert!(matches!(
+            response,
+            Ok(RemoteTransportResponse::TunnelStream(_))
+        ));
+        (allocations, broker)
+    }
+
     #[tokio::test]
     async fn reverse_tunnel_transport_uses_poll_fallback_without_stream_lane() {
         let broker = Arc::new(TestTunnelBroker::new(false));
@@ -873,6 +1056,138 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn reverse_tunnel_transport_streams_empty_body_when_lane_is_available() {
+        let broker = Arc::new(BoundaryTunnelBroker::new(true));
+        let transport = ReverseTunnelTransport::new(&build_remote_node(), broker.clone());
+
+        let response = transport
+            .send(RemoteTransportRequest {
+                method: Method::PUT,
+                path_and_query: "/api/v1/internal/storage/objects/empty.bin".to_string(),
+                content_type: None,
+                body: RemoteRequestBody::Empty,
+            })
+            .await
+            .expect("empty body should use available stream lane");
+
+        assert!(matches!(response, RemoteTransportResponse::TunnelStream(_)));
+        assert_eq!(broker.stream_calls.load(Ordering::SeqCst), 1);
+        assert_eq!(broker.request_calls.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn reverse_tunnel_transport_polls_bytes_when_lane_is_unavailable() {
+        let broker = Arc::new(BoundaryTunnelBroker::new(false));
+        let transport = ReverseTunnelTransport::new(&build_remote_node(), broker.clone());
+
+        transport
+            .send(RemoteTransportRequest {
+                method: Method::PUT,
+                path_and_query: "/api/v1/internal/storage/objects/bytes.bin".to_string(),
+                content_type: None,
+                body: RemoteRequestBody::Bytes(Bytes::from_static(b"bytes-body")),
+            })
+            .await
+            .expect("bytes body should use polling without a stream lane");
+
+        assert_eq!(broker.stream_calls.load(Ordering::SeqCst), 0);
+        assert_eq!(broker.request_calls.load(Ordering::SeqCst), 1);
+        assert_eq!(
+            broker
+                .request_body
+                .lock()
+                .expect("boundary request body lock should not be poisoned")
+                .as_ref(),
+            Some(&Bytes::from_static(b"bytes-body"))
+        );
+    }
+
+    #[tokio::test]
+    async fn reverse_tunnel_transport_streams_reader_without_polling_or_full_body_allocation() {
+        let small_size = 64 * 1024;
+        let large_size = 64 * 1024 * 1024;
+        let (small_allocations, small_broker) =
+            measure_streaming_reader_allocations(small_size).await;
+        let (large_allocations, large_broker) =
+            measure_streaming_reader_allocations(large_size).await;
+
+        for (size, broker) in [(small_size, small_broker), (large_size, large_broker)] {
+            assert_eq!(broker.stream_calls.load(Ordering::SeqCst), 1);
+            assert_eq!(broker.request_calls.load(Ordering::SeqCst), 0);
+            assert_eq!(broker.bytes_read.load(Ordering::SeqCst), size);
+        }
+        assert!(
+            large_allocations.count <= small_allocations.count.saturating_add(4),
+            "streaming allocation count grew from {} to {} with object size",
+            small_allocations.count,
+            large_allocations.count
+        );
+        assert!(
+            large_allocations.bytes <= small_allocations.bytes.saturating_add(128 * 1024),
+            "streaming allocated bytes grew from {} to {} with object size",
+            small_allocations.bytes,
+            large_allocations.bytes
+        );
+        assert!(
+            large_allocations.bytes < large_size / 2,
+            "streaming reader allocated {} bytes for a {} byte body",
+            large_allocations.bytes,
+            large_size
+        );
+    }
+
+    #[tokio::test]
+    async fn reverse_tunnel_transport_does_not_poll_after_reader_stream_failure() {
+        let broker = Arc::new(TestTunnelBroker::new(true));
+        broker
+            .fail_stream_with_lane_closed
+            .store(true, Ordering::SeqCst);
+        let transport = ReverseTunnelTransport::new(&build_remote_node(), broker.clone());
+
+        let result = transport
+            .send(RemoteTransportRequest {
+                method: Method::PUT,
+                path_and_query: "/api/v1/internal/storage/objects/stream-reader.bin".to_string(),
+                content_type: Some("application/octet-stream"),
+                body: RemoteRequestBody::Reader {
+                    reader: Box::new(std::io::Cursor::new(Bytes::from_static(b"reader-body"))),
+                    size: 11,
+                },
+            })
+            .await;
+        let error = match result {
+            Ok(_) => panic!("consumed reader stream failure must not fall back to polling"),
+            Err(error) => error,
+        };
+
+        assert!(error.message().contains("streaming lane closed"));
+        assert_eq!(
+            error.storage_error_kind(),
+            Some(StorageErrorKind::Transient)
+        );
+        assert_eq!(broker.stream_calls.load(Ordering::SeqCst), 1);
+        assert_eq!(broker.request_calls.load(Ordering::SeqCst), 0);
+    }
+
+    #[test]
+    fn stream_fallback_classifier_only_accepts_replayable_transport_failures() {
+        for message in [
+            "remote node #9 reverse tunnel is offline",
+            "reverse tunnel streaming lane closed",
+            "reverse tunnel streaming response channel closed",
+            "reverse tunnel streaming request timed out waiting for follower response",
+        ] {
+            assert!(
+                should_fallback_stream_error_to_poll(message),
+                "expected replayable stream failure: {message}"
+            );
+        }
+        assert!(!should_fallback_stream_error_to_poll(
+            "reverse tunnel returned invalid response metadata"
+        ));
+    }
+
+    #[tokio::test]
     async fn reverse_tunnel_transport_falls_back_to_poll_when_stream_lane_closes() {
         let broker = Arc::new(TestTunnelBroker::new(true));
         broker
@@ -912,8 +1227,9 @@ mod tests {
     async fn reverse_tunnel_poll_fallback_rejects_oversized_reader_before_dispatch() {
         let broker = Arc::new(TestTunnelBroker::new(false));
         let transport = ReverseTunnelTransport::new(&build_remote_node(), broker.clone());
-        let oversized =
-            u64::try_from(REMOTE_TUNNEL_BODY_LIMIT).expect("tunnel body limit should fit u64") + 1;
+        let oversized = u64::try_from(REMOTE_TUNNEL_POLL_BODY_LIMIT)
+            .expect("poll body limit should fit u64")
+            + 1;
 
         let result = transport
             .send(RemoteTransportRequest {
@@ -935,7 +1251,99 @@ mod tests {
             error.storage_error_kind(),
             Some(StorageErrorKind::Unsupported)
         );
-        assert!(error.message().contains("streaming upload exceeds"));
+        assert!(error.message().contains("polling upload exceeds"));
+        assert_eq!(broker.request_calls.load(Ordering::SeqCst), 0);
+        assert_eq!(broker.stream_calls.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn reverse_tunnel_poll_fallback_accepts_exact_poll_body_limit() {
+        let broker = Arc::new(BoundaryTunnelBroker::new(false));
+        let transport = ReverseTunnelTransport::new(&build_remote_node(), broker.clone());
+        let body = Bytes::from(vec![0x5a; REMOTE_TUNNEL_POLL_BODY_LIMIT]);
+
+        transport
+            .send(RemoteTransportRequest {
+                method: Method::PUT,
+                path_and_query: "/api/v1/internal/storage/objects/exact-limit.bin".to_string(),
+                content_type: None,
+                body: RemoteRequestBody::Reader {
+                    reader: Box::new(std::io::Cursor::new(body.clone())),
+                    size: body.len() as u64,
+                },
+            })
+            .await
+            .expect("reader at the exact polling body limit should be accepted");
+
+        assert_eq!(broker.request_calls.load(Ordering::SeqCst), 1);
+        assert_eq!(broker.stream_calls.load(Ordering::SeqCst), 0);
+        assert_eq!(
+            broker
+                .request_body
+                .lock()
+                .expect("boundary request body lock should not be poisoned")
+                .as_ref()
+                .map(Bytes::len),
+            Some(REMOTE_TUNNEL_POLL_BODY_LIMIT)
+        );
+    }
+
+    #[tokio::test]
+    async fn reverse_tunnel_poll_fallback_rejects_reader_one_byte_over_declared_size() {
+        let broker = Arc::new(TestTunnelBroker::new(false));
+        let transport = ReverseTunnelTransport::new(&build_remote_node(), broker.clone());
+
+        let result = transport
+            .send(RemoteTransportRequest {
+                method: Method::PUT,
+                path_and_query: "/api/v1/internal/storage/objects/poll.bin".to_string(),
+                content_type: Some("application/octet-stream"),
+                body: RemoteRequestBody::Reader {
+                    reader: Box::new(std::io::Cursor::new(Bytes::from_static(b"poll-body!"))),
+                    size: 9,
+                },
+            })
+            .await;
+        let error = match result {
+            Ok(_) => panic!("reader longer than declared size must be rejected"),
+            Err(error) => error,
+        };
+
+        assert_eq!(
+            error.storage_error_kind(),
+            Some(StorageErrorKind::Precondition)
+        );
+        assert!(error.message().contains("length mismatch"));
+        assert_eq!(broker.request_calls.load(Ordering::SeqCst), 0);
+        assert_eq!(broker.stream_calls.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn reverse_tunnel_poll_fallback_rejects_reader_one_byte_under_declared_size() {
+        let broker = Arc::new(TestTunnelBroker::new(false));
+        let transport = ReverseTunnelTransport::new(&build_remote_node(), broker.clone());
+
+        let result = transport
+            .send(RemoteTransportRequest {
+                method: Method::PUT,
+                path_and_query: "/api/v1/internal/storage/objects/poll.bin".to_string(),
+                content_type: Some("application/octet-stream"),
+                body: RemoteRequestBody::Reader {
+                    reader: Box::new(std::io::Cursor::new(Bytes::from_static(b"poll-bod"))),
+                    size: 9,
+                },
+            })
+            .await;
+        let error = match result {
+            Ok(_) => panic!("reader shorter than declared size must be rejected"),
+            Err(error) => error,
+        };
+
+        assert_eq!(
+            error.storage_error_kind(),
+            Some(StorageErrorKind::Precondition)
+        );
+        assert!(error.message().contains("expected 9, got 8"));
         assert_eq!(broker.request_calls.load(Ordering::SeqCst), 0);
         assert_eq!(broker.stream_calls.load(Ordering::SeqCst), 0);
     }

--- a/src/storage/remote_protocol/tunnel/server/mod.rs
+++ b/src/storage/remote_protocol/tunnel/server/mod.rs
@@ -55,6 +55,12 @@ const REMOTE_TUNNEL_POLL_TIMEOUT: Duration = Duration::from_secs(25);
 const REMOTE_TUNNEL_STREAM_READ_TIMEOUT: Duration = Duration::from_secs(60);
 pub const REMOTE_TUNNEL_BODY_LIMIT: usize = 64 * 1024 * 1024;
 pub const REMOTE_TUNNEL_JSON_LIMIT: usize = REMOTE_TUNNEL_BODY_LIMIT * 2 + 1024 * 1024;
+pub const REMOTE_TUNNEL_POLL_METADATA_BUDGET: usize = 64 * 1024;
+pub const REMOTE_TUNNEL_POLL_BODY_LIMIT: usize =
+    ((crate::storage::remote_protocol::REMOTE_CONTROL_PLANE_BODY_LIMIT
+        - REMOTE_TUNNEL_POLL_METADATA_BUDGET)
+        / 4)
+        * 3;
 pub const REMOTE_TUNNEL_STREAM_CHUNK_SIZE: usize = 64 * 1024;
 pub const REMOTE_TUNNEL_STREAM_FRAME_LIMIT: usize = 256 * 1024;
 

--- a/src/storage/remote_protocol/tunnel/server/payload.rs
+++ b/src/storage/remote_protocol/tunnel/server/payload.rs
@@ -1,5 +1,10 @@
-use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64_STANDARD};
+use base64::{
+    Engine as _, display::Base64Display, engine::general_purpose::STANDARD as BASE64_STANDARD,
+};
+use bytes::Bytes;
 use serde::{Deserialize, Serialize};
+
+use crate::api::response::ApiResponse;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(all(debug_assertions, feature = "openapi"), derive(utoipa::ToSchema))]
@@ -8,9 +13,9 @@ pub struct RemoteTunnelRequest {
     pub method: String,
     pub path_and_query: String,
     pub headers: Vec<(String, String)>,
-    #[serde(with = "base64_body")]
+    #[serde(with = "base64_bytes_body")]
     #[cfg_attr(all(debug_assertions, feature = "openapi"), schema(value_type = String))]
-    pub body: Vec<u8>,
+    pub body: Bytes,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -34,6 +39,25 @@ pub struct RemoteTunnelPollRequest {
 #[cfg_attr(all(debug_assertions, feature = "openapi"), derive(utoipa::ToSchema))]
 pub struct RemoteTunnelPollResponse {
     pub request: Option<RemoteTunnelRequest>,
+}
+
+pub(crate) fn serialized_poll_response_len(
+    request: &RemoteTunnelRequest,
+) -> Result<usize, serde_json::Error> {
+    let mut metadata_only = request.clone();
+    metadata_only.body = Bytes::new();
+    let metadata_len = serde_json::to_vec(&ApiResponse::ok(RemoteTunnelPollResponse {
+        request: Some(metadata_only),
+    }))?
+    .len();
+    let encoded_body_len = request
+        .body
+        .len()
+        .checked_add(2)
+        .and_then(|len| len.checked_div(3))
+        .and_then(|groups| groups.checked_mul(4))
+        .unwrap_or(usize::MAX);
+    Ok(metadata_len.saturating_add(encoded_body_len))
 }
 
 mod base64_body {
@@ -63,6 +87,38 @@ mod base64_body {
                 .decode(value)
                 .map_err(|error| D::Error::custom(format!("invalid base64 body: {error}"))),
             EncodedBody::LegacyArray(body) => Ok(body),
+        }
+    }
+}
+
+mod base64_bytes_body {
+    use super::*;
+    use serde::{Deserializer, Serializer, de::Error as _};
+
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum EncodedBody {
+        Base64(String),
+        LegacyArray(Vec<u8>),
+    }
+
+    pub fn serialize<S>(body: &Bytes, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.collect_str(&Base64Display::new(body.as_ref(), &BASE64_STANDARD))
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> std::result::Result<Bytes, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        match EncodedBody::deserialize(deserializer)? {
+            EncodedBody::Base64(value) => BASE64_STANDARD
+                .decode(value)
+                .map(Bytes::from)
+                .map_err(|error| D::Error::custom(format!("invalid base64 body: {error}"))),
+            EncodedBody::LegacyArray(body) => Ok(Bytes::from(body)),
         }
     }
 }

--- a/src/storage/remote_protocol/tunnel/server/registry/mod.rs
+++ b/src/storage/remote_protocol/tunnel/server/registry/mod.rs
@@ -66,6 +66,11 @@ impl RemoteTunnelRegistry {
             .map(|entry| entry.value().clone())
     }
 
+    #[cfg(test)]
+    pub(crate) fn pending_poll_request_count(&self) -> usize {
+        self.pending.len()
+    }
+
     fn record_error(&self, remote_node_id: i64, error: impl Into<String>) {
         let error = error.into();
         if error.trim().is_empty() {

--- a/src/storage/remote_protocol/tunnel/server/registry/polling.rs
+++ b/src/storage/remote_protocol/tunnel/server/registry/polling.rs
@@ -2,6 +2,7 @@ use bytes::Bytes;
 use http::Method;
 use tokio::sync::oneshot;
 
+use super::super::payload::serialized_poll_response_len;
 use super::broker::RemoteTunnelHttpResponse;
 use super::headers::request_headers;
 use super::{
@@ -11,7 +12,7 @@ use super::{
 use crate::errors::{AsterError, Result};
 use crate::storage::remote_protocol::tunnel::server::response::tunnel_http_response;
 use crate::storage::remote_protocol::tunnel::server::{
-    REMOTE_TUNNEL_BODY_LIMIT, RemoteTunnelRequest, RemoteTunnelResponse,
+    REMOTE_TUNNEL_POLL_BODY_LIMIT, RemoteTunnelRequest, RemoteTunnelResponse,
 };
 use aster_drive_model::entities::managed_follower;
 use aster_drive_storage::StorageErrorKind;
@@ -115,13 +116,38 @@ impl RemoteTunnelRegistry {
         extra_headers: Vec<(String, String)>,
         body: Bytes,
     ) -> Result<RemoteTunnelHttpResponse> {
-        if body.len() > REMOTE_TUNNEL_BODY_LIMIT {
+        if body.len() > REMOTE_TUNNEL_POLL_BODY_LIMIT {
             let error = crate::errors::storage_driver_error(
                 StorageErrorKind::Unsupported,
                 format!(
-                    "reverse tunnel request body exceeds {} bytes; use direct transport or a streaming tunnel",
-                    REMOTE_TUNNEL_BODY_LIMIT
+                    "reverse tunnel polling request body exceeds {} bytes; use direct transport or a streaming tunnel",
+                    REMOTE_TUNNEL_POLL_BODY_LIMIT
                 ),
+            );
+            self.record_error(remote_node.id, error.message());
+            return Err(error);
+        }
+
+        let request_id = aster_forge_utils::id::new_uuid();
+        let request = RemoteTunnelRequest {
+            request_id: request_id.clone(),
+            method: method.as_str().to_string(),
+            headers: request_headers(remote_node, &method, &path_and_query, content_length)
+                .chain(extra_headers)
+                .collect(),
+            path_and_query,
+            body,
+        };
+        let serialized_len = serialized_poll_response_len(&request).map_err(|error| {
+            crate::errors::storage_driver_error(
+                StorageErrorKind::Misconfigured,
+                format!("serialize reverse tunnel poll response budget: {error}"),
+            )
+        })?;
+        if serialized_len > crate::storage::remote_protocol::REMOTE_CONTROL_PLANE_BODY_LIMIT {
+            let error = crate::errors::storage_driver_error(
+                StorageErrorKind::Unsupported,
+                "reverse tunnel polling request envelope exceeds follower control-plane body limit",
             );
             self.record_error(remote_node.id, error.message());
             return Err(error);
@@ -135,7 +161,6 @@ impl RemoteTunnelRegistry {
             }
         };
 
-        let request_id = aster_forge_utils::id::new_uuid();
         let (response_tx, response_rx) = oneshot::channel();
         self.pending.insert(
             request_id.clone(),
@@ -147,15 +172,6 @@ impl RemoteTunnelRegistry {
         let _pending_guard = PendingTunnelGuard {
             registry: self,
             request_id: request_id.clone(),
-        };
-        let request = RemoteTunnelRequest {
-            request_id: request_id.clone(),
-            method: method.as_str().to_string(),
-            headers: request_headers(remote_node, &method, &path_and_query, content_length)
-                .chain(extra_headers)
-                .collect(),
-            path_and_query,
-            body: body.to_vec(),
         };
 
         if request_tx.send(QueuedTunnelRequest { request }).is_err() {

--- a/src/storage/remote_protocol/tunnel/server/tests.rs
+++ b/src/storage/remote_protocol/tunnel/server/tests.rs
@@ -1,6 +1,9 @@
 use super::frame::{REMOTE_TUNNEL_STREAM_FRAME_VERSION, REMOTE_TUNNEL_STREAM_META_LIMIT};
 use super::*;
-use crate::storage::remote_protocol::INTERNAL_AUTH_ACCESS_KEY_HEADER;
+use crate::api::response::ApiResponse;
+use crate::storage::remote_protocol::{
+    INTERNAL_AUTH_ACCESS_KEY_HEADER, REMOTE_CONTROL_PLANE_BODY_LIMIT,
+};
 use bytes::Bytes;
 use http::{Method, StatusCode};
 use std::sync::Arc;
@@ -76,7 +79,7 @@ fn tunnel_payloads_serialize_body_as_base64() {
         method: "PUT".to_string(),
         path_and_query: "/api/v1/internal/storage/objects/a".to_string(),
         headers: Vec::new(),
-        body: b"hello tunnel".to_vec(),
+        body: Bytes::from_static(b"hello tunnel"),
     };
 
     let value = serde_json::to_value(&request).expect("request should serialize");
@@ -84,7 +87,7 @@ fn tunnel_payloads_serialize_body_as_base64() {
 
     let decoded: RemoteTunnelRequest =
         serde_json::from_value(value).expect("request should deserialize");
-    assert_eq!(decoded.body, b"hello tunnel");
+    assert_eq!(decoded.body, &b"hello tunnel"[..]);
 }
 
 #[test]
@@ -99,6 +102,67 @@ fn tunnel_payloads_still_accept_legacy_byte_arrays() {
     let decoded: RemoteTunnelResponse =
         serde_json::from_value(value).expect("legacy response should deserialize");
     assert_eq!(decoded.body, b"hello");
+}
+
+#[test]
+fn tunnel_request_still_accepts_legacy_byte_arrays() {
+    let value = serde_json::json!({
+        "request_id": "req-legacy",
+        "method": "PUT",
+        "path_and_query": "/api/v1/internal/storage/objects/legacy.bin",
+        "headers": [],
+        "body": [0, 1, 2, 255]
+    });
+
+    let decoded: RemoteTunnelRequest =
+        serde_json::from_value(value).expect("legacy request body should deserialize");
+    assert_eq!(decoded.body, &b"\x00\x01\x02\xff"[..]);
+}
+
+#[test]
+fn tunnel_request_rejects_invalid_base64_body() {
+    let value = serde_json::json!({
+        "request_id": "req-invalid-base64",
+        "method": "PUT",
+        "path_and_query": "/api/v1/internal/storage/objects/invalid.bin",
+        "headers": [],
+        "body": "***"
+    });
+
+    let error = serde_json::from_value::<RemoteTunnelRequest>(value)
+        .expect_err("invalid base64 request body should fail");
+    assert!(error.to_string().contains("invalid base64 body"));
+}
+
+#[test]
+fn poll_response_serialized_length_matches_json_at_base64_boundaries() {
+    for body_len in [0, 1, 2, 3, 4, 5, 6, 7, 1023, 1024, 1025] {
+        let request = RemoteTunnelRequest {
+            request_id: "req-budget".to_string(),
+            method: "PUT".to_string(),
+            path_and_query: "/api/v1/internal/storage/objects/budget.bin".to_string(),
+            headers: vec![(
+                "content-type".to_string(),
+                "application/octet-stream".to_string(),
+            )],
+            body: Bytes::from(vec![0x5a; body_len]),
+        };
+        let expected = serde_json::to_vec(&ApiResponse::ok(RemoteTunnelPollResponse {
+            request: Some(request.clone()),
+        }))
+        .expect("poll response should serialize");
+        let measured = super::payload::serialized_poll_response_len(&request)
+            .expect("poll response length should be measurable");
+        assert_eq!(measured, expected.len(), "body length {body_len}");
+    }
+
+    assert_eq!(
+        REMOTE_TUNNEL_POLL_BODY_LIMIT,
+        ((crate::storage::remote_protocol::REMOTE_CONTROL_PLANE_BODY_LIMIT
+            - REMOTE_TUNNEL_POLL_METADATA_BUDGET)
+            / 4)
+            * 3
+    );
 }
 
 #[test]
@@ -236,7 +300,7 @@ async fn registry_send_dispatches_to_poll_connection_and_completes_response() {
         request.path_and_query,
         "/api/v1/internal/storage/objects/file.txt"
     );
-    assert_eq!(request.body, b"body");
+    assert_eq!(request.body, &b"body"[..]);
     assert!(
         request.headers.iter().any(|(name, value)| {
             name == INTERNAL_AUTH_ACCESS_KEY_HEADER && value == "poll-access"
@@ -282,6 +346,144 @@ async fn registry_send_dispatches_to_poll_connection_and_completes_response() {
         Some("ok")
     );
     assert_eq!(response.body, Bytes::from_static(b"created"));
+}
+
+#[tokio::test]
+async fn registry_poll_accepts_body_at_exact_policy_limit() {
+    let registry = Arc::new(RemoteTunnelRegistry::new());
+    let node = build_remote_node(61, "poll-exact-limit");
+    let (request_rx, _registration) = registry.register_poll(&node);
+    let exact_limit =
+        u64::try_from(REMOTE_TUNNEL_POLL_BODY_LIMIT).expect("poll body limit should fit u64");
+    let send_handle = tokio::spawn({
+        let registry = registry.clone();
+        let node = node.clone();
+        async move {
+            registry
+                .send(
+                    &node,
+                    Method::PUT,
+                    "/api/v1/internal/storage/objects/exact-limit.bin".to_string(),
+                    Some(exact_limit),
+                    Vec::new(),
+                    Bytes::from(vec![0x5a; REMOTE_TUNNEL_POLL_BODY_LIMIT]),
+                )
+                .await
+        }
+    });
+
+    let request = request_rx
+        .await
+        .expect("poll connection should receive exact-limit request")
+        .request;
+    assert_eq!(request.body.len(), REMOTE_TUNNEL_POLL_BODY_LIMIT);
+    let measured_len = super::payload::serialized_poll_response_len(&request)
+        .expect("exact-limit response length should be measurable");
+    assert!(measured_len <= REMOTE_CONTROL_PLANE_BODY_LIMIT);
+
+    let encoded = serde_json::to_vec(&ApiResponse::ok(RemoteTunnelPollResponse {
+        request: Some(request.clone()),
+    }))
+    .expect("exact-limit poll response should serialize");
+    assert_eq!(encoded.len(), measured_len);
+    assert!(encoded.len() <= REMOTE_CONTROL_PLANE_BODY_LIMIT);
+    #[derive(serde::Deserialize)]
+    struct FollowerPollEnvelope {
+        data: Option<RemoteTunnelPollResponse>,
+    }
+    let decoded: FollowerPollEnvelope = serde_json::from_slice(&encoded)
+        .expect("follower should deserialize exact-limit poll response");
+    assert_eq!(
+        decoded
+            .data
+            .and_then(|poll| poll.request)
+            .map(|request| request.body.len()),
+        Some(REMOTE_TUNNEL_POLL_BODY_LIMIT)
+    );
+
+    registry
+        .complete(
+            &node,
+            RemoteTunnelResponse {
+                request_id: request.request_id,
+                status: 200,
+                headers: Vec::new(),
+                body: Vec::new(),
+            },
+        )
+        .expect("exact-limit poll response should complete");
+    send_handle
+        .await
+        .expect("exact-limit send task should join")
+        .expect("exact-limit poll request should succeed");
+}
+
+#[tokio::test]
+async fn registry_poll_rejects_one_byte_over_policy_limit_before_dispatch() {
+    let registry = Arc::new(RemoteTunnelRegistry::new());
+    let node = build_remote_node(62, "poll-over-limit");
+    let (request_rx, _registration) = registry.register_poll(&node);
+
+    let error = registry
+        .send(
+            &node,
+            Method::PUT,
+            "/api/v1/internal/storage/objects/over-limit.bin".to_string(),
+            None,
+            Vec::new(),
+            Bytes::from(vec![0; REMOTE_TUNNEL_POLL_BODY_LIMIT + 1]),
+        )
+        .await
+        .expect_err("poll body one byte over the policy limit should fail");
+
+    assert_eq!(
+        error.storage_error_kind(),
+        Some(StorageErrorKind::Unsupported)
+    );
+    assert!(error.message().contains("polling request body exceeds"));
+    assert_eq!(registry.pending_poll_request_count(), 0);
+    assert!(
+        tokio::time::timeout(Duration::from_millis(20), request_rx)
+            .await
+            .is_err(),
+        "oversized body must not consume or dispatch the poll connection"
+    );
+}
+
+#[tokio::test]
+async fn registry_poll_rejects_oversized_metadata_before_dispatch() {
+    let registry = Arc::new(RemoteTunnelRegistry::new());
+    let node = build_remote_node(63, "poll-metadata-over-limit");
+    let (request_rx, _registration) = registry.register_poll(&node);
+    let oversized_path = format!(
+        "/api/v1/internal/storage/objects/{}",
+        "x".repeat(REMOTE_CONTROL_PLANE_BODY_LIMIT)
+    );
+
+    let error = registry
+        .send(
+            &node,
+            Method::GET,
+            oversized_path,
+            None,
+            Vec::new(),
+            Bytes::new(),
+        )
+        .await
+        .expect_err("poll metadata beyond the follower budget should fail");
+
+    assert_eq!(
+        error.storage_error_kind(),
+        Some(StorageErrorKind::Unsupported)
+    );
+    assert!(error.message().contains("envelope exceeds"));
+    assert_eq!(registry.pending_poll_request_count(), 0);
+    assert!(
+        tokio::time::timeout(Duration::from_millis(20), request_rx)
+            .await
+            .is_err(),
+        "oversized metadata must not consume or dispatch the poll connection"
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- transfer `RemoteRequestBody::Reader` ownership directly into the reverse-tunnel stream lane when one is available
- return the stream transport error after a Reader has been consumed, while retaining polling fallback for replayable `Bytes` and `Empty` bodies
- derive the polling binary limit from the follower 1 MiB control-plane response budget and reject oversized body or metadata before pending request creation
- keep request bodies as `Bytes` and serialize base64 through `Base64Display`, avoiding the extra body copy and full intermediate base64 string
- document the data-plane and memory-boundary change once under `Unreleased / Changed`

The polling binary limit is 720 KiB after reserving 64 KiB for JSON metadata and accounting for base64 expansion.

## Correctness and boundaries

Coverage includes Reader, Bytes, and Empty bodies; stream lanes that are available, unavailable, or closed; exact polling limits and one-byte overflow; Reader declared-length mismatch in both directions; metadata overflow; base64 grouping boundaries; legacy byte-array decoding; invalid base64; and a 64 MiB allocation regression.

## Before / after

A local before/after allocation probe used a 64 MiB Reader with an available stream lane:

| Metric | Before | After |
| --- | ---: | ---: |
| Transport path | polling | streaming |
| Cumulative allocated bytes | 67,109,000 | 65,921 |
| Allocation count | 2 | 4 |
| Probe time | 5.525 ms | 1.305 ms |
| Polling request bytes | 64 MiB | 0 |
| Stream bytes | 0 | 64 MiB |

Cumulative allocated bytes drop by about 99.90% (about 1018x). The optimization is necessary for correctness as well as memory use: the former polling path could build an envelope larger than the follower 1 MiB response limit after already buffering and copying the upload.

## Validation

- `cargo test --lib storage::remote_protocol::transport::tests` (15 passed)
- `cargo test --lib storage::remote_protocol::tunnel::server::tests` (29 passed)
- `cargo test --test storage remote_storage::test_reverse_tunnel_production_worker_falls_back_to_poll_when_stream_unavailable`
- `cargo test --test storage remote_storage::test_reverse_tunnel_e2e_over_http_with_follower_worker`
- `cargo check --lib`
- `cargo fmt -- --check`
- `git diff --check`

Closes #494

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **改进**
  - 优化反向隧道上传，支持可重试的数据传输并减少不必要的内存占用。
  - 流式上传失败时可重新打开数据源重试；已消费的读取器数据不会被错误重复发送。
  - 轮询模式新增明确的请求体和响应大小限制，超出限制的请求会在发送前及时拒绝。
  - 增强 Base64 请求体兼容性，继续支持旧格式数据。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->