### PR TITLE
fix(onedrive): reuse simple-upload bodies across auth retries

### DIFF
--- a/src/storage/drivers/onedrive/client.rs
+++ b/src/storage/drivers/onedrive/client.rs
@@ -1,5 +1,6 @@
 use crate::errors::Result as AsterResult;
 use async_trait::async_trait;
+use bytes::Bytes;
 use chrono::{DateTime, Utc};
 use futures::TryStreamExt;
 use reqwest::StatusCode;
@@ -305,9 +306,8 @@ impl MicrosoftGraphClient {
         })
     }
 
-    pub async fn put_small_content(&self, content_path: &str, data: &[u8]) -> Result<()> {
+    pub async fn put_small_content(&self, content_path: &str, body: Bytes) -> Result<()> {
         let url = self.url(content_path)?;
-        let body = data.to_vec();
         let response = self
             .send_with_auth("put OneDrive small content", |access_token| {
                 self.http
@@ -815,6 +815,7 @@ mod tests {
         base_url: String,
         ranges: Arc<Mutex<Vec<Option<String>>>>,
         auth_headers: Arc<Mutex<Vec<Option<String>>>>,
+        bodies: Arc<Mutex<Vec<Bytes>>>,
         handle: actix_web::dev::ServerHandle,
         task: tokio::task::JoinHandle<std::io::Result<()>>,
     }
@@ -930,6 +931,7 @@ mod tests {
             base_url,
             ranges,
             auth_headers,
+            bodies: Arc::new(Mutex::new(Vec::new())),
             handle,
             task,
         }
@@ -989,6 +991,7 @@ mod tests {
             base_url,
             ranges: Arc::new(Mutex::new(Vec::new())),
             auth_headers,
+            bodies: Arc::new(Mutex::new(Vec::new())),
             handle,
             task,
         }
@@ -1043,6 +1046,66 @@ mod tests {
             base_url,
             ranges: Arc::new(Mutex::new(Vec::new())),
             auth_headers,
+            bodies: Arc::new(Mutex::new(Vec::new())),
+            handle,
+            task,
+        }
+    }
+
+    async fn spawn_authorized_put_server() -> TestHttpServer {
+        async fn content(
+            req: HttpRequest,
+            body: web::Bytes,
+            auth_headers: web::Data<Arc<Mutex<Vec<Option<String>>>>>,
+            bodies: web::Data<Arc<Mutex<Vec<Bytes>>>>,
+        ) -> HttpResponse {
+            let authorization = req
+                .headers()
+                .get("authorization")
+                .and_then(|value| value.to_str().ok())
+                .map(str::to_string);
+            auth_headers
+                .lock()
+                .expect("auth header log lock")
+                .push(authorization.clone());
+            bodies.lock().expect("request body log lock").push(body);
+            match authorization.as_deref() {
+                Some("Bearer refreshed-token") => HttpResponse::Created().finish(),
+                _ => HttpResponse::Unauthorized().json(serde_json::json!({
+                    "error": {
+                        "code": "InvalidAuthenticationToken",
+                        "message": "expired"
+                    }
+                })),
+            }
+        }
+
+        let listener = TcpListener::bind(("127.0.0.1", 0)).expect("listener should bind");
+        let base_url = format!(
+            "http://{}",
+            listener.local_addr().expect("listener addr should exist")
+        );
+        let auth_headers = Arc::new(Mutex::new(Vec::new()));
+        let bodies = Arc::new(Mutex::new(Vec::new()));
+        let auth_headers_data = web::Data::new(auth_headers.clone());
+        let bodies_data = web::Data::new(bodies.clone());
+        let server = HttpServer::new(move || {
+            App::new()
+                .app_data(auth_headers_data.clone())
+                .app_data(bodies_data.clone())
+                .app_data(web::PayloadConfig::new(2 * 1024 * 1024))
+                .route("/v1.0/content", web::put().to(content))
+        })
+        .listen(listener)
+        .expect("server should listen")
+        .run();
+        let handle = server.handle();
+        let task = tokio::spawn(server);
+        TestHttpServer {
+            base_url,
+            ranges: Arc::new(Mutex::new(Vec::new())),
+            auth_headers,
+            bodies,
             handle,
             task,
         }
@@ -1091,6 +1154,7 @@ mod tests {
             base_url,
             ranges: Arc::new(Mutex::new(Vec::new())),
             auth_headers,
+            bodies: Arc::new(Mutex::new(Vec::new())),
             handle,
             task,
         }
@@ -1351,6 +1415,46 @@ mod tests {
                 Some("Bearer refreshed-token".to_string()),
             ]
         );
+        server.stop().await;
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn small_content_auth_retry_reuses_the_owned_body() {
+        let server = spawn_authorized_put_server().await;
+        let provider = Arc::new(RefreshingTestTokenProvider::new("refreshed-token"));
+        let client = MicrosoftGraphClient::new(MicrosoftGraphClientConfig::with_token_provider(
+            &server.base_url,
+            provider.clone(),
+        ))
+        .expect("client should build");
+        let body = Bytes::from(vec![7_u8; 1024 * 1024]);
+
+        let future = client.put_small_content("/content", body.clone());
+        let (result, allocations) = crate::test_support::allocations::measure_future(future).await;
+
+        result.expect("refreshed upload should succeed");
+        assert!(
+            allocations.bytes < body.len(),
+            "auth retry allocated a payload-sized body: {allocations:?}"
+        );
+
+        assert_eq!(provider.access_token_calls(), 1);
+        assert_eq!(provider.refresh_calls(), 1);
+        assert_eq!(
+            server
+                .auth_headers
+                .lock()
+                .expect("auth header log lock")
+                .as_slice(),
+            [
+                Some("Bearer expired-token".to_string()),
+                Some("Bearer refreshed-token".to_string()),
+            ]
+        );
+        {
+            let bodies = server.bodies.lock().expect("request body log lock");
+            assert_eq!(bodies.as_slice(), [body.clone(), body]);
+        }
         server.stop().await;
     }
 

--- a/src/storage/drivers/onedrive/mod.rs
+++ b/src/storage/drivers/onedrive/mod.rs
@@ -5,6 +5,7 @@ mod error;
 mod paths;
 
 use async_trait::async_trait;
+use bytes::Bytes;
 use tokio::io::{AsyncRead, AsyncReadExt};
 
 use aster_drive_storage::traits::driver::{BlobMetadata, StorageDriver};
@@ -211,6 +212,23 @@ impl OneDriveDriver {
         }
     }
 
+    async fn put_owned(&self, path: &str, data: Bytes) -> Result<String> {
+        if data.len() > GRAPH_SIMPLE_UPLOAD_MAX_BYTES {
+            return Err(graph_simple_upload_too_large_error());
+        }
+        let parent_path = self.ensure_named_object_parent(path).await?;
+        if let Err(error) = self
+            .client
+            .put_small_content(&self.graph_content_path(path)?, data)
+            .await
+        {
+            self.cleanup_named_object_parent(parent_path.as_deref())
+                .await;
+            return Err(error);
+        }
+        Ok(path.to_string())
+    }
+
     pub async fn validate_root(&self) -> Result<MicrosoftGraphDriveItem> {
         self.client
             .get_drive_item_by_id(&self.drive_id, &self.root_item_id)
@@ -226,8 +244,7 @@ impl OneDriveDriver {
         let total_size = numbers::i64_to_u64(size, "OneDrive put_reader declared size")
             .map_storage_err(StorageErrorKind::Misconfigured)?;
         if total_size == 0 {
-            self.put(path, &[]).await?;
-            return Ok(path.to_string());
+            return self.put_owned(path, Bytes::new()).await;
         }
         if can_use_graph_in_memory_upload(total_size, self.policy_chunk_size) {
             let capacity = numbers::u64_to_usize(total_size, "OneDrive simple upload size")
@@ -238,8 +255,7 @@ impl OneDriveDriver {
                 "read OneDrive simple upload stream",
             )?;
             reject_extra_upload_bytes(reader).await?;
-            self.put(path, &data).await?;
-            return Ok(path.to_string());
+            return self.put_owned(path, Bytes::from(data)).await;
         }
 
         let parent_path = self.ensure_named_object_parent(path).await?;
@@ -319,17 +335,7 @@ impl StorageDriver for OneDriveDriver {
         if data.len() > GRAPH_SIMPLE_UPLOAD_MAX_BYTES {
             return Err(graph_simple_upload_too_large_error());
         }
-        let parent_path = self.ensure_named_object_parent(path).await?;
-        if let Err(error) = self
-            .client
-            .put_small_content(&self.graph_content_path(path)?, data)
-            .await
-        {
-            self.cleanup_named_object_parent(parent_path.as_deref())
-                .await;
-            return Err(error);
-        }
-        Ok(path.to_string())
+        self.put_owned(path, Bytes::copy_from_slice(data)).await
     }
 
     async fn get(&self, path: &str) -> aster_drive_storage::Result<Vec<u8>> {
@@ -691,6 +697,9 @@ mod tests {
             App::new()
                 .app_data(state_data.clone())
                 .app_data(config_data.clone())
+                .app_data(web::PayloadConfig::new(
+                    GRAPH_SIMPLE_UPLOAD_IN_MEMORY_MAX_BYTES + 1024,
+                ))
                 .default_service(web::to(graph))
         })
         .listen(listener)
@@ -732,6 +741,8 @@ mod tests {
 
     #[test]
     fn graph_in_memory_upload_uses_policy_chunk_size_capped_at_50_mib() {
+        assert!(can_use_graph_in_memory_upload(0, 5 * 1024 * 1024));
+        assert!(can_use_graph_in_memory_upload(1, 5 * 1024 * 1024));
         assert!(can_use_graph_in_memory_upload(
             5 * 1024 * 1024,
             5 * 1024 * 1024
@@ -757,6 +768,94 @@ mod tests {
             0
         ));
         assert!(can_use_graph_in_memory_upload(1, -1));
+    }
+
+    #[tokio::test]
+    async fn simple_reader_uploads_accept_zero_and_one_byte() {
+        let server = spawn_graph_lifecycle_server(GraphLifecycleConfig::default()).await;
+        let driver = lifecycle_driver(&server);
+
+        driver
+            .put_reader(NAMED_PATH, Box::new(tokio::io::empty()), 0)
+            .await
+            .expect("empty simple upload should succeed");
+        driver
+            .put_reader(NAMED_PATH, Box::new(std::io::Cursor::new(vec![7_u8])), 1)
+            .await
+            .expect("one-byte simple upload should succeed");
+
+        {
+            let state = server.state.lock().expect("Graph lifecycle state lock");
+            assert_eq!(
+                state
+                    .methods
+                    .iter()
+                    .filter(|method| *method == "PUT")
+                    .count(),
+                2
+            );
+        }
+        server.stop().await;
+    }
+
+    #[tokio::test]
+    async fn simple_reader_upload_rejects_short_and_long_sources_before_provider_mutation() {
+        let server = spawn_graph_lifecycle_server(GraphLifecycleConfig::default()).await;
+        let driver = lifecycle_driver(&server);
+
+        let short = driver
+            .put_reader(NAMED_PATH, Box::new(std::io::Cursor::new(vec![1_u8])), 2)
+            .await
+            .expect_err("short reader must not satisfy the declared size");
+        assert_eq!(short.kind(), StorageErrorKind::Precondition);
+
+        let long = driver
+            .put_reader(
+                NAMED_PATH,
+                Box::new(std::io::Cursor::new(vec![1_u8, 2_u8])),
+                1,
+            )
+            .await
+            .expect_err("extra reader bytes must be rejected");
+        assert_eq!(long.kind(), StorageErrorKind::Misconfigured);
+
+        assert!(
+            server
+                .state
+                .lock()
+                .expect("Graph lifecycle state lock")
+                .methods
+                .is_empty()
+        );
+        server.stop().await;
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn fifty_mib_simple_reader_upload_has_one_object_sized_allocation() {
+        let server = spawn_graph_lifecycle_server(GraphLifecycleConfig::default()).await;
+        let client =
+            MicrosoftGraphClient::new(MicrosoftGraphClientConfig::new(&server.base_url, "token"))
+                .expect("Graph client should build");
+        let driver = OneDriveDriver::new(
+            client,
+            "drive-id",
+            "root-id",
+            "",
+            GRAPH_SIMPLE_UPLOAD_IN_MEMORY_MAX_BYTES as i64,
+        );
+        let size = GRAPH_SIMPLE_UPLOAD_IN_MEMORY_MAX_BYTES;
+        let reader = tokio::io::AsyncReadExt::take(tokio::io::repeat(7), size as u64);
+        let future = driver.put_reader(NAMED_PATH, Box::new(reader), size as i64);
+
+        let (result, allocations) = crate::test_support::allocations::measure_future(future).await;
+
+        result.expect("50 MiB boundary upload should succeed");
+        assert!(allocations.bytes >= size);
+        assert!(
+            allocations.bytes < size + 1024 * 1024,
+            "simple upload allocated more than one object body: {allocations:?}"
+        );
+        server.stop().await;
     }
 
     #[test]


### PR DESCRIPTION
# Pull request

## Summary

- move OneDrive simple uploads onto an owned `Bytes` boundary so Reader buffers transfer without a full-body copy
- reuse the same reference-counted request body when a 401 triggers token refresh and request reconstruction
- keep the #434 provider-native resumable path unchanged for uploads above the policy/50 MiB in-memory boundary; this does not add Pod-local staging
- preserve declared-size validation, extra-byte rejection, Graph error mapping, and named namespace cleanup

Closes #496

## Test plan

- [ ] Not needed: documentation, metadata, or configuration-only change
- [x] Backend: `cargo clippy --lib -- -D warnings`
- [x] Backend: `cargo test --lib storage::drivers::onedrive`
- [ ] Frontend: `bun run check`
- [ ] Frontend: `bun run build`
- [ ] Manual UI check for user-facing changes

Additional regression evidence:

- 50 MiB Reader simple upload allocates exactly one object-sized body within a bounded overhead budget
- a 401 refresh retry adds less than one payload-sized allocation while sending identical bodies before and after refresh
- 0/1 byte, policy boundary, 50 MiB/50 MiB+1 selection, short source, long source, provider fragment cap, and namespace cleanup remain covered
- `cargo fmt --all -- --check`
- `git diff --check`

## Notes for reviewers

- Database migrations: none
- Runtime configuration changes: none
- Deployment or upgrade notes: none


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改进**
  * 优化 OneDrive 小对象上传流程，认证失败重试时可复用上传内容，减少大型载荷的额外复制与内存分配。
  * 增强上传稳定性，完善空内容、异常长度及大文件内存上传场景的处理。
  * 优化上传失败后的清理行为，避免残留不完整对象。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->