### PR TITLE
fix(azure): stream block uploads without whole-block buffers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,7 @@ WebDAV 迁移到 AsterForge WebDAV 0.2 协议引擎，加入多 Range 下载、R
 - **存储原生处理语义** — 缩略图与媒体元数据分别使用显式 enabled flag 和 extension list；关闭开关时保留扩展名作为 dormant configuration，空扩展列表即使在开启时也不匹配任何文件。
 - **Presigned 请求所有权** — URL 与签名所需 headers 由同一个 storage driver 生成完整 request descriptor；S3、Azure Blob、Alibaba OSS、Tencent COS、Remote 以及 multipart refresh 统一走该契约，前端不再硬编码 `Content-Type: application/octet-stream`。
 - **异步 Future 体积** — 归档预览与解压 copy loop 的 64 KiB 栈内 buffer 改为每次操作一次有界分配，把相关 Future 压到 16 KiB 以下；上传与 WebDAV 热路径未引入额外 boxing 或每请求动态分配。
+- **Azure Blob 分块上传内存边界** — `put_reader` 按 Azure block boundary 流式提交，每个 block 使用固定 64 KiB 请求缓冲，不再按有效 block size 分配整块 heap；50,000-block 规划、提交顺序和 declared-size 校验保持不变。
 - **反向隧道上传内存边界** — Reader 上传在 stream lane 可用时直接流式传输，消费后失败由上层重新打开数据源重试；polling 仅承载符合 follower 1 MiB control-plane envelope 预算的小型 body，并移除请求 body 与完整 base64 字符串的额外副本。
 - **Local 默认存储路径** — Local connector、driver、首次配置和测试统一使用 `./data/uploads`；缺失或空 base path 由 connector default 补全，不再散落多套 fallback。
 - **S3-compatible driver 复用** — 提取 AWS request vendor normalization，并用 storage / multipart delegation macro 收敛 S3-compatible 与 Tencent COS 重复实现；S3 driver 构造改为显式 options + SDK config hook，供 provider auth 和 signing customization 使用。

--- a/src/storage/drivers/azure_blob/mod.rs
+++ b/src/storage/drivers/azure_blob/mod.rs
@@ -594,10 +594,34 @@ mod tests {
             usize::try_from(configured + 1).expect("raised chunk size usize"),
         );
 
-        let too_large = super::AZURE_BLOCK_BLOB_MAX_BLOCKS
+        let service_limit = super::AZURE_BLOCK_BLOB_MAX_BLOCKS
             .checked_mul(super::AZURE_BLOCK_BLOB_MAX_BLOCK_SIZE)
-            .and_then(|value| value.checked_add(1))
             .expect("test size within u64");
-        assert!(driver.chunk_size_for_content(too_large).is_err());
+        assert_eq!(
+            driver
+                .chunk_size_for_content(service_limit)
+                .expect("service limit should be accepted"),
+            usize::try_from(super::AZURE_BLOCK_BLOB_MAX_BLOCK_SIZE)
+                .expect("service block size usize"),
+        );
+        assert!(
+            driver.chunk_size_for_content(service_limit + 1).is_err(),
+            "one byte beyond 50,000 maximum-size blocks must be rejected"
+        );
+        assert!(
+            driver.chunk_size_for_content(u64::MAX).is_err(),
+            "content-length arithmetic overflow must be rejected"
+        );
+
+        let oversized_config = AzureBlobDriver::new(
+            AzureBlobDriverConfig {
+                chunk_size: i64::try_from(super::AZURE_BLOCK_BLOB_MAX_BLOCK_SIZE + 1)
+                    .expect("oversized config fits i64"),
+                ..sample_config()
+            },
+            sample_credentials(),
+        )
+        .expect("driver should retain oversized config for runtime validation");
+        assert!(oversized_config.chunk_size_for_content(0).is_err());
     }
 }

--- a/src/storage/drivers/azure_blob/multipart.rs
+++ b/src/storage/drivers/azure_blob/multipart.rs
@@ -477,7 +477,7 @@ impl StreamUploadDriver for AzureBlobDriver {
         )?;
         if extra_read != 0 {
             return Err(storage_driver_error(
-                StorageErrorKind::Misconfigured,
+                StorageErrorKind::Precondition,
                 "Azure Blob upload stream exceeded declared size",
             ));
         }

--- a/src/storage/drivers/azure_blob/multipart.rs
+++ b/src/storage/drivers/azure_blob/multipart.rs
@@ -7,6 +7,7 @@ use azure_storage_blob::models::{BlockListType, BlockLookupList};
 use bytes::Bytes;
 use futures::io::AsyncRead as FuturesAsyncRead;
 use std::pin::Pin;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::task::{Context, Poll};
 use tokio::io::{AsyncRead, ReadBuf};
@@ -30,6 +31,82 @@ struct AzureSizedReaderStream {
 struct AzureSizedReaderState {
     reader: Option<Box<dyn AsyncRead + Unpin + Send + Sync>>,
     remaining: u64,
+}
+
+struct AzureChunkReader {
+    reader: Arc<Mutex<Box<dyn AsyncRead + Unpin + Send + Sync>>>,
+    remaining: u64,
+    ended_early: Arc<AtomicBool>,
+}
+
+impl AzureChunkReader {
+    fn new(
+        reader: Arc<Mutex<Box<dyn AsyncRead + Unpin + Send + Sync>>>,
+        len: u64,
+        ended_early: Arc<AtomicBool>,
+    ) -> Self {
+        Self {
+            reader,
+            remaining: len,
+            ended_early,
+        }
+    }
+}
+
+impl AsyncRead for AzureChunkReader {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        output: &mut ReadBuf<'_>,
+    ) -> Poll<std::io::Result<()>> {
+        if self.remaining == 0 || output.remaining() == 0 {
+            return Poll::Ready(Ok(()));
+        }
+
+        let max_read = match aster_forge_utils::numbers::u64_to_usize(
+            self.remaining,
+            "Azure Blob upload chunk remaining",
+        )
+        .map_err(|error| std::io::Error::new(std::io::ErrorKind::InvalidData, error))
+        {
+            Ok(value) => value.min(output.remaining()),
+            Err(error) => return Poll::Ready(Err(error)),
+        };
+        let mut limited = ReadBuf::new(&mut output.initialize_unfilled()[..max_read]);
+        let poll_result = {
+            let mut state = match self.reader.lock() {
+                Ok(state) => state,
+                Err(_) => {
+                    return Poll::Ready(Err(std::io::Error::other(
+                        "Azure Blob upload reader lock poisoned",
+                    )));
+                }
+            };
+            Pin::new(&mut **state).poll_read(cx, &mut limited)
+        };
+        match poll_result {
+            Poll::Pending => Poll::Pending,
+            Poll::Ready(Ok(())) => {
+                let read = limited.filled().len();
+                if read == 0 {
+                    self.ended_early.store(true, Ordering::Relaxed);
+                    return Poll::Ready(Ok(()));
+                }
+                output.advance(read);
+                self.remaining -= match u64::try_from(read) {
+                    Ok(read) => read,
+                    Err(error) => {
+                        return Poll::Ready(Err(std::io::Error::new(
+                            std::io::ErrorKind::InvalidData,
+                            error,
+                        )));
+                    }
+                };
+                Poll::Ready(Ok(()))
+            }
+            Poll::Ready(Err(error)) => Poll::Ready(Err(error)),
+        }
+    }
 }
 
 impl AzureSizedReaderStream {
@@ -313,14 +390,13 @@ impl StreamUploadDriver for AzureBlobDriver {
     async fn put_reader(
         &self,
         storage_path: &str,
-        mut reader: Box<dyn AsyncRead + Unpin + Send + Sync>,
+        reader: Box<dyn AsyncRead + Unpin + Send + Sync>,
         size: i64,
     ) -> aster_drive_storage::Result<String> {
-        use tokio::io::AsyncReadExt as _;
-
         let expected_size = numbers::i64_to_u64(size, "Azure Blob put_reader declared size")
             .map_storage_err(StorageErrorKind::Misconfigured)?;
         let chunk_size = self.chunk_size_for_content(expected_size)?;
+        let reader = Arc::new(Mutex::new(reader));
         let mut remaining = expected_size;
         let mut part_number = 1_i32;
         let mut parts = Vec::new();
@@ -339,17 +415,48 @@ impl StreamUploadDriver for AzureBlobDriver {
                 "Azure Blob put_reader next chunk size",
             )
             .map_storage_err(StorageErrorKind::Misconfigured)?;
-            let mut chunk = vec![0_u8; read_limit];
-            reader.read_exact(&mut chunk).await.map_storage_err_ctx(
-                StorageErrorKind::Precondition,
-                "read Azure Blob upload chunk",
-            )?;
+            let ended_early = Arc::new(AtomicBool::new(false));
+            let chunk_reader = AzureChunkReader::new(
+                Arc::clone(&reader),
+                u64::try_from(read_limit).map_err(|error| {
+                    storage_driver_error(
+                        StorageErrorKind::Misconfigured,
+                        format!("Azure Blob upload chunk size conversion failed: {error}"),
+                    )
+                })?,
+                Arc::clone(&ended_early),
+            );
             let marker = self
-                .upload_multipart_part_bytes(storage_path, "", part_number, Bytes::from(chunk))
-                .await?;
+                .upload_multipart_part_reader(
+                    storage_path,
+                    "",
+                    part_number,
+                    Box::new(chunk_reader),
+                    i64::try_from(read_limit).map_err(|error| {
+                        storage_driver_error(
+                            StorageErrorKind::Misconfigured,
+                            format!("Azure Blob upload chunk size conversion failed: {error}"),
+                        )
+                    })?,
+                )
+                .await
+                .map_err(|error| {
+                    if ended_early.load(Ordering::Relaxed) {
+                        storage_driver_error(
+                            StorageErrorKind::Precondition,
+                            format!("read Azure Blob upload chunk: {error}"),
+                        )
+                    } else {
+                        error
+                    }
+                })?;
             parts.push((part_number, marker));
-            remaining -= numbers::usize_to_u64(read_limit, "Azure Blob uploaded chunk size")
-                .map_storage_err(StorageErrorKind::Misconfigured)?;
+            remaining -= u64::try_from(read_limit).map_err(|error| {
+                storage_driver_error(
+                    StorageErrorKind::Misconfigured,
+                    format!("Azure Blob uploaded chunk size conversion failed: {error}"),
+                )
+            })?;
             part_number = part_number.checked_add(1).ok_or_else(|| {
                 storage_driver_error(
                     StorageErrorKind::Misconfigured,
@@ -359,7 +466,12 @@ impl StreamUploadDriver for AzureBlobDriver {
         }
 
         let mut extra = [0_u8; 1];
-        let extra_read = reader.read(&mut extra).await.map_storage_err_ctx(
+        let extra_read = tokio::io::AsyncReadExt::read(
+            &mut AzureChunkReader::new(Arc::clone(&reader), 1, Arc::new(AtomicBool::new(false))),
+            &mut extra,
+        )
+        .await
+        .map_storage_err_ctx(
             StorageErrorKind::Precondition,
             "check Azure Blob upload stream length",
         )?;
@@ -397,8 +509,11 @@ impl StreamUploadDriver for AzureBlobDriver {
 #[cfg(test)]
 mod tests {
     use futures::io::AsyncReadExt as _;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::{Arc, Mutex};
+    use tokio::io::AsyncReadExt as _;
 
-    use super::{AZURE_STREAM_BUFFER_SIZE, AzureSizedReaderStream};
+    use super::{AZURE_STREAM_BUFFER_SIZE, AzureChunkReader, AzureSizedReaderStream};
     use azure_core::stream::SeekableStream;
 
     #[tokio::test]
@@ -438,5 +553,66 @@ mod tests {
         let mut stream = AzureSizedReaderStream::new(reader, 3);
 
         assert!(stream.reset().await.is_err());
+    }
+
+    #[tokio::test]
+    async fn chunk_reader_limits_each_block_without_consuming_the_next_one() {
+        let reader: Arc<Mutex<Box<dyn tokio::io::AsyncRead + Unpin + Send + Sync>>> = Arc::new(
+            Mutex::new(Box::new(std::io::Cursor::new(b"abcdef".to_vec()))),
+        );
+        let mut first =
+            AzureChunkReader::new(Arc::clone(&reader), 3, Arc::new(AtomicBool::new(false)));
+        let mut first_body = Vec::new();
+        first
+            .read_to_end(&mut first_body)
+            .await
+            .expect("first chunk should read");
+        assert_eq!(first_body, b"abc");
+
+        let mut second = AzureChunkReader::new(reader, 3, Arc::new(AtomicBool::new(false)));
+        let mut second_body = Vec::new();
+        second
+            .read_to_end(&mut second_body)
+            .await
+            .expect("second chunk should read");
+        assert_eq!(second_body, b"def");
+    }
+
+    #[tokio::test]
+    async fn chunk_reader_marks_short_block_for_precondition_mapping() {
+        let reader: Arc<Mutex<Box<dyn tokio::io::AsyncRead + Unpin + Send + Sync>>> =
+            Arc::new(Mutex::new(Box::new(std::io::Cursor::new(b"abc".to_vec()))));
+        let ended_early = Arc::new(AtomicBool::new(false));
+        let chunk = AzureChunkReader::new(Arc::clone(&reader), 5, Arc::clone(&ended_early));
+        let mut stream = AzureSizedReaderStream::new(Box::new(chunk), 5);
+        let mut body = Vec::new();
+
+        let error = futures::io::AsyncReadExt::read_to_end(&mut stream, &mut body)
+            .await
+            .expect_err("short block should fail");
+
+        assert_eq!(error.kind(), std::io::ErrorKind::UnexpectedEof);
+        assert_eq!(body, b"abc");
+        assert!(ended_early.load(Ordering::Relaxed));
+    }
+
+    #[tokio::test]
+    async fn chunk_reader_handles_huge_declared_block_with_small_input() {
+        let reader: Arc<Mutex<Box<dyn tokio::io::AsyncRead + Unpin + Send + Sync>>> =
+            Arc::new(Mutex::new(Box::new(std::io::Cursor::new(b"x".to_vec()))));
+        let ended_early = Arc::new(AtomicBool::new(false));
+        let declared_size = 100_u64 * 1024 * 1024 * 1024 * 1024;
+        let chunk =
+            AzureChunkReader::new(Arc::clone(&reader), declared_size, Arc::clone(&ended_early));
+        let mut stream = AzureSizedReaderStream::new(Box::new(chunk), declared_size);
+        let mut body = Vec::new();
+
+        let error = futures::io::AsyncReadExt::read_to_end(&mut stream, &mut body)
+            .await
+            .expect_err("short huge declared block should fail");
+
+        assert_eq!(error.kind(), std::io::ErrorKind::UnexpectedEof);
+        assert_eq!(body, b"x");
+        assert!(ended_early.load(Ordering::Relaxed));
     }
 }

--- a/tests/storage/azure_blob.rs
+++ b/tests/storage/azure_blob.rs
@@ -440,14 +440,7 @@ async fn test_azure_blob_put_reader_length_boundaries_with_azurite() {
         )
         .await
         .expect_err("long stream should fail");
-    assert!(
-        matches!(
-            long_error.kind(),
-            StorageErrorKind::Misconfigured | StorageErrorKind::Precondition
-        ),
-        "unexpected long reader error kind: {:?}",
-        long_error.kind()
-    );
+    assert_eq!(long_error.kind(), StorageErrorKind::Precondition);
 
     let upload_id = driver
         .create_multipart_upload("multipart/reader.bin")

--- a/tests/storage/azure_blob.rs
+++ b/tests/storage/azure_blob.rs
@@ -376,6 +376,19 @@ async fn test_azure_blob_driver_e2e_with_azurite() {
     assert_eq!(reader_body.len(), usize::try_from(reader_size).unwrap());
     assert!(reader_body.iter().all(|byte| *byte == b'Z'));
 
+    driver
+        .put_reader(
+            "stream/single.bin",
+            Box::new(std::io::Cursor::new(b"single block".to_vec())),
+            12,
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        driver.get("stream/single.bin").await.unwrap(),
+        b"single block"
+    );
+
     driver.delete("docs/hello.txt").await.unwrap();
     driver.delete("docs/hello.txt").await.unwrap();
     assert!(!driver.exists("docs/hello.txt").await.unwrap());


### PR DESCRIPTION
## Summary

- stream Azure Blob `put_reader` blocks through the existing reader-part upload path
- keep Azure block planning, block IDs, ordering, declared-size checks, and completion semantics unchanged
- add planning and reader boundary coverage for single/multi block, short/extra input, 50,000-block and 4000 MiB limits, arithmetic overflow, and huge declared sizes
- update the Unreleased changelog

Closes #499

## Validation

- `cargo test -p aster_drive azure_blob::tests::chunk_size_respects_configured_minimum_and_azure_block_limits --lib`
- `cargo test -p aster_drive azure_blob::multipart --lib`
- `cargo test -p aster_drive --test storage azure_blob::test_azure_blob_driver_e2e_with_azurite -- --nocapture`
- `cargo test -p aster_drive --test storage azure_blob::test_azure_blob_put_reader_length_boundaries_with_azurite -- --nocapture`
- `cargo clippy -p aster_drive --lib --all-features -- -D warnings`
- `cargo clippy -p aster_drive --test storage -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - Azure Blob 分块上传改为流式处理，降低大文件上传的内存占用。
  - 增强分块边界、声明长度及额外数据校验，提升上传可靠性。
- **问题修复**
  - 改进短输入、提前结束及超大配置的错误处理。
- **测试**
  - 新增单块上传及多种边界场景验证。
- **文档**
  - 补充分块上传的内存使用限制与处理说明。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->