### PR TITLE
feat(docker): publish slim images without FFmpeg and libvips

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -15,8 +15,8 @@ developer-docs/
 tests/
 !tests/
 tests/*
-!tests/test_multi_primary_e2e.rs
-!tests/test_multi_primary_storage_events_e2e.rs
+!tests/multi_primary/
+!tests/multi_primary/**
 .DS_Store
 *.db
 *.db-shm

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -27,25 +27,21 @@ jobs:
         include:
           - variant: default
             features: server,cli
-            suffix: ""
             platform: linux/amd64
             arch: amd64
             runner: ubuntu-latest
           - variant: default
             features: server,cli
-            suffix: ""
             platform: linux/arm64
             arch: arm64
             runner: ubuntu-24.04-arm
           - variant: metrics
             features: server,cli,metrics
-            suffix: "-metrics"
             platform: linux/amd64
             arch: amd64
             runner: ubuntu-latest
           - variant: metrics
             features: server,cli,metrics
-            suffix: "-metrics"
             platform: linux/arm64
             arch: arm64
             runner: ubuntu-24.04-arm
@@ -77,21 +73,18 @@ jobs:
           images: |
             ${{ env.REGISTRY_IMAGE_GHCR }}
             ${{ env.REGISTRY_IMAGE_DOCKERHUB }}
-          tags: |
-            type=ref,event=tag,suffix=${{ matrix.suffix }}
-            type=raw,value=latest${{ matrix.suffix }},enable=${{ !contains(github.ref_name, 'alpha') && !contains(github.ref_name, 'beta') && !contains(github.ref_name, 'rc') }}
-            type=raw,value=stable${{ matrix.suffix }},enable=${{ !contains(github.ref_name, 'alpha') && !contains(github.ref_name, 'beta') && !contains(github.ref_name, 'rc') }}
-            type=raw,value=edge${{ matrix.suffix }},enable=${{ contains(github.ref_name, 'alpha') || contains(github.ref_name, 'beta') || contains(github.ref_name, 'rc') }}
           labels: |
             org.opencontainers.image.title=AsterDrive
             org.opencontainers.image.description=Self-hosted cloud storage system built with Rust
             org.opencontainers.image.vendor=AsterCommunity
 
-      - name: Build and push Docker image
-        id: build-push
+      # Build full first so the slim target reuses the exact same feature/architecture binary.
+      - name: Build and push full Docker image
+        id: build-push-full
         uses: docker/build-push-action@v7
         with:
           context: .
+          target: runtime-full
           platforms: ${{ matrix.platform }}
           push: true
           tags: |
@@ -101,10 +94,30 @@ jobs:
           cache-from: |
             type=gha,scope=docker-image-${{ matrix.variant }}-${{ matrix.arch }}
             type=registry,ref=${{ env.REGISTRY_IMAGE_GHCR }}:buildcache-${{ matrix.variant }}-${{ matrix.arch }}
-            type=registry,ref=${{ env.REGISTRY_IMAGE_GHCR }}:buildcache-${{ matrix.variant }}
           cache-to: |
             type=gha,mode=max,scope=docker-image-${{ matrix.variant }}-${{ matrix.arch }}
             type=registry,ref=${{ env.REGISTRY_IMAGE_GHCR }}:buildcache-${{ matrix.variant }}-${{ matrix.arch }},mode=max
+          build-args: |
+            CARGO_FEATURES=${{ matrix.features }}
+            ASTER_BUILD_REVISION=${{ github.sha }}
+          provenance: true
+          sbom: true
+
+      - name: Build and push slim Docker image
+        id: build-push-slim
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          target: runtime-slim
+          platforms: ${{ matrix.platform }}
+          push: true
+          tags: |
+            ${{ env.REGISTRY_IMAGE_GHCR }}:${{ env.TEMP_IMAGE_TAG }}-${{ matrix.variant }}-slim-${{ matrix.arch }}
+            ${{ env.REGISTRY_IMAGE_DOCKERHUB }}:${{ env.TEMP_IMAGE_TAG }}-${{ matrix.variant }}-slim-${{ matrix.arch }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: |
+            type=gha,scope=docker-image-${{ matrix.variant }}-${{ matrix.arch }}
+            type=registry,ref=${{ env.REGISTRY_IMAGE_GHCR }}:buildcache-${{ matrix.variant }}-${{ matrix.arch }}
           build-args: |
             CARGO_FEATURES=${{ matrix.features }}
             ASTER_BUILD_REVISION=${{ github.sha }}
@@ -122,8 +135,12 @@ jobs:
         include:
           - variant: default
             suffix: ""
+          - variant: default-slim
+            suffix: "-slim"
           - variant: metrics
             suffix: "-metrics"
+          - variant: metrics-slim
+            suffix: "-metrics-slim"
 
     steps:
       - name: Login to Docker Hub

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ WebDAV 迁移到 AsterForge WebDAV 0.2 协议引擎，加入多 Range 下载、R
 - **Kubernetes / Helm 部署**
   - 新增多 Primary StatefulSet、headless / ClusterIP Service、PodDisruptionBudget、RWX avatar PVC、Ingress 示例和 NetworkPolicy
   - 提供 OrbStack smoke-test overlay、production-example overlay 与 Helm chart；chart 校验敏感配置、selector label、资源名长度和固定共享存储边界
+- **Slim Docker 镜像** — GHCR 与 Docker Hub 新增 default / metrics 的 `-slim` 多架构标签，不内置可选的 FFmpeg、ffprobe 和 libvips 工具链；现有标签继续发布开箱即用的完整媒体处理镜像，同 feature / architecture 的 full 与 slim 产物复用一次 Rust binary build。
 - **三态系统初始化** — 新增 `SystemSetupState`（`needs_admin` / `needs_storage` / `ready`），并同步到 `/auth/check`、`/health/ready`、路由守卫和前端首次存储配置流程。
 - **结构化连接凭据** — database、cache 和 config-sync endpoint 支持 `{ base_url, username, password }` inline table 与嵌套环境变量，原始保留字符由配置层安全编码。
 - **Plugin-ready storage connector registry**

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,34 +16,32 @@ FROM rust:1-alpine AS builder
 RUN apk add --no-cache build-base pkgconfig sqlite-dev curl
 
 WORKDIR /build
+ARG CARGO_FEATURES="server,cli"
+
 COPY Cargo.toml Cargo.lock ./
 COPY crates/ crates/
 COPY benches/ benches/
 COPY tests/multi_primary/ tests/multi_primary/
 
 # Pre-build dependencies (cache layer)
-RUN mkdir src && echo 'fn main() {}' > src/main.rs && \
-    cargo build --release 2>/dev/null || true && \
+RUN mkdir src && \
+    echo 'fn main() {}' > src/main.rs && \
+    echo '' > src/lib.rs && \
+    cargo build --release --locked --features "${CARGO_FEATURES}" && \
     rm -rf src
 
 COPY src/ src/
 COPY build.rs ./
 COPY --from=frontend /build/frontend-panel/dist/ frontend-panel/dist/
 
-ARG CARGO_FEATURES="server,cli"
 ARG ASTER_BUILD_REVISION="unknown"
-ENV RUSTFLAGS="-C link-arg=-s"
 
-RUN cargo build --release --features "${CARGO_FEATURES}"
+RUN cargo build --release --locked --features "${CARGO_FEATURES}"
 
-# Stage 3: Alpine runtime
-FROM alpine:3.24
+# Stage 3: Shared Alpine runtime
+FROM alpine:3.24 AS runtime-base
 
-# Alpine 3.24 still ships libtiff 4.7.1, which is affected by CVE-2026-4775.
-RUN apk add --no-cache ca-certificates sqlite-libs vips-tools vips-poppler 'ffmpeg>=8.1.2-r0' libheif && \
-    apk add --no-cache \
-      --repository=https://dl-cdn.alpinelinux.org/alpine/edge/main \
-      'tiff=4.7.2-r0' && \
+RUN apk add --no-cache ca-certificates sqlite-libs && \
     addgroup -S -g 10001 aster && \
     adduser -S -D -H -u 10001 -G aster -s /sbin/nologin aster && \
     mkdir -p /data && \
@@ -55,21 +53,47 @@ LABEL org.opencontainers.image.description="Self-hosted cloud storage system bui
 LABEL org.opencontainers.image.source="https://github.com/AsterCommunity/AsterDrive"
 LABEL org.opencontainers.image.license="MIT"
 
-COPY --from=builder /build/target/release/aster_drive /usr/local/bin/aster_drive
-
 VOLUME ["/data"]
 EXPOSE 3000
 
 WORKDIR /
 ENV ASTER__SERVER__HOST=0.0.0.0
-ENV ASTER_BOOTSTRAP_ENABLE_VIPS_CLI=true
-ENV ASTER_BOOTSTRAP_ENABLE_FFMPEG_CLI=true
-ENV ASTER_BOOTSTRAP_ENABLE_FFPROBE_CLI=true
-
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
   CMD ["wget", "-q", "-O", "/dev/null", "http://127.0.0.1:3000/health/ready"]
 
+ENTRYPOINT ["/usr/local/bin/aster_drive"]
+
+# Stage 4: Slim runtime base without optional external media processors
+FROM runtime-base AS runtime-slim-base
+
+ENV ASTER_BOOTSTRAP_ENABLE_VIPS_CLI=false
+ENV ASTER_BOOTSTRAP_ENABLE_FFMPEG_CLI=false
+ENV ASTER_BOOTSTRAP_ENABLE_FFPROBE_CLI=false
+
+# Stage 5: Slim runtime image
+FROM runtime-slim-base AS runtime-slim
+
+COPY --from=builder /build/target/release/aster_drive /usr/local/bin/aster_drive
+
 USER aster:aster
 
-ENTRYPOINT ["/usr/local/bin/aster_drive"]
+# Stage 6: Full runtime base with the optional external media processors
+# Alpine 3.24 still ships libtiff 4.7.1, which is affected by CVE-2026-4775.
+FROM runtime-base AS runtime-full-base
+
+RUN apk add --no-cache vips-tools vips-poppler 'ffmpeg>=8.1.2-r0' libheif && \
+    apk add --no-cache \
+      --repository=https://dl-cdn.alpinelinux.org/alpine/edge/main \
+      'tiff=4.7.2-r0'
+
+ENV ASTER_BOOTSTRAP_ENABLE_VIPS_CLI=true
+ENV ASTER_BOOTSTRAP_ENABLE_FFMPEG_CLI=true
+ENV ASTER_BOOTSTRAP_ENABLE_FFPROBE_CLI=true
+
+# Stage 7: Full runtime image (kept last so plain `docker build` remains full)
+FROM runtime-full-base AS runtime-full
+
+COPY --from=builder /build/target/release/aster_drive /usr/local/bin/aster_drive
+
+USER aster:aster

--- a/docs/src/content/docs/deploy/docker.md
+++ b/docs/src/content/docs/deploy/docker.md
@@ -24,6 +24,18 @@ NAS、单机、小团队，或者已经在用容器编排的单实例部署。10
 
 官方镜像默认以 **非 root 用户** 运行（UID/GID 固定为 `10001:10001`，用户名 `aster`），并内置了基于 `/health/ready` 的 `HEALTHCHECK`。
 
+### 选择完整镜像或 slim 镜像
+
+默认标签仍然发布完整镜像，内置 `vips`、`ffmpeg` 和 `ffprobe`，适合需要 HEIC / AVIF / PDF 封面、视频缩略图或视频元数据的实例。Slim 镜像不包含这些外部媒体命令，下载、存储和软件物料清单更小；常见图片与音频的内置处理器、存储提供商原生处理能力，以及数据库、存储、WebDAV、WOPI 和远程节点等其他产品能力不受影响。
+
+| 版本通道 | 默认功能 | 启用 metrics |
+| --- | --- | --- |
+| 正式版本 | `vX.Y.Z` / `latest` / `stable` | `vX.Y.Z-metrics` / `latest-metrics` / `stable-metrics` |
+| Slim | `vX.Y.Z-slim` / `latest-slim` / `stable-slim` | `vX.Y.Z-metrics-slim` / `latest-metrics-slim` / `stable-metrics-slim` |
+| 预发布 | `edge` / `edge-slim` | `edge-metrics` / `edge-metrics-slim` |
+
+新建 slim 实例时，`vips_cli`、`ffmpeg_cli` 和 `ffprobe_cli` 默认关闭。从完整镜像切换已有实例之前，先到 `管理 -> 系统设置 -> 文件处理 -> 媒体处理` 检查这三个处理器；已有数据库会保留原配置，但 slim 容器会将缺失命令报告为不可用，也不会在公开能力接口中继续声明对应格式。如果实例需要其中任一能力，继续使用完整镜像。
+
 如果你把宿主机目录直接 bind mount 到 `/data`，**一定要先把目录创建好并把属主改成 `10001:10001`**，否则容器启动时生成 `config.toml`、SQLite 文件或临时目录都会直接报权限错误：
 
 ```bash

--- a/docs/src/content/docs/en/deploy/docker.md
+++ b/docs/src/content/docs/en/deploy/docker.md
@@ -24,6 +24,18 @@ For **production launch**, put a reverse proxy in front to handle HTTPS. Do not 
 
 The official image runs as a **non-root user** by default (UID/GID fixed to `10001:10001`, username `aster`) and includes a `HEALTHCHECK` based on `/health/ready`.
 
+### Choose the full or slim image
+
+The default tags continue to publish the full image with `vips`, `ffmpeg`, and `ffprobe`. Use it for HEIC/AVIF/PDF covers, video thumbnails, or video metadata. Slim images omit those external media commands to reduce downloads, storage, and the software bill of materials. Built-in processing for common images and audio, storage-provider-native processing, and all other product capabilities such as databases, storage backends, WebDAV, WOPI, and remote nodes remain available.
+
+| Release channel | Default features | Metrics enabled |
+| --- | --- | --- |
+| Stable release | `vX.Y.Z` / `latest` / `stable` | `vX.Y.Z-metrics` / `latest-metrics` / `stable-metrics` |
+| Slim | `vX.Y.Z-slim` / `latest-slim` / `stable-slim` | `vX.Y.Z-metrics-slim` / `latest-metrics-slim` / `stable-metrics-slim` |
+| Prerelease | `edge` / `edge-slim` | `edge-metrics` / `edge-metrics-slim` |
+
+Fresh slim instances disable the `vips_cli`, `ffmpeg_cli`, and `ffprobe_cli` processors by default. Before switching an existing instance from the full image, review these processors under `Admin -> System Settings -> File Processing -> Media Processing`. The existing database keeps its configuration, but a slim container reports the missing commands as unavailable and does not advertise their formats through public capability endpoints. Keep using the full image when the instance needs any of these processors.
+
 If you bind mount a host directory directly to `/data`, **create the directory first and change its owner to `10001:10001`**. Otherwise, container startup will fail with permission errors when generating `config.toml`, creating the SQLite file, or creating temporary directories:
 
 ```bash

--- a/docs/src/content/docs/en/reference/config/runtime/file-processing.md
+++ b/docs/src/content/docs/en/reference/config/runtime/file-processing.md
@@ -136,7 +136,7 @@ ASTER_BOOTSTRAP_ENABLE_FFMPEG_CLI=true
 ASTER_BOOTSTRAP_ENABLE_FFPROBE_CLI=true
 ```
 
-The official Docker image already installs `vips`, `ffmpeg`, and `ffprobe`, and enables these three bootstrap ENV values by default. New databases usually get the corresponding processors directly.
+The full official Docker image installs `vips`, `ffmpeg`, and `ffprobe`, and enables these three bootstrap ENV values by default. The `-slim` / `-metrics-slim` images omit these commands and disable their processors for new databases. Existing databases retain their configuration when switched to a slim image, but public capability endpoints do not advertise processors whose commands are missing. See [Single-Instance Docker Deployment](/en/deploy/docker/#choose-the-full-or-slim-image) for tags and switching guidance.
 
 These three variables only affect the initial default value when `media_processing_registry_json` does not yet exist. This rule table is the unified media processing configuration entry point. It manages enabled state, capability purposes, extension bindings, and command paths for built-in `images`, built-in `lofty`, VIPS CLI, FFmpeg CLI, and FFprobe CLI. Thumbnails and media metadata both use this path.
 </details>

--- a/docs/src/content/docs/reference/config/runtime/file-processing.md
+++ b/docs/src/content/docs/reference/config/runtime/file-processing.md
@@ -136,7 +136,7 @@ ASTER_BOOTSTRAP_ENABLE_FFMPEG_CLI=true
 ASTER_BOOTSTRAP_ENABLE_FFPROBE_CLI=true
 ```
 
-官方 Docker 镜像已经安装 `vips`、`ffmpeg` 和 `ffprobe`，并默认打开这三个 bootstrap ENV，所以新库通常会直接带上对应处理器。
+官方 Docker 完整镜像已经安装 `vips`、`ffmpeg` 和 `ffprobe`，并默认打开这三个 bootstrap ENV，所以新库通常会直接带上对应处理器。`-slim` / `-metrics-slim` 镜像不包含这些命令，并在新库中默认关闭对应处理器；已有数据库切换到 slim 镜像时会保留配置，但缺失的命令不会被公开能力接口声明为可用。镜像标签和切换注意事项见[单实例 Docker 部署](/deploy/docker/#选择完整镜像或-slim-镜像)。
 
 这三个变量只影响 `media_processing_registry_json` 还不存在时的初始默认值。这个规则表是统一媒体处理配置入口，用来管理内置 `images`、内置 `lofty`、VIPS CLI、FFmpeg CLI、FFprobe CLI 的启用状态、能力用途、后缀绑定和命令路径；缩略图和媒体元数据都会走这条链路。
 </details>


### PR DESCRIPTION
## Summary

- Publish full and slim multi-arch Docker variants for default and metrics builds.
- Keep `latest` / `latest-metrics` as the full images and add `latest-slim` / `latest-metrics-slim` plus stable, edge, and versioned equivalents.
- Build full first and slim second within each feature and architecture job so both targets reuse the same Rust binary, frontend, and runtime cache.
- Remove the Dockerfile-level `RUSTFLAGS` override and follow the release profile in `Cargo.toml`.
- Document slim media-processing boundaries in Chinese and English deployment/configuration docs.

## Runtime contract

- Full images include `vips`, `ffmpeg`, `ffprobe`, `libheif`, and the pinned `tiff` security update.
- Slim images retain the AsterDrive product capabilities and database/storage dependencies but omit optional external media processors.
- Slim bootstrap defaults disable the three CLI processors; existing database configuration remains preserved when switching from full to slim.

## Validation

- `actionlint .github/workflows/docker-image.yml`
- `git diff --check` and staged diff check
- Default and metrics full/slim Docker builds
- Plain `docker build .` still resolves to `runtime-full`
- Four layered images start healthy
- Full/slim media command, package, UID, and bootstrap ENV checks
- Metrics endpoint checks for metrics and non-metrics variants
- ELF symbol inspection confirms function symbols remain available
- Documentation build and internal-link validation

Closes #513