### PR TITLE
chore(deps): upgrade Lofty to 0.25.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4880,9 +4880,9 @@ dependencies = [
 
 [[package]]
 name = "lofty"
-version = "0.24.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dec4feeff6c7d75093278133a06e827d7af6d2bfe20b0f331f9d10338a5ec7ca"
+checksum = "6e14b9bf7c3438887f72d71d21368a6a9ad120d8408a168ef61272907304fc3c"
 dependencies = [
  "byteorder",
  "data-encoding",
@@ -4895,13 +4895,13 @@ dependencies = [
 
 [[package]]
 name = "lofty_attr"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "458ace39169e4b83c4f77ae3d42d5d1d11c422feef590219a97c973d3b524557"
+checksum = "fdbca1b60ba7cea959ffc84ac27f3dbdbacd6dfda168c7eabbc00e48654bb9fd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -271,7 +271,7 @@ webauthn-rs = { version = "0.6.1-dev", default-features = false, features = ["co
 webauthn-rs-proto = "0.6.1-dev"
 
 zip = { version = "8", default-features = false, features = ["deflate"] }
-lofty = "0.24.0"
+lofty = "0.25.0"
 
 [dev-dependencies]
 aes-gcm = "0.11"


### PR DESCRIPTION
## Summary

- Upgrade `lofty` from `0.24.0` to `0.25.0` and `lofty_attr` from `0.12.0` to `0.13.0`.
- Keep AsterDrive's audio metadata, embedded artwork, and media-extension integration unchanged.
- Accept Lofty 0.25's source-based error refactor without application code changes; AsterDrive does not use the removed `LoftyError` or `lofty::error::Result` APIs.

## Compatibility

- Lofty 0.25 raises its MSRV from Rust 1.85 to 1.89; AsterDrive already requires Rust 1.95.
- Lofty's supported extension set used by the media processor registry is unchanged.
- No API schema, database migration, runtime configuration, or deployment behavior changes.

## Validation

- `cargo fmt --check`
- `cargo check --workspace --all-features --locked -j 1`
- `cargo clippy --workspace --all-targets --all-features --locked -j 1 -- -D warnings`
- `cargo test --lib services::media::metadata::tests::audio_metadata_does_not_read_embedded_cover_art --locked -j 1`
- `cargo test --lib config::media_processing::tests::builtin_audio_metadata_supports_lofty_extensions --locked -j 1`
- `cargo test --lib config::media_processing::tests::audio_metadata_uses_builtin_lofty_extensions_over_stored_match_list --locked -j 1`
- `cargo audit -D warnings`
- `git diff --check`, staged diff check, and HEAD diff check

## CI Bot Exercise

This dependency-only PR intentionally leaves deterministic metadata to the repository automation. Expected managed labels are `Rust` and `Dependencies`, and the current HEAD should receive the aggregated `PR Gate` check.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **更新**
  * 将音频元数据处理组件升级至新版本，提升兼容性与稳定性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->