### PR TITLE
fix(remote): keep idle reverse tunnel lanes alive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **Reverse tunnel 空闲连接保活与关闭握手** — single 与 cluster Primary 统一使用 WebSocket Ping/Pong 判断 streaming lane 存活，不再把 60 秒无业务帧误判为断链并触发四 lane 重连风暴；心跳失联仍会记录一次可操作告警，Primary / follower 主动关闭时完成正常 close handshake，follower 运行日志改用 binding ID，避免输出完整 access key。
+- **Reverse tunnel 空闲连接保活与关闭握手** — single 与 cluster Primary 统一使用 WebSocket Ping/Pong 判断 streaming lane 存活，不再把 60 秒无业务帧误判为断链并触发四 lane 重连风暴；Primary shutdown 会停止接收新请求、在有界时间内排空 lane 上的在途请求后发送 Close，正常 Close 记录 info 而不告警，EOF/ConnectionReset 等异常掉线保留 WARN；心跳失联仍会记录一次可操作告警，Primary 离线期间的 lane / poll 重试只在故障开始时告警并在恢复后记录，运行日志改用 binding ID，避免输出完整 access key。
 
 ## [v0.5.0-rc.1] - 2026-08-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Reverse tunnel 空闲连接保活与关闭握手** — single 与 cluster Primary 统一使用 WebSocket Ping/Pong 判断 streaming lane 存活，不再把 60 秒无业务帧误判为断链并触发四 lane 重连风暴；心跳失联仍会记录一次可操作告警，Primary / follower 主动关闭时完成正常 close handshake，follower 运行日志改用 binding ID，避免输出完整 access key。
+
 ## [v0.5.0-rc.1] - 2026-08-18
 
 ### Release Highlights

--- a/src/api/routes/remote_tunnel.rs
+++ b/src/api/routes/remote_tunnel.rs
@@ -10,6 +10,7 @@ use crate::storage::remote_protocol::tunnel::server::{
 };
 use actix_web::{HttpRequest, HttpResponse, web};
 use actix_ws::MessageStream;
+use tokio_util::sync::CancellationToken;
 use validator::Validate;
 
 #[derive(Debug, serde::Deserialize, Validate)]
@@ -101,6 +102,7 @@ pub async fn complete_remote_tunnel(
 
 pub async fn connect_remote_tunnel(
     state: web::Data<PrimaryAppState>,
+    shutdown_token: web::Data<CancellationToken>,
     req: HttpRequest,
     body: web::Payload,
 ) -> Result<HttpResponse> {
@@ -117,9 +119,16 @@ pub async fn connect_remote_tunnel(
             AsterError::validation_error(format!("upgrade reverse tunnel websocket: {error}"))
         })?;
     let stream = stream.max_frame_size(REMOTE_TUNNEL_STREAM_FRAME_LIMIT);
+    let shutdown_token = shutdown_token.get_ref().clone();
     actix_web::rt::spawn(async move {
-        if let Err(error) =
-            tunnel::connect_stream(state.get_ref(), remote_node, session, stream).await
+        if let Err(error) = tunnel::connect_stream(
+            state.get_ref(),
+            remote_node,
+            session,
+            stream,
+            shutdown_token,
+        )
+        .await
         {
             tracing::warn!("reverse tunnel streaming connection ended with error: {error}");
         }

--- a/src/storage/remote_protocol/tunnel/client.rs
+++ b/src/storage/remote_protocol/tunnel/client.rs
@@ -39,6 +39,7 @@ const FOLLOWER_TUNNEL_BASE_BACKOFF: Duration = Duration::from_secs(1);
 const FOLLOWER_TUNNEL_MAX_BACKOFF: Duration = Duration::from_secs(30);
 const FOLLOWER_TUNNEL_RECONCILE_INTERVAL: Duration = Duration::from_secs(30);
 const FOLLOWER_TUNNEL_WORKER_JOIN_TIMEOUT: Duration = Duration::from_secs(5);
+const FOLLOWER_TUNNEL_CLOSE_HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(2);
 const FOLLOWER_TUNNEL_CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
 const FOLLOWER_TUNNEL_READ_TIMEOUT: Duration = Duration::from_secs(30);
 const FOLLOWER_TUNNEL_OPERATION_TIMEOUT: Duration = Duration::from_secs(60 * 60);
@@ -55,6 +56,34 @@ struct BindingTunnelWorker {
 enum StreamRequestOutcome {
     Completed,
     Shutdown,
+    PeerClosed,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RequestBodyReadOutcome {
+    End,
+    RemoteCancelled,
+    PeerClosed,
+}
+
+#[derive(Debug, Default)]
+struct RetryWarningState {
+    reported: bool,
+}
+
+impl RetryWarningState {
+    fn record_failure(&mut self) -> bool {
+        if self.reported {
+            false
+        } else {
+            self.reported = true;
+            true
+        }
+    }
+
+    fn record_success(&mut self) -> bool {
+        std::mem::take(&mut self.reported)
+    }
 }
 
 pub async fn run_follower_tunnel_worker(
@@ -211,6 +240,7 @@ async fn run_binding_poll_loop(
     shutdown_token: CancellationToken,
 ) {
     let mut backoff = FOLLOWER_TUNNEL_BASE_BACKOFF;
+    let mut warning_state = RetryWarningState::default();
     loop {
         let result = tokio::select! {
             biased;
@@ -220,22 +250,37 @@ async fn run_binding_poll_loop(
 
         match result {
             Ok(()) => {
+                if warning_state.record_success() {
+                    tracing::info!(
+                        binding_id = binding.id,
+                        master_url = %binding.master_url,
+                        "reverse tunnel polling connection recovered"
+                    );
+                }
                 backoff = FOLLOWER_TUNNEL_BASE_BACKOFF;
             }
             Err(error) => {
                 if let Err(mark_error) = mark_tunnel_error(&client, &binding, error.message()).await
                 {
-                    tracing::warn!(
+                    tracing::debug!(
                         binding_id = binding.id,
                         master_url = %binding.master_url,
                         "failed to report reverse tunnel error to primary: {mark_error}"
                     );
                 }
-                tracing::warn!(
-                    binding_id = binding.id,
-                    master_url = %binding.master_url,
-                    "reverse tunnel poll failed: {error}"
-                );
+                if warning_state.record_failure() {
+                    tracing::warn!(
+                        binding_id = binding.id,
+                        master_url = %binding.master_url,
+                        "reverse tunnel polling connection unavailable; retrying: {error}"
+                    );
+                } else {
+                    tracing::debug!(
+                        binding_id = binding.id,
+                        master_url = %binding.master_url,
+                        "reverse tunnel poll retry failed: {error}"
+                    );
+                }
                 tokio::select! {
                     biased;
                     _ = shutdown_token.cancelled() => break,
@@ -331,24 +376,44 @@ async fn run_binding_stream_lane_loop(
     shutdown_token: CancellationToken,
 ) {
     let mut backoff = FOLLOWER_TUNNEL_BASE_BACKOFF;
+    let mut warning_state = RetryWarningState::default();
     loop {
-        let result = tokio::select! {
-            biased;
-            _ = shutdown_token.cancelled() => break,
-            result = connect_stream_lane_once(&client, &binding, &local_base_url, lane_index, &shutdown_token) => result,
-        };
+        if shutdown_token.is_cancelled() {
+            break;
+        }
+        let result = connect_stream_lane_once(
+            &client,
+            &binding,
+            &local_base_url,
+            lane_index,
+            &shutdown_token,
+            &mut warning_state,
+        )
+        .await;
+        if shutdown_token.is_cancelled() {
+            break;
+        }
 
         match result {
             Ok(()) => {
+                warning_state.record_success();
                 backoff = FOLLOWER_TUNNEL_BASE_BACKOFF;
             }
             Err(error) => {
-                tracing::warn!(
-                    binding_id = binding.id,
-                    master_url = %binding.master_url,
-                    lane_index,
-                    "reverse tunnel streaming lane failed: {error}"
-                );
+                if lane_index == 0 && warning_state.record_failure() {
+                    tracing::warn!(
+                        binding_id = binding.id,
+                        master_url = %binding.master_url,
+                        "reverse tunnel streaming connection unavailable; retrying: {error}"
+                    );
+                } else {
+                    tracing::debug!(
+                        binding_id = binding.id,
+                        master_url = %binding.master_url,
+                        lane_index,
+                        "reverse tunnel streaming lane retry failed: {error}"
+                    );
+                }
                 tokio::select! {
                     biased;
                     _ = shutdown_token.cancelled() => break,
@@ -392,10 +457,16 @@ async fn connect_stream_lane_once(
     local_base_url: &str,
     lane_index: usize,
     shutdown_token: &CancellationToken,
+    warning_state: &mut RetryWarningState,
 ) -> Result<()> {
     let connect_url = stream_connect_url(&binding.master_url)?;
     let request = signed_master_ws_request(binding, &connect_url)?;
-    let (ws, _) = connect_async(request).await.map_err(|error| {
+    let connected = tokio::select! {
+        biased;
+        _ = shutdown_token.cancelled() => return Ok(()),
+        result = connect_async(request) => result,
+    };
+    let (ws, _) = connected.map_err(|error| {
         crate::errors::storage_driver_error(
             StorageErrorKind::Transient,
             format!("connect reverse tunnel streaming lane: {error}"),
@@ -407,6 +478,13 @@ async fn connect_stream_lane_once(
         lane_index,
         "reverse tunnel streaming lane connected"
     );
+    if lane_index == 0 && warning_state.record_success() {
+        tracing::info!(
+            binding_id = binding.id,
+            master_url = %binding.master_url,
+            "reverse tunnel streaming connection recovered"
+        );
+    }
 
     let (mut write, mut read) = ws.split();
     loop {
@@ -490,6 +568,7 @@ where
             close_stream_lane(write, read).await?;
             Ok(false)
         }
+        StreamRequestOutcome::PeerClosed => Ok(false),
     }
 }
 
@@ -506,7 +585,7 @@ where
             format!("close reverse tunnel streaming lane: {error}"),
         )
     })?;
-    let _ = tokio::time::timeout(FOLLOWER_TUNNEL_WORKER_JOIN_TIMEOUT, async {
+    let _ = tokio::time::timeout(FOLLOWER_TUNNEL_CLOSE_HANDSHAKE_TIMEOUT, async {
         while let Some(message) = read.next().await {
             match message {
                 Ok(WsMessage::Close(_)) | Err(_) => break,
@@ -528,6 +607,29 @@ where
             format!("acknowledge reverse tunnel streaming lane close: {error}"),
         )
     })
+}
+
+async fn handle_stream_control_message<W>(message: WsMessage, write: &mut W) -> Result<bool>
+where
+    W: futures::Sink<WsMessage, Error = tokio_tungstenite::tungstenite::Error> + Unpin,
+{
+    match message {
+        WsMessage::Ping(bytes) => {
+            write.send(WsMessage::Pong(bytes)).await.map_err(|error| {
+                crate::errors::storage_driver_error(
+                    StorageErrorKind::Transient,
+                    format!("pong reverse tunnel streaming lane: {error}"),
+                )
+            })?;
+            Ok(true)
+        }
+        WsMessage::Pong(_) => Ok(true),
+        WsMessage::Close(_) => {
+            acknowledge_stream_lane_close(write).await?;
+            Ok(false)
+        }
+        _ => Ok(true),
+    }
 }
 
 async fn execute_stream_tunnel_request<R, W>(
@@ -561,13 +663,7 @@ where
             FORBIDDEN_TUNNEL_TARGET_BODY,
         )
         .await?;
-        let drain_result = tokio::select! {
-            biased;
-            _ = shutdown_token.cancelled() => return Ok(StreamRequestOutcome::Shutdown),
-            result = drain_stream_request_body(&request_id, read) => result,
-        };
-        drain_result?;
-        return Ok(StreamRequestOutcome::Completed);
+        return drain_stream_request_body(&request_id, read, write, shutdown_token).await;
     }
 
     let method = Method::from_bytes(method.as_bytes()).map_err(|error| {
@@ -628,9 +724,11 @@ where
                             }
                             RemoteTunnelStreamFrameKind::RequestEnd => {
                                 body_tx = None;
-                                return Ok(false);
+                                return Ok(RequestBodyReadOutcome::End);
                             }
-                            RemoteTunnelStreamFrameKind::Error => return Ok(true),
+                            RemoteTunnelStreamFrameKind::Error => {
+                                return Ok(RequestBodyReadOutcome::RemoteCancelled);
+                            }
                             _ => {
                                 return Err(AsterError::validation_error(
                                     "unexpected reverse tunnel streaming request body frame",
@@ -638,22 +736,15 @@ where
                             }
                         }
                     }
-                    WsMessage::Ping(bytes) => {
-                        write.send(WsMessage::Pong(bytes)).await.map_err(|error| {
-                            crate::errors::storage_driver_error(
-                                StorageErrorKind::Transient,
-                                format!("pong reverse tunnel streaming request body: {error}"),
-                            )
-                        })?;
-                    }
-                    WsMessage::Pong(_) => {}
                     WsMessage::Close(_) => {
-                        return Err(crate::errors::storage_driver_error(
-                            StorageErrorKind::Transient,
-                            "reverse tunnel streaming lane closed during request",
-                        ));
+                        acknowledge_stream_lane_close(write).await?;
+                        return Ok(RequestBodyReadOutcome::PeerClosed);
                     }
-                    _ => {}
+                    message => {
+                        if !handle_stream_control_message(message, write).await? {
+                            return Ok(RequestBodyReadOutcome::PeerClosed);
+                        }
+                    }
                 }
             }
         } => Some(result),
@@ -664,7 +755,13 @@ where
             let _ = response_task.await;
             return Ok(StreamRequestOutcome::Shutdown);
         }
-        Some(Ok(remote_cancelled)) => remote_cancelled,
+        Some(Ok(RequestBodyReadOutcome::End)) => false,
+        Some(Ok(RequestBodyReadOutcome::RemoteCancelled)) => true,
+        Some(Ok(RequestBodyReadOutcome::PeerClosed)) => {
+            response_task.abort();
+            let _ = response_task.await;
+            return Ok(StreamRequestOutcome::PeerClosed);
+        }
         Some(Err(error)) => {
             response_task.abort();
             let _ = response_task.await;
@@ -678,14 +775,41 @@ where
     }
     drop(body_tx);
 
-    let response_result = tokio::select! {
-        biased;
-        _ = shutdown_token.cancelled() => {
-            response_task.abort();
-            let _ = response_task.await;
-            return Ok(StreamRequestOutcome::Shutdown);
+    let mut read_open = true;
+    let response_result = loop {
+        tokio::select! {
+            biased;
+            _ = shutdown_token.cancelled() => {
+                response_task.abort();
+                let _ = response_task.await;
+                return Ok(StreamRequestOutcome::Shutdown);
+            }
+            result = &mut response_task => break result,
+            message = read.next(), if read_open => {
+                let Some(message) = message else {
+                    read_open = false;
+                    continue;
+                };
+                let message = message.map_err(|error| {
+                    crate::errors::storage_driver_error(
+                        StorageErrorKind::Transient,
+                        format!("read reverse tunnel streaming lane control frame: {error}"),
+                    )
+                })?;
+                if let WsMessage::Binary(_) = message {
+                    response_task.abort();
+                    let _ = response_task.await;
+                    return Err(AsterError::validation_error(
+                        "reverse tunnel streaming lane received interleaved request while waiting for local response",
+                    ));
+                }
+                if !handle_stream_control_message(message, write).await? {
+                    response_task.abort();
+                    let _ = response_task.await;
+                    return Ok(StreamRequestOutcome::PeerClosed);
+                }
+            }
         }
-        result = &mut response_task => result,
     };
     let response = match response_result {
         Ok(Ok(response)) => response,
@@ -712,24 +836,29 @@ where
             return Ok(StreamRequestOutcome::Completed);
         }
     };
-    tokio::select! {
-        biased;
-        _ = shutdown_token.cancelled() => Ok(StreamRequestOutcome::Shutdown),
-        result = send_stream_response(write, &request_id, response) => {
-            result.map(|()| StreamRequestOutcome::Completed)
-        }
-    }
+    send_stream_response(read, write, &request_id, response, shutdown_token).await
 }
 
-async fn drain_stream_request_body<R>(request_id: &str, read: &mut R) -> Result<()>
+async fn drain_stream_request_body<R, W>(
+    request_id: &str,
+    read: &mut R,
+    write: &mut W,
+    shutdown_token: &CancellationToken,
+) -> Result<StreamRequestOutcome>
 where
     R: futures::Stream<
             Item = std::result::Result<WsMessage, tokio_tungstenite::tungstenite::Error>,
         > + Unpin,
+    W: futures::Sink<WsMessage, Error = tokio_tungstenite::tungstenite::Error> + Unpin,
 {
     loop {
-        let Some(message) = read.next().await else {
-            return Ok(());
+        let message = tokio::select! {
+            biased;
+            _ = shutdown_token.cancelled() => return Ok(StreamRequestOutcome::Shutdown),
+            message = read.next() => message,
+        };
+        let Some(message) = message else {
+            return Ok(StreamRequestOutcome::Completed);
         };
         let message = message.map_err(|error| {
             crate::errors::storage_driver_error(
@@ -738,6 +867,9 @@ where
             )
         })?;
         let WsMessage::Binary(bytes) = message else {
+            if !handle_stream_control_message(message, write).await? {
+                return Ok(StreamRequestOutcome::PeerClosed);
+            }
             continue;
         };
         let frame = decode_stream_frame(bytes)?;
@@ -748,7 +880,7 @@ where
         }
         match frame.kind {
             RemoteTunnelStreamFrameKind::RequestEnd | RemoteTunnelStreamFrameKind::Error => {
-                return Ok(());
+                return Ok(StreamRequestOutcome::Completed);
             }
             RemoteTunnelStreamFrameKind::RequestBody => {}
             _ => {
@@ -809,12 +941,17 @@ where
     .await
 }
 
-async fn send_stream_response<W>(
+async fn send_stream_response<R, W>(
+    read: &mut R,
     write: &mut W,
     request_id: &str,
     response: reqwest::Response,
-) -> Result<()>
+    shutdown_token: &CancellationToken,
+) -> Result<StreamRequestOutcome>
 where
+    R: futures::Stream<
+            Item = std::result::Result<WsMessage, tokio_tungstenite::tungstenite::Error>,
+        > + Unpin,
     W: futures::Sink<WsMessage, Error = tokio_tungstenite::tungstenite::Error> + Unpin,
 {
     let status = response.status();
@@ -836,17 +973,45 @@ where
     .await?;
 
     let mut stream = response.bytes_stream();
-    while let Some(chunk) = stream.next().await {
-        let chunk = chunk.map_err(|error| {
-            crate::errors::storage_driver_error(
-                StorageErrorKind::Transient,
-                format!("read reverse tunnel streaming local response body: {error}"),
-            )
-        })?;
-        if chunk.is_empty() {
-            continue;
+    let mut read_open = true;
+    loop {
+        tokio::select! {
+            biased;
+            _ = shutdown_token.cancelled() => return Ok(StreamRequestOutcome::Shutdown),
+            message = read.next(), if read_open => {
+                let Some(message) = message else {
+                    read_open = false;
+                    continue;
+                };
+                let message = message.map_err(|error| {
+                    crate::errors::storage_driver_error(
+                        StorageErrorKind::Transient,
+                        format!("read reverse tunnel streaming lane control frame: {error}"),
+                    )
+                })?;
+                if let WsMessage::Binary(_) = message {
+                    return Err(AsterError::validation_error(
+                        "reverse tunnel streaming lane received interleaved request while sending local response",
+                    ));
+                }
+                if !handle_stream_control_message(message, write).await? {
+                    return Ok(StreamRequestOutcome::PeerClosed);
+                }
+            }
+            chunk = stream.next() => {
+                let Some(chunk) = chunk else { break; };
+                let chunk = chunk.map_err(|error| {
+                    crate::errors::storage_driver_error(
+                        StorageErrorKind::Transient,
+                        format!("read reverse tunnel streaming local response body: {error}"),
+                    )
+                })?;
+                if chunk.is_empty() {
+                    continue;
+                }
+                send_stream_body_chunks(write, request_id, chunk).await?;
+            }
         }
-        send_stream_body_chunks(write, request_id, chunk).await?;
     }
 
     send_stream_frame(
@@ -863,7 +1028,8 @@ where
             body: Bytes::new(),
         },
     )
-    .await
+    .await?;
+    Ok(StreamRequestOutcome::Completed)
 }
 
 async fn send_stream_frame<W>(write: &mut W, frame: RemoteTunnelStreamFrame) -> Result<()>
@@ -1169,9 +1335,9 @@ fn binding_needs_reverse_tunnel(binding: &master_binding::Model) -> bool {
 #[cfg(test)]
 mod tests {
     use super::{
-        BindingTunnelWorker, StreamRequestOutcome, acknowledge_stream_lane_close,
-        binding_needs_reverse_tunnel, binding_worker_fingerprint, close_stream_lane,
-        ensure_binding_worker, execute_stream_tunnel_request,
+        BindingTunnelWorker, RetryWarningState, StreamRequestOutcome,
+        acknowledge_stream_lane_close, binding_needs_reverse_tunnel, binding_worker_fingerprint,
+        close_stream_lane, ensure_binding_worker, execute_stream_tunnel_request,
         execute_stream_tunnel_request_or_close, is_allowed_tunnel_target, signed_master_ws_request,
         stop_all_binding_workers, stop_binding_tunnel_tasks, stream_connect_url,
     };
@@ -1685,6 +1851,17 @@ mod tests {
         assert!(matches!(rx.recv().await, Some(WsMessage::Close(None))));
     }
 
+    #[test]
+    fn retry_warning_state_reports_once_until_recovery() {
+        let mut state = RetryWarningState::default();
+
+        assert!(state.record_failure());
+        assert!(!state.record_failure());
+        assert!(state.record_success());
+        assert!(!state.record_success());
+        assert!(state.record_failure());
+    }
+
     #[tokio::test]
     async fn peer_close_flushes_automatic_reply_without_sending_another_close() {
         let (tx, mut rx) = mpsc::unbounded_channel();
@@ -1695,6 +1872,37 @@ mod tests {
             .expect("peer close reply should flush cleanly");
 
         assert!(rx.try_recv().is_err());
+    }
+
+    #[tokio::test]
+    async fn peer_close_during_request_is_a_clean_lane_shutdown() {
+        let client = reqwest::Client::builder()
+            .no_proxy()
+            .build()
+            .expect("test client should build without proxy");
+        let (read_tx, mut read) = websocket_channel_stream();
+        read_tx
+            .send(WsMessage::Close(None))
+            .expect("peer close should be delivered");
+        let (mut write, mut written_rx) = channel_sink();
+
+        let outcome = execute_stream_tunnel_request_or_close(
+            &client,
+            "http://127.0.0.1:9",
+            request_start_frame(
+                "peer-close-during-request",
+                "PUT",
+                "/api/v1/internal/storage/objects/peer-close.bin",
+            ),
+            &mut read,
+            &mut write,
+            &CancellationToken::new(),
+        )
+        .await
+        .expect("peer close should not become a lane error");
+
+        assert!(!outcome);
+        assert!(written_rx.try_recv().is_err());
     }
 
     #[tokio::test]

--- a/src/storage/remote_protocol/tunnel/client.rs
+++ b/src/storage/remote_protocol/tunnel/client.rs
@@ -226,13 +226,13 @@ async fn run_binding_poll_loop(
                 if let Err(mark_error) = mark_tunnel_error(&client, &binding, error.message()).await
                 {
                     tracing::warn!(
-                        access_key = %binding.access_key,
+                        binding_id = binding.id,
                         master_url = %binding.master_url,
                         "failed to report reverse tunnel error to primary: {mark_error}"
                     );
                 }
                 tracing::warn!(
-                    access_key = %binding.access_key,
+                    binding_id = binding.id,
                     master_url = %binding.master_url,
                     "reverse tunnel poll failed: {error}"
                 );
@@ -344,7 +344,7 @@ async fn run_binding_stream_lane_loop(
             }
             Err(error) => {
                 tracing::warn!(
-                    access_key = %binding.access_key,
+                    binding_id = binding.id,
                     master_url = %binding.master_url,
                     lane_index,
                     "reverse tunnel streaming lane failed: {error}"
@@ -402,7 +402,7 @@ async fn connect_stream_lane_once(
         )
     })?;
     tracing::debug!(
-        access_key = %binding.access_key,
+        binding_id = binding.id,
         master_url = %binding.master_url,
         lane_index,
         "reverse tunnel streaming lane connected"
@@ -439,7 +439,10 @@ async fn connect_stream_lane_once(
                 continue;
             }
             WsMessage::Pong(_) => continue,
-            WsMessage::Close(_) => break,
+            WsMessage::Close(_) => {
+                acknowledge_stream_lane_close(&mut write).await?;
+                break;
+            }
             _ => continue,
         };
         if frame.kind != RemoteTunnelStreamFrameKind::RequestStart {
@@ -513,6 +516,18 @@ where
     })
     .await;
     Ok(())
+}
+
+async fn acknowledge_stream_lane_close<W>(write: &mut W) -> Result<()>
+where
+    W: futures::Sink<WsMessage, Error = tokio_tungstenite::tungstenite::Error> + Unpin,
+{
+    write.flush().await.map_err(|error| {
+        crate::errors::storage_driver_error(
+            StorageErrorKind::Transient,
+            format!("acknowledge reverse tunnel streaming lane close: {error}"),
+        )
+    })
 }
 
 async fn execute_stream_tunnel_request<R, W>(
@@ -1154,11 +1169,11 @@ fn binding_needs_reverse_tunnel(binding: &master_binding::Model) -> bool {
 #[cfg(test)]
 mod tests {
     use super::{
-        BindingTunnelWorker, StreamRequestOutcome, binding_needs_reverse_tunnel,
-        binding_worker_fingerprint, close_stream_lane, ensure_binding_worker,
-        execute_stream_tunnel_request, execute_stream_tunnel_request_or_close,
-        is_allowed_tunnel_target, signed_master_ws_request, stop_all_binding_workers,
-        stop_binding_tunnel_tasks, stream_connect_url,
+        BindingTunnelWorker, StreamRequestOutcome, acknowledge_stream_lane_close,
+        binding_needs_reverse_tunnel, binding_worker_fingerprint, close_stream_lane,
+        ensure_binding_worker, execute_stream_tunnel_request,
+        execute_stream_tunnel_request_or_close, is_allowed_tunnel_target, signed_master_ws_request,
+        stop_all_binding_workers, stop_binding_tunnel_tasks, stream_connect_url,
     };
     use crate::storage::remote_protocol::tunnel::server::{
         RemoteTunnelStreamFrame, RemoteTunnelStreamFrameKind, decode_stream_frame,
@@ -1668,6 +1683,18 @@ mod tests {
             .expect("stream lane should close cleanly");
 
         assert!(matches!(rx.recv().await, Some(WsMessage::Close(None))));
+    }
+
+    #[tokio::test]
+    async fn peer_close_flushes_automatic_reply_without_sending_another_close() {
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let mut sink = ChannelSink { tx };
+
+        acknowledge_stream_lane_close(&mut sink)
+            .await
+            .expect("peer close reply should flush cleanly");
+
+        assert!(rx.try_recv().is_err());
     }
 
     #[tokio::test]

--- a/src/storage/remote_protocol/tunnel/client.rs
+++ b/src/storage/remote_protocol/tunnel/client.rs
@@ -28,10 +28,17 @@ use bytes::Bytes;
 use futures::{SinkExt, StreamExt};
 use reqwest::Method;
 use std::collections::HashMap;
+use std::sync::{
+    Arc,
+    atomic::{AtomicBool, Ordering},
+};
 use std::time::Duration;
 use tokio::task::{JoinHandle, JoinSet};
 use tokio_tungstenite::tungstenite::client::IntoClientRequest;
-use tokio_tungstenite::{connect_async, tungstenite::protocol::Message as WsMessage};
+use tokio_tungstenite::{
+    connect_async,
+    tungstenite::protocol::{Message as WsMessage, frame::coding::CloseCode},
+};
 use tokio_util::sync::CancellationToken;
 
 const FOLLOWER_TUNNEL_STREAM_LANES: usize = 4;
@@ -57,6 +64,32 @@ enum StreamRequestOutcome {
     Completed,
     Shutdown,
     PeerClosed,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum StreamLaneExit {
+    Reconnect,
+    PrimaryShutdown,
+    Shutdown,
+}
+
+#[derive(Debug, Default)]
+struct BindingConnectionState {
+    primary_shutdown: AtomicBool,
+}
+
+impl BindingConnectionState {
+    fn mark_primary_shutdown(&self) {
+        self.primary_shutdown.store(true, Ordering::Release);
+    }
+
+    fn is_primary_shutdown(&self) -> bool {
+        self.primary_shutdown.load(Ordering::Acquire)
+    }
+
+    fn mark_available(&self) -> bool {
+        self.primary_shutdown.swap(false, Ordering::AcqRel)
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -238,6 +271,7 @@ async fn run_binding_poll_loop(
     binding: master_binding::Model,
     local_base_url: String,
     shutdown_token: CancellationToken,
+    connection_state: Arc<BindingConnectionState>,
 ) {
     let mut backoff = FOLLOWER_TUNNEL_BASE_BACKOFF;
     let mut warning_state = RetryWarningState::default();
@@ -250,11 +284,19 @@ async fn run_binding_poll_loop(
 
         match result {
             Ok(()) => {
+                let primary_recovered = connection_state.mark_available();
                 if warning_state.record_success() {
                     tracing::info!(
                         binding_id = binding.id,
                         master_url = %binding.master_url,
                         "reverse tunnel polling connection recovered"
+                    );
+                }
+                if primary_recovered {
+                    tracing::info!(
+                        binding_id = binding.id,
+                        master_url = %binding.master_url,
+                        "reverse tunnel primary connection recovered"
                     );
                 }
                 backoff = FOLLOWER_TUNNEL_BASE_BACKOFF;
@@ -268,7 +310,13 @@ async fn run_binding_poll_loop(
                         "failed to report reverse tunnel error to primary: {mark_error}"
                     );
                 }
-                if warning_state.record_failure() {
+                if connection_state.is_primary_shutdown() {
+                    tracing::debug!(
+                        binding_id = binding.id,
+                        master_url = %binding.master_url,
+                        "reverse tunnel poll retry deferred during primary shutdown: {error}"
+                    );
+                } else if warning_state.record_failure() {
                     tracing::warn!(
                         binding_id = binding.id,
                         master_url = %binding.master_url,
@@ -299,12 +347,14 @@ async fn run_binding_tunnel_loop(
     shutdown_token: CancellationToken,
 ) {
     let task_shutdown = shutdown_token.child_token();
+    let connection_state = Arc::new(BindingConnectionState::default());
     let mut tasks = JoinSet::new();
     for lane_index in 0..FOLLOWER_TUNNEL_STREAM_LANES {
         let lane_client = client.clone();
         let lane_binding = binding.clone();
         let lane_base_url = local_base_url.clone();
         let lane_shutdown = task_shutdown.child_token();
+        let lane_connection_state = connection_state.clone();
         tasks.spawn(async move {
             run_binding_stream_lane_loop(
                 lane_client,
@@ -312,6 +362,7 @@ async fn run_binding_tunnel_loop(
                 lane_base_url,
                 lane_index,
                 lane_shutdown,
+                lane_connection_state,
             )
             .await;
         });
@@ -321,8 +372,16 @@ async fn run_binding_tunnel_loop(
     let poll_client = client.clone();
     let poll_binding = binding;
     let poll_base_url = local_base_url;
+    let poll_connection_state = connection_state;
     tasks.spawn(async move {
-        run_binding_poll_loop(poll_client, poll_binding, poll_base_url, poll_shutdown).await;
+        run_binding_poll_loop(
+            poll_client,
+            poll_binding,
+            poll_base_url,
+            poll_shutdown,
+            poll_connection_state,
+        )
+        .await;
     });
 
     tokio::select! {
@@ -374,6 +433,7 @@ async fn run_binding_stream_lane_loop(
     local_base_url: String,
     lane_index: usize,
     shutdown_token: CancellationToken,
+    connection_state: Arc<BindingConnectionState>,
 ) {
     let mut backoff = FOLLOWER_TUNNEL_BASE_BACKOFF;
     let mut warning_state = RetryWarningState::default();
@@ -388,6 +448,7 @@ async fn run_binding_stream_lane_loop(
             lane_index,
             &shutdown_token,
             &mut warning_state,
+            &connection_state,
         )
         .await;
         if shutdown_token.is_cancelled() {
@@ -395,12 +456,36 @@ async fn run_binding_stream_lane_loop(
         }
 
         match result {
-            Ok(()) => {
+            Ok(StreamLaneExit::PrimaryShutdown) => {
+                connection_state.mark_primary_shutdown();
+                if lane_index == 0 {
+                    tracing::info!(
+                        binding_id = binding.id,
+                        master_url = %binding.master_url,
+                        "reverse tunnel primary requested shutdown; deferring reconnect"
+                    );
+                }
+                tokio::select! {
+                    biased;
+                    _ = shutdown_token.cancelled() => break,
+                    _ = tokio::time::sleep(FOLLOWER_TUNNEL_RECONCILE_INTERVAL) => {}
+                }
+                backoff = FOLLOWER_TUNNEL_BASE_BACKOFF;
+            }
+            Ok(StreamLaneExit::Shutdown) => break,
+            Ok(StreamLaneExit::Reconnect) => {
                 warning_state.record_success();
                 backoff = FOLLOWER_TUNNEL_BASE_BACKOFF;
             }
             Err(error) => {
-                if lane_index == 0 && warning_state.record_failure() {
+                if connection_state.is_primary_shutdown() {
+                    tracing::debug!(
+                        binding_id = binding.id,
+                        master_url = %binding.master_url,
+                        lane_index,
+                        "reverse tunnel streaming retry deferred during primary shutdown: {error}"
+                    );
+                } else if lane_index == 0 && warning_state.record_failure() {
                     tracing::warn!(
                         binding_id = binding.id,
                         master_url = %binding.master_url,
@@ -458,12 +543,13 @@ async fn connect_stream_lane_once(
     lane_index: usize,
     shutdown_token: &CancellationToken,
     warning_state: &mut RetryWarningState,
-) -> Result<()> {
+    connection_state: &BindingConnectionState,
+) -> Result<StreamLaneExit> {
     let connect_url = stream_connect_url(&binding.master_url)?;
     let request = signed_master_ws_request(binding, &connect_url)?;
     let connected = tokio::select! {
         biased;
-        _ = shutdown_token.cancelled() => return Ok(()),
+        _ = shutdown_token.cancelled() => return Ok(StreamLaneExit::Shutdown),
         result = connect_async(request) => result,
     };
     let (ws, _) = connected.map_err(|error| {
@@ -478,7 +564,9 @@ async fn connect_stream_lane_once(
         lane_index,
         "reverse tunnel streaming lane connected"
     );
-    if lane_index == 0 && warning_state.record_success() {
+    let primary_recovered = connection_state.mark_available();
+    let stream_recovered = lane_index == 0 && warning_state.record_success();
+    if primary_recovered || stream_recovered {
         tracing::info!(
             binding_id = binding.id,
             master_url = %binding.master_url,
@@ -492,12 +580,12 @@ async fn connect_stream_lane_once(
             biased;
             _ = shutdown_token.cancelled() => {
                 close_stream_lane(&mut write, &mut read).await?;
-                break;
+                return Ok(StreamLaneExit::Shutdown);
             },
             message = read.next() => message,
         };
         let Some(message) = message else {
-            break;
+            return Ok(StreamLaneExit::Reconnect);
         };
         let message = message.map_err(|error| {
             crate::errors::storage_driver_error(
@@ -517,9 +605,16 @@ async fn connect_stream_lane_once(
                 continue;
             }
             WsMessage::Pong(_) => continue,
-            WsMessage::Close(_) => {
+            WsMessage::Close(reason) => {
                 acknowledge_stream_lane_close(&mut write).await?;
-                break;
+                let primary_shutdown = reason.as_ref().is_some_and(|frame| {
+                    frame.code == CloseCode::Away && frame.reason == "primary shutdown"
+                });
+                return Ok(if primary_shutdown {
+                    StreamLaneExit::PrimaryShutdown
+                } else {
+                    StreamLaneExit::Reconnect
+                });
             }
             _ => continue,
         };
@@ -539,11 +634,9 @@ async fn connect_stream_lane_once(
         )
         .await?
         {
-            break;
+            return Ok(StreamLaneExit::Shutdown);
         }
     }
-
-    Ok(())
 }
 
 async fn execute_stream_tunnel_request_or_close<R, W>(
@@ -585,15 +678,27 @@ where
             format!("close reverse tunnel streaming lane: {error}"),
         )
     })?;
-    let _ = tokio::time::timeout(FOLLOWER_TUNNEL_CLOSE_HANDSHAKE_TIMEOUT, async {
+    let handshake = tokio::time::timeout(FOLLOWER_TUNNEL_CLOSE_HANDSHAKE_TIMEOUT, async {
         while let Some(message) = read.next().await {
             match message {
-                Ok(WsMessage::Close(_)) | Err(_) => break,
+                Ok(WsMessage::Close(_)) => return Ok(()),
+                Err(error) => return Err(error),
                 _ => {}
             }
         }
+        Ok(())
     })
     .await;
+    match handshake {
+        Ok(Ok(())) => {}
+        Ok(Err(error)) => {
+            tracing::warn!("reverse tunnel streaming lane close handshake read failed: {error}")
+        }
+        Err(_) => tracing::warn!(
+            timeout_secs = FOLLOWER_TUNNEL_CLOSE_HANDSHAKE_TIMEOUT.as_secs(),
+            "reverse tunnel streaming lane close handshake timed out"
+        ),
+    }
     Ok(())
 }
 

--- a/src/storage/remote_protocol/tunnel/server/mod.rs
+++ b/src/storage/remote_protocol/tunnel/server/mod.rs
@@ -8,7 +8,7 @@ use aster_drive_storage::StorageErrorKind;
 use chrono::Utc;
 use futures::StreamExt as _;
 use serde::Serialize;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 mod auth;
 mod frame;
@@ -52,7 +52,9 @@ pub const REMOTE_TUNNEL_COMPLETE_PATH: &str = "/api/v1/internal/remote-tunnel/co
 pub const REMOTE_TUNNEL_CONNECT_PATH: &str = "/api/v1/internal/remote-tunnel/connect";
 
 const REMOTE_TUNNEL_POLL_TIMEOUT: Duration = Duration::from_secs(25);
-const REMOTE_TUNNEL_STREAM_READ_TIMEOUT: Duration = Duration::from_secs(60);
+const REMOTE_TUNNEL_HEARTBEAT_INTERVAL: Duration = Duration::from_secs(15);
+const REMOTE_TUNNEL_HEARTBEAT_TIMEOUT: Duration = Duration::from_secs(45);
+const REMOTE_TUNNEL_CLOSE_HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(5);
 pub const REMOTE_TUNNEL_BODY_LIMIT: usize = 64 * 1024 * 1024;
 pub const REMOTE_TUNNEL_JSON_LIMIT: usize = REMOTE_TUNNEL_BODY_LIMIT * 2 + 1024 * 1024;
 pub const REMOTE_TUNNEL_POLL_METADATA_BUDGET: usize = 64 * 1024;
@@ -218,6 +220,10 @@ async fn run_connected_stream<S: RemoteProtocolRuntimeState>(
     let mut owner_renewal = tokio::time::interval(REMOTE_TUNNEL_OWNER_RENEW_INTERVAL);
     owner_renewal.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
     owner_renewal.tick().await;
+    let mut heartbeat = tokio::time::interval(REMOTE_TUNNEL_HEARTBEAT_INTERVAL);
+    heartbeat.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+    heartbeat.tick().await;
+    let mut liveness = TunnelHeartbeat::new(Instant::now());
 
     loop {
         tokio::select! {
@@ -228,9 +234,6 @@ async fn run_connected_stream<S: RemoteProtocolRuntimeState>(
                 };
                 match directory.renew(remote_node.id).await {
                     Ok(true) => {
-                        if session.ping(b"owner-renew".as_slice()).await.is_err() {
-                            break;
-                        }
                     }
                     Ok(false) => {
                         tracing::warn!(
@@ -250,19 +253,23 @@ async fn run_connected_stream<S: RemoteProtocolRuntimeState>(
                     }
                 }
             }
-            message = tokio::time::timeout(REMOTE_TUNNEL_STREAM_READ_TIMEOUT, stream.next()) => {
-                let Some(message) = (match message {
-                    Ok(message) => message,
-                    Err(_) => {
-                        tracing::warn!(
-                            remote_node_id = remote_node.id,
-                            lane_id = %lane_id,
-                            timeout_secs = REMOTE_TUNNEL_STREAM_READ_TIMEOUT.as_secs(),
-                            "reverse tunnel streaming lane timed out waiting for follower frames"
-                        );
-                        break;
-                    }
-                }) else {
+            _ = heartbeat.tick() => {
+                let now = Instant::now();
+                if liveness.is_timed_out(now) {
+                    tracing::warn!(
+                        remote_node_id = remote_node.id,
+                        lane_id = %lane_id,
+                        timeout_secs = REMOTE_TUNNEL_HEARTBEAT_TIMEOUT.as_secs(),
+                        "reverse tunnel streaming lane heartbeat timed out waiting for follower activity"
+                    );
+                    break;
+                }
+                if session.ping(b"aster-tunnel-heartbeat").await.is_err() {
+                    break;
+                }
+            }
+            message = stream.next() => {
+                let Some(message) = message else {
                     break;
                 };
                 let message = match message {
@@ -278,6 +285,7 @@ async fn run_connected_stream<S: RemoteProtocolRuntimeState>(
                 };
                 match message {
                     actix_ws::Message::Binary(bytes) => {
+                        liveness.record_activity(Instant::now());
                         match decode_stream_frame(bytes) {
                             Ok(frame) => {
                                 registry.update_last_seen(remote_node.id);
@@ -306,9 +314,11 @@ async fn run_connected_stream<S: RemoteProtocolRuntimeState>(
                         if session.pong(&bytes).await.is_err() {
                             break;
                         }
+                        liveness.record_activity(Instant::now());
                         registry.update_last_seen(remote_node.id);
                     }
                     actix_ws::Message::Pong(_) => {
+                        liveness.record_activity(Instant::now());
                         registry.update_last_seen(remote_node.id);
                     }
                     actix_ws::Message::Close(_) => break,
@@ -327,7 +337,42 @@ async fn run_connected_stream<S: RemoteProtocolRuntimeState>(
         }
     }
 
+    close_connected_stream(session, stream).await;
     Ok(())
+}
+
+#[derive(Debug, Clone, Copy)]
+struct TunnelHeartbeat {
+    last_activity_at: Instant,
+}
+
+impl TunnelHeartbeat {
+    fn new(now: Instant) -> Self {
+        Self {
+            last_activity_at: now,
+        }
+    }
+
+    fn record_activity(&mut self, now: Instant) {
+        self.last_activity_at = now;
+    }
+
+    fn is_timed_out(&self, now: Instant) -> bool {
+        now.duration_since(self.last_activity_at) >= REMOTE_TUNNEL_HEARTBEAT_TIMEOUT
+    }
+}
+
+async fn close_connected_stream(session: actix_ws::Session, mut stream: actix_ws::MessageStream) {
+    let _ = session.close(None).await;
+    let _ = tokio::time::timeout(REMOTE_TUNNEL_CLOSE_HANDSHAKE_TIMEOUT, async {
+        while let Some(message) = stream.next().await {
+            match message {
+                Ok(actix_ws::Message::Close(_)) | Err(_) => break,
+                Ok(_) => {}
+            }
+        }
+    })
+    .await;
 }
 
 async fn claim_tunnel_ownership<S: RemoteProtocolRuntimeState>(

--- a/src/storage/remote_protocol/tunnel/server/mod.rs
+++ b/src/storage/remote_protocol/tunnel/server/mod.rs
@@ -211,6 +211,11 @@ async fn run_connected_stream<S: RemoteProtocolRuntimeState>(
 ) -> Result<()> {
     let registry = state.remote_protocol().tunnel_registry().clone();
     let (lane_id, mut request_rx, _registration) = registry.register_stream_lane(&remote_node);
+    tracing::info!(
+        remote_node_id = remote_node.id,
+        lane_id = %lane_id,
+        "reverse tunnel streaming lane connected"
+    );
     managed_follower_repo::touch_tunnel_result(
         state.writer_db(),
         remote_node.id,
@@ -301,7 +306,12 @@ async fn run_connected_stream<S: RemoteProtocolRuntimeState>(
                     );
                     break;
                 }
-                if session.ping(b"aster-tunnel-heartbeat").await.is_err() {
+                if let Err(error) = session.ping(b"aster-tunnel-heartbeat").await {
+                    tracing::warn!(
+                        remote_node_id = remote_node.id,
+                        lane_id = %lane_id,
+                        "failed to send reverse tunnel heartbeat ping: {error}"
+                    );
                     break;
                 }
             }
@@ -370,7 +380,7 @@ async fn run_connected_stream<S: RemoteProtocolRuntimeState>(
                     _ => {}
                 }
             }
-            frame = request_rx.recv(), if !draining => {
+            frame = request_rx.recv() => {
                 let Some(frame) = frame else {
                     break;
                 };
@@ -390,7 +400,21 @@ async fn run_connected_stream<S: RemoteProtocolRuntimeState>(
         }
     }
 
-    close_connected_stream(session, stream, remote_node.id, &lane_id).await;
+    close_connected_stream(
+        session,
+        stream,
+        remote_node.id,
+        &lane_id,
+        if shutdown_token.is_cancelled() {
+            Some(actix_ws::CloseReason {
+                code: actix_ws::CloseCode::Away,
+                description: Some("primary shutdown".to_string()),
+            })
+        } else {
+            None
+        },
+    )
+    .await;
     Ok(())
 }
 
@@ -420,8 +444,9 @@ async fn close_connected_stream(
     mut stream: actix_ws::MessageStream,
     remote_node_id: i64,
     lane_id: &str,
+    reason: Option<actix_ws::CloseReason>,
 ) {
-    if let Err(error) = session.close(None).await {
+    if let Err(error) = session.close(reason).await {
         tracing::warn!(
             remote_node_id,
             lane_id,

--- a/src/storage/remote_protocol/tunnel/server/mod.rs
+++ b/src/storage/remote_protocol/tunnel/server/mod.rs
@@ -9,6 +9,7 @@ use chrono::Utc;
 use futures::StreamExt as _;
 use serde::Serialize;
 use std::time::{Duration, Instant};
+use tokio_util::sync::CancellationToken;
 
 mod auth;
 mod frame;
@@ -55,6 +56,7 @@ const REMOTE_TUNNEL_POLL_TIMEOUT: Duration = Duration::from_secs(25);
 const REMOTE_TUNNEL_HEARTBEAT_INTERVAL: Duration = Duration::from_secs(15);
 const REMOTE_TUNNEL_HEARTBEAT_TIMEOUT: Duration = Duration::from_secs(45);
 const REMOTE_TUNNEL_CLOSE_HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(5);
+const REMOTE_TUNNEL_SHUTDOWN_DRAIN_TIMEOUT: Duration = Duration::from_secs(5);
 pub const REMOTE_TUNNEL_BODY_LIMIT: usize = 64 * 1024 * 1024;
 pub const REMOTE_TUNNEL_JSON_LIMIT: usize = REMOTE_TUNNEL_BODY_LIMIT * 2 + 1024 * 1024;
 pub const REMOTE_TUNNEL_POLL_METADATA_BUDGET: usize = 64 * 1024;
@@ -161,6 +163,7 @@ pub async fn connect_stream<S: RemoteProtocolRuntimeState>(
     remote_node: managed_follower::Model,
     session: actix_ws::Session,
     stream: actix_ws::MessageStream,
+    shutdown_token: CancellationToken,
 ) -> Result<()> {
     if !remote_node.is_enabled {
         return Err(AsterError::validation_error("remote node is disabled"));
@@ -177,6 +180,7 @@ pub async fn connect_stream<S: RemoteProtocolRuntimeState>(
             session,
             stream,
             owner_directory,
+            shutdown_token,
         ))
         .await
 }
@@ -203,6 +207,7 @@ async fn run_connected_stream<S: RemoteProtocolRuntimeState>(
     mut session: actix_ws::Session,
     mut stream: actix_ws::MessageStream,
     owner_directory: Option<std::sync::Arc<RemoteTunnelOwnerDirectory>>,
+    shutdown_token: CancellationToken,
 ) -> Result<()> {
     let registry = state.remote_protocol().tunnel_registry().clone();
     let (lane_id, mut request_rx, _registration) = registry.register_stream_lane(&remote_node);
@@ -224,10 +229,42 @@ async fn run_connected_stream<S: RemoteProtocolRuntimeState>(
     heartbeat.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
     heartbeat.tick().await;
     let mut liveness = TunnelHeartbeat::new(Instant::now());
+    let mut draining = false;
+    let mut drain_deadline = Box::pin(tokio::time::sleep(Duration::from_secs(24 * 60 * 60)));
 
     loop {
         tokio::select! {
             biased;
+            _ = shutdown_token.cancelled(), if !draining => {
+                draining = true;
+                if registry.stream_lane_is_busy(&remote_node, &lane_id) {
+                    tracing::info!(
+                        remote_node_id = remote_node.id,
+                        lane_id = %lane_id,
+                        timeout_secs = REMOTE_TUNNEL_SHUTDOWN_DRAIN_TIMEOUT.as_secs(),
+                        "reverse tunnel primary shutdown draining in-flight streaming request"
+                    );
+                    drain_deadline.as_mut().reset(
+                        tokio::time::Instant::now() + REMOTE_TUNNEL_SHUTDOWN_DRAIN_TIMEOUT,
+                    );
+                } else {
+                    tracing::info!(
+                        remote_node_id = remote_node.id,
+                        lane_id = %lane_id,
+                        "reverse tunnel streaming lane closing for primary shutdown"
+                    );
+                    break;
+                }
+            }
+            _ = &mut drain_deadline, if draining => {
+                tracing::warn!(
+                    remote_node_id = remote_node.id,
+                    lane_id = %lane_id,
+                    timeout_secs = REMOTE_TUNNEL_SHUTDOWN_DRAIN_TIMEOUT.as_secs(),
+                    "reverse tunnel shutdown drain timed out; closing streaming lane with in-flight request"
+                );
+                break;
+            }
             _ = owner_renewal.tick(), if owner_directory.is_some() => {
                 let Some(directory) = owner_directory.as_ref() else {
                     continue;
@@ -321,11 +358,19 @@ async fn run_connected_stream<S: RemoteProtocolRuntimeState>(
                         liveness.record_activity(Instant::now());
                         registry.update_last_seen(remote_node.id);
                     }
-                    actix_ws::Message::Close(_) => break,
+                    actix_ws::Message::Close(reason) => {
+                        tracing::info!(
+                            remote_node_id = remote_node.id,
+                            lane_id = %lane_id,
+                            close_reason = ?reason,
+                            "reverse tunnel streaming lane closed by follower"
+                        );
+                        break;
+                    }
                     _ => {}
                 }
             }
-            frame = request_rx.recv() => {
+            frame = request_rx.recv(), if !draining => {
                 let Some(frame) = frame else {
                     break;
                 };
@@ -335,9 +380,17 @@ async fn run_connected_stream<S: RemoteProtocolRuntimeState>(
                 }
             }
         }
+        if draining && !registry.stream_lane_is_busy(&remote_node, &lane_id) {
+            tracing::info!(
+                remote_node_id = remote_node.id,
+                lane_id = %lane_id,
+                "reverse tunnel streaming lane drained before primary shutdown"
+            );
+            break;
+        }
     }
 
-    close_connected_stream(session, stream).await;
+    close_connected_stream(session, stream, remote_node.id, &lane_id).await;
     Ok(())
 }
 
@@ -362,17 +415,45 @@ impl TunnelHeartbeat {
     }
 }
 
-async fn close_connected_stream(session: actix_ws::Session, mut stream: actix_ws::MessageStream) {
-    let _ = session.close(None).await;
-    let _ = tokio::time::timeout(REMOTE_TUNNEL_CLOSE_HANDSHAKE_TIMEOUT, async {
+async fn close_connected_stream(
+    session: actix_ws::Session,
+    mut stream: actix_ws::MessageStream,
+    remote_node_id: i64,
+    lane_id: &str,
+) {
+    if let Err(error) = session.close(None).await {
+        tracing::warn!(
+            remote_node_id,
+            lane_id,
+            "failed to send reverse tunnel streaming lane close frame: {error}"
+        );
+        return;
+    }
+    let handshake = tokio::time::timeout(REMOTE_TUNNEL_CLOSE_HANDSHAKE_TIMEOUT, async {
         while let Some(message) = stream.next().await {
             match message {
-                Ok(actix_ws::Message::Close(_)) | Err(_) => break,
+                Ok(actix_ws::Message::Close(_)) => return Ok(()),
+                Err(error) => return Err(error),
                 Ok(_) => {}
             }
         }
+        Ok(())
     })
     .await;
+    match handshake {
+        Ok(Ok(())) => {}
+        Ok(Err(error)) => tracing::warn!(
+            remote_node_id,
+            lane_id,
+            "reverse tunnel streaming lane close handshake read failed: {error}"
+        ),
+        Err(_) => tracing::warn!(
+            remote_node_id,
+            lane_id,
+            timeout_secs = REMOTE_TUNNEL_CLOSE_HANDSHAKE_TIMEOUT.as_secs(),
+            "reverse tunnel streaming lane close handshake timed out"
+        ),
+    }
 }
 
 async fn claim_tunnel_ownership<S: RemoteProtocolRuntimeState>(

--- a/src/storage/remote_protocol/tunnel/server/registry/streaming.rs
+++ b/src/storage/remote_protocol/tunnel/server/registry/streaming.rs
@@ -510,6 +510,23 @@ impl RemoteTunnelRegistry {
             .unwrap_or(false)
     }
 
+    pub(crate) fn stream_lane_is_busy(
+        &self,
+        remote_node: &managed_follower::Model,
+        lane_id: &str,
+    ) -> bool {
+        self.stream_lanes
+            .get(&remote_node.access_key)
+            .map(|lanes| {
+                lanes.iter().any(|lane| {
+                    lane.remote_node_id == remote_node.id
+                        && lane.lane_id == lane_id
+                        && lane.busy.load(Ordering::Acquire)
+                })
+            })
+            .unwrap_or(false)
+    }
+
     #[cfg(test)]
     pub(crate) fn has_pending_stream_response(&self, request_id: &str) -> bool {
         self.stream_pending.contains_key(request_id)

--- a/src/storage/remote_protocol/tunnel/server/tests.rs
+++ b/src/storage/remote_protocol/tunnel/server/tests.rs
@@ -7,7 +7,7 @@ use crate::storage::remote_protocol::{
 use bytes::Bytes;
 use http::{Method, StatusCode};
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use tokio::io::AsyncReadExt as _;
 
 fn build_remote_node(id: i64, access_key: &str) -> managed_follower::Model {
@@ -30,6 +30,26 @@ fn build_remote_node(id: i64, access_key: &str) -> managed_follower::Model {
         created_at: now,
         updated_at: now,
     }
+}
+
+#[test]
+fn tunnel_heartbeat_tracks_activity_and_missed_pongs() {
+    let started = Instant::now();
+    let mut heartbeat = TunnelHeartbeat::new(started);
+
+    for elapsed in [15, 30, 45, 60, 75].map(Duration::from_secs) {
+        let pong_at = started + elapsed;
+        assert!(!heartbeat.is_timed_out(pong_at));
+        heartbeat.record_activity(pong_at);
+    }
+
+    let last_pong_at = started + Duration::from_secs(75);
+    assert!(
+        !heartbeat.is_timed_out(
+            last_pong_at + REMOTE_TUNNEL_HEARTBEAT_TIMEOUT - Duration::from_millis(1)
+        )
+    );
+    assert!(heartbeat.is_timed_out(last_pong_at + REMOTE_TUNNEL_HEARTBEAT_TIMEOUT));
 }
 
 #[test]

--- a/src/storage/remote_protocol/tunnel/server/tests.rs
+++ b/src/storage/remote_protocol/tunnel/server/tests.rs
@@ -762,6 +762,63 @@ fn registry_tracks_stream_lane_until_registration_guard_drops() {
 }
 
 #[tokio::test]
+async fn registry_reports_stream_lane_busy_only_for_matching_in_flight_request() {
+    let registry = Arc::new(RemoteTunnelRegistry::new());
+    let node = build_remote_node(45, "stream-busy");
+    let (lane_id, mut request_rx, _guard) = registry.register_stream_lane(&node);
+    let send_handle = tokio::spawn({
+        let registry = registry.clone();
+        let node = node.clone();
+        async move {
+            registry
+                .send_stream(
+                    &node,
+                    Method::GET,
+                    "/api/v1/internal/storage/objects/busy.bin".to_string(),
+                    Some(0),
+                    Vec::new(),
+                    Box::new(std::io::Cursor::new(Bytes::new())),
+                )
+                .await
+        }
+    });
+
+    let start = request_rx
+        .recv()
+        .await
+        .expect("stream lane should receive request start");
+    assert!(registry.stream_lane_is_busy(&node, &lane_id));
+    assert!(!registry.stream_lane_is_busy(&node, "other-lane"));
+
+    let end = request_rx
+        .recv()
+        .await
+        .expect("stream lane should receive request end");
+    assert_eq!(end.kind, RemoteTunnelStreamFrameKind::RequestEnd);
+    registry
+        .complete_stream_frame(
+            &node,
+            &lane_id,
+            stream_response_start_frame(&start.request_id, StatusCode::OK),
+        )
+        .await
+        .expect("stream response start should complete");
+    registry
+        .complete_stream_frame(
+            &node,
+            &lane_id,
+            stream_response_end_frame(&start.request_id),
+        )
+        .await
+        .expect("stream response end should complete");
+    send_handle
+        .await
+        .expect("stream send task should join")
+        .expect("stream send should complete");
+    assert!(!registry.stream_lane_is_busy(&node, &lane_id));
+}
+
+#[tokio::test]
 async fn registry_stream_invalid_start_does_not_consume_pending_response() {
     let registry = Arc::new(RemoteTunnelRegistry::new());
     let node = build_remote_node(53, "stream-invalid-start");

--- a/tests/storage/remote_storage.rs
+++ b/tests/storage/remote_storage.rs
@@ -53,6 +53,7 @@ struct TestHttpServer {
     base_url: String,
     handle: actix_web::dev::ServerHandle,
     task: tokio::task::JoinHandle<std::io::Result<()>>,
+    shutdown_token: Option<CancellationToken>,
 }
 
 struct TestReverseTunnelHttpWorker {
@@ -87,6 +88,9 @@ impl RemotePolicyTransferOptions {
 
 impl TestHttpServer {
     async fn stop(self) {
+        if let Some(shutdown_token) = self.shutdown_token {
+            shutdown_token.cancel();
+        }
         self.handle.stop(true).await;
         let _ = self.task.await;
     }
@@ -125,6 +129,7 @@ async fn spawn_internal_storage_server_on_listener(
         base_url: format!("http://127.0.0.1:{}", addr.port()),
         handle,
         task,
+        shutdown_token: None,
     }
 }
 
@@ -156,11 +161,14 @@ async fn spawn_reverse_tunnel_primary_server(
         .local_addr()
         .expect("test reverse tunnel primary listener should expose local addr");
     let state_for_server = state.clone();
+    let shutdown_token = CancellationToken::new();
+    let shutdown_data = web::Data::new(shutdown_token.clone());
     let server = HttpServer::new(move || {
         App::new()
             .app_data(web::PayloadConfig::new(REMOTE_TUNNEL_JSON_LIMIT))
             .app_data(web::JsonConfig::default().limit(REMOTE_TUNNEL_JSON_LIMIT))
             .app_data(web::Data::new(state_for_server.clone()))
+            .app_data(shutdown_data.clone())
             .service(
                 web::scope("/api/v1")
                     .service(aster_drive::api::routes::remote_node_control::routes())
@@ -177,6 +185,7 @@ async fn spawn_reverse_tunnel_primary_server(
         base_url: format!("http://127.0.0.1:{}", addr.port()),
         handle,
         task,
+        shutdown_token: Some(shutdown_token),
     }
 }
 
@@ -217,6 +226,7 @@ async fn spawn_reverse_tunnel_poll_only_primary_server(
         base_url: format!("http://127.0.0.1:{}", addr.port()),
         handle,
         task,
+        shutdown_token: None,
     }
 }
 
@@ -255,6 +265,7 @@ async fn spawn_capabilities_server(capabilities: serde_json::Value) -> TestHttpS
         base_url: format!("http://127.0.0.1:{}", addr.port()),
         handle,
         task,
+        shutdown_token: None,
     }
 }
 
@@ -292,6 +303,7 @@ async fn spawn_counting_internal_storage_server(
             base_url: format!("http://127.0.0.1:{}", addr.port()),
             handle,
             task,
+            shutdown_token: None,
         },
         request_count,
     )


### PR DESCRIPTION
# Pull request

## Summary

- replace the 60-second business-frame read timeout with a shared WebSocket Ping/Pong liveness loop for standalone and cluster primaries
- close streaming lanes with a normal WebSocket closing handshake and acknowledge peer-initiated closes without sending a duplicate Close frame
- remove full remote binding access keys from follower tunnel logs and cover idle-over-60s, missed-heartbeat, and close behavior

## Test plan

- [ ] Not needed: documentation, metadata, or configuration-only change
- [x] Backend: `cargo check -j 4 --lib`
- [x] Backend: `cargo nextest run --profile ci --lib storage::remote_protocol::tunnel::client::tests`
- [x] Backend: `cargo nextest run --profile ci --lib storage::remote_protocol::tunnel::server::tests`
- [ ] Frontend: `bun run check`
- [ ] Frontend: `bun run build`
- [ ] Manual UI check for user-facing changes

## Notes for reviewers

- Database migrations: none
- Runtime configuration changes: none; heartbeat interval/timeout remain internal constants
- Deployment or upgrade notes: none

Fixes #542


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug 修复**
  * 优化反向隧道空闲连接保活与活动检测，及时清理失联连接。
  * 改进连接关闭握手及对端关闭处理，减少异常断开和重复响应。
  * 增加连接重试告警分级，降低重复日志干扰，并在恢复时提供提示。
  * 日志改用绑定标识，避免暴露敏感访问密钥信息。
  * 优化服务关闭时的请求排空，提升连接退出的可靠性。

* **测试**
  * 增加心跳、活动检测及连接关闭流程覆盖。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->