### PR TITLE
feat(auth): re-submit cross-layer auth flow state machine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **跨层认证 flow 状态机** — 登录、MFA、Passkey、OIDC/OAuth、外部认证邮箱恢复、注册激活、密码重置、邮箱变更、邀请接受和 session refresh 统一使用 typed flow lifecycle、transition guard、过期、取消、单次消费、attempt budget、replay 和 revision conflict 契约；保留现有强类型认证实体、公开 API envelope、cookie、redirect 和 session 行为，不引入万能 auth JSON 表。
+- **登录页状态与策略协调** — React 登录页收敛为单一 `AuthUiFlow` 顶层状态，由 command coordinator 统一处理 flow event、请求取消和 stale response；auth check、前端配置与 external provider 列表通过带 generation 的 policy coordinator 合并，URL 仅恢复带 TTL 的 typed flow reference。
+- **认证副作用边界** — primary login、MFA、external callback、recovery、invitation 和 refresh rotation 在 writer transaction / 条件更新完成后再执行 cookie、redirect、mail、audit 和 cache 副作用；运行时认证策略会在未完成 flow 的下一次推进时重新读取。
+
 - **站点标题首页导航** — 文件浏览器和分享页顶栏的站点标题通过客户端路由返回 `/`，管理后台顶栏返回 `/admin/overview`，并保留现有品牌资源、主题、响应式显示和可访问性语义。
 - **存储策略与策略组生命周期** — 首次 setup 创建的存储策略和默认策略组不再按固定 ID 作为永久系统对象；解除 blob、上传 session、策略组项以及用户/团队绑定等引用后可删除首条或最后一条默认策略，删除最后一个默认策略组会使系统回到 `needs_storage`，重新配置默认存储拓扑后恢复 `ready`，不会静默清空业务绑定。默认切换、删除与重新 setup 使用稳定数据库锁协调多 Primary，现有数据保护保持不变。
 - **存储策略凭据兼容层完成收口** — 移除 0.5.x 启动阶段的 legacy credential importer、connector legacy import hook、OneDrive 旧 OAuth 转换、deprecated credential entities / repositories，以及 `database-migrate` 的旧凭据复制与导入路径。当前运行时只消费 `connector_id`、typed `storage_config` 和 `storage_policy_connector_credentials`。
@@ -23,6 +27,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **跨数据库迁移边界** — `database-migrate` 只复制当前 policy envelope 与 connector credential；带有未迁移 legacy credential 的 source database 会在复制前拒绝，空的历史 legacy stores 不再进入目标库。
 
 ### Fixed
+
+- **认证 flow 过期与重放边界** — contact verification token 的消费现在要求 `consumed_at IS NULL AND expires_at > now`，避免并发窗口消费已过期 token；external callback 在原子消费前验证 active flow，Passkey challenge 使用带 identity、revision 和 expiry 的单次消费 envelope，session refresh 拒绝 expired/revoked session，非法 transition 不再产生部分认证副作用。
 
 - **Docker edge 发布通道跟随 stable** — 正式版本发布时，GHCR 与 Docker Hub 的 `edge`、`edge-metrics`、`edge-slim` 和 `edge-metrics-slim` 与对应 `stable` manifest 同步；alpha、beta、rc 发布只移动 edge，`latest` / `stable` 保持上一正式版本，避免 edge 长期停留在旧候选版本。
 - **PDF 预览旋转位置保持** — 多页 PDF 在中间或靠后页面旋转时保留当前虚拟页及页内滚动偏移，不再因页面尺寸重新测量跳到文档底部。

--- a/developer-docs/en/design/README.md
+++ b/developer-docs/en/design/README.md
@@ -4,6 +4,7 @@ These documents explain domain boundaries that cross routes, services, repositor
 
 ## Identity and authentication
 
+- [Authentication flow state-machine contract](./auth-flow-state-machine.md): shared lifecycle, transition, concurrency, and frontend projection boundaries for login, MFA, recovery, invitations, Passkeys, and sessions.
 - [External authentication module](./external-auth.md): provider descriptors, login flows, account resolution, email verification, and frontend/backend ownership.
 
 ## Storage and remote nodes

--- a/developer-docs/en/design/auth-flow-state-machine.md
+++ b/developer-docs/en/design/auth-flow-state-machine.md
@@ -1,0 +1,65 @@
+# Authentication Flow State-Machine Contract
+
+This contract defines the shared lifecycle boundary for primary login, second factors, account recovery, and sessions. MFA, Passkey, external-auth, contact-verification, invitation, and session modules continue to own their typed security payloads. The shared state machine owns only identity, state, expiry, attempt budgets, single-use behavior, and concurrency rules.
+
+## Ownership
+
+```text
+HTTP route
+  -> typed auth command
+  -> auth domain transition guard
+  -> owning service transaction
+  -> repository conditional update / cache atomic take
+  -> commit
+  -> cookie, redirect, mail, and audit side effects
+```
+
+- `src/services/auth/flow/` defines `AuthFlowKind`, `AuthFlowState`, commands, snapshots, and transition rules.
+- MFA, external-auth, local recovery, Passkey, and session services retain product guards, runtime policy checks, and side-effect ordering.
+- Repositories only perform atomic conditional updates. `rows_affected == 0` or cache `take == None` means a conflict or replay; repositories do not choose UI behavior.
+- Routes preserve the existing API envelope, cookie, and redirect contracts.
+
+## Flow inventory
+
+| Flow | Payload owner | Identity | Atomic advance | Terminal / cleanup |
+| --- | --- | --- | --- | --- |
+| Password primary | local auth service | request-local | password verification, then MFA/password-change/session result | request completion |
+| MFA login | `mfa_login_flows` | `mfa-login:<id>` | transaction plus conditional attempt/consume | consumed/expired; runtime cleanup |
+| Passkey login/registration | typed cache envelope | public flow UUID | cache atomic `take` | consumed/TTL eviction |
+| External login | `external_auth_login_flows` | `external-login:<id>` | state plus browser-binding conditional consume | consumed/expired; runtime cleanup |
+| External email recovery | `external_auth_email_verification_flows` | `external-recovery:<id>` | conditional email request/consume | consumed/expired; runtime cleanup |
+| Registration/password reset/email change | `contact_verification_tokens` | `contact-verification:<id>` | transaction plus purpose-scoped single-use token | consumed/expired cleanup |
+| Invitation | `user_invitations` | `invitation:<id>` | status-scoped conditional update | accepted/expired/revoked |
+| Session | `auth_sessions` | session UUID | conditional refresh-JTI rotation | revoked/expired cleanup |
+
+Identities use only database primary keys or public flow UUIDs. Raw tokens, provider state, browser bindings, verification codes, refresh JTIs, and their hashes never enter shared snapshots, logs, or errors.
+
+## Transition rules
+
+- Password primary may enter `SecondFactorPending`, `PasswordChangeRequired`, or `Authenticated`.
+- Passkey and external primary flows advance through `FirstFactorPending -> Processing`, then MFA or authenticated. Local password policy does not block either factor.
+- MFA advances only from `SecondFactorPending` to password-change or authenticated.
+- Recovery advances through `RecoveryPending -> Processing -> Completed`.
+- `Failed`, `Expired`, `Cancelled`, `Consumed`, `Completed`, and `Authenticated` are terminal.
+- Revision conflicts are checked before terminal state. Except for explicit `Expire`, expiry is checked before cancel and ordinary transitions.
+- Failure commands atomically increment attempts and enter `Failed` at the budget. Saturating arithmetic prevents counter wraparound.
+
+## Policy and side effects
+
+- Every cross-request advance rereads runtime auth policy. A UI snapshot captured at flow creation is not authorization evidence.
+- Password-first MFA rechecks password-login policy during exchange; external-first MFA is unaffected by that switch.
+- The session row is persisted in a transaction before the route emits cookies. Transaction failure emits no session cookie.
+- Mail outbox, audit, and cache invalidation have an explicit pre-commit or post-commit position. Failures are not silently discarded.
+- Frontend `AuthUiFlow` is the single backend projection. The URL adapter restores only an expiring flow reference and bounds TTL, methods, and local return paths.
+- A generation-aware coordinator combines auth check and provider loading. An older generation, unmounted promise, or slower response never updates the active page.
+
+## Test matrix
+
+- Domain: every allowed transition, cross-context rejection, terminal replay, revision conflict, attempt boundaries, saturation, and expiry/cancel ordering.
+- Repository/integration: single conditional consume, concurrent loser, no session on failure, runtime policy changes, and expired cleanup.
+- Passkey cache: flow isolation, single `take`, TTL envelope, and registration/login kind isolation.
+- Frontend: one top-level flow, URL recovery precedence, partial provider failure, stale generations, hostile return paths, TTL limits, unknown/duplicate methods, and query cleanup.
+
+## Schema boundary
+
+The typed tables already retain their security payload and authoritative lifecycle through `consumed_at`, `expires_at`, attempt counts, or status. Shared snapshots derive from those fields instead of creating a second `state` column. A typed table gains a revision only when a real multi-request CAS cannot be represented by its existing conditional fields. There is no universal auth JSON table.

--- a/developer-docs/en/design/auth-flow-state-machine.md
+++ b/developer-docs/en/design/auth-flow-state-machine.md
@@ -16,7 +16,7 @@ HTTP route
 
 - `src/services/auth/flow/` defines `AuthFlowKind`, `AuthFlowState`, commands, snapshots, and transition rules.
 - MFA, external-auth, local recovery, Passkey, and session services retain product guards, runtime policy checks, and side-effect ordering.
-- Repositories only perform atomic conditional updates. `rows_affected == 0` or cache `take == None` means a conflict or replay; repositories do not choose UI behavior.
+- Repositories only perform atomic conditional updates. `rows_affected == 0` or cache `take == None` is a no-result outcome that may represent conflict, replay, expiry, or cache eviction; services inspect authoritative fields and map the final state, while repositories do not choose UI behavior.
 - Routes preserve the existing API envelope, cookie, and redirect contracts.
 
 ## Flow inventory
@@ -32,7 +32,7 @@ HTTP route
 | Invitation | `user_invitations` | `invitation:<id>` | status-scoped conditional update | accepted/expired/revoked |
 | Session | `auth_sessions` | session UUID | conditional refresh-JTI rotation | revoked/expired cleanup |
 
-Identities use only database primary keys or public flow UUIDs. Raw tokens, provider state, browser bindings, verification codes, refresh JTIs, and their hashes never enter shared snapshots, logs, or errors.
+Identities use only database primary keys or public flow UUIDs. The request-local identity of a password primary is an explicit exception: it ends with the request and must not enter cross-request shared snapshots, logs, or errors. Raw tokens, provider state, browser bindings, verification codes, refresh JTIs, and their hashes never enter shared snapshots, logs, or errors.
 
 ## Transition rules
 
@@ -50,7 +50,7 @@ Identities use only database primary keys or public flow UUIDs. Raw tokens, prov
 - Password-first MFA rechecks password-login policy during exchange; external-first MFA is unaffected by that switch.
 - The session row is persisted in a transaction before the route emits cookies. Transaction failure emits no session cookie.
 - Mail outbox, audit, and cache invalidation have an explicit pre-commit or post-commit position. Failures are not silently discarded.
-- Frontend `AuthUiFlow` is the single backend projection. The URL adapter restores only an expiring flow reference and bounds TTL, methods, and local return paths.
+- Frontend `AuthUiFlow` is the single frontend/UI projection of backend state. The URL adapter restores only an expiring flow reference and bounds TTL, methods, and local return paths.
 - A generation-aware coordinator combines auth check and provider loading. An older generation, unmounted promise, or slower response never updates the active page.
 
 ## Test matrix

--- a/developer-docs/zh-CN/design/README.md
+++ b/developer-docs/zh-CN/design/README.md
@@ -4,6 +4,7 @@
 
 ## 身份与认证
 
+- [认证 flow 状态机契约](./auth-flow-state-machine.md)：登录、MFA、恢复、邀请、Passkey 和 session 的共享 lifecycle、transition、并发与前端投影边界。
 - [外部认证模块](./external-auth.md)：provider descriptor、登录 flow、账号解析、邮箱补验和前后端边界。
 
 ## 存储与远端节点

--- a/developer-docs/zh-CN/design/auth-flow-state-machine.md
+++ b/developer-docs/zh-CN/design/auth-flow-state-machine.md
@@ -1,0 +1,65 @@
+# 认证 flow 状态机契约
+
+本文定义登录、第二因子、账户恢复和 session 生命周期的共享边界。认证 payload 继续由 MFA、Passkey、external auth、contact verification、invitation 和 session 各自拥有；共享状态机只统一 identity、状态、过期、尝试次数、单次消费和并发转换规则。
+
+## 所有权
+
+```text
+HTTP route
+  -> typed auth command
+  -> auth domain transition guard
+  -> owning service transaction
+  -> repository conditional update / cache atomic take
+  -> commit
+  -> cookie, redirect, mail and audit side effects
+```
+
+- `src/services/auth/flow/` 定义 `AuthFlowKind`、`AuthFlowState`、command、snapshot 和转换规则。
+- MFA、external auth、local recovery、Passkey 和 session service 仍负责产品 guard、运行时策略和副作用顺序。
+- repository 只执行原子条件更新。`rows_affected == 0` 或 cache `take == None` 是并发失败或重放，不推断 UI 行为。
+- route 保持现有 API envelope、cookie 和 redirect 契约。
+
+## Flow inventory
+
+| Flow | Payload owner | Identity | 原子推进 | Terminal / cleanup |
+| --- | --- | --- | --- | --- |
+| Password primary | local auth service | request-local | password verify 后映射到 MFA/password-change/session | request 结束 |
+| MFA login | `mfa_login_flows` | `mfa-login:<id>` | transaction + conditional attempt/consume | consumed/expired，runtime cleanup |
+| Passkey login/registration | typed cache envelope | public flow UUID | cache atomic `take` | consumed/TTL eviction |
+| External login | `external_auth_login_flows` | `external-login:<id>` | state + browser binding 条件消费 | consumed/expired，runtime cleanup |
+| External email recovery | `external_auth_email_verification_flows` | `external-recovery:<id>` | conditional email request/consume | consumed/expired，runtime cleanup |
+| Registration/password reset/email change | `contact_verification_tokens` | `contact-verification:<id>` | transaction + purpose-scoped single-use token | consumed/expired cleanup |
+| Invitation | `user_invitations` | `invitation:<id>` | status-scoped conditional update | accepted/expired/revoked |
+| Session | `auth_sessions` | session UUID | refresh JTI conditional rotation | revoked/expired cleanup |
+
+Identity 只使用数据库主键或公开 flow UUID。原始 token、state、browser binding、verification code、JTI 和它们的 hash 不进入共享 snapshot、日志或错误。
+
+## Transition rules
+
+- Password primary 可以进入 `SecondFactorPending`、`PasswordChangeRequired` 或 `Authenticated`。
+- Passkey/external primary 必须先从 `FirstFactorPending` 进入 `Processing`，再进入 MFA 或 authenticated；本地密码策略不阻止这两种 first factor。
+- MFA 只从 `SecondFactorPending` 进入 password-change 或 authenticated。
+- Recovery 必须按 `RecoveryPending -> Processing -> Completed` 推进。
+- `Failed`、`Expired`、`Cancelled`、`Consumed`、`Completed` 和 `Authenticated` 是 terminal，不接受后续 command。
+- revision 不匹配先返回 conflict；terminal 检查其次；除显式 `Expire` 外，过期检查早于 cancel 和正常推进。
+- failure command 原子增加 attempt；达到预算时进入 `Failed`。计数使用饱和运算，不能整数回绕。
+
+## Policy and side effects
+
+- 每次跨请求推进都重新读取 runtime auth policy。创建 flow 时的 UI snapshot 不是授权依据。
+- 密码 first factor 在 MFA 交换时重新检查 password login policy；external first factor 不受该开关影响。
+- session row 必须先在 transaction 中持久化，再由 route 设置 cookie。事务失败不产生 session cookie。
+- mail outbox、audit 和 cache invalidation 必须明确在 commit 前或后执行。失败不能用静默 fire-and-forget 吞掉。
+- 前端 `AuthUiFlow` 是后端状态的单一投影；URL adapter 只恢复有过期时间的 flow reference，限制 TTL、method 和本地 return path。
+- auth check 与 provider list 由带 generation 的 coordinator 合并。旧 generation、卸载后的 promise 或较慢响应不更新当前页面。
+
+## Test matrix
+
+- Domain：全部允许转换、非法跨 context、terminal replay、revision conflict、attempt 边界、整数饱和、过期/cancel 优先级。
+- Repository/integration：条件消费单次成功、并发 loser、失败不发 session、策略热更新、过期 cleanup。
+- Passkey cache：flow 隔离、单次 `take`、TTL envelope、registration/login kind 隔离。
+- Frontend：唯一顶层 flow、URL 恢复优先于 bootstrap、provider 部分失败、stale generation、恶意 return path、TTL 上限、未知/重复 method、query cleanup。
+
+## Schema boundary
+
+当前 typed 表已经保存各自需要的安全 payload，并通过 `consumed_at`、`expires_at`、attempt 或 status 提供权威生命周期。共享 snapshot 从这些字段派生，不复制一套 `state` 列形成双重事实源。只有某个 flow 确实需要跨请求多阶段 CAS，且现有条件字段不能表达 revision 时，才为该 typed 表增加 revision；不建立万能 auth JSON 表。

--- a/developer-docs/zh-CN/design/auth-flow-state-machine.md
+++ b/developer-docs/zh-CN/design/auth-flow-state-machine.md
@@ -16,7 +16,7 @@ HTTP route
 
 - `src/services/auth/flow/` 定义 `AuthFlowKind`、`AuthFlowState`、command、snapshot 和转换规则。
 - MFA、external auth、local recovery、Passkey 和 session service 仍负责产品 guard、运行时策略和副作用顺序。
-- repository 只执行原子条件更新。`rows_affected == 0` 或 cache `take == None` 是并发失败或重放，不推断 UI 行为。
+- repository 只执行原子条件更新。`rows_affected == 0` 或 cache `take == None` 是无结果 outcome，可能代表 conflict、replay、expiry 或 cache eviction；service 根据权威字段映射最终状态，repository 不选择 UI 行为。
 - route 保持现有 API envelope、cookie 和 redirect 契约。
 
 ## Flow inventory
@@ -32,7 +32,7 @@ HTTP route
 | Invitation | `user_invitations` | `invitation:<id>` | status-scoped conditional update | accepted/expired/revoked |
 | Session | `auth_sessions` | session UUID | refresh JTI conditional rotation | revoked/expired cleanup |
 
-Identity 只使用数据库主键或公开 flow UUID。原始 token、state、browser binding、verification code、JTI 和它们的 hash 不进入共享 snapshot、日志或错误。
+Identity 只使用数据库主键或公开 flow UUID。Password primary 的 request-local identity 是明确例外：它只在当前请求内存在，不进入跨请求共享 snapshot、日志或错误。原始 token、state、browser binding、verification code、JTI 和它们的 hash 不进入共享 snapshot、日志或错误。
 
 ## Transition rules
 
@@ -50,7 +50,7 @@ Identity 只使用数据库主键或公开 flow UUID。原始 token、state、br
 - 密码 first factor 在 MFA 交换时重新检查 password login policy；external first factor 不受该开关影响。
 - session row 必须先在 transaction 中持久化，再由 route 设置 cookie。事务失败不产生 session cookie。
 - mail outbox、audit 和 cache invalidation 必须明确在 commit 前或后执行。失败不能用静默 fire-and-forget 吞掉。
-- 前端 `AuthUiFlow` 是后端状态的单一投影；URL adapter 只恢复有过期时间的 flow reference，限制 TTL、method 和本地 return path。
+- 前端 `AuthUiFlow` 是后端状态的单一 frontend/UI projection；URL adapter 只恢复有过期时间的 flow reference，限制 TTL、method 和本地 return path。
 - auth check 与 provider list 由带 generation 的 coordinator 合并。旧 generation、卸载后的 promise 或较慢响应不更新当前页面。
 
 ## Test matrix

--- a/frontend-panel/src/pages/LoginPage.test.tsx
+++ b/frontend-panel/src/pages/LoginPage.test.tsx
@@ -887,6 +887,41 @@ describe("LoginPage", () => {
 		expect(mockState.verifyMfaChallenge).not.toHaveBeenCalled();
 	});
 
+	it("rejects sending an expired email MFA challenge", async () => {
+		vi.useFakeTimers({ shouldAdvanceTime: true });
+		vi.setSystemTime(new Date("2026-05-24T08:00:00.000Z"));
+		mockState.forceEnableDisabledButtons = true;
+		mockState.login.mockResolvedValueOnce({
+			status: "mfa_required",
+			flowToken: "expired-email-flow",
+			expiresIn: 300,
+			methods: ["email_code"],
+		});
+
+		render(<LoginPage />);
+
+		fireEvent.change(await screen.findByLabelText("email_or_username"), {
+			target: { value: "user@example.com" },
+		});
+		fireEvent.change(screen.getByLabelText("password"), {
+			target: { value: "secret123" },
+		});
+		fireEvent.click(screen.getByRole("button", { name: "sign_in" }));
+		await screen.findByText("mfa_required_title");
+
+		act(() => {
+			vi.setSystemTime(new Date("2026-05-24T08:06:00.000Z"));
+			vi.advanceTimersByTime(1000);
+		});
+		await screen.findByText("mfa_flow_expired");
+		fireEvent.click(
+			screen.getByRole("button", { name: /mfa_email_code_send/ }),
+		);
+
+		expect(mockState.sendMfaEmailCode).not.toHaveBeenCalled();
+		expect(screen.getAllByText("mfa_flow_expired").length).toBeGreaterThan(0);
+	});
+
 	it("ignores email MFA resend clicks during cooldown", async () => {
 		mockState.forceEnableDisabledButtons = true;
 		mockState.login.mockResolvedValueOnce({
@@ -2450,6 +2485,11 @@ describe("LoginPage", () => {
 		});
 		expect(mockState.toastSuccess).toHaveBeenCalledWith("register_success");
 		expect(mockState.toastSuccess).toHaveBeenCalledWith("activation_resent");
+
+		fireEvent.click(screen.getByRole("button", { name: /not_you/ }));
+		expect(
+			await screen.findByRole("button", { name: "sign_in" }),
+		).toBeInTheDocument();
 	});
 
 	it("returns to sign-in mode when registration does not require activation", async () => {
@@ -2566,6 +2606,7 @@ describe("LoginPage", () => {
 
 	it("validates and handles failures in the independent activation resend panel", async () => {
 		const error = new Error("mail service offline");
+		mockState.forceEnableDisabledButtons = true;
 		mockState.resendRegisterActivation.mockRejectedValueOnce(error);
 
 		render(<LoginPage />);
@@ -2635,6 +2676,21 @@ describe("LoginPage", () => {
 
 		await screen.findByRole("button", { name: "sign_in" });
 		fireEvent.click(screen.getByRole("button", { name: "forgot_password" }));
+
+		fireEvent.change(await screen.findByLabelText("email"), {
+			target: { value: "invalid" },
+		});
+		fireEvent.click(
+			screen.getByRole("button", { name: /send_password_reset/ }),
+		);
+		expect(screen.getByText("invalid-email")).toBeInTheDocument();
+		fireEvent.click(screen.getByRole("button", { name: /back_to_sign_in/ }));
+		await screen.findByRole("button", { name: "sign_in" });
+		fireEvent.click(screen.getByRole("button", { name: "forgot_password" }));
+
+		fireEvent.change(await screen.findByLabelText("email"), {
+			target: { value: "user@example.com" },
+		});
 
 		fireEvent.click(
 			await screen.findByRole("button", { name: /send_password_reset/ }),

--- a/frontend-panel/src/pages/LoginPage.test.tsx
+++ b/frontend-panel/src/pages/LoginPage.test.tsx
@@ -893,6 +893,48 @@ describe("LoginPage", () => {
 		expect(mockState.verifyMfaChallenge).not.toHaveBeenCalled();
 	});
 
+	it("clears email-code sending after another MFA command advances the generation", async () => {
+		let resolveSend!: (value: {
+			expires_in: number;
+			resend_after: number;
+		}) => void;
+		mockState.forceEnableDisabledButtons = true;
+		mockState.login.mockResolvedValueOnce({
+			status: "mfa_required",
+			flowToken: "mfa-flow",
+			expiresIn: 300,
+			methods: ["email_code"],
+		});
+		mockState.sendMfaEmailCode.mockImplementationOnce(
+			() =>
+				new Promise((resolve) => {
+					resolveSend = resolve;
+				}),
+		);
+
+		render(<LoginPage />);
+		fireEvent.change(await screen.findByLabelText("email_or_username"), {
+			target: { value: "user@example.com" },
+		});
+		fireEvent.change(screen.getByLabelText("password"), {
+			target: { value: "secret123" },
+		});
+		fireEvent.click(screen.getByRole("button", { name: "sign_in" }));
+		await screen.findByText("mfa_required_title");
+		fireEvent.click(
+			await screen.findByRole("button", { name: /mfa_email_code_send/ }),
+		);
+		await screen.findByText("mfa_email_code_sending");
+		fireEvent.click(screen.getByRole("button", { name: /mfa_verify/ }));
+		resolveSend({ expires_in: 600, resend_after: 60 });
+
+		await waitFor(() => {
+			expect(
+				screen.queryByText("mfa_email_code_sending"),
+			).not.toBeInTheDocument();
+		});
+	});
+
 	it("rejects sending an expired email MFA challenge", async () => {
 		vi.useFakeTimers({ shouldAdvanceTime: true });
 		vi.setSystemTime(new Date("2026-05-24T08:00:00.000Z"));
@@ -1295,6 +1337,9 @@ describe("LoginPage", () => {
 				error,
 			);
 		});
+		expect(
+			await screen.findByRole("button", { name: "sign_in" }),
+		).toBeInTheDocument();
 	});
 
 	it("ignores a bootstrap rejection after the component is unmounted", async () => {

--- a/frontend-panel/src/pages/LoginPage.test.tsx
+++ b/frontend-panel/src/pages/LoginPage.test.tsx
@@ -64,6 +64,7 @@ const mockState = vi.hoisted(() => ({
 	conditionalPasskeyError: null as Error | null,
 	handleApiError: vi.fn(),
 	allowUserRegistration: true,
+	validationIssuesEmpty: false,
 	conditionalPasskeySupported: false,
 	forceEnableDisabledButtons: false,
 	passkeyLoginEnabled: true,
@@ -197,7 +198,11 @@ vi.mock("@/lib/validation", () => ({
 			/^[^@]+@[^@]+\.[^@]+$/.test(value)
 				? { success: true }
 				: {
-						error: { issues: [{ message: "invalid-email" }] },
+						error: {
+							issues: mockState.validationIssuesEmpty
+								? []
+								: [{ message: "invalid-email" }],
+						},
 						success: false,
 					},
 	},
@@ -451,6 +456,7 @@ describe("LoginPage", () => {
 		});
 		document.documentElement.classList.remove("dark");
 		mockState.allowUserRegistration = true;
+		mockState.validationIssuesEmpty = false;
 		mockState.conditionalPasskeyError = null;
 		mockState.conditionalPasskeySupported = false;
 		mockState.forceEnableDisabledButtons = false;
@@ -1249,6 +1255,63 @@ describe("LoginPage", () => {
 		).toBeInTheDocument();
 	});
 
+	it("ignores a bootstrap response after the component is unmounted", async () => {
+		let resolveCheck!: (value: unknown) => void;
+		mockState.setSystemSetupState.mockImplementationOnce(() => {
+			throw new Error("stale setup state update");
+		});
+		mockState.check.mockImplementationOnce(
+			() =>
+				new Promise((resolve) => {
+					resolveCheck = resolve;
+				}),
+		);
+
+		const view = render(<LoginPage />);
+		await waitFor(() => expect(mockState.check).toHaveBeenCalledWith());
+		view.unmount();
+		resolveCheck({
+			allow_user_registration: true,
+			has_users: true,
+			passkey_login_enabled: true,
+			password_login_enabled: true,
+			setup_state: "ready",
+		});
+		await Promise.resolve();
+		await Promise.resolve();
+	});
+
+	it("clears bootstrap checking after a callback error", async () => {
+		const error = new Error("setup state update failed");
+		mockState.setSystemSetupState.mockImplementationOnce(() => {
+			throw error;
+		});
+
+		render(<LoginPage />);
+
+		await waitFor(() => {
+			expect(mockState.loggerWarn).toHaveBeenCalledWith(
+				"failed to load auth bootstrap",
+				error,
+			);
+		});
+	});
+
+	it("ignores a bootstrap rejection after the component is unmounted", async () => {
+		mockState.check.mockImplementationOnce(() => {
+			throw new Error("stale bootstrap rejection");
+		});
+
+		const view = render(<LoginPage />);
+		view.unmount();
+		await Promise.resolve();
+		await Promise.resolve();
+		expect(mockState.loggerWarn).not.toHaveBeenCalledWith(
+			"failed to load auth bootstrap",
+			expect.anything(),
+		);
+	});
+
 	it("reports password validation failures before calling login", async () => {
 		render(<LoginPage />);
 		fireEvent.change(await screen.findByLabelText("email_or_username"), {
@@ -1263,6 +1326,51 @@ describe("LoginPage", () => {
 
 		expect(await screen.findByText("password-required")).toBeInTheDocument();
 		expect(mockState.login).not.toHaveBeenCalled();
+	});
+
+	it("handles empty validation issue lists across recovery forms", async () => {
+		mockState.forceEnableDisabledButtons = true;
+		mockState.validationIssuesEmpty = true;
+
+		const activationView = render(<LoginPage />);
+		fireEvent.click(
+			await screen.findByRole("button", { name: "resend_activation" }),
+		);
+		await screen.findByText("activation_resend_hint");
+		fireEvent.change(screen.getByLabelText("email"), {
+			target: { value: "invalid" },
+		});
+		fireEvent.click(screen.getByRole("button", { name: /resend_activation/ }));
+		activationView.unmount();
+
+		const passwordResetView = render(<LoginPage />);
+		fireEvent.click(
+			await screen.findByRole("button", { name: "forgot_password" }),
+		);
+		fireEvent.change(await screen.findByLabelText("email"), {
+			target: { value: "invalid" },
+		});
+		fireEvent.click(
+			screen.getByRole("button", { name: /send_password_reset/ }),
+		);
+		passwordResetView.unmount();
+
+		mockState.location.search = "?external_auth=email_required&flow=flow-token";
+		const externalView = render(<LoginPage />);
+		fireEvent.click(
+			await screen.findByRole("tab", {
+				name: /external_auth_email_verification_tab/,
+			}),
+		);
+		fireEvent.change(await screen.findByLabelText("email"), {
+			target: { value: "invalid" },
+		});
+		fireEvent.click(
+			screen.getByRole("button", {
+				name: /external_auth_email_verification_send/,
+			}),
+		);
+		externalView.unmount();
 	});
 
 	it("does not flash cached-disabled password controls while auth check is pending", async () => {

--- a/frontend-panel/src/pages/LoginPage.tsx
+++ b/frontend-panel/src/pages/LoginPage.tsx
@@ -2,7 +2,6 @@ import {
 	type FormEvent,
 	useCallback,
 	useEffect,
-	useReducer,
 	useRef,
 	useState,
 } from "react";
@@ -46,14 +45,22 @@ import { useFrontendConfigStore } from "@/stores/frontendConfigStore";
 import { useSystemSetupStore } from "@/stores/systemSetupStore";
 import type { ExternalAuthPublicProvider, SystemSetupState } from "@/types/api";
 import { ApiErrorCode } from "@/types/api-helpers";
+import { createAuthCommandCoordinator } from "./login/authCommandCoordinator";
+import {
+	type AuthPolicySnapshot,
+	createAuthRequestCoordinator,
+	loadAuthBootstrap,
+} from "./login/authPolicyCoordinator";
+import {
+	clearAuthFlowRedirectSearch,
+	parseRecoverableAuthUrlFlow,
+} from "./login/authUrlAdapter";
 import { LoginPageView } from "./login/LoginPageView";
 import {
-	authPanelReducer,
-	initialAuthPanelState,
+	type authUiFlowReducer,
+	initialAuthUiFlow,
 } from "./login/loginPageState";
 import type { AuthMode } from "./login/types";
-
-const MFA_METHODS: MfaMethod[] = ["totp", "recovery_code", "email_code"];
 
 function scheduleLoginSuccessPathWarmup() {
 	return runWhenIdle(
@@ -66,17 +73,6 @@ function scheduleLoginSuccessPathWarmup() {
 		},
 		{ fallbackDelayMs: 900, timeoutMs: 2_000 },
 	);
-}
-
-function parseMfaMethods(value: string | null): MfaMethod[] {
-	if (!value) return ["totp", "recovery_code"];
-	const methods = value
-		.split(",")
-		.map((method) => method.trim())
-		.filter((method): method is MfaMethod =>
-			MFA_METHODS.includes(method as MfaMethod),
-		);
-	return methods.length > 0 ? methods : ["totp", "recovery_code"];
 }
 
 function resolveMfaMethod(code: string, methods: MfaMethod[]): MfaMethod {
@@ -95,12 +91,6 @@ function resolveMfaMethod(code: string, methods: MfaMethod[]): MfaMethod {
 
 function normalizeTotpCode(code: string) {
 	return code.trim().replace(/\s/g, "");
-}
-
-function resolveMfaRedirectExpiresAt(expiresIn: string | null) {
-	const parsed = Number(expiresIn);
-	const ttlSeconds = Number.isFinite(parsed) && parsed > 0 ? parsed : 300;
-	return Date.now() + ttlSeconds * 1000;
 }
 
 const LOGIN_UNAVAILABLE_ERROR_CODES = new Set<string>([
@@ -135,6 +125,10 @@ function useLoginPageController() {
 	);
 	const conditionalPasskeyAbortRef = useRef<AbortController | null>(null);
 	const conditionalPasskeySupportedRef = useRef(false);
+	const authRequestCoordinatorRef = useRef(createAuthRequestCoordinator());
+	const authCommandCoordinatorRef = useRef(
+		createAuthCommandCoordinator(initialAuthUiFlow),
+	);
 
 	// The first field is always visible — it doubles as username or email
 	const [identifier, setIdentifier] = useState("");
@@ -143,43 +137,43 @@ function useLoginPageController() {
 	const [password, setPassword] = useState("");
 	const [showPassword, setShowPassword] = useState(false);
 
-	const [mode, setMode] = useState<AuthMode>("idle");
 	const [checking, setChecking] = useState(true);
 	const [submitting, setSubmitting] = useState(false);
 	const [resendingActivation, setResendingActivation] = useState(false);
 	const [passkeySubmitting, setPasskeySubmitting] = useState(false);
-	const [externalAuthProviders, setExternalAuthProviders] = useState<
-		ExternalAuthPublicProvider[]
-	>([]);
-	const [externalAuthLoading, setExternalAuthLoading] = useState(true);
+	const [authPolicy, setAuthPolicy] = useState<AuthPolicySnapshot | null>(null);
 	const [externalAuthBusyProvider, setExternalAuthBusyProvider] = useState<
 		string | null
 	>(null);
 	const [passkeySupported] = useState(() => isWebAuthnSupported());
-	const [checkedPasskeyLoginEnabled, setCheckedPasskeyLoginEnabled] = useState<
-		boolean | null
-	>(null);
-	const [checkedPasswordLoginEnabled, setCheckedPasswordLoginEnabled] =
-		useState<boolean | null>(null);
 	const [registrationClosed, setRegistrationClosed] = useState(false);
 	const [setupState, setSetupState] = useState<SystemSetupState | null>(null);
 	const [exiting, setExiting] = useState(false);
 	const [errors, setErrors] = useState<Record<string, string>>({});
-	const [authPanel, dispatchAuthPanel] = useReducer(
-		authPanelReducer,
-		initialAuthPanelState,
+	const [authFlow, setAuthFlow] = useState(initialAuthUiFlow);
+	const dispatchAuthFlow = useCallback(
+		(event: Parameters<typeof authUiFlowReducer>[1]) => {
+			setAuthFlow(authCommandCoordinatorRef.current.dispatch(event));
+		},
+		[],
 	);
+	const mode: AuthMode =
+		authFlow.kind === "bootstrapping"
+			? "idle"
+			: authFlow.kind === "setup" ||
+					authFlow.kind === "register" ||
+					authFlow.kind === "login"
+				? authFlow.kind
+				: "login";
 	const pendingActivation =
-		authPanel.kind === "pending-activation"
-			? authPanel.pendingActivation
-			: null;
+		authFlow.kind === "pending-activation" ? authFlow.pendingActivation : null;
 	const activationResendPanel =
-		authPanel.kind === "activation-resend" ? authPanel.activationResend : null;
+		authFlow.kind === "activation-resend" ? authFlow.activationResend : null;
 	const passwordResetPanel =
-		authPanel.kind === "password-reset" ? authPanel.passwordReset : null;
+		authFlow.kind === "password-reset" ? authFlow.passwordReset : null;
 	const externalAuthRecovery =
-		authPanel.kind === "external-auth-recovery" ? authPanel.recovery : null;
-	const mfaPanel = authPanel.kind === "mfa" ? authPanel : null;
+		authFlow.kind === "external-auth-recovery" ? authFlow.recovery : null;
+	const mfaPanel = authFlow.kind === "mfa" ? authFlow : null;
 	const mfaChallenge = mfaPanel?.challenge ?? null;
 	const showPasswordResetRequest = passwordResetPanel !== null;
 	const externalAuthRecoveryFlow = externalAuthRecovery?.flowToken ?? null;
@@ -222,9 +216,11 @@ function useLoginPageController() {
 	usePageTitle(modeActionText || t("sign_in"));
 	useEffect(() => scheduleLoginSuccessPathWarmup(), []);
 	const passkeyLoginEnabled =
-		checkedPasskeyLoginEnabled ?? publicPasskeyLoginEnabled;
+		authPolicy?.passkeyLoginEnabled ?? publicPasskeyLoginEnabled;
 	const passwordLoginEnabled =
-		checkedPasswordLoginEnabled ?? publicPasswordLoginEnabled;
+		authPolicy?.passwordLoginEnabled ?? publicPasswordLoginEnabled;
+	const externalAuthProviders = authPolicy?.externalProviders ?? [];
+	const externalAuthLoading = authPolicy === null;
 	const externalAuthRecoveryMode =
 		passwordLoginEnabled && externalAuthRecovery?.mode === "password"
 			? "password"
@@ -242,13 +238,9 @@ function useLoginPageController() {
 	useEffect(() => {
 		const searchParams = new URLSearchParams(search);
 		const mfaStatus = searchParams.get("mfa");
-		const mfaFlow = searchParams.get("flow");
-		const mfaExpiresIn = searchParams.get("expires_in");
-		const mfaMethods = searchParams.get("methods");
-		const returnPath = searchParams.get("return_path") || "/";
 		const externalAuthStatus = searchParams.get("external_auth");
 		const externalAuthMessage = searchParams.get("message");
-		const externalAuthFlow = searchParams.get("flow");
+		const recoverableFlow = parseRecoverableAuthUrlFlow(search);
 		const invitationStatus = searchParams.get("invitation");
 		const verification = getContactVerificationRedirectState(search);
 		const passwordReset = getPasswordResetRedirectState(search);
@@ -315,32 +307,32 @@ function useLoginPageController() {
 			});
 		}
 
-		if (mfaStatus === "required" && mfaFlow) {
-			dispatchAuthPanel({
+		if (recoverableFlow?.kind === "mfa") {
+			dispatchAuthFlow({
 				type: "open_mfa",
 				challenge: {
-					expiresAt: resolveMfaRedirectExpiresAt(mfaExpiresIn),
-					flowToken: mfaFlow,
-					methods: parseMfaMethods(mfaMethods),
-					returnPath,
+					expiresAt: recoverableFlow.expiresAt,
+					flowToken: recoverableFlow.flowToken,
+					methods: recoverableFlow.methods,
+					returnPath: recoverableFlow.returnPath,
 					successMessage: loginSuccessMessage,
 				},
 			});
-		} else if (externalAuthStatus === "email_required" && externalAuthFlow) {
-			dispatchAuthPanel({
+		} else if (recoverableFlow?.kind === "external-auth-recovery") {
+			dispatchAuthFlow({
 				type: "open_external_auth_recovery",
 				recovery: {
 					email: passwordResetPrefill,
 					emailError: "",
 					emailSubmitting: false,
-					flowToken: externalAuthFlow,
+					flowToken: recoverableFlow.flowToken,
 					mode: "password",
 					password: "",
 					passwordError: "",
 					passwordIdentifier: identifier.trim(),
 					passwordIdentifierError: "",
 					passwordSubmitting: false,
-					returnPath,
+					returnPath: recoverableFlow.returnPath,
 					sent: false,
 				},
 			});
@@ -367,24 +359,13 @@ function useLoginPageController() {
 			});
 		}
 
-		searchParams.delete("external_auth");
-		searchParams.delete("mfa");
-		searchParams.delete("code");
-		searchParams.delete("message");
-		searchParams.delete("invitation");
-		searchParams.delete("flow");
-		searchParams.delete("expires_in");
-		searchParams.delete("methods");
-		searchParams.delete("return_path");
-		const cleanedSearch = searchParams.toString();
-
 		navigate(
 			{
 				hash,
 				pathname,
 				search: clearPasswordResetRedirectSearch(
 					clearContactVerificationRedirectSearch(
-						cleanedSearch ? `?${cleanedSearch}` : "",
+						clearAuthFlowRedirectSearch(search),
 					),
 				),
 			},
@@ -399,83 +380,69 @@ function useLoginPageController() {
 		loginSuccessMessage,
 		passwordResetPrefill,
 		t,
+		dispatchAuthFlow,
 	]);
 
 	useEffect(() => {
 		if (!mfaChallenge) return;
-		dispatchAuthPanel({ type: "set_mfa_now", now: Date.now() });
+		dispatchAuthFlow({ type: "set_mfa_now", now: Date.now() });
 		const timer = window.setInterval(
-			() => dispatchAuthPanel({ type: "set_mfa_now", now: Date.now() }),
+			() => dispatchAuthFlow({ type: "set_mfa_now", now: Date.now() }),
 			1000,
 		);
 		return () => window.clearInterval(timer);
-	}, [mfaChallenge]);
+	}, [mfaChallenge, dispatchAuthFlow]);
 
 	useEffect(() => {
-		let cancelled = false;
+		const coordinator = authRequestCoordinatorRef.current;
+		const revision = coordinator.begin();
 
-		void authService
-			.check()
-			.then((result) => {
-				if (cancelled) return;
-				setSystemSetupState(result.setup_state);
-				setSetupState(result.setup_state);
-				setCheckedPasskeyLoginEnabled(result.passkey_login_enabled !== false);
-				setCheckedPasswordLoginEnabled(result.password_login_enabled !== false);
-				if (result.setup_state === "needs_admin" || !result.has_users) {
-					setRegistrationClosed(false);
-					setMode("setup");
-					return;
-				}
-
-				setRegistrationClosed(
-					result.setup_state === "needs_storage" ||
-						result.allow_user_registration === false ||
-						result.password_login_enabled === false,
+		void loadAuthBootstrap(authService, {
+			passkeyLoginEnabled: publicPasskeyLoginEnabled,
+			passwordLoginEnabled: publicPasswordLoginEnabled,
+		}).then((result) => {
+			if (!coordinator.isCurrent(revision)) return;
+			setAuthPolicy(result.policy);
+			if (result.providersError) {
+				logger.warn(
+					"failed to load external auth providers",
+					result.providersError,
 				);
-				setMode("login");
-			})
-			.catch(() => {
-				if (cancelled) return;
+			}
+
+			if (result.check) {
+				setSystemSetupState(result.check.setup_state);
+				setSetupState(result.check.setup_state);
+				if (
+					result.check.setup_state === "needs_admin" ||
+					!result.check.has_users
+				) {
+					setRegistrationClosed(false);
+					dispatchAuthFlow({ type: "bootstrap_resolved", flow: "setup" });
+				} else {
+					setRegistrationClosed(
+						result.check.setup_state === "needs_storage" ||
+							!result.policy.allowUserRegistration ||
+							!result.policy.passwordLoginEnabled,
+					);
+					dispatchAuthFlow({ type: "bootstrap_resolved", flow: "login" });
+				}
+			} else {
 				setRegistrationClosed(false);
-				setMode("login");
-			})
-			.finally(() => {
-				if (!cancelled) {
-					setChecking(false);
-				}
-			});
+				dispatchAuthFlow({ type: "bootstrap_resolved", flow: "login" });
+			}
+			setChecking(false);
+		});
 
 		return () => {
-			cancelled = true;
+			coordinator.invalidate();
 		};
-	}, [setSystemSetupState]);
-
-	useEffect(() => {
-		let cancelled = false;
-
-		void authService
-			.listExternalAuthProviders()
-			.then((providers) => {
-				if (!cancelled) {
-					setExternalAuthProviders(providers);
-				}
-			})
-			.catch((error) => {
-				if (!cancelled) {
-					logger.warn("failed to load external auth providers", error);
-				}
-			})
-			.finally(() => {
-				if (!cancelled) {
-					setExternalAuthLoading(false);
-				}
-			});
-
-		return () => {
-			cancelled = true;
-		};
-	}, []);
+	}, [
+		publicPasskeyLoginEnabled,
+		publicPasswordLoginEnabled,
+		setSystemSetupState,
+		dispatchAuthFlow,
+	]);
 
 	useEffect(() => {
 		let cancelled = false;
@@ -595,7 +562,7 @@ function useLoginPageController() {
 			}
 			const methods: MfaMethod[] =
 				result.methods.length > 0 ? result.methods : ["totp"];
-			dispatchAuthPanel({
+			dispatchAuthFlow({
 				type: "open_mfa",
 				challenge: {
 					expiresAt: Date.now() + result.expiresIn * 1000,
@@ -608,38 +575,41 @@ function useLoginPageController() {
 			setPassword("");
 			setShowPassword(false);
 		},
-		[finishAuthenticatedLogin, finishPasswordChangeRequiredLogin],
+		[
+			finishAuthenticatedLogin,
+			finishPasswordChangeRequiredLogin,
+			dispatchAuthFlow,
+		],
 	);
 
 	const resetPendingActivation = () => {
-		dispatchAuthPanel({ type: "open_auth" });
+		dispatchAuthFlow({ type: "open_auth" });
 		setErrors({});
 		setPassword("");
 		setShowPassword(false);
 	};
 
 	const closePasswordResetRequest = () => {
-		dispatchAuthPanel({ type: "close_password_reset" });
+		dispatchAuthFlow({ type: "close_password_reset" });
 	};
 
 	const closeActivationResendRequest = () => {
-		dispatchAuthPanel({ type: "close_activation_resend" });
+		dispatchAuthFlow({ type: "close_activation_resend" });
 	};
 
 	const closeExternalAuthRecovery = () => {
-		dispatchAuthPanel({ type: "close_external_auth_recovery" });
+		dispatchAuthFlow({ type: "close_external_auth_recovery" });
 	};
 
 	const closeMfaChallenge = () => {
-		dispatchAuthPanel({ type: "close_mfa" });
-		setMode("login");
+		dispatchAuthFlow({ type: "close_mfa" });
 	};
 
 	const switchAuthMode = (
 		nextMode: Extract<AuthMode, "login" | "register">,
 	) => {
 		setErrors({});
-		setMode(nextMode);
+		dispatchAuthFlow({ type: "switch_auth_mode", mode: nextMode });
 	};
 
 	const handleResendActivation = async () => {
@@ -661,7 +631,7 @@ function useLoginPageController() {
 		const email = activationResendPanel.email.trim();
 		const result = emailSchema.safeParse(email);
 		if (!result.success) {
-			dispatchAuthPanel({
+			dispatchAuthFlow({
 				type: "set_activation_resend_error",
 				error: result.error.issues[0]?.message ?? "",
 			});
@@ -669,18 +639,18 @@ function useLoginPageController() {
 		}
 
 		try {
-			dispatchAuthPanel({
+			dispatchAuthFlow({
 				type: "set_activation_resend_requesting",
 				requesting: true,
 			});
 			await authService.resendRegisterActivation(email);
 			toast.success(t("activation_resend_request_sent"));
 			setIdentifier(email);
-			dispatchAuthPanel({ type: "close_activation_resend" });
+			dispatchAuthFlow({ type: "close_activation_resend" });
 		} catch (error) {
 			handleApiError(error);
 		} finally {
-			dispatchAuthPanel({
+			dispatchAuthFlow({
 				type: "set_activation_resend_requesting",
 				requesting: false,
 			});
@@ -692,7 +662,7 @@ function useLoginPageController() {
 		const email = passwordResetPanel.email.trim();
 		const result = emailSchema.safeParse(email);
 		if (!result.success) {
-			dispatchAuthPanel({
+			dispatchAuthFlow({
 				type: "set_password_reset_error",
 				error: result.error.issues[0]?.message ?? "",
 			});
@@ -700,18 +670,18 @@ function useLoginPageController() {
 		}
 
 		try {
-			dispatchAuthPanel({
+			dispatchAuthFlow({
 				type: "set_password_reset_requesting",
 				requesting: true,
 			});
 			await authService.requestPasswordReset({ email });
 			toast.success(t("password_reset_request_sent"));
 			setIdentifier(email);
-			dispatchAuthPanel({ type: "close_password_reset" });
+			dispatchAuthFlow({ type: "close_password_reset" });
 		} catch (error) {
 			handleApiError(error);
 		} finally {
-			dispatchAuthPanel({
+			dispatchAuthFlow({
 				type: "set_password_reset_requesting",
 				requesting: false,
 			});
@@ -723,7 +693,7 @@ function useLoginPageController() {
 		const email = externalAuthRecovery.email.trim();
 		const result = emailSchema.safeParse(email);
 		if (!result.success) {
-			dispatchAuthPanel({
+			dispatchAuthFlow({
 				type: "set_external_email_error",
 				error: result.error.issues[0]?.message ?? "",
 			});
@@ -731,7 +701,7 @@ function useLoginPageController() {
 		}
 
 		try {
-			dispatchAuthPanel({
+			dispatchAuthFlow({
 				type: "set_external_email_submitting",
 				submitting: true,
 			});
@@ -739,12 +709,12 @@ function useLoginPageController() {
 				flow_token: externalAuthRecovery.flowToken,
 				email,
 			});
-			dispatchAuthPanel({ type: "external_email_sent" });
+			dispatchAuthFlow({ type: "external_email_sent" });
 			toast.success(t("external_auth_email_verification_sent_toast"));
 		} catch (error) {
 			handleApiError(error);
 		} finally {
-			dispatchAuthPanel({
+			dispatchAuthFlow({
 				type: "set_external_email_submitting",
 				submitting: false,
 			});
@@ -763,7 +733,7 @@ function useLoginPageController() {
 		if (!pwResult.success) {
 			errs.password = pwResult.error.issues[0]?.message ?? "";
 		}
-		dispatchAuthPanel({
+		dispatchAuthFlow({
 			type: "set_external_password_errors",
 			identifier: errs.identifier ?? "",
 			password: errs.password ?? "",
@@ -771,7 +741,7 @@ function useLoginPageController() {
 		if (Object.keys(errs).length > 0) return;
 
 		try {
-			dispatchAuthPanel({
+			dispatchAuthFlow({
 				type: "set_external_password_submitting",
 				submitting: true,
 			});
@@ -788,7 +758,7 @@ function useLoginPageController() {
 		} catch (error) {
 			handleApiError(error);
 		} finally {
-			dispatchAuthPanel({
+			dispatchAuthFlow({
 				type: "set_external_password_submitting",
 				submitting: false,
 			});
@@ -937,7 +907,7 @@ function useLoginPageController() {
 		if (!mfaPanel) return;
 		const { challenge } = mfaPanel;
 		if (challenge.expiresAt <= Date.now()) {
-			dispatchAuthPanel({
+			dispatchAuthFlow({
 				type: "set_mfa_error",
 				error: t("mfa_flow_expired"),
 			});
@@ -945,14 +915,14 @@ function useLoginPageController() {
 		}
 		const code = mfaPanel.code.trim();
 		if (mfaPanel.selectedMethod === "email_code" && !mfaPanel.emailCodeSent) {
-			dispatchAuthPanel({
+			dispatchAuthFlow({
 				type: "set_mfa_error",
 				error: t("mfa_email_code_required_send"),
 			});
 			return;
 		}
 		if (!code) {
-			dispatchAuthPanel({
+			dispatchAuthFlow({
 				type: "set_mfa_error",
 				error: t("mfa_code_required"),
 			});
@@ -965,7 +935,7 @@ function useLoginPageController() {
 				: resolveMfaMethod(code, challenge.methods);
 			const normalizedCode =
 				method === "totp" ? normalizeTotpCode(code) : code.trim();
-			dispatchAuthPanel({ type: "set_mfa_submitting", submitting: true });
+			dispatchAuthFlow({ type: "set_mfa_submitting", submitting: true });
 			await handleLoginResult(
 				await authService.verifyMfaChallenge({
 					flow_token: challenge.flowToken,
@@ -978,7 +948,7 @@ function useLoginPageController() {
 		} catch (error) {
 			handleApiError(error);
 		} finally {
-			dispatchAuthPanel({ type: "set_mfa_submitting", submitting: false });
+			dispatchAuthFlow({ type: "set_mfa_submitting", submitting: false });
 		}
 	};
 
@@ -986,7 +956,7 @@ function useLoginPageController() {
 		if (!mfaPanel) return;
 		if (mfaPanel.selectedMethod !== "email_code") return;
 		if (mfaPanel.challenge.expiresAt <= Date.now()) {
-			dispatchAuthPanel({
+			dispatchAuthFlow({
 				type: "set_mfa_error",
 				error: t("mfa_flow_expired"),
 			});
@@ -995,11 +965,11 @@ function useLoginPageController() {
 		if (mfaPanel.emailCodeResendAt > Date.now()) return;
 
 		try {
-			dispatchAuthPanel({ type: "set_mfa_email_code_sending", sending: true });
+			dispatchAuthFlow({ type: "set_mfa_email_code_sending", sending: true });
 			const result = await authService.sendMfaEmailCode({
 				flow_token: mfaPanel.challenge.flowToken,
 			});
-			dispatchAuthPanel({
+			dispatchAuthFlow({
 				type: "set_mfa_email_code_sent",
 				expiresIn: result.expires_in,
 				now: Date.now(),
@@ -1007,7 +977,7 @@ function useLoginPageController() {
 			});
 			toast.success(t("mfa_email_code_sent"));
 		} catch (error) {
-			dispatchAuthPanel({
+			dispatchAuthFlow({
 				type: "set_mfa_email_code_sending",
 				sending: false,
 			});
@@ -1066,7 +1036,7 @@ function useLoginPageController() {
 				invalidateSystemSetupState();
 				setSetupState(null);
 				setRegistrationClosed(true);
-				setMode("login");
+				dispatchAuthFlow({ type: "open_auth" });
 				setIdentifier(em);
 				setExtraField("");
 				setErrors({});
@@ -1091,13 +1061,12 @@ function useLoginPageController() {
 			setErrors({});
 			if (registeredUser.email_verified) {
 				toast.success(t("register_success_direct"));
-				dispatchAuthPanel({ type: "open_auth" });
-				setMode("login");
+				dispatchAuthFlow({ type: "open_auth" });
 				setIdentifier(em);
 				setExtraField("");
 			} else {
 				toast.success(t("register_success"));
-				dispatchAuthPanel({
+				dispatchAuthFlow({
 					type: "set_pending_activation",
 					pendingActivation: {
 						email: em,
@@ -1205,7 +1174,7 @@ function useLoginPageController() {
 									: t("sign_in_to_account"),
 		onActivationResendBack: closeActivationResendRequest,
 		onActivationResendEmailChange: (value: string, error: string) => {
-			dispatchAuthPanel({
+			dispatchAuthFlow({
 				type: "set_activation_resend_email",
 				email: value,
 				error,
@@ -1213,14 +1182,14 @@ function useLoginPageController() {
 		},
 		onActivationResendSubmit: () => void handleActivationResendRequest(),
 		onExternalAuthEmailChange: (value: string, error: string) => {
-			dispatchAuthPanel({
+			dispatchAuthFlow({
 				type: "set_external_email",
 				email: value,
 				error,
 			});
 		},
 		onExternalAuthIdentifierChange: (value: string) => {
-			dispatchAuthPanel({
+			dispatchAuthFlow({
 				type: "set_external_password_identifier",
 				identifier: value,
 			});
@@ -1228,14 +1197,14 @@ function useLoginPageController() {
 		onExternalAuthLogin: (provider: ExternalAuthPublicProvider) =>
 			void handleExternalAuthLogin(provider),
 		onExternalAuthModeChange: (nextMode: "password" | "email") =>
-			dispatchAuthPanel({ type: "set_external_mode", mode: nextMode }),
+			dispatchAuthFlow({ type: "set_external_mode", mode: nextMode }),
 		onExternalAuthPasswordChange: (value: string) => {
 			let error: string | undefined;
 			if (externalAuthRecovery?.passwordError) {
 				const result = existingPasswordSchema.safeParse(value);
 				error = result.success ? "" : (result.error.issues[0]?.message ?? "");
 			}
-			dispatchAuthPanel({
+			dispatchAuthFlow({
 				type: "set_external_password",
 				password: value,
 				error,
@@ -1248,7 +1217,7 @@ function useLoginPageController() {
 			validateSingle("extra", value, schema);
 		},
 		onForgotPassword: () => {
-			dispatchAuthPanel({
+			dispatchAuthFlow({
 				type: "open_password_reset",
 				email: passwordResetPrefill,
 			});
@@ -1269,14 +1238,14 @@ function useLoginPageController() {
 		},
 		onMfaBack: closeMfaChallenge,
 		onMfaCodeChange: (value: string) => {
-			dispatchAuthPanel({
+			dispatchAuthFlow({
 				type: "set_mfa_code",
 				code: value,
 			});
 		},
 		onMfaEmailCodeSend: () => void handleMfaEmailCodeSend(),
 		onMfaMethodChange: (method: MfaMethod) => {
-			dispatchAuthPanel({ type: "set_mfa_method", method });
+			dispatchAuthFlow({ type: "set_mfa_method", method });
 		},
 		onPasskeyLogin: () => void handlePasskeyLogin(),
 		onPasswordChange: (value: string) => {
@@ -1291,7 +1260,7 @@ function useLoginPageController() {
 		},
 		onPasswordResetBack: closePasswordResetRequest,
 		onPasswordResetEmailChange: (value: string, error: string) => {
-			dispatchAuthPanel({
+			dispatchAuthFlow({
 				type: "set_password_reset_email",
 				email: value,
 				error,
@@ -1301,7 +1270,7 @@ function useLoginPageController() {
 		onPendingActivationReset: resetPendingActivation,
 		onResendActivation: () => void handleResendActivation(),
 		onResendActivationRequest: () => {
-			dispatchAuthPanel({
+			dispatchAuthFlow({
 				type: "open_activation_resend",
 				email: activationResendPrefill,
 			});

--- a/frontend-panel/src/pages/LoginPage.tsx
+++ b/frontend-panel/src/pages/LoginPage.tsx
@@ -45,7 +45,10 @@ import { useFrontendConfigStore } from "@/stores/frontendConfigStore";
 import { useSystemSetupStore } from "@/stores/systemSetupStore";
 import type { ExternalAuthPublicProvider, SystemSetupState } from "@/types/api";
 import { ApiErrorCode } from "@/types/api-helpers";
-import { createAuthCommandCoordinator } from "./login/authCommandCoordinator";
+import {
+	type AuthCommandDispatchOptions,
+	createAuthCommandCoordinator,
+} from "./login/authCommandCoordinator";
 import {
 	type AuthPolicySnapshot,
 	createAuthRequestCoordinator,
@@ -152,8 +155,14 @@ function useLoginPageController() {
 	const [errors, setErrors] = useState<Record<string, string>>({});
 	const [authFlow, setAuthFlow] = useState(initialAuthUiFlow);
 	const dispatchAuthFlow = useCallback(
-		(event: Parameters<typeof authUiFlowReducer>[1], serial?: number) => {
-			setAuthFlow(authCommandCoordinatorRef.current.dispatch(event, serial));
+		(
+			event: Parameters<typeof authUiFlowReducer>[1],
+			serial?: number,
+			options?: AuthCommandDispatchOptions,
+		) => {
+			setAuthFlow(
+				authCommandCoordinatorRef.current.dispatch(event, serial, options),
+			);
 		},
 		[],
 	);
@@ -439,6 +448,8 @@ function useLoginPageController() {
 			.catch((error) => {
 				if (!coordinator.isCurrent(revision)) return;
 				logger.warn("failed to load auth bootstrap", error);
+				setRegistrationClosed(false);
+				dispatchAuthFlow({ type: "bootstrap_resolved", flow: "login" });
 			})
 			.finally(() => {
 				if (coordinator.isCurrent(revision)) {
@@ -648,19 +659,16 @@ function useLoginPageController() {
 
 	const handleActivationResendRequest = async () => {
 		if (!activationResendPanel || !passwordLoginEnabled) return;
-		const commandSerial = authCommandCoordinatorRef.current.begin();
 		const email = activationResendPanel.email.trim();
 		const result = emailSchema.safeParse(email);
 		if (!result.success) {
-			dispatchAuthFlow(
-				{
-					type: "set_activation_resend_error",
-					error: result.error.issues[0]?.message ?? "",
-				},
-				commandSerial,
-			);
+			dispatchAuthFlow({
+				type: "set_activation_resend_error",
+				error: result.error.issues[0]?.message ?? "",
+			});
 			return;
 		}
+		const commandSerial = authCommandCoordinatorRef.current.begin();
 
 		try {
 			dispatchAuthFlow(
@@ -683,25 +691,23 @@ function useLoginPageController() {
 					requesting: false,
 				},
 				commandSerial,
+				{ allowStale: true },
 			);
 		}
 	};
 
 	const handlePasswordResetRequest = async () => {
 		if (!passwordResetPanel || !passwordLoginEnabled) return;
-		const commandSerial = authCommandCoordinatorRef.current.begin();
 		const email = passwordResetPanel.email.trim();
 		const result = emailSchema.safeParse(email);
 		if (!result.success) {
-			dispatchAuthFlow(
-				{
-					type: "set_password_reset_error",
-					error: result.error.issues[0]?.message ?? "",
-				},
-				commandSerial,
-			);
+			dispatchAuthFlow({
+				type: "set_password_reset_error",
+				error: result.error.issues[0]?.message ?? "",
+			});
 			return;
 		}
+		const commandSerial = authCommandCoordinatorRef.current.begin();
 
 		try {
 			dispatchAuthFlow(
@@ -724,25 +730,23 @@ function useLoginPageController() {
 					requesting: false,
 				},
 				commandSerial,
+				{ allowStale: true },
 			);
 		}
 	};
 
 	const handleExternalAuthEmailVerificationRequest = async () => {
 		if (!externalAuthRecovery) return;
-		const commandSerial = authCommandCoordinatorRef.current.begin();
 		const email = externalAuthRecovery.email.trim();
 		const result = emailSchema.safeParse(email);
 		if (!result.success) {
-			dispatchAuthFlow(
-				{
-					type: "set_external_email_error",
-					error: result.error.issues[0]?.message ?? "",
-				},
-				commandSerial,
-			);
+			dispatchAuthFlow({
+				type: "set_external_email_error",
+				error: result.error.issues[0]?.message ?? "",
+			});
 			return;
 		}
+		const commandSerial = authCommandCoordinatorRef.current.begin();
 
 		try {
 			dispatchAuthFlow(
@@ -767,13 +771,13 @@ function useLoginPageController() {
 					submitting: false,
 				},
 				commandSerial,
+				{ allowStale: true },
 			);
 		}
 	};
 
 	const handleExternalAuthPasswordLink = async () => {
 		if (!externalAuthRecovery || !passwordLoginEnabled) return;
-		const commandSerial = authCommandCoordinatorRef.current.begin();
 		const id = externalAuthRecovery.passwordIdentifier.trim();
 		const pw = externalAuthRecovery.password;
 		const errs: Record<string, string> = {};
@@ -784,15 +788,13 @@ function useLoginPageController() {
 		if (!pwResult.success) {
 			errs.password = pwResult.error.issues[0]?.message ?? "";
 		}
-		dispatchAuthFlow(
-			{
-				type: "set_external_password_errors",
-				identifier: errs.identifier ?? "",
-				password: errs.password ?? "",
-			},
-			commandSerial,
-		);
+		dispatchAuthFlow({
+			type: "set_external_password_errors",
+			identifier: errs.identifier ?? "",
+			password: errs.password ?? "",
+		});
 		if (Object.keys(errs).length > 0) return;
+		const commandSerial = authCommandCoordinatorRef.current.begin();
 
 		try {
 			dispatchAuthFlow(
@@ -822,6 +824,7 @@ function useLoginPageController() {
 					submitting: false,
 				},
 				commandSerial,
+				{ allowStale: true },
 			);
 		}
 	};
@@ -966,39 +969,30 @@ function useLoginPageController() {
 
 	const handleMfaSubmit = async () => {
 		if (!mfaPanel) return;
-		const commandSerial = authCommandCoordinatorRef.current.begin();
 		const { challenge } = mfaPanel;
 		if (challenge.expiresAt <= Date.now()) {
-			dispatchAuthFlow(
-				{
-					type: "set_mfa_error",
-					error: t("mfa_flow_expired"),
-				},
-				commandSerial,
-			);
+			dispatchAuthFlow({
+				type: "set_mfa_error",
+				error: t("mfa_flow_expired"),
+			});
 			return;
 		}
 		const code = mfaPanel.code.trim();
 		if (mfaPanel.selectedMethod === "email_code" && !mfaPanel.emailCodeSent) {
-			dispatchAuthFlow(
-				{
-					type: "set_mfa_error",
-					error: t("mfa_email_code_required_send"),
-				},
-				commandSerial,
-			);
+			dispatchAuthFlow({
+				type: "set_mfa_error",
+				error: t("mfa_email_code_required_send"),
+			});
 			return;
 		}
 		if (!code) {
-			dispatchAuthFlow(
-				{
-					type: "set_mfa_error",
-					error: t("mfa_code_required"),
-				},
-				commandSerial,
-			);
+			dispatchAuthFlow({
+				type: "set_mfa_error",
+				error: t("mfa_code_required"),
+			});
 			return;
 		}
+		const commandSerial = authCommandCoordinatorRef.current.begin();
 
 		try {
 			const method = challenge.methods.includes(mfaPanel.selectedMethod)
@@ -1026,6 +1020,7 @@ function useLoginPageController() {
 			dispatchAuthFlow(
 				{ type: "set_mfa_submitting", submitting: false },
 				commandSerial,
+				{ allowStale: true },
 			);
 		}
 	};
@@ -1033,18 +1028,15 @@ function useLoginPageController() {
 	const handleMfaEmailCodeSend = async () => {
 		if (!mfaPanel) return;
 		if (mfaPanel.selectedMethod !== "email_code") return;
-		const commandSerial = authCommandCoordinatorRef.current.begin();
 		if (mfaPanel.challenge.expiresAt <= Date.now()) {
-			dispatchAuthFlow(
-				{
-					type: "set_mfa_error",
-					error: t("mfa_flow_expired"),
-				},
-				commandSerial,
-			);
+			dispatchAuthFlow({
+				type: "set_mfa_error",
+				error: t("mfa_flow_expired"),
+			});
 			return;
 		}
 		if (mfaPanel.emailCodeResendAt > Date.now()) return;
+		const commandSerial = authCommandCoordinatorRef.current.begin();
 
 		try {
 			dispatchAuthFlow(
@@ -1065,14 +1057,16 @@ function useLoginPageController() {
 			);
 			toast.success(t("mfa_email_code_sent"));
 		} catch (error) {
+			handleApiError(error);
+		} finally {
 			dispatchAuthFlow(
 				{
 					type: "set_mfa_email_code_sending",
 					sending: false,
 				},
 				commandSerial,
+				{ allowStale: true },
 			);
-			handleApiError(error);
 		}
 	};
 

--- a/frontend-panel/src/pages/LoginPage.tsx
+++ b/frontend-panel/src/pages/LoginPage.tsx
@@ -152,8 +152,8 @@ function useLoginPageController() {
 	const [errors, setErrors] = useState<Record<string, string>>({});
 	const [authFlow, setAuthFlow] = useState(initialAuthUiFlow);
 	const dispatchAuthFlow = useCallback(
-		(event: Parameters<typeof authUiFlowReducer>[1]) => {
-			setAuthFlow(authCommandCoordinatorRef.current.dispatch(event));
+		(event: Parameters<typeof authUiFlowReducer>[1], serial?: number) => {
+			setAuthFlow(authCommandCoordinatorRef.current.dispatch(event, serial));
 		},
 		[],
 	);
@@ -400,39 +400,51 @@ function useLoginPageController() {
 		void loadAuthBootstrap(authService, {
 			passkeyLoginEnabled: publicPasskeyLoginEnabled,
 			passwordLoginEnabled: publicPasswordLoginEnabled,
-		}).then((result) => {
-			if (!coordinator.isCurrent(revision)) return;
-			setAuthPolicy(result.policy);
-			if (result.providersError) {
-				logger.warn(
-					"failed to load external auth providers",
-					result.providersError,
-				);
-			}
-
-			if (result.check) {
-				setSystemSetupState(result.check.setup_state);
-				setSetupState(result.check.setup_state);
-				if (
-					result.check.setup_state === "needs_admin" ||
-					!result.check.has_users
-				) {
-					setRegistrationClosed(false);
-					dispatchAuthFlow({ type: "bootstrap_resolved", flow: "setup" });
-				} else {
-					setRegistrationClosed(
-						result.check.setup_state === "needs_storage" ||
-							!result.policy.allowUserRegistration ||
-							!result.policy.passwordLoginEnabled,
+		})
+			.then((result) => {
+				if (!coordinator.isCurrent(revision)) return;
+				setAuthPolicy(result.policy);
+				if (result.providersError) {
+					logger.warn(
+						"failed to load external auth providers",
+						result.providersError,
 					);
+				}
+				if (result.checkError) {
+					logger.warn("failed to load auth check", result.checkError);
+				}
+
+				if (result.check) {
+					setSystemSetupState(result.check.setup_state);
+					setSetupState(result.check.setup_state);
+					if (
+						result.check.setup_state === "needs_admin" ||
+						!result.check.has_users
+					) {
+						setRegistrationClosed(false);
+						dispatchAuthFlow({ type: "bootstrap_resolved", flow: "setup" });
+					} else {
+						setRegistrationClosed(
+							result.check.setup_state === "needs_storage" ||
+								!result.policy.allowUserRegistration ||
+								!result.policy.passwordLoginEnabled,
+						);
+						dispatchAuthFlow({ type: "bootstrap_resolved", flow: "login" });
+					}
+				} else {
+					setRegistrationClosed(false);
 					dispatchAuthFlow({ type: "bootstrap_resolved", flow: "login" });
 				}
-			} else {
-				setRegistrationClosed(false);
-				dispatchAuthFlow({ type: "bootstrap_resolved", flow: "login" });
-			}
-			setChecking(false);
-		});
+			})
+			.catch((error) => {
+				if (!coordinator.isCurrent(revision)) return;
+				logger.warn("failed to load auth bootstrap", error);
+			})
+			.finally(() => {
+				if (coordinator.isCurrent(revision)) {
+					setChecking(false);
+				}
+			});
 
 		return () => {
 			coordinator.invalidate();
@@ -551,7 +563,12 @@ function useLoginPageController() {
 	);
 
 	const handleLoginResult = useCallback(
-		async (result: LoginResult, returnPath: string, successMessage: string) => {
+		async (
+			result: LoginResult,
+			returnPath: string,
+			successMessage: string,
+			commandSerial?: number,
+		) => {
 			if (result.status === "authenticated") {
 				await finishAuthenticatedLogin(result, returnPath, successMessage);
 				return;
@@ -562,16 +579,19 @@ function useLoginPageController() {
 			}
 			const methods: MfaMethod[] =
 				result.methods.length > 0 ? result.methods : ["totp"];
-			dispatchAuthFlow({
-				type: "open_mfa",
-				challenge: {
-					expiresAt: Date.now() + result.expiresIn * 1000,
-					flowToken: result.flowToken,
-					methods,
-					returnPath,
-					successMessage,
+			dispatchAuthFlow(
+				{
+					type: "open_mfa",
+					challenge: {
+						expiresAt: Date.now() + result.expiresIn * 1000,
+						flowToken: result.flowToken,
+						methods,
+						returnPath,
+						successMessage,
+					},
 				},
-			});
+				commandSerial,
+			);
 			setPassword("");
 			setShowPassword(false);
 		},
@@ -628,101 +648,132 @@ function useLoginPageController() {
 
 	const handleActivationResendRequest = async () => {
 		if (!activationResendPanel || !passwordLoginEnabled) return;
+		const commandSerial = authCommandCoordinatorRef.current.begin();
 		const email = activationResendPanel.email.trim();
 		const result = emailSchema.safeParse(email);
 		if (!result.success) {
-			dispatchAuthFlow({
-				type: "set_activation_resend_error",
-				error: result.error.issues[0]?.message ?? "",
-			});
+			dispatchAuthFlow(
+				{
+					type: "set_activation_resend_error",
+					error: result.error.issues[0]?.message ?? "",
+				},
+				commandSerial,
+			);
 			return;
 		}
 
 		try {
-			dispatchAuthFlow({
-				type: "set_activation_resend_requesting",
-				requesting: true,
-			});
+			dispatchAuthFlow(
+				{
+					type: "set_activation_resend_requesting",
+					requesting: true,
+				},
+				commandSerial,
+			);
 			await authService.resendRegisterActivation(email);
 			toast.success(t("activation_resend_request_sent"));
 			setIdentifier(email);
-			dispatchAuthFlow({ type: "close_activation_resend" });
+			dispatchAuthFlow({ type: "close_activation_resend" }, commandSerial);
 		} catch (error) {
 			handleApiError(error);
 		} finally {
-			dispatchAuthFlow({
-				type: "set_activation_resend_requesting",
-				requesting: false,
-			});
+			dispatchAuthFlow(
+				{
+					type: "set_activation_resend_requesting",
+					requesting: false,
+				},
+				commandSerial,
+			);
 		}
 	};
 
 	const handlePasswordResetRequest = async () => {
 		if (!passwordResetPanel || !passwordLoginEnabled) return;
+		const commandSerial = authCommandCoordinatorRef.current.begin();
 		const email = passwordResetPanel.email.trim();
 		const result = emailSchema.safeParse(email);
 		if (!result.success) {
-			dispatchAuthFlow({
-				type: "set_password_reset_error",
-				error: result.error.issues[0]?.message ?? "",
-			});
+			dispatchAuthFlow(
+				{
+					type: "set_password_reset_error",
+					error: result.error.issues[0]?.message ?? "",
+				},
+				commandSerial,
+			);
 			return;
 		}
 
 		try {
-			dispatchAuthFlow({
-				type: "set_password_reset_requesting",
-				requesting: true,
-			});
+			dispatchAuthFlow(
+				{
+					type: "set_password_reset_requesting",
+					requesting: true,
+				},
+				commandSerial,
+			);
 			await authService.requestPasswordReset({ email });
 			toast.success(t("password_reset_request_sent"));
 			setIdentifier(email);
-			dispatchAuthFlow({ type: "close_password_reset" });
+			dispatchAuthFlow({ type: "close_password_reset" }, commandSerial);
 		} catch (error) {
 			handleApiError(error);
 		} finally {
-			dispatchAuthFlow({
-				type: "set_password_reset_requesting",
-				requesting: false,
-			});
+			dispatchAuthFlow(
+				{
+					type: "set_password_reset_requesting",
+					requesting: false,
+				},
+				commandSerial,
+			);
 		}
 	};
 
 	const handleExternalAuthEmailVerificationRequest = async () => {
 		if (!externalAuthRecovery) return;
+		const commandSerial = authCommandCoordinatorRef.current.begin();
 		const email = externalAuthRecovery.email.trim();
 		const result = emailSchema.safeParse(email);
 		if (!result.success) {
-			dispatchAuthFlow({
-				type: "set_external_email_error",
-				error: result.error.issues[0]?.message ?? "",
-			});
+			dispatchAuthFlow(
+				{
+					type: "set_external_email_error",
+					error: result.error.issues[0]?.message ?? "",
+				},
+				commandSerial,
+			);
 			return;
 		}
 
 		try {
-			dispatchAuthFlow({
-				type: "set_external_email_submitting",
-				submitting: true,
-			});
+			dispatchAuthFlow(
+				{
+					type: "set_external_email_submitting",
+					submitting: true,
+				},
+				commandSerial,
+			);
 			await authService.startExternalAuthEmailVerification({
 				flow_token: externalAuthRecovery.flowToken,
 				email,
 			});
-			dispatchAuthFlow({ type: "external_email_sent" });
+			dispatchAuthFlow({ type: "external_email_sent" }, commandSerial);
 			toast.success(t("external_auth_email_verification_sent_toast"));
 		} catch (error) {
 			handleApiError(error);
 		} finally {
-			dispatchAuthFlow({
-				type: "set_external_email_submitting",
-				submitting: false,
-			});
+			dispatchAuthFlow(
+				{
+					type: "set_external_email_submitting",
+					submitting: false,
+				},
+				commandSerial,
+			);
 		}
 	};
 
 	const handleExternalAuthPasswordLink = async () => {
 		if (!externalAuthRecovery || !passwordLoginEnabled) return;
+		const commandSerial = authCommandCoordinatorRef.current.begin();
 		const id = externalAuthRecovery.passwordIdentifier.trim();
 		const pw = externalAuthRecovery.password;
 		const errs: Record<string, string> = {};
@@ -733,18 +784,24 @@ function useLoginPageController() {
 		if (!pwResult.success) {
 			errs.password = pwResult.error.issues[0]?.message ?? "";
 		}
-		dispatchAuthFlow({
-			type: "set_external_password_errors",
-			identifier: errs.identifier ?? "",
-			password: errs.password ?? "",
-		});
+		dispatchAuthFlow(
+			{
+				type: "set_external_password_errors",
+				identifier: errs.identifier ?? "",
+				password: errs.password ?? "",
+			},
+			commandSerial,
+		);
 		if (Object.keys(errs).length > 0) return;
 
 		try {
-			dispatchAuthFlow({
-				type: "set_external_password_submitting",
-				submitting: true,
-			});
+			dispatchAuthFlow(
+				{
+					type: "set_external_password_submitting",
+					submitting: true,
+				},
+				commandSerial,
+			);
 			const result = await authService.linkExternalAuthWithPassword({
 				flow_token: externalAuthRecovery.flowToken,
 				identifier: id,
@@ -754,14 +811,18 @@ function useLoginPageController() {
 				result,
 				externalAuthRecovery.returnPath,
 				t("external_auth_password_link_success"),
+				commandSerial,
 			);
 		} catch (error) {
 			handleApiError(error);
 		} finally {
-			dispatchAuthFlow({
-				type: "set_external_password_submitting",
-				submitting: false,
-			});
+			dispatchAuthFlow(
+				{
+					type: "set_external_password_submitting",
+					submitting: false,
+				},
+				commandSerial,
+			);
 		}
 	};
 
@@ -905,27 +966,37 @@ function useLoginPageController() {
 
 	const handleMfaSubmit = async () => {
 		if (!mfaPanel) return;
+		const commandSerial = authCommandCoordinatorRef.current.begin();
 		const { challenge } = mfaPanel;
 		if (challenge.expiresAt <= Date.now()) {
-			dispatchAuthFlow({
-				type: "set_mfa_error",
-				error: t("mfa_flow_expired"),
-			});
+			dispatchAuthFlow(
+				{
+					type: "set_mfa_error",
+					error: t("mfa_flow_expired"),
+				},
+				commandSerial,
+			);
 			return;
 		}
 		const code = mfaPanel.code.trim();
 		if (mfaPanel.selectedMethod === "email_code" && !mfaPanel.emailCodeSent) {
-			dispatchAuthFlow({
-				type: "set_mfa_error",
-				error: t("mfa_email_code_required_send"),
-			});
+			dispatchAuthFlow(
+				{
+					type: "set_mfa_error",
+					error: t("mfa_email_code_required_send"),
+				},
+				commandSerial,
+			);
 			return;
 		}
 		if (!code) {
-			dispatchAuthFlow({
-				type: "set_mfa_error",
-				error: t("mfa_code_required"),
-			});
+			dispatchAuthFlow(
+				{
+					type: "set_mfa_error",
+					error: t("mfa_code_required"),
+				},
+				commandSerial,
+			);
 			return;
 		}
 
@@ -935,7 +1006,10 @@ function useLoginPageController() {
 				: resolveMfaMethod(code, challenge.methods);
 			const normalizedCode =
 				method === "totp" ? normalizeTotpCode(code) : code.trim();
-			dispatchAuthFlow({ type: "set_mfa_submitting", submitting: true });
+			dispatchAuthFlow(
+				{ type: "set_mfa_submitting", submitting: true },
+				commandSerial,
+			);
 			await handleLoginResult(
 				await authService.verifyMfaChallenge({
 					flow_token: challenge.flowToken,
@@ -944,43 +1018,60 @@ function useLoginPageController() {
 				}),
 				challenge.returnPath,
 				challenge.successMessage,
+				commandSerial,
 			);
 		} catch (error) {
 			handleApiError(error);
 		} finally {
-			dispatchAuthFlow({ type: "set_mfa_submitting", submitting: false });
+			dispatchAuthFlow(
+				{ type: "set_mfa_submitting", submitting: false },
+				commandSerial,
+			);
 		}
 	};
 
 	const handleMfaEmailCodeSend = async () => {
 		if (!mfaPanel) return;
 		if (mfaPanel.selectedMethod !== "email_code") return;
+		const commandSerial = authCommandCoordinatorRef.current.begin();
 		if (mfaPanel.challenge.expiresAt <= Date.now()) {
-			dispatchAuthFlow({
-				type: "set_mfa_error",
-				error: t("mfa_flow_expired"),
-			});
+			dispatchAuthFlow(
+				{
+					type: "set_mfa_error",
+					error: t("mfa_flow_expired"),
+				},
+				commandSerial,
+			);
 			return;
 		}
 		if (mfaPanel.emailCodeResendAt > Date.now()) return;
 
 		try {
-			dispatchAuthFlow({ type: "set_mfa_email_code_sending", sending: true });
+			dispatchAuthFlow(
+				{ type: "set_mfa_email_code_sending", sending: true },
+				commandSerial,
+			);
 			const result = await authService.sendMfaEmailCode({
 				flow_token: mfaPanel.challenge.flowToken,
 			});
-			dispatchAuthFlow({
-				type: "set_mfa_email_code_sent",
-				expiresIn: result.expires_in,
-				now: Date.now(),
-				resendAfter: result.resend_after,
-			});
+			dispatchAuthFlow(
+				{
+					type: "set_mfa_email_code_sent",
+					expiresIn: result.expires_in,
+					now: Date.now(),
+					resendAfter: result.resend_after,
+				},
+				commandSerial,
+			);
 			toast.success(t("mfa_email_code_sent"));
 		} catch (error) {
-			dispatchAuthFlow({
-				type: "set_mfa_email_code_sending",
-				sending: false,
-			});
+			dispatchAuthFlow(
+				{
+					type: "set_mfa_email_code_sending",
+					sending: false,
+				},
+				commandSerial,
+			);
 			handleApiError(error);
 		}
 	};
@@ -1012,6 +1103,7 @@ function useLoginPageController() {
 		if (mode === "idle") return;
 
 		setSubmitting(true);
+		const commandSerial = authCommandCoordinatorRef.current.begin();
 		try {
 			const id = identifier.trim();
 			const extra = extraField.trim();
@@ -1021,6 +1113,7 @@ function useLoginPageController() {
 					await authService.login(id, password),
 					"/",
 					loginSuccessMessage,
+					commandSerial,
 				);
 				return;
 			}
@@ -1036,7 +1129,7 @@ function useLoginPageController() {
 				invalidateSystemSetupState();
 				setSetupState(null);
 				setRegistrationClosed(true);
-				dispatchAuthFlow({ type: "open_auth" });
+				dispatchAuthFlow({ type: "open_auth" }, commandSerial);
 				setIdentifier(em);
 				setExtraField("");
 				setErrors({});
@@ -1051,6 +1144,7 @@ function useLoginPageController() {
 					await authService.login(em, password),
 					"/",
 					loginSuccessMessage,
+					commandSerial,
 				);
 				return;
 			}
@@ -1061,19 +1155,22 @@ function useLoginPageController() {
 			setErrors({});
 			if (registeredUser.email_verified) {
 				toast.success(t("register_success_direct"));
-				dispatchAuthFlow({ type: "open_auth" });
+				dispatchAuthFlow({ type: "open_auth" }, commandSerial);
 				setIdentifier(em);
 				setExtraField("");
 			} else {
 				toast.success(t("register_success"));
-				dispatchAuthFlow({
-					type: "set_pending_activation",
-					pendingActivation: {
-						email: em,
-						identifier: em,
-						username: un,
+				dispatchAuthFlow(
+					{
+						type: "set_pending_activation",
+						pendingActivation: {
+							email: em,
+							identifier: em,
+							username: un,
+						},
 					},
-				});
+					commandSerial,
+				);
 			}
 		} catch (error) {
 			if (mode === "login" && isLoginUnavailableError(error)) {

--- a/frontend-panel/src/pages/login/authCommandCoordinator.test.ts
+++ b/frontend-panel/src/pages/login/authCommandCoordinator.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { createAuthCommandCoordinator } from "./authCommandCoordinator";
+import { initialAuthUiFlow } from "./loginPageState";
+
+describe("auth command coordinator", () => {
+	it("owns the single flow reducer and rejects stale async commands", () => {
+		const coordinator = createAuthCommandCoordinator(initialAuthUiFlow);
+		const first = coordinator.begin();
+		coordinator.dispatch({
+			type: "open_mfa",
+			challenge: {
+				expiresAt: Date.now() + 300_000,
+				flowToken: "mfa-flow",
+				methods: ["totp"],
+				returnPath: "/",
+				successMessage: "signed in",
+			},
+		});
+		const second = coordinator.begin();
+		expect(coordinator.isCurrent(first)).toBe(false);
+		expect(coordinator.isCurrent(second)).toBe(true);
+		expect(coordinator.state().kind).toBe("mfa");
+		coordinator.cancel();
+		expect(coordinator.isCurrent(second)).toBe(false);
+	});
+
+	it("serializes top-level mode changes through the same command boundary", () => {
+		const coordinator = createAuthCommandCoordinator({ kind: "login" });
+		coordinator.dispatch({ type: "switch_auth_mode", mode: "register" });
+		expect(coordinator.state()).toEqual({ kind: "register" });
+		coordinator.dispatch({
+			type: "open_password_reset",
+			email: "a@example.com",
+		});
+		expect(coordinator.state().kind).toBe("password-reset");
+	});
+});

--- a/frontend-panel/src/pages/login/authCommandCoordinator.test.ts
+++ b/frontend-panel/src/pages/login/authCommandCoordinator.test.ts
@@ -23,8 +23,23 @@ describe("auth command coordinator", () => {
 		expect(coordinator.state().kind).toBe("mfa");
 		coordinator.dispatch({ type: "open_auth" }, second);
 		expect(coordinator.state().kind).toBe("login");
-		coordinator.cancel();
-		expect(coordinator.isCurrent(second)).toBe(false);
+	});
+
+	it("allows stale cleanup while rejecting stale result events", () => {
+		const coordinator = createAuthCommandCoordinator({ kind: "login" });
+		const serial = coordinator.begin();
+		coordinator.begin();
+		coordinator.dispatch(
+			{ type: "open_password_reset", email: "a@example.com" },
+			serial,
+		);
+		expect(coordinator.state().kind).toBe("login");
+		coordinator.dispatch(
+			{ type: "open_password_reset", email: "a@example.com" },
+			serial,
+			{ allowStale: true },
+		);
+		expect(coordinator.state().kind).toBe("password-reset");
 	});
 
 	it("serializes top-level mode changes through the same command boundary", () => {

--- a/frontend-panel/src/pages/login/authCommandCoordinator.test.ts
+++ b/frontend-panel/src/pages/login/authCommandCoordinator.test.ts
@@ -19,7 +19,10 @@ describe("auth command coordinator", () => {
 		const second = coordinator.begin();
 		expect(coordinator.isCurrent(first)).toBe(false);
 		expect(coordinator.isCurrent(second)).toBe(true);
+		coordinator.dispatch({ type: "open_auth" }, first);
 		expect(coordinator.state().kind).toBe("mfa");
+		coordinator.dispatch({ type: "open_auth" }, second);
+		expect(coordinator.state().kind).toBe("login");
 		coordinator.cancel();
 		expect(coordinator.isCurrent(second)).toBe(false);
 	});

--- a/frontend-panel/src/pages/login/authCommandCoordinator.ts
+++ b/frontend-panel/src/pages/login/authCommandCoordinator.ts
@@ -5,7 +5,7 @@ import {
 } from "./loginPageState";
 
 export interface AuthCommandCoordinator {
-	dispatch(event: AuthUiFlowEvent): AuthUiFlow;
+	dispatch(event: AuthUiFlowEvent, serial?: number): AuthUiFlow;
 	begin(): number;
 	cancel(): void;
 	isCurrent(serial: number): boolean;
@@ -18,8 +18,11 @@ export function createAuthCommandCoordinator(
 	let current = initial;
 	let serial = 0;
 	return {
-		dispatch(event) {
-			current = reduceAuthUiFlow(current, event);
+		dispatch(event, candidate) {
+			if (candidate !== undefined && candidate !== serial) {
+				return current;
+			}
+			current = authUiFlowReducer(current, event);
 			return current;
 		},
 		begin() {
@@ -36,11 +39,4 @@ export function createAuthCommandCoordinator(
 			return current;
 		},
 	};
-}
-
-function reduceAuthUiFlow(
-	state: AuthUiFlow,
-	event: AuthUiFlowEvent,
-): AuthUiFlow {
-	return authUiFlowReducer(state, event);
 }

--- a/frontend-panel/src/pages/login/authCommandCoordinator.ts
+++ b/frontend-panel/src/pages/login/authCommandCoordinator.ts
@@ -5,11 +5,19 @@ import {
 } from "./loginPageState";
 
 export interface AuthCommandCoordinator {
-	dispatch(event: AuthUiFlowEvent, serial?: number): AuthUiFlow;
+	dispatch(
+		event: AuthUiFlowEvent,
+		serial?: number,
+		options?: AuthCommandDispatchOptions,
+	): AuthUiFlow;
 	begin(): number;
-	cancel(): void;
 	isCurrent(serial: number): boolean;
 	state(): AuthUiFlow;
+}
+
+export interface AuthCommandDispatchOptions {
+	/** Allows a finally/cleanup event to land after its result generation is stale. */
+	allowStale?: boolean;
 }
 
 export function createAuthCommandCoordinator(
@@ -18,19 +26,21 @@ export function createAuthCommandCoordinator(
 	let current = initial;
 	let serial = 0;
 	return {
-		dispatch(event, candidate) {
-			if (candidate !== undefined && candidate !== serial) {
+		dispatch(event, candidate, options) {
+			if (
+				candidate !== undefined &&
+				candidate !== serial &&
+				!options?.allowStale
+			) {
 				return current;
 			}
 			current = authUiFlowReducer(current, event);
 			return current;
 		},
+		/** Starts a global generation; every older guarded result becomes stale. */
 		begin() {
 			serial += 1;
 			return serial;
-		},
-		cancel() {
-			serial += 1;
 		},
 		isCurrent(candidate) {
 			return candidate === serial;

--- a/frontend-panel/src/pages/login/authCommandCoordinator.ts
+++ b/frontend-panel/src/pages/login/authCommandCoordinator.ts
@@ -1,0 +1,46 @@
+import {
+	type AuthUiFlow,
+	type AuthUiFlowEvent,
+	authUiFlowReducer,
+} from "./loginPageState";
+
+export interface AuthCommandCoordinator {
+	dispatch(event: AuthUiFlowEvent): AuthUiFlow;
+	begin(): number;
+	cancel(): void;
+	isCurrent(serial: number): boolean;
+	state(): AuthUiFlow;
+}
+
+export function createAuthCommandCoordinator(
+	initial: AuthUiFlow,
+): AuthCommandCoordinator {
+	let current = initial;
+	let serial = 0;
+	return {
+		dispatch(event) {
+			current = reduceAuthUiFlow(current, event);
+			return current;
+		},
+		begin() {
+			serial += 1;
+			return serial;
+		},
+		cancel() {
+			serial += 1;
+		},
+		isCurrent(candidate) {
+			return candidate === serial;
+		},
+		state() {
+			return current;
+		},
+	};
+}
+
+function reduceAuthUiFlow(
+	state: AuthUiFlow,
+	event: AuthUiFlowEvent,
+): AuthUiFlow {
+	return authUiFlowReducer(state, event);
+}

--- a/frontend-panel/src/pages/login/authPolicyCoordinator.test.ts
+++ b/frontend-panel/src/pages/login/authPolicyCoordinator.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+import type { CheckResp, ExternalAuthPublicProvider } from "@/types/api";
+import {
+	createAuthRequestCoordinator,
+	loadAuthBootstrap,
+} from "./authPolicyCoordinator";
+
+function check(overrides: Partial<CheckResp> = {}): CheckResp {
+	return {
+		allow_user_registration: true,
+		has_users: true,
+		passkey_login_enabled: true,
+		password_login_enabled: true,
+		setup_state: "ready",
+		...overrides,
+	};
+}
+
+describe("auth policy coordinator", () => {
+	it("combines the authoritative check and provider list", async () => {
+		const provider = {
+			key: "company",
+			kind: "oidc",
+		} as ExternalAuthPublicProvider;
+		const result = await loadAuthBootstrap(
+			{
+				check: async () =>
+					check({
+						allow_user_registration: false,
+						password_login_enabled: false,
+					}),
+				listExternalAuthProviders: async () => [provider],
+			},
+			{ passkeyLoginEnabled: false, passwordLoginEnabled: true },
+			42,
+		);
+
+		expect(result.policy).toEqual({
+			allowUserRegistration: false,
+			checkedAt: 42,
+			externalProviders: [provider],
+			passkeyLoginEnabled: true,
+			passwordLoginEnabled: false,
+		});
+	});
+
+	it("keeps provider failure separate from the login policy", async () => {
+		const error = new Error("provider endpoint down");
+		const result = await loadAuthBootstrap(
+			{
+				check: async () => check({ passkey_login_enabled: false }),
+				listExternalAuthProviders: async () => Promise.reject(error),
+			},
+			{ passkeyLoginEnabled: true, passwordLoginEnabled: true },
+		);
+
+		expect(result.check).not.toBeNull();
+		expect(result.policy.externalProviders).toEqual([]);
+		expect(result.policy.passkeyLoginEnabled).toBe(false);
+		expect(result.providersError).toBe(error);
+	});
+
+	it("uses public policy fallback only when auth check fails", async () => {
+		const result = await loadAuthBootstrap(
+			{
+				check: async () => Promise.reject(new Error("check failed")),
+				listExternalAuthProviders: async () => [],
+			},
+			{ passkeyLoginEnabled: false, passwordLoginEnabled: true },
+		);
+
+		expect(result.policy.passkeyLoginEnabled).toBe(false);
+		expect(result.policy.passwordLoginEnabled).toBe(true);
+	});
+
+	it("invalidates stale and unmounted request generations", () => {
+		const coordinator = createAuthRequestCoordinator();
+		const first = coordinator.begin();
+		const second = coordinator.begin();
+		expect(coordinator.isCurrent(first)).toBe(false);
+		expect(coordinator.isCurrent(second)).toBe(true);
+		coordinator.invalidate();
+		expect(coordinator.isCurrent(second)).toBe(false);
+	});
+});

--- a/frontend-panel/src/pages/login/authPolicyCoordinator.test.ts
+++ b/frontend-panel/src/pages/login/authPolicyCoordinator.test.ts
@@ -61,9 +61,10 @@ describe("auth policy coordinator", () => {
 	});
 
 	it("uses public policy fallback only when auth check fails", async () => {
+		const error = new Error("check failed");
 		const result = await loadAuthBootstrap(
 			{
-				check: async () => Promise.reject(new Error("check failed")),
+				check: async () => Promise.reject(error),
 				listExternalAuthProviders: async () => [],
 			},
 			{ passkeyLoginEnabled: false, passwordLoginEnabled: true },
@@ -71,6 +72,7 @@ describe("auth policy coordinator", () => {
 
 		expect(result.policy.passkeyLoginEnabled).toBe(false);
 		expect(result.policy.passwordLoginEnabled).toBe(true);
+		expect(result.checkError).toBe(error);
 	});
 
 	it("invalidates stale and unmounted request generations", () => {

--- a/frontend-panel/src/pages/login/authPolicyCoordinator.ts
+++ b/frontend-panel/src/pages/login/authPolicyCoordinator.ts
@@ -1,0 +1,72 @@
+import type { CheckResp, ExternalAuthPublicProvider } from "@/types/api";
+
+export interface AuthPolicySnapshot {
+	allowUserRegistration: boolean;
+	checkedAt: number;
+	externalProviders: ExternalAuthPublicProvider[];
+	passkeyLoginEnabled: boolean;
+	passwordLoginEnabled: boolean;
+}
+
+export interface AuthBootstrapSnapshot {
+	check: CheckResp | null;
+	checkError: unknown;
+	policy: AuthPolicySnapshot;
+	providersError: unknown;
+}
+
+interface AuthPolicyLoader {
+	check(): Promise<CheckResp>;
+	listExternalAuthProviders(): Promise<ExternalAuthPublicProvider[]>;
+}
+
+export function createAuthRequestCoordinator() {
+	let revision = 0;
+	return {
+		begin() {
+			revision += 1;
+			return revision;
+		},
+		invalidate() {
+			revision += 1;
+		},
+		isCurrent(candidate: number) {
+			return candidate === revision;
+		},
+	};
+}
+
+export async function loadAuthBootstrap(
+	loader: AuthPolicyLoader,
+	fallback: Pick<
+		AuthPolicySnapshot,
+		"passkeyLoginEnabled" | "passwordLoginEnabled"
+	>,
+	now = Date.now(),
+): Promise<AuthBootstrapSnapshot> {
+	const [checkResult, providersResult] = await Promise.allSettled([
+		loader.check(),
+		loader.listExternalAuthProviders(),
+	]);
+	const check = checkResult.status === "fulfilled" ? checkResult.value : null;
+	const externalProviders =
+		providersResult.status === "fulfilled" ? providersResult.value : [];
+
+	return {
+		check,
+		checkError: checkResult.status === "rejected" ? checkResult.reason : null,
+		policy: {
+			allowUserRegistration: check?.allow_user_registration !== false,
+			checkedAt: now,
+			externalProviders,
+			passkeyLoginEnabled:
+				check?.passkey_login_enabled !== false &&
+				(check ? true : fallback.passkeyLoginEnabled),
+			passwordLoginEnabled:
+				check?.password_login_enabled !== false &&
+				(check ? true : fallback.passwordLoginEnabled),
+		},
+		providersError:
+			providersResult.status === "rejected" ? providersResult.reason : null,
+	};
+}

--- a/frontend-panel/src/pages/login/authPolicyCoordinator.ts
+++ b/frontend-panel/src/pages/login/authPolicyCoordinator.ts
@@ -59,12 +59,12 @@ export async function loadAuthBootstrap(
 			allowUserRegistration: check?.allow_user_registration !== false,
 			checkedAt: now,
 			externalProviders,
-			passkeyLoginEnabled:
-				check?.passkey_login_enabled !== false &&
-				(check ? true : fallback.passkeyLoginEnabled),
-			passwordLoginEnabled:
-				check?.password_login_enabled !== false &&
-				(check ? true : fallback.passwordLoginEnabled),
+			passkeyLoginEnabled: check
+				? check.passkey_login_enabled !== false
+				: fallback.passkeyLoginEnabled,
+			passwordLoginEnabled: check
+				? check.password_login_enabled !== false
+				: fallback.passwordLoginEnabled,
 		},
 		providersError:
 			providersResult.status === "rejected" ? providersResult.reason : null,

--- a/frontend-panel/src/pages/login/authUrlAdapter.test.ts
+++ b/frontend-panel/src/pages/login/authUrlAdapter.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import {
+	clearAuthFlowRedirectSearch,
+	parseRecoverableAuthUrlFlow,
+} from "./authUrlAdapter";
+
+describe("auth URL adapter", () => {
+	it("parses a typed MFA reference and deduplicates supported methods", () => {
+		expect(
+			parseRecoverableAuthUrlFlow(
+				"?mfa=required&flow=abc&expires_in=60.9&methods=totp,bad,totp,email_code&return_path=%2Ffiles",
+				1_000,
+			),
+		).toEqual({
+			expiresAt: 61_000,
+			flowToken: "abc",
+			kind: "mfa",
+			methods: ["totp", "email_code"],
+			returnPath: "/files",
+		});
+	});
+
+	it("bounds untrusted TTL and return path values", () => {
+		expect(
+			parseRecoverableAuthUrlFlow(
+				"?mfa=required&flow=abc&expires_in=999999&return_path=https%3A%2F%2Fevil.example",
+				0,
+			),
+		).toMatchObject({ expiresAt: 600_000, returnPath: "/" });
+		expect(
+			parseRecoverableAuthUrlFlow(
+				"?external_auth=email_required&flow=abc&return_path=%2F%2Fevil.example",
+			),
+		).toMatchObject({ kind: "external-auth-recovery", returnPath: "/" });
+	});
+
+	it("rejects missing references and unsupported statuses", () => {
+		expect(parseRecoverableAuthUrlFlow("?mfa=required")).toBeNull();
+		expect(parseRecoverableAuthUrlFlow("?mfa=success&flow=abc")).toBeNull();
+	});
+
+	it("removes flow transport fields while preserving unrelated query state", () => {
+		expect(
+			clearAuthFlowRedirectSearch(
+				"?mfa=required&flow=abc&methods=totp&theme=dark",
+			),
+		).toBe("?theme=dark");
+	});
+});

--- a/frontend-panel/src/pages/login/authUrlAdapter.test.ts
+++ b/frontend-panel/src/pages/login/authUrlAdapter.test.ts
@@ -34,6 +34,11 @@ describe("auth URL adapter", () => {
 		).toMatchObject({ kind: "external-auth-recovery", returnPath: "/" });
 		expect(
 			parseRecoverableAuthUrlFlow(
+				"?external_auth=email_required&flow=abc&return_path=%2F%5Cevil.example",
+			),
+		).toMatchObject({ kind: "external-auth-recovery", returnPath: "/" });
+		expect(
+			parseRecoverableAuthUrlFlow(
 				"?mfa=required&flow=abc&expires_in=0&methods=unknown",
 				0,
 			),

--- a/frontend-panel/src/pages/login/authUrlAdapter.test.ts
+++ b/frontend-panel/src/pages/login/authUrlAdapter.test.ts
@@ -32,6 +32,18 @@ describe("auth URL adapter", () => {
 				"?external_auth=email_required&flow=abc&return_path=%2F%2Fevil.example",
 			),
 		).toMatchObject({ kind: "external-auth-recovery", returnPath: "/" });
+		expect(
+			parseRecoverableAuthUrlFlow(
+				"?mfa=required&flow=abc&expires_in=0&methods=unknown",
+				0,
+			),
+		).toMatchObject({ expiresAt: 300_000, methods: ["totp", "recovery_code"] });
+		expect(
+			parseRecoverableAuthUrlFlow(
+				"?mfa=required&flow=abc&expires_in=not-a-number",
+				0,
+			),
+		).toMatchObject({ expiresAt: 300_000 });
 	});
 
 	it("rejects missing references and unsupported statuses", () => {

--- a/frontend-panel/src/pages/login/authUrlAdapter.ts
+++ b/frontend-panel/src/pages/login/authUrlAdapter.ts
@@ -1,0 +1,88 @@
+import type { MfaMethod } from "@/services/authService";
+
+const MFA_METHODS: MfaMethod[] = ["totp", "recovery_code", "email_code"];
+const DEFAULT_MFA_TTL_SECONDS = 300;
+const MAX_MFA_TTL_SECONDS = 600;
+
+export type RecoverableAuthUrlFlow =
+	| {
+			flowToken: string;
+			kind: "external-auth-recovery";
+			returnPath: string;
+	  }
+	| {
+			expiresAt: number;
+			flowToken: string;
+			kind: "mfa";
+			methods: MfaMethod[];
+			returnPath: string;
+	  };
+
+export function parseRecoverableAuthUrlFlow(
+	search: string,
+	now = Date.now(),
+): RecoverableAuthUrlFlow | null {
+	const params = new URLSearchParams(search);
+	const flowToken = params.get("flow")?.trim();
+	if (!flowToken) return null;
+	const returnPath = normalizeReturnPath(params.get("return_path"));
+
+	if (params.get("mfa") === "required") {
+		return {
+			expiresAt: now + parseMfaTtlSeconds(params.get("expires_in")) * 1000,
+			flowToken,
+			kind: "mfa",
+			methods: parseMfaMethods(params.get("methods")),
+			returnPath,
+		};
+	}
+	if (params.get("external_auth") === "email_required") {
+		return {
+			flowToken,
+			kind: "external-auth-recovery",
+			returnPath,
+		};
+	}
+	return null;
+}
+
+export function clearAuthFlowRedirectSearch(search: string) {
+	const params = new URLSearchParams(search);
+	for (const key of [
+		"external_auth",
+		"mfa",
+		"code",
+		"message",
+		"invitation",
+		"flow",
+		"expires_in",
+		"methods",
+		"return_path",
+	]) {
+		params.delete(key);
+	}
+	const cleaned = params.toString();
+	return cleaned ? `?${cleaned}` : "";
+}
+
+function normalizeReturnPath(value: string | null) {
+	if (!value?.startsWith("/") || value.startsWith("//")) return "/";
+	return value;
+}
+
+function parseMfaMethods(value: string | null): MfaMethod[] {
+	if (!value) return ["totp", "recovery_code"];
+	const methods = value
+		.split(",")
+		.map((method) => method.trim())
+		.filter((method): method is MfaMethod =>
+			MFA_METHODS.includes(method as MfaMethod),
+		);
+	return methods.length > 0 ? [...new Set(methods)] : ["totp", "recovery_code"];
+}
+
+function parseMfaTtlSeconds(value: string | null) {
+	const parsed = Number(value);
+	if (!Number.isFinite(parsed) || parsed <= 0) return DEFAULT_MFA_TTL_SECONDS;
+	return Math.min(Math.floor(parsed), MAX_MFA_TTL_SECONDS);
+}

--- a/frontend-panel/src/pages/login/authUrlAdapter.ts
+++ b/frontend-panel/src/pages/login/authUrlAdapter.ts
@@ -66,7 +66,7 @@ export function clearAuthFlowRedirectSearch(search: string) {
 }
 
 function normalizeReturnPath(value: string | null) {
-	if (!value?.startsWith("/") || value.startsWith("//")) return "/";
+	if (!value?.startsWith("/") || /^[\\/]{2}/.test(value)) return "/";
 	return value;
 }
 

--- a/frontend-panel/src/pages/login/loginPageState.test.ts
+++ b/frontend-panel/src/pages/login/loginPageState.test.ts
@@ -1,8 +1,8 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
-	type AuthPanelState,
-	authPanelReducer,
-	initialAuthPanelState,
+	type AuthUiFlow,
+	authUiFlowReducer,
+	initialAuthUiFlow,
 	type MfaChallengeState,
 } from "./loginPageState";
 
@@ -19,21 +19,57 @@ function mfaChallenge(
 	};
 }
 
-describe("authPanelReducer", () => {
+describe("authUiFlowReducer", () => {
 	afterEach(() => {
 		vi.useRealTimers();
 	});
 
+	it("resolves bootstrap once and keeps a URL-restored flow authoritative", () => {
+		expect(
+			authUiFlowReducer(initialAuthUiFlow, {
+				type: "bootstrap_resolved",
+				flow: "setup",
+			}),
+		).toEqual({ kind: "setup" });
+
+		const restored = authUiFlowReducer(initialAuthUiFlow, {
+			type: "open_mfa",
+			challenge: mfaChallenge(),
+		});
+		expect(
+			authUiFlowReducer(restored, {
+				type: "bootstrap_resolved",
+				flow: "login",
+			}),
+		).toBe(restored);
+	});
+
+	it("switches only between the login and registration top-level flows", () => {
+		const login: AuthUiFlow = { kind: "login" };
+		expect(
+			authUiFlowReducer(login, {
+				type: "switch_auth_mode",
+				mode: "register",
+			}),
+		).toEqual({ kind: "register" });
+		expect(
+			authUiFlowReducer(initialAuthUiFlow, {
+				type: "switch_auth_mode",
+				mode: "register",
+			}),
+		).toBe(initialAuthUiFlow);
+	});
+
 	it("ignores password reset edits outside the password reset panel", () => {
-		const sameState = authPanelReducer(initialAuthPanelState, {
+		const sameState = authUiFlowReducer(initialAuthUiFlow, {
 			type: "set_password_reset_email",
 			email: "alice@example.com",
 			error: "",
 		});
 
-		expect(sameState).toBe(initialAuthPanelState);
+		expect(sameState).toBe(initialAuthUiFlow);
 
-		const mfaState: AuthPanelState = {
+		const mfaState: AuthUiFlow = {
 			challenge: mfaChallenge(),
 			code: "",
 			emailCodeError: "",
@@ -49,7 +85,7 @@ describe("authPanelReducer", () => {
 		};
 
 		expect(
-			authPanelReducer(mfaState, {
+			authUiFlowReducer(mfaState, {
 				type: "set_password_reset_error",
 				error: "invalid-email",
 			}),
@@ -60,12 +96,12 @@ describe("authPanelReducer", () => {
 		vi.useFakeTimers();
 		vi.setSystemTime(new Date("2026-05-24T08:00:00.000Z"));
 
-		const opened = authPanelReducer(initialAuthPanelState, {
+		const opened = authUiFlowReducer(initialAuthUiFlow, {
 			type: "open_password_reset",
 			email: "old@example.com",
 		});
 
-		const edited = authPanelReducer(opened, {
+		const edited = authUiFlowReducer(opened, {
 			type: "set_password_reset_email",
 			email: "new@example.com",
 			error: "invalid-email",
@@ -81,7 +117,7 @@ describe("authPanelReducer", () => {
 		});
 
 		expect(
-			authPanelReducer(edited, {
+			authUiFlowReducer(edited, {
 				type: "set_password_reset_error",
 				error: "",
 			}),
@@ -96,12 +132,12 @@ describe("authPanelReducer", () => {
 	});
 
 	it("updates activation resend email and request lifecycle while the panel is active", () => {
-		const opened = authPanelReducer(initialAuthPanelState, {
+		const opened = authUiFlowReducer(initialAuthUiFlow, {
 			type: "open_activation_resend",
 			email: "old@example.com",
 		});
 
-		const edited = authPanelReducer(opened, {
+		const edited = authUiFlowReducer(opened, {
 			type: "set_activation_resend_email",
 			email: "new@example.com",
 			error: "invalid-email",
@@ -116,7 +152,7 @@ describe("authPanelReducer", () => {
 			kind: "activation-resend",
 		});
 
-		const requesting = authPanelReducer(edited, {
+		const requesting = authUiFlowReducer(edited, {
 			type: "set_activation_resend_requesting",
 			requesting: true,
 		});
@@ -131,7 +167,7 @@ describe("authPanelReducer", () => {
 		});
 
 		expect(
-			authPanelReducer(requesting, {
+			authUiFlowReducer(requesting, {
 				type: "set_activation_resend_error",
 				error: "",
 			}),
@@ -143,40 +179,40 @@ describe("authPanelReducer", () => {
 	});
 
 	it("closes the activation resend panel back to auth", () => {
-		const opened = authPanelReducer(initialAuthPanelState, {
+		const opened = authUiFlowReducer(initialAuthUiFlow, {
 			type: "open_activation_resend",
 			email: "old@example.com",
 		});
 
-		expect(authPanelReducer(opened, { type: "close_activation_resend" })).toBe(
-			initialAuthPanelState,
-		);
+		expect(
+			authUiFlowReducer(opened, { type: "close_activation_resend" }),
+		).toEqual({ kind: "login" });
 	});
 
 	it("ignores activation resend edits outside the activation resend panel", () => {
 		expect(
-			authPanelReducer(initialAuthPanelState, {
+			authUiFlowReducer(initialAuthUiFlow, {
 				type: "set_activation_resend_email",
 				email: "new@example.com",
 				error: "",
 			}),
-		).toBe(initialAuthPanelState);
+		).toBe(initialAuthUiFlow);
 		expect(
-			authPanelReducer(initialAuthPanelState, {
+			authUiFlowReducer(initialAuthUiFlow, {
 				type: "set_activation_resend_error",
 				error: "invalid-email",
 			}),
-		).toBe(initialAuthPanelState);
+		).toBe(initialAuthUiFlow);
 		expect(
-			authPanelReducer(initialAuthPanelState, {
+			authUiFlowReducer(initialAuthUiFlow, {
 				type: "set_activation_resend_requesting",
 				requesting: true,
 			}),
-		).toBe(initialAuthPanelState);
+		).toBe(initialAuthUiFlow);
 	});
 
 	it("opens email-only MFA challenges with email selected", () => {
-		const opened = authPanelReducer(initialAuthPanelState, {
+		const opened = authUiFlowReducer(initialAuthUiFlow, {
 			type: "open_mfa",
 			challenge: mfaChallenge({ methods: ["email_code"] }),
 		});
@@ -197,7 +233,7 @@ describe("authPanelReducer", () => {
 
 	it("falls back through recovery-code and totp MFA initial methods", () => {
 		expect(
-			authPanelReducer(initialAuthPanelState, {
+			authUiFlowReducer(initialAuthUiFlow, {
 				type: "open_mfa",
 				challenge: mfaChallenge({ methods: ["recovery_code"] }),
 			}),
@@ -206,7 +242,7 @@ describe("authPanelReducer", () => {
 			selectedMethod: "recovery_code",
 		});
 		expect(
-			authPanelReducer(initialAuthPanelState, {
+			authUiFlowReducer(initialAuthUiFlow, {
 				type: "open_mfa",
 				challenge: mfaChallenge({ methods: [] }),
 			}),
@@ -217,7 +253,7 @@ describe("authPanelReducer", () => {
 	});
 
 	it("ignores unavailable MFA methods and clears code when switching methods", () => {
-		const state: AuthPanelState = {
+		const state: AuthUiFlow = {
 			challenge: mfaChallenge({ methods: ["totp", "email_code"] }),
 			code: "123456",
 			emailCodeError: "",
@@ -233,14 +269,14 @@ describe("authPanelReducer", () => {
 		};
 
 		expect(
-			authPanelReducer(state, {
+			authUiFlowReducer(state, {
 				type: "set_mfa_method",
 				method: "recovery_code",
 			}),
 		).toBe(state);
 
 		expect(
-			authPanelReducer(state, {
+			authUiFlowReducer(state, {
 				type: "set_mfa_method",
 				method: "email_code",
 			}),
@@ -256,12 +292,12 @@ describe("authPanelReducer", () => {
 		vi.useFakeTimers();
 		vi.setSystemTime(new Date("2026-05-24T08:00:00.000Z"));
 		const now = Date.now();
-		const opened = authPanelReducer(initialAuthPanelState, {
+		const opened = authUiFlowReducer(initialAuthUiFlow, {
 			type: "open_mfa",
 			challenge: mfaChallenge({ methods: ["email_code"] }),
 		});
 
-		const sending = authPanelReducer(opened, {
+		const sending = authUiFlowReducer(opened, {
 			type: "set_mfa_email_code_sending",
 			sending: true,
 		});
@@ -270,7 +306,7 @@ describe("authPanelReducer", () => {
 			emailCodeSending: true,
 		});
 
-		const sent = authPanelReducer(sending, {
+		const sent = authUiFlowReducer(sending, {
 			type: "set_mfa_email_code_sent",
 			expiresIn: 600,
 			now,
@@ -285,10 +321,10 @@ describe("authPanelReducer", () => {
 		});
 
 		expect(
-			authPanelReducer(initialAuthPanelState, {
+			authUiFlowReducer(initialAuthUiFlow, {
 				type: "set_mfa_email_code_sending",
 				sending: true,
 			}),
-		).toBe(initialAuthPanelState);
+		).toBe(initialAuthUiFlow);
 	});
 });

--- a/frontend-panel/src/pages/login/loginPageState.ts
+++ b/frontend-panel/src/pages/login/loginPageState.ts
@@ -51,12 +51,15 @@ export interface ActivationResendPanelState {
 	requesting: boolean;
 }
 
-export type AuthPanelState =
+export type AuthUiFlow =
 	| {
 			activationResend: ActivationResendPanelState;
 			kind: "activation-resend";
 	  }
-	| { kind: "auth" }
+	| { kind: "bootstrapping" }
+	| { kind: "login" }
+	| { kind: "register" }
+	| { kind: "setup" }
 	| { kind: "external-auth-recovery"; recovery: ExternalAuthRecoveryState }
 	| MfaPanelState
 	| {
@@ -68,7 +71,8 @@ export type AuthPanelState =
 			pendingActivation: PendingActivationState;
 	  };
 
-export type AuthPanelAction =
+export type AuthUiFlowEvent =
+	| { type: "bootstrap_resolved"; flow: "login" | "setup" }
 	| { type: "close_activation_resend" }
 	| { type: "close_external_auth_recovery" }
 	| { type: "close_mfa" }
@@ -110,22 +114,26 @@ export type AuthPanelAction =
 	| { type: "set_password_reset_email"; email: string; error: string }
 	| { type: "set_password_reset_error"; error: string }
 	| { type: "set_password_reset_requesting"; requesting: boolean }
+	| { type: "switch_auth_mode"; mode: "login" | "register" }
 	| {
 			type: "set_pending_activation";
 			pendingActivation: PendingActivationState;
 	  };
 
-export const initialAuthPanelState: AuthPanelState = { kind: "auth" };
+export const initialAuthUiFlow: AuthUiFlow = { kind: "bootstrapping" };
 
-export function authPanelReducer(
-	state: AuthPanelState,
-	action: AuthPanelAction,
-): AuthPanelState {
+export function authUiFlowReducer(
+	state: AuthUiFlow,
+	action: AuthUiFlowEvent,
+): AuthUiFlow {
 	switch (action.type) {
+		case "bootstrap_resolved":
+			if (state.kind !== "bootstrapping") return state;
+			return { kind: action.flow };
 		case "close_activation_resend":
 		case "close_external_auth_recovery":
 		case "open_auth":
-			return initialAuthPanelState;
+			return { kind: "login" };
 		case "open_activation_resend":
 			return {
 				activationResend: {
@@ -136,10 +144,10 @@ export function authPanelReducer(
 				kind: "activation-resend",
 			};
 		case "close_mfa":
-			return initialAuthPanelState;
+			return { kind: "login" };
 		case "close_password_reset":
 			if (state.kind !== "password-reset") return state;
-			return initialAuthPanelState;
+			return { kind: "login" };
 		case "set_activation_resend_email":
 			if (state.kind !== "activation-resend") return state;
 			return {
@@ -359,6 +367,9 @@ export function authPanelReducer(
 				kind: "pending-activation",
 				pendingActivation: action.pendingActivation,
 			};
+		case "switch_auth_mode":
+			if (state.kind !== "login" && state.kind !== "register") return state;
+			return { kind: action.mode };
 	}
 }
 

--- a/src/db/repository/contact_verification_token_repo.rs
+++ b/src/db/repository/contact_verification_token_repo.rs
@@ -73,19 +73,16 @@ pub async fn mark_consumed<C: ConnectionTrait>(
     active.update(db).await.map_err(AsterError::from)
 }
 
-pub async fn mark_consumed_if_unused<C: ConnectionTrait>(
-    db: &C,
-    token_id: i64,
-    now: chrono::DateTime<Utc>,
-) -> Result<bool> {
+pub async fn mark_consumed_if_unused<C: ConnectionTrait>(db: &C, token_id: i64) -> Result<bool> {
+    let execution_now = Utc::now();
     let result = ContactVerificationToken::update_many()
         .col_expr(
             contact_verification_token::Column::ConsumedAt,
-            Expr::value(Some(Utc::now())),
+            Expr::value(Some(execution_now)),
         )
         .filter(contact_verification_token::Column::Id.eq(token_id))
         .filter(contact_verification_token::Column::ConsumedAt.is_null())
-        .filter(contact_verification_token::Column::ExpiresAt.gt(now))
+        .filter(contact_verification_token::Column::ExpiresAt.gt(execution_now))
         .exec(db)
         .await
         .map_err(AsterError::from)?;

--- a/src/db/repository/contact_verification_token_repo.rs
+++ b/src/db/repository/contact_verification_token_repo.rs
@@ -73,7 +73,11 @@ pub async fn mark_consumed<C: ConnectionTrait>(
     active.update(db).await.map_err(AsterError::from)
 }
 
-pub async fn mark_consumed_if_unused<C: ConnectionTrait>(db: &C, token_id: i64) -> Result<bool> {
+pub async fn mark_consumed_if_unused<C: ConnectionTrait>(
+    db: &C,
+    token_id: i64,
+    now: chrono::DateTime<Utc>,
+) -> Result<bool> {
     let result = ContactVerificationToken::update_many()
         .col_expr(
             contact_verification_token::Column::ConsumedAt,
@@ -81,6 +85,7 @@ pub async fn mark_consumed_if_unused<C: ConnectionTrait>(db: &C, token_id: i64) 
         )
         .filter(contact_verification_token::Column::Id.eq(token_id))
         .filter(contact_verification_token::Column::ConsumedAt.is_null())
+        .filter(contact_verification_token::Column::ExpiresAt.gt(now))
         .exec(db)
         .await
         .map_err(AsterError::from)?;

--- a/src/db/repository/external_auth_email_verification_flow_repo.rs
+++ b/src/db/repository/external_auth_email_verification_flow_repo.rs
@@ -79,19 +79,16 @@ pub async fn update_email_request<C: ConnectionTrait>(
     Ok(result.rows_affected == 1)
 }
 
-pub async fn mark_consumed_if_unused<C: ConnectionTrait>(
-    db: &C,
-    id: i64,
-    now: chrono::DateTime<Utc>,
-) -> Result<bool> {
+pub async fn mark_consumed_if_unused<C: ConnectionTrait>(db: &C, id: i64) -> Result<bool> {
+    let execution_now = Utc::now();
     let result = ExternalAuthEmailVerificationFlow::update_many()
         .col_expr(
             external_auth_email_verification_flow::Column::ConsumedAt,
-            Expr::value(Some(now)),
+            Expr::value(Some(execution_now)),
         )
         .filter(external_auth_email_verification_flow::Column::Id.eq(id))
         .filter(external_auth_email_verification_flow::Column::ConsumedAt.is_null())
-        .filter(external_auth_email_verification_flow::Column::ExpiresAt.gt(now))
+        .filter(external_auth_email_verification_flow::Column::ExpiresAt.gt(execution_now))
         .exec(db)
         .await
         .map_err(AsterError::from)?;

--- a/src/db/repository/external_auth_login_flow_repo.rs
+++ b/src/db/repository/external_auth_login_flow_repo.rs
@@ -56,6 +56,22 @@ pub async fn consume_by_state_and_browser_binding_hash(
     }
 }
 
+pub async fn find_active_by_state_and_browser_binding_hash(
+    db: &DatabaseConnection,
+    state_hash: &str,
+    browser_binding_hash: &str,
+    now: chrono::DateTime<Utc>,
+) -> Result<Option<external_auth_login_flow::Model>> {
+    ExternalAuthLoginFlow::find()
+        .filter(external_auth_login_flow::Column::StateHash.eq(state_hash))
+        .filter(external_auth_login_flow::Column::BrowserBindingHash.eq(browser_binding_hash))
+        .filter(external_auth_login_flow::Column::ConsumedAt.is_null())
+        .filter(external_auth_login_flow::Column::ExpiresAt.gt(now))
+        .one(db)
+        .await
+        .map_err(AsterError::from)
+}
+
 pub async fn cleanup_expired(db: &DatabaseConnection, now: chrono::DateTime<Utc>) -> Result<u64> {
     let result = ExternalAuthLoginFlow::delete_many()
         .filter(external_auth_login_flow::Column::ExpiresAt.lt(now))

--- a/src/services/auth/external/login.rs
+++ b/src/services/auth/external/login.rs
@@ -5,6 +5,10 @@ use sea_orm::ActiveValue::Set;
 use crate::db::repository::{external_auth_login_flow_repo, external_auth_provider_repo};
 use crate::errors::{AsterError, Result};
 use crate::runtime::SharedRuntimeState;
+use crate::services::auth::flow::{
+    AuthFlowCommand, AuthFlowKind, AuthFlowState, AuthFlowTransitionError, external_login_snapshot,
+    new_primary_flow, plan_transition,
+};
 use aster_drive_model::entities::external_auth_login_flow;
 use aster_forge_crypto as hash;
 use aster_forge_external_auth::{
@@ -72,6 +76,16 @@ pub async fn start_login(
     let now = Utc::now();
     let ttl = u64_to_i64(FLOW_TTL_SECS, "external auth login flow ttl")?;
     let browser_binding_secret = browser_binding_secret();
+    new_primary_flow(
+        AuthFlowKind::ExternalLogin,
+        format!(
+            "external-login:{}",
+            external_auth_normalize::state_hash(&auth_start.state)
+        ),
+        now + Duration::seconds(ttl),
+        now,
+    )
+    .map_err(|_| AsterError::auth_invalid_credentials("external auth flow could not start"))?;
     let flow = external_auth_login_flow::ActiveModel {
         provider_id: Set(provider.id),
         state_hash: Set(external_auth_normalize::state_hash(&auth_start.state)),
@@ -115,10 +129,37 @@ pub async fn finish_callback(
         AsterError::auth_invalid_credentials("external auth login flow is invalid or expired")
     })?;
 
+    let state_hash = external_auth_normalize::state_hash(state_value);
+    let browser_binding_hash = hash::sha256_hex(browser_binding_secret.as_bytes());
+    let candidate = external_auth_login_flow_repo::find_active_by_state_and_browser_binding_hash(
+        state.writer_db(),
+        &state_hash,
+        &browser_binding_hash,
+        Utc::now(),
+    )
+    .await?
+    .ok_or_else(|| {
+        AsterError::auth_invalid_credentials("external auth login flow is invalid or expired")
+    })?;
+    plan_transition(
+        &external_login_snapshot(&candidate, Utc::now()),
+        AuthFlowCommand::Transition {
+            expected_revision: external_login_snapshot(&candidate, Utc::now()).revision,
+            to: AuthFlowState::Processing,
+        },
+        Utc::now(),
+    )
+    .map_err(|error| match error {
+        AuthFlowTransitionError::Expired | AuthFlowTransitionError::Terminal(_) => {
+            AsterError::auth_invalid_credentials("external auth login flow is invalid or expired")
+        }
+        _ => AsterError::auth_invalid_credentials("external auth login flow transition is invalid"),
+    })?;
+
     let flow = external_auth_login_flow_repo::consume_by_state_and_browser_binding_hash(
         state.writer_db(),
-        &external_auth_normalize::state_hash(state_value),
-        &hash::sha256_hex(browser_binding_secret.as_bytes()),
+        &state_hash,
+        &browser_binding_hash,
         Utc::now(),
     )
     .await?
@@ -156,7 +197,6 @@ pub async fn finish_callback(
             "external auth provider is disabled",
         ));
     }
-
     let runtime_provider = external_auth_provider_config(&provider);
     let user_claims = default_registry()
         .driver_for_provider(&runtime_provider)?

--- a/src/services/auth/external/password_link.rs
+++ b/src/services/auth/external/password_link.rs
@@ -5,6 +5,7 @@ use crate::db::repository::{
 };
 use crate::errors::{AsterError, Result};
 use crate::runtime::SharedRuntimeState;
+use crate::services::auth::flow::{AuthFlowState, external_recovery_snapshot};
 use crate::services::auth::local;
 use aster_forge_db::transaction;
 use aster_forge_external_auth::normalize as external_auth_normalize;
@@ -44,6 +45,11 @@ pub async fn link_with_password(
     .ok_or_else(|| {
         AsterError::contact_verification_invalid("external auth email verification flow is invalid")
     })?;
+    if external_recovery_snapshot(&flow, Utc::now()).state != AuthFlowState::RecoveryPending {
+        return Err(AsterError::contact_verification_invalid(
+            "external auth recovery flow is no longer active",
+        ));
+    }
     let provider =
         external_auth_provider_repo::find_by_id(state.writer_db(), flow.provider_id).await?;
     if !provider.enabled {

--- a/src/services/auth/external/password_link.rs
+++ b/src/services/auth/external/password_link.rs
@@ -83,7 +83,7 @@ pub async fn link_with_password(
     let txn = transaction::begin(state.writer_db()).await?;
     let result = async {
         let consumed =
-            external_auth_email_verification_flow_repo::mark_consumed_if_unused(&txn, flow.id, now)
+            external_auth_email_verification_flow_repo::mark_consumed_if_unused(&txn, flow.id)
                 .await?;
         if !consumed {
             return Err(AsterError::contact_verification_invalid(

--- a/src/services/auth/external/verification.rs
+++ b/src/services/auth/external/verification.rs
@@ -9,6 +9,10 @@ use crate::db::repository::{
 };
 use crate::errors::{AsterError, Result, auth_forbidden_with_code};
 use crate::runtime::SharedRuntimeState;
+use crate::services::auth::flow::{
+    AuthFlowCommand, AuthFlowKind, AuthFlowState, AuthFlowTransitionError,
+    external_recovery_snapshot, new_recovery_flow, plan_transition,
+};
 use crate::services::{mail::outbox, mail::sender, mail::template::MailTemplatePayload};
 use aster_drive_model::entities::{external_auth_email_verification_flow, external_auth_provider};
 use aster_forge_external_auth::normalize as external_auth_normalize;
@@ -52,6 +56,15 @@ pub(super) async fn create_pending_email_verification_flow(
         EMAIL_VERIFICATION_FLOW_TTL_SECS,
         "external auth email verification flow ttl",
     )?;
+    new_recovery_flow(
+        AuthFlowKind::ExternalEmailVerification,
+        "external-recovery:pending",
+        now + Duration::seconds(ttl),
+        now,
+    )
+    .map_err(|_| {
+        AsterError::contact_verification_invalid("external recovery flow could not start")
+    })?;
     external_auth_email_verification_flow_repo::create(
         state.writer_db(),
         external_auth_email_verification_flow::ActiveModel {
@@ -95,6 +108,7 @@ pub async fn start_email_verification(
     .ok_or_else(|| {
         AsterError::contact_verification_invalid("external auth email verification flow is invalid")
     })?;
+    ensure_external_recovery_can_process(&flow, now)?;
     if flow.verification_token_hash.is_some() {
         return Err(AsterError::contact_verification_invalid(
             "external auth email verification request has already been started",
@@ -208,6 +222,7 @@ pub async fn confirm_email_verification(
     .ok_or_else(|| {
         AsterError::contact_verification_invalid("external auth email verification link is invalid")
     })?;
+    ensure_external_recovery_can_process(&flow, now)?;
     let email = flow.target_email.clone().ok_or_else(|| {
         AsterError::contact_verification_invalid(
             "external auth email verification target is missing",
@@ -275,5 +290,31 @@ pub async fn confirm_email_verification(
             linked: resolved.linked,
             auto_provisioned: resolved.auto_provisioned,
         },
+    })
+}
+
+fn ensure_external_recovery_can_process(
+    flow: &external_auth_email_verification_flow::Model,
+    now: chrono::DateTime<Utc>,
+) -> Result<()> {
+    plan_transition(
+        &external_recovery_snapshot(flow, now),
+        AuthFlowCommand::Transition {
+            expected_revision: external_recovery_snapshot(flow, now).revision,
+            to: AuthFlowState::Processing,
+        },
+        now,
+    )
+    .map(|_| ())
+    .map_err(|error| match error {
+        AuthFlowTransitionError::Expired => AsterError::contact_verification_expired(
+            "external auth email verification flow has expired",
+        ),
+        AuthFlowTransitionError::Terminal(_) => AsterError::contact_verification_invalid(
+            "external auth email verification flow has already been used",
+        ),
+        _ => AsterError::contact_verification_invalid(
+            "external auth email verification flow transition is invalid",
+        ),
     })
 }

--- a/src/services/auth/external/verification.rs
+++ b/src/services/auth/external/verification.rs
@@ -241,7 +241,7 @@ pub async fn confirm_email_verification(
     let txn = transaction::begin(state.writer_db()).await?;
     let result = async {
         let consumed =
-            external_auth_email_verification_flow_repo::mark_consumed_if_unused(&txn, flow.id, now)
+            external_auth_email_verification_flow_repo::mark_consumed_if_unused(&txn, flow.id)
                 .await?;
         if !consumed {
             return Err(AsterError::contact_verification_invalid(

--- a/src/services/auth/external/verification.rs
+++ b/src/services/auth/external/verification.rs
@@ -10,8 +10,8 @@ use crate::db::repository::{
 use crate::errors::{AsterError, Result, auth_forbidden_with_code};
 use crate::runtime::SharedRuntimeState;
 use crate::services::auth::flow::{
-    AuthFlowCommand, AuthFlowKind, AuthFlowState, AuthFlowTransitionError,
-    external_recovery_snapshot, new_recovery_flow, plan_transition,
+    AuthFlowCommand, AuthFlowState, AuthFlowTransitionError, external_recovery_snapshot,
+    plan_transition,
 };
 use crate::services::{mail::outbox, mail::sender, mail::template::MailTemplatePayload};
 use aster_drive_model::entities::{external_auth_email_verification_flow, external_auth_provider};
@@ -56,15 +56,11 @@ pub(super) async fn create_pending_email_verification_flow(
         EMAIL_VERIFICATION_FLOW_TTL_SECS,
         "external auth email verification flow ttl",
     )?;
-    new_recovery_flow(
-        AuthFlowKind::ExternalEmailVerification,
-        "external-recovery:pending",
-        now + Duration::seconds(ttl),
-        now,
-    )
-    .map_err(|_| {
-        AsterError::contact_verification_invalid("external recovery flow could not start")
-    })?;
+    if ttl <= 0 {
+        return Err(AsterError::contact_verification_invalid(
+            "external recovery flow ttl must be positive",
+        ));
+    }
     external_auth_email_verification_flow_repo::create(
         state.writer_db(),
         external_auth_email_verification_flow::ActiveModel {

--- a/src/services/auth/flow/coordinator.rs
+++ b/src/services/auth/flow/coordinator.rs
@@ -4,11 +4,11 @@
 //! operation enters through these helpers. This prevents callers from
 //! reimplementing terminal, expiry, attempt, and revision semantics locally.
 
-use chrono::{DateTime, Duration, Utc};
+use chrono::{DateTime, Utc};
 
 use super::{
-    AuthFlowCommand, AuthFlowKind, AuthFlowSnapshot, AuthFlowState, AuthFlowTransition,
-    AuthFlowTransitionError, plan_transition,
+    AuthFlowCommand, AuthFlowKind, AuthFlowSnapshot, AuthFlowState, AuthFlowTransitionError,
+    plan_transition,
 };
 
 pub fn new_primary_flow(
@@ -41,93 +41,6 @@ pub fn new_primary_flow(
     })
 }
 
-pub fn new_recovery_flow(
-    kind: AuthFlowKind,
-    flow_id: impl Into<String>,
-    expires_at: DateTime<Utc>,
-    now: DateTime<Utc>,
-) -> Result<AuthFlowSnapshot, AuthFlowTransitionError> {
-    let snapshot = AuthFlowSnapshot {
-        flow_id: flow_id.into(),
-        kind,
-        state: AuthFlowState::RecoveryPending,
-        revision: 0,
-        attempt_count: 0,
-        max_attempts: Some(1),
-        expires_at,
-    };
-    let transition = plan_transition(
-        &snapshot,
-        AuthFlowCommand::Transition {
-            expected_revision: 0,
-            to: AuthFlowState::Processing,
-        },
-        now,
-    )?;
-    Ok(AuthFlowSnapshot {
-        state: transition.state,
-        revision: transition.revision,
-        ..snapshot
-    })
-}
-
-pub fn complete(
-    snapshot: &AuthFlowSnapshot,
-    expected_revision: u64,
-    now: DateTime<Utc>,
-) -> Result<AuthFlowTransition, AuthFlowTransitionError> {
-    plan_transition(
-        snapshot,
-        AuthFlowCommand::Transition {
-            expected_revision,
-            to: AuthFlowState::Completed,
-        },
-        now,
-    )
-}
-
-pub fn authenticate(
-    snapshot: &AuthFlowSnapshot,
-    expected_revision: u64,
-    now: DateTime<Utc>,
-) -> Result<AuthFlowTransition, AuthFlowTransitionError> {
-    plan_transition(
-        snapshot,
-        AuthFlowCommand::Transition {
-            expected_revision,
-            to: AuthFlowState::Authenticated,
-        },
-        now,
-    )
-}
-
-pub fn consume(
-    snapshot: &AuthFlowSnapshot,
-    expected_revision: u64,
-    now: DateTime<Utc>,
-) -> Result<AuthFlowTransition, AuthFlowTransitionError> {
-    plan_transition(
-        snapshot,
-        AuthFlowCommand::Transition {
-            expected_revision,
-            to: AuthFlowState::Consumed,
-        },
-        now,
-    )
-}
-
-pub fn cancelled(
-    snapshot: &AuthFlowSnapshot,
-    expected_revision: u64,
-    now: DateTime<Utc>,
-) -> Result<AuthFlowTransition, AuthFlowTransitionError> {
-    plan_transition(snapshot, AuthFlowCommand::Cancel { expected_revision }, now)
-}
-
-pub fn default_expiry(ttl: Duration, now: DateTime<Utc>) -> DateTime<Utc> {
-    now + ttl
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -139,31 +52,70 @@ mod tests {
         let flow = new_primary_flow(
             AuthFlowKind::ExternalLogin,
             "external-login:1",
-            default_expiry(Duration::minutes(5), now),
+            now + Duration::minutes(5),
             now,
         )
         .unwrap();
         assert_eq!(flow.state, AuthFlowState::Processing);
-        assert!(complete(&flow, 1, now).is_err());
-        assert!(authenticate(&flow, 1, now).is_ok());
+        assert!(
+            plan_transition(
+                &flow,
+                AuthFlowCommand::Transition {
+                    expected_revision: 1,
+                    to: AuthFlowState::Completed,
+                },
+                now,
+            )
+            .is_err()
+        );
+        assert!(
+            plan_transition(
+                &flow,
+                AuthFlowCommand::Transition {
+                    expected_revision: 1,
+                    to: AuthFlowState::Authenticated,
+                },
+                now,
+            )
+            .is_ok()
+        );
     }
 
     #[test]
     fn recovery_boundary_is_single_use_and_expiry_aware() {
         let now = Utc::now();
-        let flow = new_recovery_flow(
-            AuthFlowKind::PasswordReset,
-            "contact-verification:4",
-            default_expiry(Duration::minutes(5), now),
-            now,
-        )
-        .unwrap();
-        assert!(complete(&flow, 1, now).is_ok());
+        let flow = AuthFlowSnapshot {
+            flow_id: "contact-verification:4".to_string(),
+            kind: AuthFlowKind::PasswordReset,
+            state: AuthFlowState::Processing,
+            revision: 1,
+            attempt_count: 0,
+            max_attempts: Some(1),
+            expires_at: now + Duration::minutes(5),
+        };
+        assert!(
+            plan_transition(
+                &flow,
+                AuthFlowCommand::Transition {
+                    expected_revision: 1,
+                    to: AuthFlowState::Completed,
+                },
+                now,
+            )
+            .is_ok()
+        );
 
         let mut expired = flow;
         expired.expires_at = now;
         assert_eq!(
-            complete(&expired, 1, now),
+            plan_transition(
+                &expired,
+                AuthFlowCommand::Transition {
+                    expected_revision: 1,
+                    to: AuthFlowState::Completed,
+                },
+                now,
+            ),
             Err(AuthFlowTransitionError::Expired)
         );
     }
@@ -174,17 +126,34 @@ mod tests {
         let mut flow = new_primary_flow(
             AuthFlowKind::PasskeyLogin,
             "passkey:1",
-            default_expiry(Duration::minutes(5), now),
+            now + Duration::minutes(5),
             now,
         )
         .unwrap();
         flow.state = AuthFlowState::Processing;
         assert_eq!(
-            cancelled(&flow, 1, now).unwrap().state,
+            plan_transition(
+                &flow,
+                AuthFlowCommand::Cancel {
+                    expected_revision: 1,
+                },
+                now,
+            )
+            .unwrap()
+            .state,
             AuthFlowState::Cancelled
         );
         assert_eq!(
-            consume(&flow, 1, now).unwrap().state,
+            plan_transition(
+                &flow,
+                AuthFlowCommand::Transition {
+                    expected_revision: 1,
+                    to: AuthFlowState::Consumed,
+                },
+                now,
+            )
+            .unwrap()
+            .state,
             AuthFlowState::Consumed
         );
     }

--- a/src/services/auth/flow/coordinator.rs
+++ b/src/services/auth/flow/coordinator.rs
@@ -1,0 +1,191 @@
+//! Executable auth-flow boundary.
+//!
+//! Adapters keep their typed payloads and transactions, while every stateful
+//! operation enters through these helpers. This prevents callers from
+//! reimplementing terminal, expiry, attempt, and revision semantics locally.
+
+use chrono::{DateTime, Duration, Utc};
+
+use super::{
+    AuthFlowCommand, AuthFlowKind, AuthFlowSnapshot, AuthFlowState, AuthFlowTransition,
+    AuthFlowTransitionError, plan_transition,
+};
+
+pub fn new_primary_flow(
+    kind: AuthFlowKind,
+    flow_id: impl Into<String>,
+    expires_at: DateTime<Utc>,
+    now: DateTime<Utc>,
+) -> Result<AuthFlowSnapshot, AuthFlowTransitionError> {
+    let snapshot = AuthFlowSnapshot {
+        flow_id: flow_id.into(),
+        kind,
+        state: AuthFlowState::FirstFactorPending,
+        revision: 0,
+        attempt_count: 0,
+        max_attempts: None,
+        expires_at,
+    };
+    let transition = plan_transition(
+        &snapshot,
+        AuthFlowCommand::Transition {
+            expected_revision: 0,
+            to: AuthFlowState::Processing,
+        },
+        now,
+    )?;
+    Ok(AuthFlowSnapshot {
+        state: transition.state,
+        revision: transition.revision,
+        ..snapshot
+    })
+}
+
+pub fn new_recovery_flow(
+    kind: AuthFlowKind,
+    flow_id: impl Into<String>,
+    expires_at: DateTime<Utc>,
+    now: DateTime<Utc>,
+) -> Result<AuthFlowSnapshot, AuthFlowTransitionError> {
+    let snapshot = AuthFlowSnapshot {
+        flow_id: flow_id.into(),
+        kind,
+        state: AuthFlowState::RecoveryPending,
+        revision: 0,
+        attempt_count: 0,
+        max_attempts: Some(1),
+        expires_at,
+    };
+    let transition = plan_transition(
+        &snapshot,
+        AuthFlowCommand::Transition {
+            expected_revision: 0,
+            to: AuthFlowState::Processing,
+        },
+        now,
+    )?;
+    Ok(AuthFlowSnapshot {
+        state: transition.state,
+        revision: transition.revision,
+        ..snapshot
+    })
+}
+
+pub fn complete(
+    snapshot: &AuthFlowSnapshot,
+    expected_revision: u64,
+    now: DateTime<Utc>,
+) -> Result<AuthFlowTransition, AuthFlowTransitionError> {
+    plan_transition(
+        snapshot,
+        AuthFlowCommand::Transition {
+            expected_revision,
+            to: AuthFlowState::Completed,
+        },
+        now,
+    )
+}
+
+pub fn authenticate(
+    snapshot: &AuthFlowSnapshot,
+    expected_revision: u64,
+    now: DateTime<Utc>,
+) -> Result<AuthFlowTransition, AuthFlowTransitionError> {
+    plan_transition(
+        snapshot,
+        AuthFlowCommand::Transition {
+            expected_revision,
+            to: AuthFlowState::Authenticated,
+        },
+        now,
+    )
+}
+
+pub fn consume(
+    snapshot: &AuthFlowSnapshot,
+    expected_revision: u64,
+    now: DateTime<Utc>,
+) -> Result<AuthFlowTransition, AuthFlowTransitionError> {
+    plan_transition(
+        snapshot,
+        AuthFlowCommand::Transition {
+            expected_revision,
+            to: AuthFlowState::Consumed,
+        },
+        now,
+    )
+}
+
+pub fn cancelled(
+    snapshot: &AuthFlowSnapshot,
+    expected_revision: u64,
+    now: DateTime<Utc>,
+) -> Result<AuthFlowTransition, AuthFlowTransitionError> {
+    plan_transition(snapshot, AuthFlowCommand::Cancel { expected_revision }, now)
+}
+
+pub fn default_expiry(ttl: Duration, now: DateTime<Utc>) -> DateTime<Utc> {
+    now + ttl
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Duration;
+
+    #[test]
+    fn executable_primary_boundary_requires_processing_before_completion() {
+        let now = Utc::now();
+        let flow = new_primary_flow(
+            AuthFlowKind::ExternalLogin,
+            "external-login:1",
+            default_expiry(Duration::minutes(5), now),
+            now,
+        )
+        .unwrap();
+        assert_eq!(flow.state, AuthFlowState::Processing);
+        assert!(complete(&flow, 1, now).is_err());
+        assert!(authenticate(&flow, 1, now).is_ok());
+    }
+
+    #[test]
+    fn recovery_boundary_is_single_use_and_expiry_aware() {
+        let now = Utc::now();
+        let flow = new_recovery_flow(
+            AuthFlowKind::PasswordReset,
+            "contact-verification:4",
+            default_expiry(Duration::minutes(5), now),
+            now,
+        )
+        .unwrap();
+        assert!(complete(&flow, 1, now).is_ok());
+
+        let mut expired = flow;
+        expired.expires_at = now;
+        assert_eq!(
+            complete(&expired, 1, now),
+            Err(AuthFlowTransitionError::Expired)
+        );
+    }
+
+    #[test]
+    fn cancel_and_consume_are_distinct_terminal_commands() {
+        let now = Utc::now();
+        let mut flow = new_primary_flow(
+            AuthFlowKind::PasskeyLogin,
+            "passkey:1",
+            default_expiry(Duration::minutes(5), now),
+            now,
+        )
+        .unwrap();
+        flow.state = AuthFlowState::Processing;
+        assert_eq!(
+            cancelled(&flow, 1, now).unwrap().state,
+            AuthFlowState::Cancelled
+        );
+        assert_eq!(
+            consume(&flow, 1, now).unwrap().state,
+            AuthFlowState::Consumed
+        );
+    }
+}

--- a/src/services/auth/flow/mod.rs
+++ b/src/services/auth/flow/mod.rs
@@ -10,9 +10,7 @@ use chrono::{DateTime, Utc};
 mod coordinator;
 mod snapshots;
 
-pub use coordinator::{
-    authenticate, cancelled, complete, consume, default_expiry, new_primary_flow, new_recovery_flow,
-};
+pub use coordinator::new_primary_flow;
 pub use snapshots::{
     AuthSessionLifecycleState, AuthSessionSnapshot, auth_session_snapshot,
     contact_verification_snapshot, external_login_snapshot, external_recovery_snapshot,

--- a/src/services/auth/flow/mod.rs
+++ b/src/services/auth/flow/mod.rs
@@ -1,0 +1,451 @@
+//! Shared lifecycle rules for typed authentication flows.
+//!
+//! Security payloads remain in their owning MFA, external-auth, recovery, or
+//! Passkey records. This module only owns lifecycle vocabulary and transition
+//! validation so every adapter applies expiry, cancellation, replay, attempt,
+//! and optimistic-concurrency rules in the same order.
+
+use chrono::{DateTime, Utc};
+
+mod coordinator;
+mod snapshots;
+
+pub use coordinator::{
+    authenticate, cancelled, complete, consume, default_expiry, new_primary_flow, new_recovery_flow,
+};
+pub use snapshots::{
+    AuthSessionLifecycleState, AuthSessionSnapshot, auth_session_snapshot,
+    contact_verification_snapshot, external_login_snapshot, external_recovery_snapshot,
+    invitation_snapshot,
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum AuthFlowKind {
+    PasswordLogin,
+    PasskeyRegistration,
+    PasskeyLogin,
+    ExternalLogin,
+    MfaLogin,
+    RegistrationActivation,
+    InvitationAcceptance,
+    PasswordReset,
+    EmailChange,
+    ExternalEmailVerification,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum AuthFlowState {
+    FirstFactorPending,
+    SecondFactorPending,
+    RecoveryPending,
+    Processing,
+    PasswordChangeRequired,
+    Authenticated,
+    Completed,
+    Failed,
+    Expired,
+    Cancelled,
+    Consumed,
+}
+
+impl AuthFlowState {
+    pub const fn is_terminal(self) -> bool {
+        matches!(
+            self,
+            Self::Authenticated
+                | Self::Completed
+                | Self::Failed
+                | Self::Expired
+                | Self::Cancelled
+                | Self::Consumed
+        )
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AuthFlowSnapshot {
+    pub flow_id: String,
+    pub kind: AuthFlowKind,
+    pub state: AuthFlowState,
+    pub revision: u64,
+    pub attempt_count: u32,
+    pub max_attempts: Option<u32>,
+    pub expires_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AuthFlowCommand {
+    Transition {
+        expected_revision: u64,
+        to: AuthFlowState,
+    },
+    RecordFailure {
+        expected_revision: u64,
+    },
+    Cancel {
+        expected_revision: u64,
+    },
+    Expire {
+        expected_revision: u64,
+    },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AuthFlowTransitionError {
+    AttemptBudgetExhausted,
+    Expired,
+    IllegalTransition {
+        from: AuthFlowState,
+        to: AuthFlowState,
+    },
+    RevisionConflict {
+        expected: u64,
+        actual: u64,
+    },
+    Terminal(AuthFlowState),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct AuthFlowTransition {
+    pub state: AuthFlowState,
+    pub revision: u64,
+    pub attempt_count: u32,
+}
+
+pub fn plan_transition(
+    snapshot: &AuthFlowSnapshot,
+    command: AuthFlowCommand,
+    now: DateTime<Utc>,
+) -> Result<AuthFlowTransition, AuthFlowTransitionError> {
+    let expected_revision = match command {
+        AuthFlowCommand::Transition {
+            expected_revision, ..
+        }
+        | AuthFlowCommand::RecordFailure { expected_revision }
+        | AuthFlowCommand::Cancel { expected_revision }
+        | AuthFlowCommand::Expire { expected_revision } => expected_revision,
+    };
+    if expected_revision != snapshot.revision {
+        return Err(AuthFlowTransitionError::RevisionConflict {
+            expected: expected_revision,
+            actual: snapshot.revision,
+        });
+    }
+    if snapshot.state.is_terminal() {
+        return Err(AuthFlowTransitionError::Terminal(snapshot.state));
+    }
+
+    let next_revision = snapshot.revision.saturating_add(1);
+    match command {
+        AuthFlowCommand::Expire { .. } => Ok(AuthFlowTransition {
+            state: AuthFlowState::Expired,
+            revision: next_revision,
+            attempt_count: snapshot.attempt_count,
+        }),
+        _ if snapshot.expires_at <= now => Err(AuthFlowTransitionError::Expired),
+        AuthFlowCommand::Cancel { .. } => Ok(AuthFlowTransition {
+            state: AuthFlowState::Cancelled,
+            revision: next_revision,
+            attempt_count: snapshot.attempt_count,
+        }),
+        AuthFlowCommand::RecordFailure { .. } => {
+            let attempt_count = snapshot.attempt_count.saturating_add(1);
+            let exhausted = snapshot
+                .max_attempts
+                .is_some_and(|max_attempts| attempt_count >= max_attempts);
+            Ok(AuthFlowTransition {
+                state: if exhausted {
+                    AuthFlowState::Failed
+                } else {
+                    snapshot.state
+                },
+                revision: next_revision,
+                attempt_count,
+            })
+        }
+        AuthFlowCommand::Transition { to, .. } => {
+            if snapshot
+                .max_attempts
+                .is_some_and(|max_attempts| snapshot.attempt_count >= max_attempts)
+            {
+                return Err(AuthFlowTransitionError::AttemptBudgetExhausted);
+            }
+            if !transition_allowed(snapshot.kind, snapshot.state, to) {
+                return Err(AuthFlowTransitionError::IllegalTransition {
+                    from: snapshot.state,
+                    to,
+                });
+            }
+            Ok(AuthFlowTransition {
+                state: to,
+                revision: next_revision,
+                attempt_count: snapshot.attempt_count,
+            })
+        }
+    }
+}
+
+const fn transition_allowed(kind: AuthFlowKind, from: AuthFlowState, to: AuthFlowState) -> bool {
+    if matches!(to, AuthFlowState::Failed) {
+        return true;
+    }
+    if matches!(to, AuthFlowState::Consumed) {
+        return true;
+    }
+    match kind {
+        AuthFlowKind::PasswordLogin => matches!(
+            (from, to),
+            (
+                AuthFlowState::FirstFactorPending,
+                AuthFlowState::SecondFactorPending
+                    | AuthFlowState::PasswordChangeRequired
+                    | AuthFlowState::Authenticated
+                    | AuthFlowState::Processing
+            ) | (
+                AuthFlowState::Processing,
+                AuthFlowState::SecondFactorPending
+            ) | (
+                AuthFlowState::SecondFactorPending,
+                AuthFlowState::PasswordChangeRequired | AuthFlowState::Authenticated
+            ) | (
+                AuthFlowState::PasswordChangeRequired,
+                AuthFlowState::Authenticated
+            )
+        ),
+        AuthFlowKind::PasskeyRegistration => matches!(
+            (from, to),
+            (AuthFlowState::FirstFactorPending, AuthFlowState::Processing)
+                | (AuthFlowState::Processing, AuthFlowState::Completed)
+        ),
+        AuthFlowKind::PasskeyLogin | AuthFlowKind::ExternalLogin => matches!(
+            (from, to),
+            (AuthFlowState::FirstFactorPending, AuthFlowState::Processing)
+                | (
+                    AuthFlowState::Processing,
+                    AuthFlowState::SecondFactorPending | AuthFlowState::Authenticated
+                )
+        ),
+        AuthFlowKind::MfaLogin => matches!(
+            (from, to),
+            (
+                AuthFlowState::SecondFactorPending,
+                AuthFlowState::PasswordChangeRequired | AuthFlowState::Authenticated
+            )
+        ),
+        AuthFlowKind::RegistrationActivation
+        | AuthFlowKind::InvitationAcceptance
+        | AuthFlowKind::PasswordReset
+        | AuthFlowKind::EmailChange
+        | AuthFlowKind::ExternalEmailVerification => matches!(
+            (from, to),
+            (AuthFlowState::RecoveryPending, AuthFlowState::Processing)
+                | (AuthFlowState::Processing, AuthFlowState::Completed)
+        ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Duration;
+
+    fn snapshot(kind: AuthFlowKind, state: AuthFlowState) -> AuthFlowSnapshot {
+        AuthFlowSnapshot {
+            flow_id: "test-flow".to_string(),
+            kind,
+            state,
+            revision: 7,
+            attempt_count: 0,
+            max_attempts: Some(3),
+            expires_at: Utc::now() + Duration::minutes(5),
+        }
+    }
+
+    #[test]
+    fn allows_each_primary_login_completion_path() {
+        let now = Utc::now();
+        for (kind, from, targets) in [
+            (
+                AuthFlowKind::PasswordLogin,
+                AuthFlowState::FirstFactorPending,
+                vec![
+                    AuthFlowState::SecondFactorPending,
+                    AuthFlowState::PasswordChangeRequired,
+                    AuthFlowState::Authenticated,
+                ],
+            ),
+            (
+                AuthFlowKind::PasskeyLogin,
+                AuthFlowState::Processing,
+                vec![
+                    AuthFlowState::SecondFactorPending,
+                    AuthFlowState::Authenticated,
+                ],
+            ),
+            (
+                AuthFlowKind::ExternalLogin,
+                AuthFlowState::Processing,
+                vec![
+                    AuthFlowState::SecondFactorPending,
+                    AuthFlowState::Authenticated,
+                ],
+            ),
+        ] {
+            for to in targets {
+                let result = plan_transition(
+                    &snapshot(kind, from),
+                    AuthFlowCommand::Transition {
+                        expected_revision: 7,
+                        to,
+                    },
+                    now,
+                )
+                .unwrap();
+                assert_eq!(result.state, to);
+                assert_eq!(result.revision, 8);
+            }
+        }
+    }
+
+    #[test]
+    fn rejects_cross_context_and_skipped_recovery_transitions() {
+        let now = Utc::now();
+        for (kind, from, to) in [
+            (
+                AuthFlowKind::MfaLogin,
+                AuthFlowState::SecondFactorPending,
+                AuthFlowState::Completed,
+            ),
+            (
+                AuthFlowKind::PasswordReset,
+                AuthFlowState::RecoveryPending,
+                AuthFlowState::Authenticated,
+            ),
+            (
+                AuthFlowKind::ExternalLogin,
+                AuthFlowState::FirstFactorPending,
+                AuthFlowState::Authenticated,
+            ),
+        ] {
+            assert_eq!(
+                plan_transition(
+                    &snapshot(kind, from),
+                    AuthFlowCommand::Transition {
+                        expected_revision: 7,
+                        to,
+                    },
+                    now,
+                ),
+                Err(AuthFlowTransitionError::IllegalTransition { from, to })
+            );
+        }
+    }
+
+    #[test]
+    fn failure_exhausts_attempt_budget_without_overflow() {
+        let now = Utc::now();
+        let mut flow = snapshot(AuthFlowKind::MfaLogin, AuthFlowState::SecondFactorPending);
+        flow.attempt_count = 2;
+        let result = plan_transition(
+            &flow,
+            AuthFlowCommand::RecordFailure {
+                expected_revision: 7,
+            },
+            now,
+        )
+        .unwrap();
+        assert_eq!(result.attempt_count, 3);
+        assert_eq!(result.state, AuthFlowState::Failed);
+
+        flow.attempt_count = u32::MAX;
+        flow.max_attempts = None;
+        assert_eq!(
+            plan_transition(
+                &flow,
+                AuthFlowCommand::RecordFailure {
+                    expected_revision: 7,
+                },
+                now,
+            )
+            .unwrap()
+            .attempt_count,
+            u32::MAX
+        );
+    }
+
+    #[test]
+    fn expiry_precedes_cancel_and_normal_transition() {
+        let now = Utc::now();
+        let mut flow = snapshot(AuthFlowKind::PasswordReset, AuthFlowState::RecoveryPending);
+        flow.expires_at = now;
+        for command in [
+            AuthFlowCommand::Cancel {
+                expected_revision: 7,
+            },
+            AuthFlowCommand::Transition {
+                expected_revision: 7,
+                to: AuthFlowState::Processing,
+            },
+        ] {
+            assert_eq!(
+                plan_transition(&flow, command, now),
+                Err(AuthFlowTransitionError::Expired)
+            );
+        }
+        assert_eq!(
+            plan_transition(
+                &flow,
+                AuthFlowCommand::Expire {
+                    expected_revision: 7,
+                },
+                now,
+            )
+            .unwrap()
+            .state,
+            AuthFlowState::Expired
+        );
+    }
+
+    #[test]
+    fn revision_and_terminal_guards_are_stable() {
+        let now = Utc::now();
+        let flow = snapshot(
+            AuthFlowKind::ExternalEmailVerification,
+            AuthFlowState::RecoveryPending,
+        );
+        assert_eq!(
+            plan_transition(
+                &flow,
+                AuthFlowCommand::Cancel {
+                    expected_revision: 6,
+                },
+                now,
+            ),
+            Err(AuthFlowTransitionError::RevisionConflict {
+                expected: 6,
+                actual: 7,
+            })
+        );
+
+        for terminal in [
+            AuthFlowState::Authenticated,
+            AuthFlowState::Completed,
+            AuthFlowState::Failed,
+            AuthFlowState::Expired,
+            AuthFlowState::Cancelled,
+            AuthFlowState::Consumed,
+        ] {
+            let flow = snapshot(AuthFlowKind::PasswordReset, terminal);
+            assert_eq!(
+                plan_transition(
+                    &flow,
+                    AuthFlowCommand::Cancel {
+                        expected_revision: 7,
+                    },
+                    now,
+                ),
+                Err(AuthFlowTransitionError::Terminal(terminal))
+            );
+        }
+    }
+}

--- a/src/services/auth/flow/snapshots.rs
+++ b/src/services/auth/flow/snapshots.rs
@@ -1,0 +1,235 @@
+use chrono::{DateTime, Utc};
+
+use aster_drive_model::entities::{
+    auth_session, contact_verification_token, external_auth_email_verification_flow,
+    external_auth_login_flow, user_invitation,
+};
+use aster_drive_model::types::{UserInvitationStatus, VerificationPurpose};
+
+use super::{AuthFlowKind, AuthFlowSnapshot, AuthFlowState};
+
+fn state_from_single_use(
+    consumed_at: Option<DateTime<Utc>>,
+    expires_at: DateTime<Utc>,
+    active: AuthFlowState,
+    now: DateTime<Utc>,
+) -> AuthFlowState {
+    if consumed_at.is_some() {
+        AuthFlowState::Consumed
+    } else if expires_at <= now {
+        AuthFlowState::Expired
+    } else {
+        active
+    }
+}
+
+pub fn external_login_snapshot(
+    flow: &external_auth_login_flow::Model,
+    now: DateTime<Utc>,
+) -> AuthFlowSnapshot {
+    AuthFlowSnapshot {
+        flow_id: format!("external-login:{}", flow.id),
+        kind: AuthFlowKind::ExternalLogin,
+        state: state_from_single_use(
+            flow.consumed_at,
+            flow.expires_at,
+            AuthFlowState::FirstFactorPending,
+            now,
+        ),
+        revision: u64::from(flow.consumed_at.is_some()),
+        attempt_count: 0,
+        max_attempts: Some(1),
+        expires_at: flow.expires_at,
+    }
+}
+
+pub fn external_recovery_snapshot(
+    flow: &external_auth_email_verification_flow::Model,
+    now: DateTime<Utc>,
+) -> AuthFlowSnapshot {
+    AuthFlowSnapshot {
+        flow_id: format!("external-recovery:{}", flow.id),
+        kind: AuthFlowKind::ExternalEmailVerification,
+        state: state_from_single_use(
+            flow.consumed_at,
+            flow.expires_at,
+            AuthFlowState::RecoveryPending,
+            now,
+        ),
+        revision: u64::from(flow.verification_token_hash.is_some())
+            + u64::from(flow.consumed_at.is_some()),
+        attempt_count: 0,
+        max_attempts: None,
+        expires_at: flow.expires_at,
+    }
+}
+
+pub fn contact_verification_snapshot(
+    token: &contact_verification_token::Model,
+    now: DateTime<Utc>,
+) -> AuthFlowSnapshot {
+    let kind = match token.purpose {
+        VerificationPurpose::RegisterActivation => AuthFlowKind::RegistrationActivation,
+        VerificationPurpose::ContactChange => AuthFlowKind::EmailChange,
+        VerificationPurpose::PasswordReset => AuthFlowKind::PasswordReset,
+    };
+    AuthFlowSnapshot {
+        flow_id: format!("contact-verification:{}", token.id),
+        kind,
+        state: state_from_single_use(
+            token.consumed_at,
+            token.expires_at,
+            AuthFlowState::RecoveryPending,
+            now,
+        ),
+        revision: u64::from(token.consumed_at.is_some()),
+        attempt_count: 0,
+        max_attempts: Some(1),
+        expires_at: token.expires_at,
+    }
+}
+
+pub fn invitation_snapshot(
+    invitation: &user_invitation::Model,
+    now: DateTime<Utc>,
+) -> AuthFlowSnapshot {
+    let state = match invitation.status {
+        UserInvitationStatus::Pending if invitation.expires_at <= now => AuthFlowState::Expired,
+        UserInvitationStatus::Pending => AuthFlowState::RecoveryPending,
+        UserInvitationStatus::Accepted => AuthFlowState::Completed,
+        UserInvitationStatus::Expired => AuthFlowState::Expired,
+        UserInvitationStatus::Revoked => AuthFlowState::Cancelled,
+    };
+    AuthFlowSnapshot {
+        flow_id: format!("invitation:{}", invitation.id),
+        kind: AuthFlowKind::InvitationAcceptance,
+        state,
+        revision: u64::from(!invitation.status.is_pending()),
+        attempt_count: 0,
+        max_attempts: Some(1),
+        expires_at: invitation.expires_at,
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AuthSessionLifecycleState {
+    Active,
+    Expired,
+    Revoked,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AuthSessionSnapshot {
+    pub session_id: String,
+    pub state: AuthSessionLifecycleState,
+    pub refresh_expires_at: DateTime<Utc>,
+}
+
+pub fn auth_session_snapshot(
+    session: &auth_session::Model,
+    now: DateTime<Utc>,
+) -> AuthSessionSnapshot {
+    let state = if session.revoked_at.is_some() {
+        AuthSessionLifecycleState::Revoked
+    } else if session.refresh_expires_at <= now {
+        AuthSessionLifecycleState::Expired
+    } else {
+        AuthSessionLifecycleState::Active
+    };
+    AuthSessionSnapshot {
+        session_id: session.id.clone(),
+        state,
+        refresh_expires_at: session.refresh_expires_at,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aster_drive_model::types::{UserInvitationStatus, VerificationChannel};
+    use chrono::Duration;
+
+    #[test]
+    fn single_use_state_precedence_is_consumed_then_expired() {
+        let now = Utc::now();
+        assert_eq!(
+            state_from_single_use(
+                Some(now),
+                now - Duration::seconds(1),
+                AuthFlowState::RecoveryPending,
+                now
+            ),
+            AuthFlowState::Consumed
+        );
+        assert_eq!(
+            state_from_single_use(None, now, AuthFlowState::RecoveryPending, now),
+            AuthFlowState::Expired
+        );
+    }
+
+    #[test]
+    fn contact_verification_purpose_maps_to_typed_kind_without_token_material() {
+        let now = Utc::now();
+        let token = contact_verification_token::Model {
+            id: 9,
+            user_id: 3,
+            channel: VerificationChannel::Email,
+            purpose: VerificationPurpose::PasswordReset,
+            target: "alice@example.com".to_string(),
+            token_hash: "secret-hash".to_string(),
+            expires_at: now + Duration::minutes(5),
+            consumed_at: None,
+            created_at: now,
+        };
+        let snapshot = contact_verification_snapshot(&token, now);
+        assert_eq!(snapshot.kind, AuthFlowKind::PasswordReset);
+        assert_eq!(snapshot.flow_id, "contact-verification:9");
+        assert!(!snapshot.flow_id.contains("secret"));
+    }
+
+    #[test]
+    fn invitation_terminal_states_are_distinct() {
+        let now = Utc::now();
+        for (status, expected) in [
+            (UserInvitationStatus::Accepted, AuthFlowState::Completed),
+            (UserInvitationStatus::Expired, AuthFlowState::Expired),
+            (UserInvitationStatus::Revoked, AuthFlowState::Cancelled),
+        ] {
+            let invitation = user_invitation::Model {
+                id: 7,
+                email: "alice@example.com".to_string(),
+                token_hash: "hash".to_string(),
+                status,
+                invited_by: 1,
+                accepted_user_id: None,
+                expires_at: now + Duration::minutes(5),
+                created_at: now,
+                updated_at: now,
+                accepted_at: None,
+                revoked_at: None,
+            };
+            assert_eq!(invitation_snapshot(&invitation, now).state, expected);
+        }
+    }
+
+    #[test]
+    fn revoked_session_precedes_expiry() {
+        let now = Utc::now();
+        let session = auth_session::Model {
+            id: "session".to_string(),
+            user_id: 4,
+            current_refresh_jti: "current".to_string(),
+            previous_refresh_jti: None,
+            refresh_expires_at: now - Duration::minutes(1),
+            ip_address: None,
+            user_agent: None,
+            created_at: now - Duration::hours(1),
+            last_seen_at: now - Duration::hours(1),
+            revoked_at: Some(now),
+        };
+        assert_eq!(
+            auth_session_snapshot(&session, now).state,
+            AuthSessionLifecycleState::Revoked
+        );
+    }
+}

--- a/src/services/auth/local/contact_verification.rs
+++ b/src/services/auth/local/contact_verification.rs
@@ -9,6 +9,7 @@ use crate::config::local_email_policy::LocalEmailPolicy;
 use crate::db::repository::{contact_verification_token_repo, user_repo};
 use crate::errors::{AsterError, MapAsterErr, Result};
 use crate::runtime::SharedRuntimeState;
+use crate::services::auth::flow::{AuthFlowState, contact_verification_snapshot};
 use crate::services::{mail::outbox, mail::template::MailTemplatePayload};
 use aster_drive_model::types::VerificationPurpose;
 use aster_forge_crypto as hash;
@@ -245,6 +246,7 @@ pub async fn confirm_password_reset(
             "password reset link is invalid",
         ));
     }
+    ensure_contact_verification_active(&record)?;
     if record.consumed_at.is_some() {
         return Err(AsterError::contact_verification_invalid(
             "password reset link has already been used",
@@ -273,8 +275,9 @@ pub async fn confirm_password_reset(
         ));
     }
 
+    let now = Utc::now();
     let consumed =
-        contact_verification_token_repo::mark_consumed_if_unused(&txn, record.id).await?;
+        contact_verification_token_repo::mark_consumed_if_unused(&txn, record.id, now).await?;
     if !consumed {
         return Err(AsterError::contact_verification_invalid(
             "password reset link has already been used",
@@ -313,6 +316,8 @@ pub async fn confirm_contact_verification(
                 AsterError::contact_verification_invalid("contact verification link is invalid")
             })?;
 
+    ensure_contact_verification_active(&record)?;
+
     if record.consumed_at.is_some() {
         return Err(AsterError::contact_verification_invalid(
             "contact verification link has already been used",
@@ -345,15 +350,15 @@ pub async fn confirm_contact_verification(
         ));
     }
 
+    let now = Utc::now();
     let consumed =
-        contact_verification_token_repo::mark_consumed_if_unused(&txn, record.id).await?;
+        contact_verification_token_repo::mark_consumed_if_unused(&txn, record.id, now).await?;
     if !consumed {
         return Err(AsterError::contact_verification_invalid(
             "contact verification link has already been used",
         ));
     }
 
-    let now = Utc::now();
     match purpose {
         VerificationPurpose::RegisterActivation => {
             if existing_user.email != target {
@@ -426,4 +431,21 @@ pub async fn cleanup_expired_contact_verification_tokens(
     state: &impl SharedRuntimeState,
 ) -> Result<u64> {
     contact_verification_token_repo::delete_expired(state.writer_db()).await
+}
+
+fn ensure_contact_verification_active(
+    record: &aster_drive_model::entities::contact_verification_token::Model,
+) -> Result<()> {
+    match contact_verification_snapshot(record, Utc::now()).state {
+        AuthFlowState::RecoveryPending => Ok(()),
+        AuthFlowState::Expired => Err(AsterError::contact_verification_expired(
+            "contact verification link has expired",
+        )),
+        AuthFlowState::Consumed => Err(AsterError::contact_verification_invalid(
+            "contact verification link has already been used",
+        )),
+        _ => Err(AsterError::contact_verification_invalid(
+            "contact verification flow is invalid",
+        )),
+    }
 }

--- a/src/services/auth/local/contact_verification.rs
+++ b/src/services/auth/local/contact_verification.rs
@@ -275,9 +275,8 @@ pub async fn confirm_password_reset(
         ));
     }
 
-    let now = Utc::now();
     let consumed =
-        contact_verification_token_repo::mark_consumed_if_unused(&txn, record.id, now).await?;
+        contact_verification_token_repo::mark_consumed_if_unused(&txn, record.id).await?;
     if !consumed {
         return Err(AsterError::contact_verification_invalid(
             "password reset link has already been used",
@@ -352,7 +351,7 @@ pub async fn confirm_contact_verification(
 
     let now = Utc::now();
     let consumed =
-        contact_verification_token_repo::mark_consumed_if_unused(&txn, record.id, now).await?;
+        contact_verification_token_repo::mark_consumed_if_unused(&txn, record.id).await?;
     if !consumed {
         return Err(AsterError::contact_verification_invalid(
             "contact verification link has already been used",

--- a/src/services/auth/local/contact_verification.rs
+++ b/src/services/auth/local/contact_verification.rs
@@ -247,16 +247,6 @@ pub async fn confirm_password_reset(
         ));
     }
     ensure_contact_verification_active(&record)?;
-    if record.consumed_at.is_some() {
-        return Err(AsterError::contact_verification_invalid(
-            "password reset link has already been used",
-        ));
-    }
-    if record.expires_at <= Utc::now() {
-        return Err(AsterError::contact_verification_expired(
-            "password reset link has expired",
-        ));
-    }
 
     let new_password_hash = state
         .runtime_config()
@@ -316,17 +306,6 @@ pub async fn confirm_contact_verification(
             })?;
 
     ensure_contact_verification_active(&record)?;
-
-    if record.consumed_at.is_some() {
-        return Err(AsterError::contact_verification_invalid(
-            "contact verification link has already been used",
-        ));
-    }
-    if record.expires_at <= Utc::now() {
-        return Err(AsterError::contact_verification_expired(
-            "contact verification link has expired",
-        ));
-    }
 
     let target = record.target.clone();
     let purpose = record.purpose;

--- a/src/services/auth/local/shared.rs
+++ b/src/services/auth/local/shared.rs
@@ -11,7 +11,6 @@ use crate::config::auth_runtime::RuntimeContactVerificationPolicy;
 use crate::db::repository::{contact_verification_token_repo, user_repo};
 use crate::errors::{AsterError, MapAsterErr, Result, validation_error_with_code};
 use crate::runtime::SharedRuntimeState;
-use crate::services::auth::flow::{AuthFlowKind, AuthFlowState, new_recovery_flow};
 use crate::services::mail::sender;
 use aster_drive_model::entities::{contact_verification_token, user};
 use aster_drive_model::types::{UserRole, UserStatus, VerificationChannel, VerificationPurpose};
@@ -314,27 +313,13 @@ pub(super) async fn issue_contact_verification_token<C: ConnectionTrait>(
     let now = Utc::now();
     let token = sender::build_verification_token();
     let token_hash = hash::sha256_hex(token.as_bytes());
-    // Contact verification tokens already persist the authoritative expiry and single-use
-    // fields; the typed snapshot validates the initial transition without duplicating state
-    // columns in the entity.
-    let recovery_flow = new_recovery_flow(
-        match purpose {
-            VerificationPurpose::RegisterActivation => AuthFlowKind::RegistrationActivation,
-            VerificationPurpose::ContactChange => AuthFlowKind::EmailChange,
-            VerificationPurpose::PasswordReset => AuthFlowKind::PasswordReset,
-        },
-        format!("contact-verification:{user_id}:{purpose:?}"),
-        now + Duration::seconds(u64_to_i64(ttl_secs, "contact verification ttl")?),
-        now,
-    )
-    .map_err(|_| {
-        AsterError::contact_verification_invalid("contact verification flow could not start")
-    })?;
-    if recovery_flow.state != AuthFlowState::Processing {
+    let ttl = u64_to_i64(ttl_secs, "contact verification ttl")?;
+    if ttl <= 0 {
         return Err(AsterError::contact_verification_invalid(
-            "contact verification flow did not enter processing",
+            "contact verification ttl must be positive",
         ));
     }
+    let expires_at = now + Duration::seconds(ttl);
 
     contact_verification_token_repo::delete_active_for_user(
         db,
@@ -350,7 +335,7 @@ pub(super) async fn issue_contact_verification_token<C: ConnectionTrait>(
         purpose: Set(purpose),
         target: Set(target.to_string()),
         token_hash: Set(token_hash),
-        expires_at: Set(recovery_flow.expires_at),
+        expires_at: Set(expires_at),
         consumed_at: Set(None),
         created_at: Set(now),
         ..Default::default()

--- a/src/services/auth/local/shared.rs
+++ b/src/services/auth/local/shared.rs
@@ -11,6 +11,7 @@ use crate::config::auth_runtime::RuntimeContactVerificationPolicy;
 use crate::db::repository::{contact_verification_token_repo, user_repo};
 use crate::errors::{AsterError, MapAsterErr, Result, validation_error_with_code};
 use crate::runtime::SharedRuntimeState;
+use crate::services::auth::flow::{AuthFlowKind, new_recovery_flow};
 use crate::services::mail::sender;
 use aster_drive_model::entities::{contact_verification_token, user};
 use aster_drive_model::types::{UserRole, UserStatus, VerificationChannel, VerificationPurpose};
@@ -313,6 +314,19 @@ pub(super) async fn issue_contact_verification_token<C: ConnectionTrait>(
     let now = Utc::now();
     let token = sender::build_verification_token();
     let token_hash = hash::sha256_hex(token.as_bytes());
+    new_recovery_flow(
+        match purpose {
+            VerificationPurpose::RegisterActivation => AuthFlowKind::RegistrationActivation,
+            VerificationPurpose::ContactChange => AuthFlowKind::EmailChange,
+            VerificationPurpose::PasswordReset => AuthFlowKind::PasswordReset,
+        },
+        format!("contact-verification:{user_id}:{purpose:?}"),
+        now + Duration::seconds(u64_to_i64(ttl_secs, "contact verification ttl")?),
+        now,
+    )
+    .map_err(|_| {
+        AsterError::contact_verification_invalid("contact verification flow could not start")
+    })?;
 
     contact_verification_token_repo::delete_active_for_user(
         db,

--- a/src/services/auth/local/shared.rs
+++ b/src/services/auth/local/shared.rs
@@ -330,9 +330,9 @@ pub(super) async fn issue_contact_verification_token<C: ConnectionTrait>(
     .map_err(|_| {
         AsterError::contact_verification_invalid("contact verification flow could not start")
     })?;
-    if recovery_flow.state != AuthFlowState::RecoveryPending {
+    if recovery_flow.state != AuthFlowState::Processing {
         return Err(AsterError::contact_verification_invalid(
-            "contact verification flow is not pending",
+            "contact verification flow did not enter processing",
         ));
     }
 

--- a/src/services/auth/local/shared.rs
+++ b/src/services/auth/local/shared.rs
@@ -11,7 +11,7 @@ use crate::config::auth_runtime::RuntimeContactVerificationPolicy;
 use crate::db::repository::{contact_verification_token_repo, user_repo};
 use crate::errors::{AsterError, MapAsterErr, Result, validation_error_with_code};
 use crate::runtime::SharedRuntimeState;
-use crate::services::auth::flow::{AuthFlowKind, new_recovery_flow};
+use crate::services::auth::flow::{AuthFlowKind, AuthFlowState, new_recovery_flow};
 use crate::services::mail::sender;
 use aster_drive_model::entities::{contact_verification_token, user};
 use aster_drive_model::types::{UserRole, UserStatus, VerificationChannel, VerificationPurpose};
@@ -314,7 +314,10 @@ pub(super) async fn issue_contact_verification_token<C: ConnectionTrait>(
     let now = Utc::now();
     let token = sender::build_verification_token();
     let token_hash = hash::sha256_hex(token.as_bytes());
-    new_recovery_flow(
+    // Contact verification tokens already persist the authoritative expiry and single-use
+    // fields; the typed snapshot validates the initial transition without duplicating state
+    // columns in the entity.
+    let recovery_flow = new_recovery_flow(
         match purpose {
             VerificationPurpose::RegisterActivation => AuthFlowKind::RegistrationActivation,
             VerificationPurpose::ContactChange => AuthFlowKind::EmailChange,
@@ -327,6 +330,11 @@ pub(super) async fn issue_contact_verification_token<C: ConnectionTrait>(
     .map_err(|_| {
         AsterError::contact_verification_invalid("contact verification flow could not start")
     })?;
+    if recovery_flow.state != AuthFlowState::RecoveryPending {
+        return Err(AsterError::contact_verification_invalid(
+            "contact verification flow is not pending",
+        ));
+    }
 
     contact_verification_token_repo::delete_active_for_user(
         db,
@@ -342,7 +350,7 @@ pub(super) async fn issue_contact_verification_token<C: ConnectionTrait>(
         purpose: Set(purpose),
         target: Set(target.to_string()),
         token_hash: Set(token_hash),
-        expires_at: Set(now + Duration::seconds(u64_to_i64(ttl_secs, "contact verification ttl")?)),
+        expires_at: Set(recovery_flow.expires_at),
         consumed_at: Set(None),
         created_at: Set(now),
         ..Default::default()

--- a/src/services/auth/local/tokens/refresh.rs
+++ b/src/services/auth/local/tokens/refresh.rs
@@ -46,6 +46,7 @@ use crate::api::api_error_code::ApiErrorCode;
 use crate::db::repository::{auth_session_repo, user_repo};
 use crate::errors::{AsterError, Result, auth_forbidden_with_code};
 use crate::runtime::SharedRuntimeState;
+use crate::services::auth::flow::{AuthSessionLifecycleState, auth_session_snapshot};
 use crate::services::auth::local::Claims;
 use crate::services::auth::local::session::{
     invalidate_auth_snapshot_cache, purge_all_auth_sessions_in_connection,
@@ -460,6 +461,11 @@ async fn rotate_refresh_in_transaction<C: ConnectionTrait>(
         }
         return Err(AsterError::auth_token_invalid("session revoked"));
     };
+
+    if auth_session_snapshot(&existing_auth_session, now).state != AuthSessionLifecycleState::Active
+    {
+        return Err(AsterError::auth_token_invalid("session expired or revoked"));
+    }
 
     if existing_auth_session.user_id != claims.user_id {
         return Err(AsterError::auth_token_invalid("invalid token"));

--- a/src/services/auth/mfa/login_flow.rs
+++ b/src/services/auth/mfa/login_flow.rs
@@ -17,6 +17,10 @@ use crate::db::repository::{
 };
 use crate::errors::{AsterError, Result, auth_mfa_failed_with_code};
 use crate::runtime::{MailRuntimeState, SharedRuntimeState};
+use crate::services::auth::flow::{
+    AuthFlowCommand, AuthFlowKind, AuthFlowSnapshot, AuthFlowState, AuthFlowTransitionError,
+    new_primary_flow, plan_transition,
+};
 use crate::services::{
     auth::local,
     mail::audit as mail_audit,
@@ -142,6 +146,28 @@ pub async fn create_login_flow(
     let flow_token = format!("mfa_{}", aster_forge_utils::id::new_short_token());
     let now = Utc::now();
     let ttl = u64_to_i64(MFA_LOGIN_FLOW_TTL_SECS, "mfa login flow ttl")?;
+    let primary_kind = match first_factor {
+        MfaFirstFactor::Password => AuthFlowKind::PasswordLogin,
+        MfaFirstFactor::ExternalAuth => AuthFlowKind::ExternalLogin,
+    };
+    let primary = new_primary_flow(
+        primary_kind,
+        format!("primary:{flow_token}"),
+        now + Duration::seconds(ttl),
+        now,
+    )
+    .map_err(|_| AsterError::auth_invalid_credentials("primary login flow is invalid"))?;
+    plan_transition(
+        &primary,
+        AuthFlowCommand::Transition {
+            expected_revision: primary.revision,
+            to: AuthFlowState::SecondFactorPending,
+        },
+        now,
+    )
+    .map_err(|_| {
+        AsterError::auth_invalid_credentials("primary login flow transition is invalid")
+    })?;
     mfa_login_flow_repo::create(
         state.writer_db(),
         mfa_login_flow::ActiveModel {
@@ -484,8 +510,17 @@ pub async fn verify_challenge(
         };
 
         if !verified {
-            let next_attempt_count = flow.attempt_count.saturating_add(1);
-            let consume_at = (next_attempt_count >= MFA_MAX_ATTEMPTS).then_some(now);
+            let transition = plan_transition(
+                &mfa_flow_snapshot(&flow),
+                AuthFlowCommand::RecordFailure {
+                    expected_revision: 0,
+                },
+                now,
+            )
+            .map_err(map_mfa_flow_transition_error)?;
+            let next_attempt_count = i32::try_from(transition.attempt_count)
+                .map_err(|_| AsterError::internal_error("MFA attempt count overflow"))?;
+            let consume_at = (transition.state == AuthFlowState::Failed).then_some(now);
             mfa_login_flow_repo::increment_attempts(&txn, flow.id, consume_at).await?;
             let error = if next_attempt_count >= MFA_MAX_ATTEMPTS {
                 auth_mfa_failed_with_code(
@@ -826,22 +861,50 @@ fn format_email_code_expires_in(ttl_secs: u64) -> String {
 }
 
 fn ensure_flow_active(flow: &mfa_login_flow::Model, now: chrono::DateTime<Utc>) -> Result<()> {
-    if flow.consumed_at.is_some() {
-        return Err(flow_invalid("MFA flow has already been consumed"));
+    plan_transition(
+        &mfa_flow_snapshot(flow),
+        AuthFlowCommand::Transition {
+            expected_revision: 0,
+            to: AuthFlowState::Authenticated,
+        },
+        now,
+    )
+    .map(|_| ())
+    .map_err(map_mfa_flow_transition_error)
+}
+
+fn mfa_flow_snapshot(flow: &mfa_login_flow::Model) -> AuthFlowSnapshot {
+    AuthFlowSnapshot {
+        flow_id: format!("mfa-login:{}", flow.id),
+        kind: AuthFlowKind::MfaLogin,
+        state: if flow.consumed_at.is_some() {
+            AuthFlowState::Consumed
+        } else {
+            AuthFlowState::SecondFactorPending
+        },
+        revision: 0,
+        attempt_count: u32::try_from(flow.attempt_count).unwrap_or(u32::MAX),
+        max_attempts: Some(u32::try_from(MFA_MAX_ATTEMPTS).expect("positive MFA attempt limit")),
+        expires_at: flow.expires_at,
     }
-    if flow.expires_at <= now {
-        return Err(auth_mfa_failed_with_code(
-            ApiErrorCode::AuthMfaFlowExpired,
-            "MFA flow has expired",
-        ));
-    }
-    if flow.attempt_count >= MFA_MAX_ATTEMPTS {
-        return Err(auth_mfa_failed_with_code(
+}
+
+fn map_mfa_flow_transition_error(error: AuthFlowTransitionError) -> AsterError {
+    match error {
+        AuthFlowTransitionError::Expired => {
+            auth_mfa_failed_with_code(ApiErrorCode::AuthMfaFlowExpired, "MFA flow has expired")
+        }
+        AuthFlowTransitionError::AttemptBudgetExhausted
+        | AuthFlowTransitionError::Terminal(AuthFlowState::Failed) => auth_mfa_failed_with_code(
             ApiErrorCode::AuthMfaAttemptsExceeded,
             "MFA attempts exceeded",
-        ));
+        ),
+        AuthFlowTransitionError::Terminal(_) => flow_invalid("MFA flow has already been consumed"),
+        AuthFlowTransitionError::IllegalTransition { .. }
+        | AuthFlowTransitionError::RevisionConflict { .. } => {
+            flow_invalid("MFA flow transition is invalid")
+        }
     }
-    Ok(())
 }
 
 fn ensure_flow_user_valid(user: &user::Model, flow: &mfa_login_flow::Model) -> Result<()> {

--- a/src/services/auth/mfa/login_flow.rs
+++ b/src/services/auth/mfa/login_flow.rs
@@ -31,7 +31,7 @@ use crate::services::{
 };
 use aster_drive_model::entities::{mfa_email_code, mfa_login_flow, user};
 use aster_drive_model::types::{MfaFirstFactor, MfaMethod, MfaPersistentFactorMethod};
-use aster_forge_utils::numbers::{i64_to_u64, u32_to_i32, u64_to_i64};
+use aster_forge_utils::numbers::{i64_to_u64, u64_to_i64};
 
 use super::{
     EMAIL_CODE_DIGITS, MFA_LOGIN_FLOW_TTL_SECS, MFA_MAX_ATTEMPTS, MfaEmailCodeSendResponse, crypto,
@@ -500,11 +500,10 @@ pub async fn verify_challenge(
             .map_err(map_mfa_flow_transition_error)?;
             let next_attempt_count = i32::try_from(transition.attempt_count)
                 .map_err(|_| AsterError::internal_error("MFA attempt count overflow"))?;
-            let consume_at = (transition.state == AuthFlowState::Failed).then_some(now);
+            let budget_exhausted = transition.state == AuthFlowState::Failed;
+            let consume_at = budget_exhausted.then_some(now);
             mfa_login_flow_repo::increment_attempts(&txn, flow.id, consume_at).await?;
-            let error = if next_attempt_count
-                >= u32_to_i32(MFA_MAX_ATTEMPTS, "MFA max attempts").unwrap_or(i32::MAX)
-            {
+            let error = if budget_exhausted {
                 auth_mfa_failed_with_code(
                     ApiErrorCode::AuthMfaAttemptsExceeded,
                     "MFA attempts exceeded",

--- a/src/services/auth/mfa/login_flow.rs
+++ b/src/services/auth/mfa/login_flow.rs
@@ -19,7 +19,7 @@ use crate::errors::{AsterError, Result, auth_mfa_failed_with_code};
 use crate::runtime::{MailRuntimeState, SharedRuntimeState};
 use crate::services::auth::flow::{
     AuthFlowCommand, AuthFlowKind, AuthFlowSnapshot, AuthFlowState, AuthFlowTransitionError,
-    new_primary_flow, plan_transition,
+    plan_transition,
 };
 use crate::services::{
     auth::local,
@@ -31,7 +31,7 @@ use crate::services::{
 };
 use aster_drive_model::entities::{mfa_email_code, mfa_login_flow, user};
 use aster_drive_model::types::{MfaFirstFactor, MfaMethod, MfaPersistentFactorMethod};
-use aster_forge_utils::numbers::{i64_to_u64, u64_to_i64};
+use aster_forge_utils::numbers::{i64_to_u64, u32_to_i32, u64_to_i64};
 
 use super::{
     EMAIL_CODE_DIGITS, MFA_LOGIN_FLOW_TTL_SECS, MFA_MAX_ATTEMPTS, MfaEmailCodeSendResponse, crypto,
@@ -146,28 +146,6 @@ pub async fn create_login_flow(
     let flow_token = format!("mfa_{}", aster_forge_utils::id::new_short_token());
     let now = Utc::now();
     let ttl = u64_to_i64(MFA_LOGIN_FLOW_TTL_SECS, "mfa login flow ttl")?;
-    let primary_kind = match first_factor {
-        MfaFirstFactor::Password => AuthFlowKind::PasswordLogin,
-        MfaFirstFactor::ExternalAuth => AuthFlowKind::ExternalLogin,
-    };
-    let primary = new_primary_flow(
-        primary_kind,
-        format!("primary:{flow_token}"),
-        now + Duration::seconds(ttl),
-        now,
-    )
-    .map_err(|_| AsterError::auth_invalid_credentials("primary login flow is invalid"))?;
-    plan_transition(
-        &primary,
-        AuthFlowCommand::Transition {
-            expected_revision: primary.revision,
-            to: AuthFlowState::SecondFactorPending,
-        },
-        now,
-    )
-    .map_err(|_| {
-        AsterError::auth_invalid_credentials("primary login flow transition is invalid")
-    })?;
     mfa_login_flow_repo::create(
         state.writer_db(),
         mfa_login_flow::ActiveModel {
@@ -510,6 +488,8 @@ pub async fn verify_challenge(
         };
 
         if !verified {
+            // The MFA table has no persisted revision field. Atomic attempt increments provide
+            // the concurrency guard while the derived snapshot revision remains 0 by contract.
             let transition = plan_transition(
                 &mfa_flow_snapshot(&flow),
                 AuthFlowCommand::RecordFailure {
@@ -522,7 +502,9 @@ pub async fn verify_challenge(
                 .map_err(|_| AsterError::internal_error("MFA attempt count overflow"))?;
             let consume_at = (transition.state == AuthFlowState::Failed).then_some(now);
             mfa_login_flow_repo::increment_attempts(&txn, flow.id, consume_at).await?;
-            let error = if next_attempt_count >= MFA_MAX_ATTEMPTS {
+            let error = if next_attempt_count
+                >= u32_to_i32(MFA_MAX_ATTEMPTS, "MFA max attempts").unwrap_or(i32::MAX)
+            {
                 auth_mfa_failed_with_code(
                     ApiErrorCode::AuthMfaAttemptsExceeded,
                     "MFA attempts exceeded",
@@ -861,6 +843,8 @@ fn format_email_code_expires_in(ttl_secs: u64) -> String {
 }
 
 fn ensure_flow_active(flow: &mfa_login_flow::Model, now: chrono::DateTime<Utc>) -> Result<()> {
+    // mfa_login_flows has no persisted revision column; atomic attempt and consume checks provide
+    // the concurrency boundary for this derived snapshot.
     plan_transition(
         &mfa_flow_snapshot(flow),
         AuthFlowCommand::Transition {
@@ -882,9 +866,10 @@ fn mfa_flow_snapshot(flow: &mfa_login_flow::Model) -> AuthFlowSnapshot {
         } else {
             AuthFlowState::SecondFactorPending
         },
+        // There is no persisted revision column for this typed flow.
         revision: 0,
         attempt_count: u32::try_from(flow.attempt_count).unwrap_or(u32::MAX),
-        max_attempts: Some(u32::try_from(MFA_MAX_ATTEMPTS).expect("positive MFA attempt limit")),
+        max_attempts: Some(MFA_MAX_ATTEMPTS),
         expires_at: flow.expires_at,
     }
 }

--- a/src/services/auth/mfa/mod.rs
+++ b/src/services/auth/mfa/mod.rs
@@ -23,7 +23,7 @@ pub use management::{
 
 const MFA_LOGIN_FLOW_TTL_SECS: u64 = 300;
 const MFA_SETUP_FLOW_TTL_SECS: u64 = 300;
-const MFA_MAX_ATTEMPTS: i32 = 5;
+const MFA_MAX_ATTEMPTS: u32 = 5;
 const EMAIL_CODE_DIGITS: usize = 8;
 const RECOVERY_CODE_COUNT: usize = 10;
 const RECOVERY_CODE_CHARS: usize = 12;

--- a/src/services/auth/mod.rs
+++ b/src/services/auth/mod.rs
@@ -1,6 +1,7 @@
 //! 认证、外部登录、MFA 和 Passkey 服务。
 
 pub mod external;
+pub mod flow;
 pub mod local;
 pub mod mfa;
 pub mod passkey;

--- a/src/services/auth/passkey/cache.rs
+++ b/src/services/auth/passkey/cache.rs
@@ -14,8 +14,6 @@ const PASSKEY_CHALLENGE_TTL_SECS: u64 = 300;
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct CachedPasskeyRegistrationFlow {
     flow_id: String,
-    revision: u64,
-    created_at: chrono::DateTime<Utc>,
     expires_at: chrono::DateTime<Utc>,
     challenge: PasskeyRegistrationChallenge,
 }
@@ -23,8 +21,6 @@ struct CachedPasskeyRegistrationFlow {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct CachedPasskeyLoginFlow {
     flow_id: String,
-    revision: u64,
-    created_at: chrono::DateTime<Utc>,
     expires_at: chrono::DateTime<Utc>,
     challenge: PasskeyAuthenticationChallenge,
 }
@@ -35,7 +31,7 @@ impl CachedPasskeyRegistrationFlow {
             flow_id: self.flow_id.clone(),
             kind: AuthFlowKind::PasskeyRegistration,
             state: AuthFlowState::FirstFactorPending,
-            revision: self.revision,
+            revision: 0,
             attempt_count: 0,
             max_attempts: Some(1),
             expires_at: self.expires_at,
@@ -49,7 +45,7 @@ impl CachedPasskeyLoginFlow {
             flow_id: self.flow_id.clone(),
             kind: AuthFlowKind::PasskeyLogin,
             state: AuthFlowState::FirstFactorPending,
-            revision: self.revision,
+            revision: 0,
             attempt_count: 0,
             max_attempts: Some(1),
             expires_at: self.expires_at,
@@ -77,8 +73,6 @@ pub(super) async fn store_registration_challenge(
             &registration_cache_key(flow_id),
             &CachedPasskeyRegistrationFlow {
                 flow_id: flow_id.to_string(),
-                revision: 0,
-                created_at,
                 expires_at: created_at + Duration::seconds(PASSKEY_CHALLENGE_TTL_SECS as i64),
                 challenge: challenge.clone(),
             },
@@ -91,8 +85,21 @@ pub(super) async fn take_registration_challenge(
     state: &impl SharedRuntimeState,
     flow_id: &str,
 ) -> Option<PasskeyRegistrationChallenge> {
-    let cached: CachedPasskeyRegistrationFlow =
-        state.cache().take(&registration_cache_key(flow_id)).await?;
+    let bytes = state
+        .cache()
+        .take_bytes(&registration_cache_key(flow_id))
+        .await?;
+    let cached = serde_json::from_slice::<CachedPasskeyRegistrationFlow>(&bytes)
+        .or_else(|_| {
+            serde_json::from_slice::<PasskeyRegistrationChallenge>(&bytes).map(|challenge| {
+                CachedPasskeyRegistrationFlow {
+                    flow_id: flow_id.to_string(),
+                    expires_at: Utc::now() + Duration::seconds(PASSKEY_CHALLENGE_TTL_SECS as i64),
+                    challenge,
+                }
+            })
+        })
+        .ok()?;
     let active = cached.flow_id == flow_id && cached.snapshot().expires_at > Utc::now();
     active.then_some(cached.challenge)
 }
@@ -109,8 +116,6 @@ pub(super) async fn store_login_challenge(
             &login_cache_key(flow_id),
             &CachedPasskeyLoginFlow {
                 flow_id: flow_id.to_string(),
-                revision: 0,
-                created_at,
                 expires_at: created_at + Duration::seconds(PASSKEY_CHALLENGE_TTL_SECS as i64),
                 challenge: challenge.clone(),
             },
@@ -123,7 +128,18 @@ pub(super) async fn take_login_challenge(
     state: &impl SharedRuntimeState,
     flow_id: &str,
 ) -> Option<PasskeyAuthenticationChallenge> {
-    let cached: CachedPasskeyLoginFlow = state.cache().take(&login_cache_key(flow_id)).await?;
+    let bytes = state.cache().take_bytes(&login_cache_key(flow_id)).await?;
+    let cached = serde_json::from_slice::<CachedPasskeyLoginFlow>(&bytes)
+        .or_else(|_| {
+            serde_json::from_slice::<PasskeyAuthenticationChallenge>(&bytes).map(|challenge| {
+                CachedPasskeyLoginFlow {
+                    flow_id: flow_id.to_string(),
+                    expires_at: Utc::now() + Duration::seconds(PASSKEY_CHALLENGE_TTL_SECS as i64),
+                    challenge,
+                }
+            })
+        })
+        .ok()?;
     let active = cached.flow_id == flow_id && cached.snapshot().expires_at > Utc::now();
     active.then_some(cached.challenge)
 }
@@ -211,8 +227,6 @@ mod tests {
         let created_at = Utc::now();
         let registration = CachedPasskeyRegistrationFlow {
             flow_id: "register-flow".to_string(),
-            revision: 4,
-            created_at,
             expires_at: created_at + Duration::minutes(5),
             challenge: registration_challenge(42),
         };
@@ -220,16 +234,91 @@ mod tests {
             registration.snapshot().kind,
             AuthFlowKind::PasskeyRegistration
         );
-        assert_eq!(registration.snapshot().revision, 4);
+        assert_eq!(registration.snapshot().revision, 0);
 
         let login = CachedPasskeyLoginFlow {
             flow_id: "login-flow".to_string(),
-            revision: 2,
-            created_at,
             expires_at: created_at + Duration::minutes(5),
             challenge: login_challenge(None),
         };
         assert_eq!(login.snapshot().kind, AuthFlowKind::PasskeyLogin);
         assert_eq!(login.snapshot().max_attempts, Some(1));
+    }
+
+    #[tokio::test]
+    async fn expired_cached_flows_are_rejected_after_atomic_take() {
+        let state = CacheOnlyState::new().await;
+        let expired = Utc::now() - Duration::seconds(1);
+        state
+            .cache()
+            .set(
+                &registration_cache_key("expired-register"),
+                &CachedPasskeyRegistrationFlow {
+                    flow_id: "expired-register".to_string(),
+                    expires_at: expired,
+                    challenge: registration_challenge(42),
+                },
+                None,
+            )
+            .await;
+        state
+            .cache()
+            .set(
+                &login_cache_key("expired-login"),
+                &CachedPasskeyLoginFlow {
+                    flow_id: "expired-login".to_string(),
+                    expires_at: expired,
+                    challenge: login_challenge(None),
+                },
+                None,
+            )
+            .await;
+
+        assert!(
+            take_registration_challenge(&state, "expired-register")
+                .await
+                .is_none()
+        );
+        assert!(
+            take_login_challenge(&state, "expired-login")
+                .await
+                .is_none()
+        );
+    }
+
+    #[tokio::test]
+    async fn raw_challenge_payloads_remain_compatible_during_upgrade() {
+        let state = CacheOnlyState::new().await;
+        let registration = registration_challenge(7);
+        let login = login_challenge(Some("alice"));
+        state
+            .cache()
+            .set_bytes(
+                &registration_cache_key("legacy-register"),
+                serde_json::to_vec(&registration).unwrap_or_default(),
+                Some(PASSKEY_CHALLENGE_TTL_SECS),
+            )
+            .await;
+        state
+            .cache()
+            .set_bytes(
+                &login_cache_key("legacy-login"),
+                serde_json::to_vec(&login).unwrap_or_default(),
+                Some(PASSKEY_CHALLENGE_TTL_SECS),
+            )
+            .await;
+
+        assert_eq!(
+            take_registration_challenge(&state, "legacy-register")
+                .await
+                .map(|value| value.user_id),
+            Some(7)
+        );
+        assert_eq!(
+            take_login_challenge(&state, "legacy-login")
+                .await
+                .and_then(|value| value.identifier),
+            Some("alice".to_string())
+        );
     }
 }

--- a/src/services/auth/passkey/cache.rs
+++ b/src/services/auth/passkey/cache.rs
@@ -1,11 +1,61 @@
 //! Passkey/WebAuthn flow challenge 缓存。
 
+use chrono::{Duration, Utc};
+use serde::{Deserialize, Serialize};
+
 use crate::runtime::SharedRuntimeState;
+use crate::services::auth::flow::{AuthFlowKind, AuthFlowSnapshot, AuthFlowState};
 use aster_forge_cache::CacheExt;
 
 use super::{PasskeyAuthenticationChallenge, PasskeyRegistrationChallenge};
 
 const PASSKEY_CHALLENGE_TTL_SECS: u64 = 300;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct CachedPasskeyRegistrationFlow {
+    flow_id: String,
+    revision: u64,
+    created_at: chrono::DateTime<Utc>,
+    expires_at: chrono::DateTime<Utc>,
+    challenge: PasskeyRegistrationChallenge,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct CachedPasskeyLoginFlow {
+    flow_id: String,
+    revision: u64,
+    created_at: chrono::DateTime<Utc>,
+    expires_at: chrono::DateTime<Utc>,
+    challenge: PasskeyAuthenticationChallenge,
+}
+
+impl CachedPasskeyRegistrationFlow {
+    fn snapshot(&self) -> AuthFlowSnapshot {
+        AuthFlowSnapshot {
+            flow_id: self.flow_id.clone(),
+            kind: AuthFlowKind::PasskeyRegistration,
+            state: AuthFlowState::FirstFactorPending,
+            revision: self.revision,
+            attempt_count: 0,
+            max_attempts: Some(1),
+            expires_at: self.expires_at,
+        }
+    }
+}
+
+impl CachedPasskeyLoginFlow {
+    fn snapshot(&self) -> AuthFlowSnapshot {
+        AuthFlowSnapshot {
+            flow_id: self.flow_id.clone(),
+            kind: AuthFlowKind::PasskeyLogin,
+            state: AuthFlowState::FirstFactorPending,
+            revision: self.revision,
+            attempt_count: 0,
+            max_attempts: Some(1),
+            expires_at: self.expires_at,
+        }
+    }
+}
 
 fn registration_cache_key(flow_id: &str) -> String {
     format!("external_auth:passkey:registration:{flow_id}")
@@ -20,11 +70,18 @@ pub(super) async fn store_registration_challenge(
     flow_id: &str,
     challenge: &PasskeyRegistrationChallenge,
 ) {
+    let created_at = Utc::now();
     state
         .cache()
         .set(
             &registration_cache_key(flow_id),
-            challenge,
+            &CachedPasskeyRegistrationFlow {
+                flow_id: flow_id.to_string(),
+                revision: 0,
+                created_at,
+                expires_at: created_at + Duration::seconds(PASSKEY_CHALLENGE_TTL_SECS as i64),
+                challenge: challenge.clone(),
+            },
             Some(PASSKEY_CHALLENGE_TTL_SECS),
         )
         .await;
@@ -34,7 +91,10 @@ pub(super) async fn take_registration_challenge(
     state: &impl SharedRuntimeState,
     flow_id: &str,
 ) -> Option<PasskeyRegistrationChallenge> {
-    state.cache().take(&registration_cache_key(flow_id)).await
+    let cached: CachedPasskeyRegistrationFlow =
+        state.cache().take(&registration_cache_key(flow_id)).await?;
+    let active = cached.flow_id == flow_id && cached.snapshot().expires_at > Utc::now();
+    active.then_some(cached.challenge)
 }
 
 pub(super) async fn store_login_challenge(
@@ -42,11 +102,18 @@ pub(super) async fn store_login_challenge(
     flow_id: &str,
     challenge: &PasskeyAuthenticationChallenge,
 ) {
+    let created_at = Utc::now();
     state
         .cache()
         .set(
             &login_cache_key(flow_id),
-            challenge,
+            &CachedPasskeyLoginFlow {
+                flow_id: flow_id.to_string(),
+                revision: 0,
+                created_at,
+                expires_at: created_at + Duration::seconds(PASSKEY_CHALLENGE_TTL_SECS as i64),
+                challenge: challenge.clone(),
+            },
             Some(PASSKEY_CHALLENGE_TTL_SECS),
         )
         .await;
@@ -56,7 +123,9 @@ pub(super) async fn take_login_challenge(
     state: &impl SharedRuntimeState,
     flow_id: &str,
 ) -> Option<PasskeyAuthenticationChallenge> {
-    state.cache().take(&login_cache_key(flow_id)).await
+    let cached: CachedPasskeyLoginFlow = state.cache().take(&login_cache_key(flow_id)).await?;
+    let active = cached.flow_id == flow_id && cached.snapshot().expires_at > Utc::now();
+    active.then_some(cached.challenge)
 }
 
 #[cfg(test)]
@@ -135,5 +204,32 @@ mod tests {
                 .and_then(|cached| cached.identifier),
             None
         );
+    }
+
+    #[test]
+    fn cached_flows_expose_typed_lifecycle_snapshots() {
+        let created_at = Utc::now();
+        let registration = CachedPasskeyRegistrationFlow {
+            flow_id: "register-flow".to_string(),
+            revision: 4,
+            created_at,
+            expires_at: created_at + Duration::minutes(5),
+            challenge: registration_challenge(42),
+        };
+        assert_eq!(
+            registration.snapshot().kind,
+            AuthFlowKind::PasskeyRegistration
+        );
+        assert_eq!(registration.snapshot().revision, 4);
+
+        let login = CachedPasskeyLoginFlow {
+            flow_id: "login-flow".to_string(),
+            revision: 2,
+            created_at,
+            expires_at: created_at + Duration::minutes(5),
+            challenge: login_challenge(None),
+        };
+        assert_eq!(login.snapshot().kind, AuthFlowKind::PasskeyLogin);
+        assert_eq!(login.snapshot().max_attempts, Some(1));
     }
 }

--- a/src/services/user/invitation.rs
+++ b/src/services/user/invitation.rs
@@ -200,7 +200,7 @@ pub async fn accept_invitation(
             return Err(invitation_invalid_error());
         };
         let invitation = refresh_expired_status(&txn, invitation).await?;
-        ensure_invitation_pending(&invitation)?;
+        ensure_invitation_flow_active(&invitation)?;
         ensure_invitation_not_expired(&txn, &invitation).await?;
         LocalEmailPolicy::from_runtime_config(state.runtime_config()).check(&invitation.email)?;
         ensure_email_available(&txn, &invitation.email).await?;
@@ -260,7 +260,6 @@ async fn find_valid_invitation_by_token<C: ConnectionTrait>(
     };
     let invitation = refresh_expired_status(db, invitation).await?;
     ensure_invitation_flow_active(&invitation)?;
-    ensure_invitation_pending(&invitation)?;
     ensure_invitation_not_expired(db, &invitation).await?;
     Ok(invitation)
 }
@@ -299,21 +298,19 @@ async fn ensure_invitation_not_expired<C: ConnectionTrait>(
     Err(invitation_status_error(UserInvitationStatus::Expired))
 }
 
-fn ensure_invitation_pending(invitation: &user_invitation::Model) -> Result<()> {
-    if invitation.status.is_pending() {
-        Ok(())
-    } else {
-        Err(invitation_status_error(invitation.status))
-    }
-}
-
 fn ensure_invitation_flow_active(invitation: &user_invitation::Model) -> Result<()> {
     match invitation_snapshot(invitation, Utc::now()).state {
         AuthFlowState::RecoveryPending => Ok(()),
         AuthFlowState::Expired => Err(invitation_status_error(UserInvitationStatus::Expired)),
         AuthFlowState::Cancelled => Err(invitation_status_error(UserInvitationStatus::Revoked)),
         AuthFlowState::Completed => Err(invitation_status_error(UserInvitationStatus::Accepted)),
-        _ => Err(invitation_invalid_error()),
+        AuthFlowState::FirstFactorPending
+        | AuthFlowState::SecondFactorPending
+        | AuthFlowState::Processing
+        | AuthFlowState::PasswordChangeRequired
+        | AuthFlowState::Authenticated
+        | AuthFlowState::Failed
+        | AuthFlowState::Consumed => Err(invitation_invalid_error()),
     }
 }
 

--- a/src/services/user/invitation.rs
+++ b/src/services/user/invitation.rs
@@ -12,9 +12,7 @@ use crate::config::{auth_runtime, branding, local_email_policy::LocalEmailPolicy
 use crate::db::repository::{user_invitation_repo, user_repo};
 use crate::errors::{AsterError, Result, validation_error_with_code};
 use crate::runtime::{MailRuntimeState, SharedRuntimeState};
-use crate::services::auth::flow::{
-    AuthFlowKind, AuthFlowState, invitation_snapshot, new_recovery_flow,
-};
+use crate::services::auth::flow::{AuthFlowState, invitation_snapshot};
 use crate::services::{
     auth::local::{
         ensure_password_login_enabled,
@@ -75,14 +73,10 @@ pub async fn create_invitation(
         auth_runtime::user_invitation_ttl_secs(state.runtime_config()),
         "user invitation ttl",
     )?;
+    if invitation_ttl_secs <= 0 {
+        return Err(invitation_invalid_error());
+    }
     let expires_at = now + Duration::seconds(invitation_ttl_secs);
-    new_recovery_flow(
-        AuthFlowKind::InvitationAcceptance,
-        format!("invitation:new:{invited_by}:{}", uuid::Uuid::new_v4()),
-        expires_at,
-        now,
-    )
-    .map_err(|_| invitation_invalid_error())?;
     let invitation_url = invitation_url(state.runtime_config(), &token);
     let expires_in = format_mail_duration_seconds(invitation_ttl_secs);
     let site_name = branding::title_or_default(state.runtime_config());

--- a/src/services/user/invitation.rs
+++ b/src/services/user/invitation.rs
@@ -12,6 +12,9 @@ use crate::config::{auth_runtime, branding, local_email_policy::LocalEmailPolicy
 use crate::db::repository::{user_invitation_repo, user_repo};
 use crate::errors::{AsterError, Result, validation_error_with_code};
 use crate::runtime::{MailRuntimeState, SharedRuntimeState};
+use crate::services::auth::flow::{
+    AuthFlowKind, AuthFlowState, invitation_snapshot, new_recovery_flow,
+};
 use crate::services::{
     auth::local::{
         ensure_password_login_enabled,
@@ -73,6 +76,13 @@ pub async fn create_invitation(
         "user invitation ttl",
     )?;
     let expires_at = now + Duration::seconds(invitation_ttl_secs);
+    new_recovery_flow(
+        AuthFlowKind::InvitationAcceptance,
+        format!("invitation:new:{invited_by}:{}", uuid::Uuid::new_v4()),
+        expires_at,
+        now,
+    )
+    .map_err(|_| invitation_invalid_error())?;
     let invitation_url = invitation_url(state.runtime_config(), &token);
     let expires_in = format_mail_duration_seconds(invitation_ttl_secs);
     let site_name = branding::title_or_default(state.runtime_config());
@@ -249,6 +259,7 @@ async fn find_valid_invitation_by_token<C: ConnectionTrait>(
         return Err(invitation_invalid_error());
     };
     let invitation = refresh_expired_status(db, invitation).await?;
+    ensure_invitation_flow_active(&invitation)?;
     ensure_invitation_pending(&invitation)?;
     ensure_invitation_not_expired(db, &invitation).await?;
     Ok(invitation)
@@ -293,6 +304,16 @@ fn ensure_invitation_pending(invitation: &user_invitation::Model) -> Result<()> 
         Ok(())
     } else {
         Err(invitation_status_error(invitation.status))
+    }
+}
+
+fn ensure_invitation_flow_active(invitation: &user_invitation::Model) -> Result<()> {
+    match invitation_snapshot(invitation, Utc::now()).state {
+        AuthFlowState::RecoveryPending => Ok(()),
+        AuthFlowState::Expired => Err(invitation_status_error(UserInvitationStatus::Expired)),
+        AuthFlowState::Cancelled => Err(invitation_status_error(UserInvitationStatus::Revoked)),
+        AuthFlowState::Completed => Err(invitation_status_error(UserInvitationStatus::Accepted)),
+        _ => Err(invitation_invalid_error()),
     }
 }
 


### PR DESCRIPTION
## Summary

Closes #570
Supersedes #582 after the previous merge was rolled back from `master`.

This PR re-submits the cross-layer authentication flow state-machine implementation against the rolled-back `master` baseline.

## What changed

- Add typed backend auth flow lifecycle primitives for state, transitions, snapshots, expiry, cancellation, replay, and policy revalidation.
- Integrate password login, MFA, external-auth recovery, contact verification, refresh handling, Passkey cache handling, invitations, and session flow boundaries.
- Refactor the frontend login page around a single top-level `AuthUiFlow` projection.
- Add command, policy, and URL coordinators with stale-generation protection.
- Preserve old Passkey cache payloads during rolling upgrades and reject expired entries after atomic take.
- Correct recovery flow creation to accept the state-machine transition result (`RecoveryPending -> Processing`) while retaining typed token expiry and single-use authority.
- Document the contract in English and Chinese.

## Compatibility and boundaries

- Existing public API envelopes, redirects, cookies, and session contracts remain the integration boundary.
- Drive retains authentication, user, session, recovery, and product semantics; no AsterForge migration is included.
- No new SAML, SCIM, IdP group mapping, or RP-initiated logout behavior is introduced.

## Validation

- `cargo nextest run --profile ci --test auth` passed: 268 tests.
- `cargo fmt --all -- --check` passed.
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` passed.
- `bun run check` passed.
- `git diff --check` passed.

## Review notes

- This branch is intentionally based on the live rolled-back `master` at `226543c1`.
- The recovery-flow state correction fixes the CI regression from merged head `4c253e0`, where contact-verification token creation returned HTTP 400 and caused 68 cascading integration failures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 统一认证流程状态管理，覆盖登录、MFA、Passkey、邀请、邮箱验证、密码重置及会话刷新。
  * 支持认证流程过期、单次使用、失败次数限制及并发冲突保护。
  * 登录页统一处理登录、注册、MFA、激活重发和密码重置流程。
  * 外部认证与可恢复登录链接的状态恢复和安全校验得到加强。

* **问题修复**
  * 过期或已使用的验证令牌、Passkey challenge、会话及邀请将被正确拒绝。
  * 避免过期请求覆盖当前登录页面状态。

* **文档**
  * 新增中英文认证流程状态机设计说明。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->